### PR TITLE
Restore external wallet connections with WalletConnect

### DIFF
--- a/app/components/WalletBridge.js
+++ b/app/components/WalletBridge.js
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+function getMetaMaskDeepLink() {
+  if (typeof window === 'undefined') return '';
+  const clean = window.location.href.replace(/^https?:\/\//, '');
+  return `https://metamask.app.link/dapp/${clean}`;
+}
+
+export default function WalletBridge() {
+  useEffect(() => {
+    const onClick = (event) => {
+      const target = event.target?.closest?.('button');
+      if (!target) return;
+      const label = (target.textContent || '').toLowerCase();
+      if (!label.includes('metamask')) return;
+      if (window.ethereum) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation?.();
+
+      const link = getMetaMaskDeepLink();
+      if (link) window.location.href = link;
+    };
+
+    document.addEventListener('click', onClick, true);
+    return () => document.removeEventListener('click', onClick, true);
+  }, []);
+
+  return null;
+}

--- a/app/components/WalletBridge.js
+++ b/app/components/WalletBridge.js
@@ -2,10 +2,115 @@
 
 import { useEffect } from 'react';
 
-function getMetaMaskDeepLink() {
+function dappUrl() {
   if (typeof window === 'undefined') return '';
-  const clean = window.location.href.replace(/^https?:\/\//, '');
-  return `https://metamask.app.link/dapp/${clean}`;
+  return encodeURIComponent(window.location.href);
+}
+
+function walletLinks() {
+  const url = dappUrl();
+  return [
+    ['MetaMask', `https://metamask.app.link/dapp/${decodeURIComponent(url)}`],
+    ['Coinbase Wallet', `https://go.cb-w.com/dapp?cb_url=${url}`],
+    ['Trust Wallet', `https://link.trustwallet.com/open_url?coin=60&url=${url}`],
+    ['Rainbow', `https://rnbwapp.com/dapp/${decodeURIComponent(url)}`],
+    ['OKX Wallet', `okx://wallet/dapp/url?dappUrl=${url}`],
+    ['Phantom', `https://phantom.app/ul/browse/${url}`],
+  ];
+}
+
+function closeModal() {
+  document.getElementById('vv-wallet-modal')?.remove();
+}
+
+async function connectProvider(provider, name, button) {
+  try {
+    const accounts = await provider.request({ method: 'eth_requestAccounts' });
+    const address = accounts?.[0];
+    if (address) {
+      localStorage.setItem('vv-wallet-address', address);
+      localStorage.setItem('vv-wallet-name', name);
+      document.querySelectorAll('button').forEach((b) => {
+        const text = (b.textContent || '').toLowerCase();
+        if (text.includes('metamask') || text.includes('connect wallet')) {
+          b.textContent = `${name} · ${address.slice(0, 6)}…${address.slice(-4)}`;
+        }
+      });
+      closeModal();
+    }
+  } catch (error) {
+    if (button) button.textContent = error?.message || 'Connection cancelled';
+  }
+}
+
+function showWalletModal() {
+  if (document.getElementById('vv-wallet-modal')) return;
+
+  const modal = document.createElement('div');
+  modal.id = 'vv-wallet-modal';
+  modal.innerHTML = `
+    <div class="vv-wallet-backdrop">
+      <div class="vv-wallet-card" role="dialog" aria-modal="true" aria-label="Choose wallet">
+        <button class="vv-wallet-close" aria-label="Close">×</button>
+        <div class="vv-wallet-kicker">VOXEL VAULT</div>
+        <h2>Connect your wallet</h2>
+        <p>MetaMask is only one option. Choose any supported wallet, or open Voxel Vault inside your wallet app.</p>
+        <div class="vv-wallet-list"></div>
+        <div class="vv-wallet-note">Your private keys never leave your wallet.</div>
+      </div>
+    </div>`;
+
+  const style = document.createElement('style');
+  style.textContent = `
+    #vv-wallet-modal{position:fixed;inset:0;z-index:99999;font-family:Inter,system-ui,sans-serif}
+    .vv-wallet-backdrop{position:absolute;inset:0;display:grid;place-items:center;padding:20px;background:rgba(2,3,8,.78);backdrop-filter:blur(18px)}
+    .vv-wallet-card{position:relative;width:min(430px,100%);padding:28px;border:1px solid #302d48;border-radius:20px;background:linear-gradient(145deg,#11131e,#08090f);box-shadow:0 30px 100px rgba(0,0,0,.6)}
+    .vv-wallet-close{position:absolute;right:14px;top:10px;border:0;background:transparent;color:#8d93a6;font-size:28px;cursor:pointer}
+    .vv-wallet-kicker{font-size:9px;letter-spacing:2.5px;color:#9679ff;font-weight:900}
+    .vv-wallet-card h2{margin:9px 0;font-size:28px;color:#fff}
+    .vv-wallet-card p{margin:0 0 20px;color:#8f96a9;font-size:12px;line-height:1.6}
+    .vv-wallet-list{display:grid;gap:9px}
+    .vv-wallet-option{width:100%;padding:14px 15px;border:1px solid #282b3b;border-radius:12px;background:#0d0f17;color:#fff;text-align:left;font-weight:800;cursor:pointer}
+    .vv-wallet-option:hover{border-color:#8063ff;background:#151129}
+    .vv-wallet-note{margin-top:16px;text-align:center;color:#666d80;font-size:9px;letter-spacing:.5px}
+  `;
+  document.head.appendChild(style);
+  document.body.appendChild(modal);
+
+  const list = modal.querySelector('.vv-wallet-list');
+  const discovered = [];
+  const providers = new Map();
+  const announce = (event) => {
+    const detail = event.detail;
+    if (!detail?.provider || providers.has(detail.info?.uuid)) return;
+    providers.set(detail.info?.uuid || discovered.length, detail.provider);
+    discovered.push([detail.info?.name || 'Wallet', detail.provider]);
+  };
+  window.addEventListener('eip6963:announceProvider', announce);
+  window.dispatchEvent(new Event('eip6963:requestProvider'));
+
+  setTimeout(() => {
+    window.removeEventListener('eip6963:announceProvider', announce);
+    discovered.forEach(([name, provider]) => {
+      const b = document.createElement('button');
+      b.className = 'vv-wallet-option';
+      b.textContent = `◈ ${name}`;
+      b.onclick = () => connectProvider(provider, name, b);
+      list.appendChild(b);
+    });
+
+    walletLinks().forEach(([name, href]) => {
+      if (discovered.some(([n]) => n.toLowerCase().includes(name.toLowerCase()))) return;
+      const b = document.createElement('button');
+      b.className = 'vv-wallet-option';
+      b.textContent = `↗ Open with ${name}`;
+      b.onclick = () => { window.location.href = href; };
+      list.appendChild(b);
+    });
+  }, 250);
+
+  modal.querySelector('.vv-wallet-close').onclick = closeModal;
+  modal.querySelector('.vv-wallet-backdrop').onclick = (e) => { if (e.target === e.currentTarget) closeModal(); };
 }
 
 export default function WalletBridge() {
@@ -14,15 +119,18 @@ export default function WalletBridge() {
       const target = event.target?.closest?.('button');
       if (!target) return;
       const label = (target.textContent || '').toLowerCase();
-      if (!label.includes('metamask')) return;
-      if (window.ethereum) return;
+      if (!label.includes('metamask') && !label.includes('connect wallet')) return;
 
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation?.();
 
-      const link = getMetaMaskDeepLink();
-      if (link) window.location.href = link;
+      if (window.ethereum && !window.ethereum.providers) {
+        connectProvider(window.ethereum, window.ethereum.isMetaMask ? 'MetaMask' : 'Wallet', target);
+        return;
+      }
+
+      showWalletModal();
     };
 
     document.addEventListener('click', onClick, true);

--- a/app/components/WalletBridge.js
+++ b/app/components/WalletBridge.js
@@ -2,6 +2,9 @@
 
 import { useEffect } from 'react';
 
+const SEPOLIA_CHAIN_ID = 11155111;
+let walletConnectProviderPromise = null;
+
 function dappUrl() {
   if (typeof window === 'undefined') return '';
   return encodeURIComponent(window.location.href);
@@ -23,23 +26,66 @@ function closeModal() {
   document.getElementById('vv-wallet-modal')?.remove();
 }
 
+function setConnectedButtons(name, address) {
+  localStorage.setItem('vv-wallet-address', address);
+  localStorage.setItem('vv-wallet-name', name);
+  document.querySelectorAll('button').forEach((b) => {
+    const text = (b.textContent || '').toLowerCase();
+    if (text.includes('metamask') || text.includes('connect wallet')) {
+      b.textContent = `${name} · ${address.slice(0, 6)}…${address.slice(-4)}`;
+    }
+  });
+}
+
 async function connectProvider(provider, name, button) {
   try {
     const accounts = await provider.request({ method: 'eth_requestAccounts' });
     const address = accounts?.[0];
     if (address) {
-      localStorage.setItem('vv-wallet-address', address);
-      localStorage.setItem('vv-wallet-name', name);
-      document.querySelectorAll('button').forEach((b) => {
-        const text = (b.textContent || '').toLowerCase();
-        if (text.includes('metamask') || text.includes('connect wallet')) {
-          b.textContent = `${name} · ${address.slice(0, 6)}…${address.slice(-4)}`;
-        }
-      });
+      setConnectedButtons(name, address);
       closeModal();
     }
   } catch (error) {
-    if (button) button.textContent = error?.message || 'Connection cancelled';
+    if (button) button.textContent = error?.code === 4001 ? 'Connection cancelled' : (error?.message || 'Connection failed');
+  }
+}
+
+async function getWalletConnectProvider() {
+  const projectId = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+  if (!projectId) throw new Error('WalletConnect is not configured yet. Add NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID in the Vercel environment variables.');
+
+  if (!walletConnectProviderPromise) {
+    walletConnectProviderPromise = import('@walletconnect/ethereum-provider').then(async ({ EthereumProvider }) => {
+      return EthereumProvider.init({
+        projectId,
+        optionalChains: [SEPOLIA_CHAIN_ID],
+        showQrModal: true,
+        rpcMap: { [SEPOLIA_CHAIN_ID]: 'https://rpc.sepolia.org' },
+        metadata: {
+          name: 'Voxel Vault',
+          description: '3D voxel NFT marketplace',
+          url: window.location.origin,
+          icons: [`${window.location.origin}/icon.png`],
+        },
+      });
+    });
+  }
+
+  return walletConnectProviderPromise;
+}
+
+async function connectWalletConnect(button) {
+  try {
+    if (button) button.textContent = 'Opening WalletConnect…';
+    const provider = await getWalletConnectProvider();
+    await provider.connect();
+    const accounts = await provider.request({ method: 'eth_requestAccounts' });
+    const address = accounts?.[0];
+    if (!address) throw new Error('No wallet account was returned.');
+    setConnectedButtons('WalletConnect', address);
+    closeModal();
+  } catch (error) {
+    if (button) button.textContent = error?.message || 'WalletConnect connection failed';
   }
 }
 
@@ -54,9 +100,9 @@ function showWalletModal() {
         <button class="vv-wallet-close" aria-label="Close">×</button>
         <div class="vv-wallet-kicker">VOXEL VAULT</div>
         <h2>Connect your wallet</h2>
-        <p>MetaMask is only one option. Choose any supported wallet, or open Voxel Vault inside your wallet app.</p>
+        <p>Use MetaMask, Coinbase, Trust, Rainbow, Phantom, or any compatible WalletConnect wallet. Your private keys stay inside your wallet.</p>
         <div class="vv-wallet-list"></div>
-        <div class="vv-wallet-note">Your private keys never leave your wallet.</div>
+        <div class="vv-wallet-note">Sepolia test network · Voxel Vault never asks for your seed phrase.</div>
       </div>
     </div>`;
 
@@ -72,19 +118,28 @@ function showWalletModal() {
     .vv-wallet-list{display:grid;gap:9px}
     .vv-wallet-option{width:100%;padding:14px 15px;border:1px solid #282b3b;border-radius:12px;background:#0d0f17;color:#fff;text-align:left;font-weight:800;cursor:pointer}
     .vv-wallet-option:hover{border-color:#8063ff;background:#151129}
-    .vv-wallet-note{margin-top:16px;text-align:center;color:#666d80;font-size:9px;letter-spacing:.5px}
+    .vv-wallet-option.primary{border-color:#7658ff;background:linear-gradient(135deg,#24164f,#12101f)}
+    .vv-wallet-note{margin-top:16px;text-align:center;color:#666d80;font-size:9px;letter-spacing:.5px;line-height:1.5}
   `;
   document.head.appendChild(style);
   document.body.appendChild(modal);
 
   const list = modal.querySelector('.vv-wallet-list');
+
+  const wcButton = document.createElement('button');
+  wcButton.className = 'vv-wallet-option primary';
+  wcButton.textContent = '◎ Connect with WalletConnect';
+  wcButton.onclick = () => connectWalletConnect(wcButton);
+  list.appendChild(wcButton);
+
   const discovered = [];
   const providers = new Map();
   const announce = (event) => {
     const detail = event.detail;
-    if (!detail?.provider || providers.has(detail.info?.uuid)) return;
-    providers.set(detail.info?.uuid || discovered.length, detail.provider);
-    discovered.push([detail.info?.name || 'Wallet', detail.provider]);
+    const key = detail?.info?.uuid || detail?.info?.name;
+    if (!detail?.provider || (key && providers.has(key))) return;
+    if (key) providers.set(key, detail.provider);
+    discovered.push([detail.info?.name || 'Browser Wallet', detail.provider]);
   };
   window.addEventListener('eip6963:announceProvider', announce);
   window.dispatchEvent(new Event('eip6963:requestProvider'));
@@ -125,8 +180,9 @@ export default function WalletBridge() {
       event.stopPropagation();
       event.stopImmediatePropagation?.();
 
-      if (window.ethereum && !window.ethereum.providers) {
-        connectProvider(window.ethereum, window.ethereum.isMetaMask ? 'MetaMask' : 'Wallet', target);
+      const injected = window.ethereum;
+      if (injected && !injected.providers) {
+        connectProvider(injected, injected.isMetaMask ? 'MetaMask' : 'Browser Wallet', target);
         return;
       }
 

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,8 +1,9 @@
 import MarketplaceLayer from './components/MarketplaceLayer';
 import CryptoAdSlot from './components/CryptoAdSlot';
+import WalletBridge from './components/WalletBridge';
 
 export const metadata = { title: 'VoxelVault', description: '3D asset marketplace' };
 
 export default function RootLayout({ children }) {
-  return <html lang="en"><body>{children}<CryptoAdSlot slot="global"/><MarketplaceLayer /></body></html>;
+  return <html lang="en"><body>{children}<WalletBridge /><CryptoAdSlot slot="global"/><MarketplaceLayer /></body></html>;
 }

--- a/lib/wallet-connect.js
+++ b/lib/wallet-connect.js
@@ -1,3 +1,6 @@
+export const SEPOLIA_CHAIN_ID = '0xaa36a7';
+export const SEPOLIA_CHAIN_HEX = SEPOLIA_CHAIN_ID;
+
 export function shortenAddress(address) {
   if (!address) return '';
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
@@ -16,44 +19,62 @@ export function getInjectedProvider() {
 
 export function isMetaMaskMobile() {
   if (typeof window === 'undefined') return false;
-  const ua = navigator.userAgent || '';
-  return /MetaMaskMobile/i.test(ua);
+  return /MetaMaskMobile/i.test(navigator.userAgent || '');
 }
 
-export function getMetaMaskDeepLink(url = window.location.href) {
+export function getMetaMaskDeepLink(url = typeof window !== 'undefined' ? window.location.href : '') {
   const clean = String(url).replace(/^https?:\/\//, '');
-  return `https://metamask.app.link/dapp/${clean}`;
+  return clean ? `https://metamask.app.link/dapp/${clean}` : '';
 }
 
-export async function connectWallet() {
+async function switchToSepolia(provider) {
+  try {
+    await provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: SEPOLIA_CHAIN_ID }] });
+    return true;
+  } catch (error) {
+    if (error?.code !== 4902) throw error;
+
+    await provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [{
+        chainId: SEPOLIA_CHAIN_ID,
+        chainName: 'Sepolia',
+        nativeCurrency: { name: 'Sepolia Ether', symbol: 'ETH', decimals: 18 },
+        rpcUrls: ['https://rpc.sepolia.org'],
+        blockExplorerUrls: ['https://sepolia.etherscan.io']
+      }]
+    });
+    return true;
+  }
+}
+
+export async function connectWallet({ requireSepolia = true } = {}) {
   const provider = getInjectedProvider();
   if (!provider) {
-    const deepLink = getMetaMaskDeepLink();
     return {
       ok: false,
       reason: 'no-provider',
-      deepLink,
-      message: 'Open Voxel Vault in MetaMask Mobile to connect your wallet.'
+      deepLink: getMetaMaskDeepLink(),
+      message: 'MetaMask is not open in this browser. Opening Voxel Vault in MetaMask Mobile…'
     };
   }
 
   try {
     const accounts = await provider.request({ method: 'eth_requestAccounts' });
     const address = accounts?.[0] || '';
-    if (!address) {
-      return { ok: false, reason: 'cancelled', message: 'Wallet connection cancelled.' };
+    if (!address) return { ok: false, reason: 'cancelled', message: 'Wallet connection cancelled.' };
+
+    let chainId = await provider.request({ method: 'eth_chainId' });
+    if (requireSepolia && chainId !== SEPOLIA_CHAIN_ID) {
+      await switchToSepolia(provider);
+      chainId = await provider.request({ method: 'eth_chainId' });
     }
 
-    const chainId = await provider.request({ method: 'eth_chainId' });
     return { ok: true, address, chainId, provider };
   } catch (error) {
     if (error?.code === 4001) {
       return { ok: false, reason: 'rejected', message: 'Connection was cancelled in your wallet.' };
     }
-    return {
-      ok: false,
-      reason: 'error',
-      message: error?.message || 'Wallet connection failed.'
-    };
+    return { ok: false, reason: 'error', message: error?.message || 'Wallet connection failed.' };
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-vault",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
+    "@walletconnect/ethereum-provider": "^2.23.10",
     "ethers": "^6.15.0",
     "next": "^15.5.23",
     "react": "^19.1.0",


### PR DESCRIPTION
Restores the Voxel Vault wallet flow so users are not forced into the MetaMask browser. Adds WalletConnect QR/app selection for iPhone and other compatible wallets, keeps EIP-6963 injected-wallet discovery, preserves the existing Voxel Vault UI, and keeps Sepolia as the transaction network. WalletConnect uses a public project ID from NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID; no private keys or seed phrases are handled by the site.