### PR TITLE
Fix production build and prepare universal wallet flow

### DIFF
--- a/lib/stripe-server.ts
+++ b/lib/stripe-server.ts
@@ -3,6 +3,6 @@ import Stripe from 'stripe';
 const secret = process.env.STRIPE_SECRET_KEY;
 if (!secret) throw new Error('STRIPE_SECRET_KEY is not configured');
 
-export const stripe = new Stripe(secret, { apiVersion: '2026-07-30.basil' });
+export const stripe = new Stripe(secret, { apiVersion: '2025-08-27.basil' });
 export const PLATFORM_FEE_BPS = 2000;
 export function platformFee(amountCents: number) { return Math.floor(amountCents * PLATFORM_FEE_BPS / 10000); }


### PR DESCRIPTION
Fixes the production build blocker caused by an unsupported Stripe API version in the installed Stripe SDK. This branch is the Gate 1 stabilization pass for Voxel Vault; wallet/3D verification follows after the build is green.