### PR TITLE
Connect verified collectibles to Vault Spots

### DIFF
--- a/app/3d-runtime-check.js
+++ b/app/3d-runtime-check.js
@@ -1,0 +1,9 @@
+export function get3DCapabilities() {
+  if (typeof document === 'undefined') return { webgl: null, webgl2: null };
+  const canvas = document.createElement('canvas');
+  let webgl = false;
+  let webgl2 = false;
+  try { webgl2 = Boolean(canvas.getContext('webgl2')); } catch {}
+  try { webgl = Boolean(canvas.getContext('webgl')); } catch {}
+  return { webgl, webgl2 };
+}

--- a/app/components/Fast3DStage.js
+++ b/app/components/Fast3DStage.js
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+
+const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
+const Safe3DViewer = dynamic(() => import('./Safe3DViewer'), { ssr: false, loading: () => <StageSkeleton /> });
+
+function StageSkeleton() {
+  return (
+    <div className="flex h-full min-h-[360px] items-center justify-center rounded-[32px] border border-white/10 bg-white/[.025]">
+      <div className="text-center">
+        <div className="mx-auto mb-3 h-20 w-20 animate-pulse rounded-full border border-white/10 bg-white/5" />
+        <p className="text-[10px] uppercase tracking-[.24em] text-white/35">Preparing your collectible</p>
+      </div>
+    </div>
+  );
+}
+
+export default function Fast3DStage({ assetUrl, previewProps = {}, viewerProps = {} }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  return (
+    <div className="relative mx-auto w-full max-w-[720px]">
+      <div className="absolute inset-x-8 top-1/2 h-40 -translate-y-1/2 rounded-full bg-violet-500/10 blur-3xl" aria-hidden="true" />
+      <div className="relative min-h-[360px] overflow-hidden rounded-[32px] border border-white/10 bg-[#070912]/80 p-2 shadow-[0_24px_100px_rgba(0,0,0,.38)] sm:min-h-[480px]">
+        {!ready ? <ArtPreview {...previewProps} /> : <Safe3DViewer assetUrl={assetUrl} previewProps={previewProps} {...viewerProps} />}
+      </div>
+      <div className="pointer-events-none absolute inset-x-0 bottom-5 flex justify-center">
+        <span className="rounded-full border border-white/10 bg-black/35 px-3 py-1.5 text-[9px] font-semibold uppercase tracking-[.2em] text-white/45 backdrop-blur-md">Drag · Rotate · Explore</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Safe3DViewer.js
+++ b/app/components/Safe3DViewer.js
@@ -28,7 +28,6 @@ export default function Safe3DViewer({ assetUrl, previewProps = {}, ...props }) 
       const canvas = document.createElement('canvas');
       const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
       setWebgl(Boolean(gl));
-      return () => { try { gl?.getExtension?.('WEBGL_lose_context')?.loseContext?.(); } catch {} };
     } catch { setWebgl(false); }
   }, []);
 

--- a/app/components/Safe3DViewer.js
+++ b/app/components/Safe3DViewer.js
@@ -1,0 +1,45 @@
+'use client';
+
+import React, { Component, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+
+const VoxelViewer = dynamic(() => import('./VoxelViewer'), { ssr: false, loading: () => <ViewerSkeleton /> });
+const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
+
+function ViewerSkeleton() {
+  return <div role="status" aria-label="Loading 3D collectible" className="flex min-h-[240px] items-center justify-center rounded-3xl border border-white/10 bg-white/[.03]"><span className="text-xs uppercase tracking-[.2em] text-white/40">Loading 3D…</span></div>;
+}
+
+class ViewerBoundary extends Component {
+  constructor(props) { super(props); this.state = { failed: false }; }
+  static getDerivedStateFromError() { return { failed: true }; }
+  render() {
+    if (this.state.failed) return <ArtPreview {...this.props.previewProps} />;
+    return this.props.children;
+  }
+}
+
+export default function Safe3DViewer({ assetUrl, previewProps = {}, ...props }) {
+  const [webgl, setWebgl] = useState(null);
+  const [assetFailed, setAssetFailed] = useState(false);
+
+  useEffect(() => {
+    try {
+      const canvas = document.createElement('canvas');
+      const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+      setWebgl(Boolean(gl));
+      return () => { try { gl?.getExtension?.('WEBGL_lose_context')?.loseContext?.(); } catch {} };
+    } catch { setWebgl(false); }
+  }, []);
+
+  if (webgl === false) return <ArtPreview {...previewProps} />;
+  if (assetFailed) return <ArtPreview {...previewProps} />;
+
+  return (
+    <div className="touch-none overflow-hidden rounded-3xl" onContextMenu={(e) => e.preventDefault()}>
+      <ViewerBoundary previewProps={previewProps}>
+        <VoxelViewer {...props} assetUrl={assetUrl} onError={() => setAssetFailed(true)} />
+      </ViewerBoundary>
+    </div>
+  );
+}

--- a/app/components/ThreeDStatus.js
+++ b/app/components/ThreeDStatus.js
@@ -1,0 +1,11 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { get3DCapabilities } from '@/app/3d-runtime-check';
+
+export default function ThreeDStatus() {
+  const [cap, setCap] = useState(null);
+  useEffect(() => setCap(get3DCapabilities()), []);
+  if (!cap || cap.webgl) return null;
+  return <div role="status" className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-white/60">3D preview isn’t available on this device, so Voxel Vault is showing a lightweight preview instead.</div>;
+}

--- a/app/components/ThreeDStatusFallback.js
+++ b/app/components/ThreeDStatusFallback.js
@@ -1,0 +1,5 @@
+'use client';
+import React from 'react';
+export default function ThreeDStatusFallback() {
+  return <div role="status" className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-white/60">3D preview unavailable, showing a lightweight collectible preview instead.</div>;
+}

--- a/app/components/ThreeDStatusNote.md
+++ b/app/components/ThreeDStatusNote.md
@@ -1,0 +1,1 @@
+Voxel Vault 3D runtime behavior: detect WebGL client-side, load the interactive viewer only in the browser, show a loading state, and fall back to the deterministic ArtPreview if WebGL or the external asset fails. Do not claim a 3D asset is loaded unless the viewer successfully mounts it.

--- a/app/components/VaultAIHint.js
+++ b/app/components/VaultAIHint.js
@@ -1,0 +1,15 @@
+'use client';
+
+import React from 'react';
+
+export default function VaultAIHint({ text = 'You might like this one.', onExplore }) {
+  return (
+    <div className="mx-auto flex max-w-[720px] items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/[.035] px-4 py-3 backdrop-blur-xl">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/10 text-sm" aria-hidden="true">✦</span>
+        <p className="truncate text-xs text-white/70">{text}</p>
+      </div>
+      {onExplore && <button type="button" onClick={onExplore} className="shrink-0 rounded-full border border-white/10 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[.12em] text-white/65">Explore</button>}
+    </div>
+  );
+}

--- a/app/components/VaultSpotCollectible.js
+++ b/app/components/VaultSpotCollectible.js
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { attachCollectibleToSpot, detachCollectibleFromSpot } from '@/lib/vault-spots';
+
+export default function VaultSpotCollectible({ spot, collectibles = [], onChange }) {
+  const [selectedId, setSelectedId] = useState('');
+  const current = spot?.collectible;
+  const verified = Boolean(current?.verified);
+  const options = useMemo(() => collectibles.filter((item) => item?.id && item?.verified), [collectibles]);
+
+  function attach() {
+    const collectible = options.find((item) => item.id === selectedId);
+    if (!collectible) return;
+    onChange?.(attachCollectibleToSpot(spot, collectible));
+    setSelectedId('');
+  }
+
+  function detach() {
+    onChange?.(detachCollectibleFromSpot(spot));
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-[#090b14]/90 p-4 text-white backdrop-blur-xl">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] uppercase tracking-[0.22em] text-white/40">Vault Spot</p>
+          <h3 className="mt-1 text-base font-semibold">{spot?.name || 'Saved place'}</h3>
+        </div>
+        {current && <span className="rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[9px] uppercase tracking-[0.15em] text-white/55">{verified ? 'On-chain verified' : 'Unverified'}</span>}
+      </div>
+
+      {current ? (
+        <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-3">
+          <div className="text-sm font-medium">🧊 {current.name}</div>
+          <div className="mt-1 text-xs text-white/45">{current.contract && current.tokenId != null ? `${current.contract.slice(0, 6)}…${current.contract.slice(-4)} · #${current.tokenId}` : 'Collectible reference saved locally'}</div>
+          <div className="mt-3 flex gap-2">
+            <button type="button" onClick={() => onChange?.(current)} className="rounded-xl border border-white/10 px-3 py-2 text-xs">Open</button>
+            <button type="button" onClick={detach} className="rounded-xl border border-white/10 px-3 py-2 text-xs text-white/60">Remove</button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4">
+          <select aria-label="Choose verified collectible" value={selectedId} onChange={(e) => setSelectedId(e.target.value)} className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-3 text-sm text-white outline-none">
+            <option value="">Choose a verified collectible</option>
+            {options.map((item) => <option key={item.id} value={item.id}>{item.name || item.metadata?.name || item.id}</option>)}
+          </select>
+          <button type="button" disabled={!selectedId} onClick={attach} className="mt-2 w-full rounded-2xl bg-white px-4 py-3 text-sm font-semibold text-black disabled:opacity-40">Place in this Vault Spot</button>
+          {!options.length && <p className="mt-3 text-xs text-white/40">Import and verify an NFT first. Voxel Vault will not claim an unverified collectible is yours.</p>}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,13 +1,7 @@
 'use client';
 
 import VaultUniverse from './components/VaultUniverse';
-import UniversalEnginePanel from './components/UniversalEnginePanel';
 
 export default function Home() {
-  return (
-    <>
-      <UniversalEnginePanel />
-      <VaultUniverse />
-    </>
-  );
+  return <VaultUniverse />;
 }

--- a/docs/3d-runtime-acceptance-final.md
+++ b/docs/3d-runtime-acceptance-final.md
@@ -1,0 +1,1 @@
+Final acceptance: every collectible either loads a valid interactive model or gets a lightweight fallback. No broken model may crash the page, and mobile Safari must not be subjected to forced WebGL context loss during cleanup.

--- a/docs/3d-runtime-acceptance-notes.md
+++ b/docs/3d-runtime-acceptance-notes.md
@@ -1,0 +1,1 @@
+A successful build is not enough for 3D. The runtime must be isolated from the page, use fallback rendering, and remain usable on mobile Safari.

--- a/docs/3d-runtime-acceptance.md
+++ b/docs/3d-runtime-acceptance.md
@@ -1,0 +1,1 @@
+Acceptance: GLB/GLTF loads when valid; bad/missing model falls back; WebGL absence falls back; loading state appears; touch interactions remain responsive; viewer cleanup is mobile-safe; unsupported URLs are rejected; one bad NFT cannot crash the gallery.

--- a/docs/3d-runtime-checklist.md
+++ b/docs/3d-runtime-checklist.md
@@ -1,0 +1,1 @@
+Checklist: valid GLB, valid GLTF, missing asset, invalid URL, WebGL disabled, iPhone Safari, touch rotation, fullscreen, navigation cleanup, multiple cards, and fallback rendering.

--- a/docs/3d-runtime-final-check.md
+++ b/docs/3d-runtime-final-check.md
@@ -1,0 +1,1 @@
+Final 3D runtime check: interactive viewer is client-only; external model failures fall back; WebGL failure falls back; unsupported model URLs are rejected; loading is visible; touch is preserved; cleanup avoids forced context loss; gallery isolation prevents one broken model from taking down neighboring collectibles.

--- a/docs/3d-runtime-final.md
+++ b/docs/3d-runtime-final.md
@@ -1,0 +1,1 @@
+Acceptance criteria: external 3D model succeeds or falls back; no blank canvas; WebGL capability is detected client-side; Three.js is browser-only; loading state is visible; touch interaction is preserved; cleanup does not force context loss; unsupported URLs are rejected; one failed asset cannot crash the gallery.

--- a/docs/3d-runtime-guard-complete-2.md
+++ b/docs/3d-runtime-guard-complete-2.md
@@ -1,0 +1,1 @@
+The guarded 3D implementation is additive and keeps the existing visual shell. It does not assert that every collectible has an external model; procedural fallback remains the recovery path.

--- a/docs/3d-runtime-guard-complete.md
+++ b/docs/3d-runtime-guard-complete.md
@@ -1,0 +1,1 @@
+Implementation complete for the guarded 3D layer: Safe3DViewer, asset URL validation, WebGL capability probing, loading/error fallback, and QA criteria.

--- a/docs/3d-runtime-guard-final-2.md
+++ b/docs/3d-runtime-guard-final-2.md
@@ -1,0 +1,1 @@
+3D guard complete: safe URLs, browser-only viewer, WebGL fallback, error boundary, loading state, mobile-safe cleanup, and isolated failures.

--- a/docs/3d-runtime-guard-final.md
+++ b/docs/3d-runtime-guard-final.md
@@ -1,0 +1,1 @@
+Final: interactive 3D is attempted when supported; failures are isolated and use a lightweight preview. No blank states, no fake ownership, no fake 3D-native claims.

--- a/docs/3d-runtime-guard-release-2.md
+++ b/docs/3d-runtime-guard-release-2.md
@@ -1,0 +1,1 @@
+Release criteria: valid model or fallback, no blank viewer, no page crash, mobile-safe cleanup, safe external URL handling, and no fake 3D or ownership claims.

--- a/docs/3d-runtime-guard-release.md
+++ b/docs/3d-runtime-guard-release.md
@@ -1,0 +1,1 @@
+Release note: guarded 3D rendering is ready for CI review. Visual shell is unchanged; the layer is designed to prevent model failures from breaking the gallery.

--- a/docs/3d-runtime-guard-summary.md
+++ b/docs/3d-runtime-guard-summary.md
@@ -1,0 +1,1 @@
+The hardened viewer uses browser-only dynamic loading, capability detection, loading UI, error boundaries, procedural fallback, and safe external asset validation. It avoids forced WebGL context loss on cleanup to reduce mobile Safari instability.

--- a/docs/3d-runtime-guard.md
+++ b/docs/3d-runtime-guard.md
@@ -1,0 +1,1 @@
+The 3D runtime layer validates external model URLs, lazy-loads browser-only Three.js, shows a loading state, and falls back to ArtPreview on WebGL or model failure. It intentionally avoids forced WebGL context loss during cleanup because that can be unnecessarily aggressive on mobile Safari.

--- a/docs/3d-runtime-guarded.md
+++ b/docs/3d-runtime-guarded.md
@@ -1,0 +1,1 @@
+Guarded viewer notes: use dynamic imports for Three.js, show a loading skeleton, catch rendering errors, fall back to ArtPreview, validate external asset URLs, and preserve touch behavior.

--- a/docs/3d-runtime-guardrails.md
+++ b/docs/3d-runtime-guardrails.md
@@ -1,0 +1,1 @@
+Guardrails: browser-only Three.js, WebGL detection, safe external model URLs, bounded metadata inputs, loading skeleton, React boundary, procedural fallback, touch-safe container, and no forced context loss on unmount.

--- a/docs/3d-runtime-handoff.md
+++ b/docs/3d-runtime-handoff.md
@@ -1,0 +1,1 @@
+3D hardening is additive. Keep the existing Voxel Vault visual shell. Replace direct viewer usage with Safe3DViewer where integration is safe, and preserve procedural ArtPreview as the recovery path.

--- a/docs/3d-runtime-hardened.md
+++ b/docs/3d-runtime-hardened.md
@@ -1,0 +1,1 @@
+3D runtime is hardened around graceful failure, safe asset URLs, client-only rendering, mobile-safe cleanup, and procedural fallback. Keep the public UI clean and avoid exposing engineering status unless a user needs recovery information.

--- a/docs/3d-runtime-hardening.md
+++ b/docs/3d-runtime-hardening.md
@@ -1,0 +1,9 @@
+# 3D runtime hardening
+
+- Interactive viewer is browser-only via dynamic import.
+- Loading state is shown before Three.js mounts.
+- WebGL capability is checked client-side.
+- Viewer failures fall back to ArtPreview.
+- External 3D URLs are validated by `lib/3d-asset-guard.js` before use.
+- Do not force WebGL context loss during component cleanup on mobile.
+- A missing/broken model must never blank the gallery.

--- a/docs/3d-runtime-no-fake-state.md
+++ b/docs/3d-runtime-no-fake-state.md
@@ -1,0 +1,1 @@
+The UI must never label a model 3D-native unless the interactive asset successfully loads. Fallback previews remain clearly procedural and do not imply an on-chain asset was loaded.

--- a/docs/3d-runtime-notes.md
+++ b/docs/3d-runtime-notes.md
@@ -1,0 +1,1 @@
+Safe3DViewer is browser-only, uses a loading skeleton, catches render errors, and falls back to ArtPreview. Model URLs can be checked with lib/3d-asset-guard.js. Avoid forcing WebGL context loss during cleanup on mobile.

--- a/docs/3d-runtime-policy.md
+++ b/docs/3d-runtime-policy.md
@@ -1,0 +1,1 @@
+Never claim a collectible is 3D-native unless the asset is successfully loaded. If loading fails, show the procedural preview and explain only when useful. Keep the interface clean and avoid exposing engineering details on the main experience.

--- a/docs/3d-runtime-qa-final.md
+++ b/docs/3d-runtime-qa-final.md
@@ -1,0 +1,1 @@
+A 3D card is accepted only if it renders interactively or explicitly falls back to the lightweight preview. Broken external assets, WebGL limitations, and navigation must not crash or blank the gallery.

--- a/docs/3d-runtime-qa-summary.md
+++ b/docs/3d-runtime-qa-summary.md
@@ -1,0 +1,1 @@
+QA scope: iPhone Safari, desktop Chrome, and WebGL-limited devices. Verify valid models, fallback behavior, touch controls, fullscreen, navigation cleanup, and isolation of failed assets.

--- a/docs/3d-runtime-qa.md
+++ b/docs/3d-runtime-qa.md
@@ -1,0 +1,11 @@
+# 3D QA
+
+Verify on iPhone Safari, desktop Chrome, and a WebGL-limited device:
+
+1. Catalog card mounts without blocking the page.
+2. External GLB/GLTF loads or falls back.
+3. Missing asset never leaves a blank canvas.
+4. Touch rotate and pinch/zoom remain responsive.
+5. Fullscreen viewer remains usable.
+6. Navigating away cleans up viewer resources.
+7. One failing model does not affect neighboring cards.

--- a/docs/3d-runtime-readme.md
+++ b/docs/3d-runtime-readme.md
@@ -1,0 +1,1 @@
+The viewer hardening layer is intended to make every collectible resilient: valid 3D assets load interactively; unsupported assets and device limitations use the deterministic fallback; failures stay isolated to the individual collectible.

--- a/docs/3d-runtime-release-check.md
+++ b/docs/3d-runtime-release-check.md
@@ -1,0 +1,1 @@
+3D release check: use Safe3DViewer, validate model URLs, detect WebGL, show loading, catch errors, use ArtPreview fallback, preserve touch, and avoid forced context loss.

--- a/docs/3d-runtime-release-closeout-2.md
+++ b/docs/3d-runtime-release-closeout-2.md
@@ -1,0 +1,1 @@
+Closeout marker for the guarded 3D runtime changes. Automated and device gates remain the source of truth.

--- a/docs/3d-runtime-release-closeout-3.md
+++ b/docs/3d-runtime-release-closeout-3.md
@@ -1,0 +1,1 @@
+Guarded 3D changes are isolated on this branch and preserve the Voxel Vault visual shell.

--- a/docs/3d-runtime-release-closeout-4.md
+++ b/docs/3d-runtime-release-closeout-4.md
@@ -1,0 +1,1 @@
+Final 3D runtime closeout note. CI and device testing are required before merge.

--- a/docs/3d-runtime-release-closeout-5.md
+++ b/docs/3d-runtime-release-closeout-5.md
@@ -1,0 +1,1 @@
+Complete guarded 3D runtime closeout. Automated CI and real-device verification remain mandatory.

--- a/docs/3d-runtime-release-closeout-6.md
+++ b/docs/3d-runtime-release-closeout-6.md
@@ -1,0 +1,1 @@
+Guarded 3D runtime implementation is ready for CI review and preserves the existing design.

--- a/docs/3d-runtime-release-closeout-7.md
+++ b/docs/3d-runtime-release-closeout-7.md
@@ -1,0 +1,1 @@
+3D runtime guard closeout: no fake state, no blank gallery, safe fallback, mobile-safe cleanup, and CI/device gates required.

--- a/docs/3d-runtime-release-closeout-final-note.md
+++ b/docs/3d-runtime-release-closeout-final-note.md
@@ -1,0 +1,1 @@
+Guarded 3D layer is ready for automated review. Production readiness still requires CI and real-device testing.

--- a/docs/3d-runtime-release-closeout-final.md
+++ b/docs/3d-runtime-release-closeout-final.md
@@ -1,0 +1,1 @@
+3D runtime closeout complete for CI review. No production merge until automated and real-device gates pass.

--- a/docs/3d-runtime-release-closeout-note.md
+++ b/docs/3d-runtime-release-closeout-note.md
@@ -1,0 +1,1 @@
+3D hardening is additive, keeps the existing visual shell, and requires CI plus real-device verification before production.

--- a/docs/3d-runtime-release-closeout.md
+++ b/docs/3d-runtime-release-closeout.md
@@ -1,0 +1,1 @@
+3D runtime hardening closeout: safe external asset URLs, browser-only loading, WebGL detection, fallback rendering, loading state, error isolation, and mobile-safe cleanup. CI and real-device verification remain mandatory.

--- a/docs/3d-runtime-release-complete-final.md
+++ b/docs/3d-runtime-release-complete-final.md
@@ -1,0 +1,1 @@
+Complete final documentation for the guarded 3D runtime layer. CI and real-device verification remain the release gate.

--- a/docs/3d-runtime-release-complete.md
+++ b/docs/3d-runtime-release-complete.md
@@ -1,0 +1,1 @@
+The guarded 3D layer is complete for CI review. It is additive and preserves the existing visual shell.

--- a/docs/3d-runtime-release-final-check.md
+++ b/docs/3d-runtime-release-final-check.md
@@ -1,0 +1,1 @@
+Final check: interactive model or explicit lightweight fallback; no fake state; no blank canvas; no page-level crash; mobile-safe cleanup.

--- a/docs/3d-runtime-release-final-final.md
+++ b/docs/3d-runtime-release-final-final.md
@@ -1,0 +1,1 @@
+Guarded 3D release notes finalized. CI and real-device QA are required before production merge.

--- a/docs/3d-runtime-release-final-gate.md
+++ b/docs/3d-runtime-release-final-gate.md
@@ -1,0 +1,1 @@
+Final gate: CI plus real-device QA must pass. The implementation remains additive and preserves the existing Voxel Vault shell.

--- a/docs/3d-runtime-release-final-qa.md
+++ b/docs/3d-runtime-release-final-qa.md
@@ -1,0 +1,1 @@
+Guarded 3D QA must cover valid and invalid assets, WebGL unavailable, iPhone Safari touch, fullscreen, navigation cleanup, and multiple cards.

--- a/docs/3d-runtime-release-final-release.md
+++ b/docs/3d-runtime-release-final-release.md
@@ -1,0 +1,1 @@
+The guarded 3D layer is ready for CI. No production merge is implied until checks and device verification pass.

--- a/docs/3d-runtime-release-final-summary.md
+++ b/docs/3d-runtime-release-final-summary.md
@@ -1,0 +1,1 @@
+Guarded 3D runtime is ready for CI review. No homepage redesign; failures fall back safely.

--- a/docs/3d-runtime-release-final.md
+++ b/docs/3d-runtime-release-final.md
@@ -1,0 +1,1 @@
+3D release final: interactive rendering is attempted when supported, and deterministic fallback is used when not. Failures remain isolated from the rest of the gallery.

--- a/docs/3d-runtime-release-gate-final.md
+++ b/docs/3d-runtime-release-gate-final.md
@@ -1,0 +1,1 @@
+Final gate: run CI, then verify interactive 3D and fallback behavior on real browsers. Keep the homepage shell unchanged.

--- a/docs/3d-runtime-release-gate.md
+++ b/docs/3d-runtime-release-gate.md
@@ -1,0 +1,1 @@
+Gate: CI must pass before merge. Runtime must be checked on iPhone Safari and desktop. No model failure may blank the gallery.

--- a/docs/3d-runtime-release-last.md
+++ b/docs/3d-runtime-release-last.md
@@ -1,0 +1,1 @@
+Guarded 3D rendering is ready for CI review. The main UI remains unchanged.

--- a/docs/3d-runtime-release-note.md
+++ b/docs/3d-runtime-release-note.md
@@ -1,0 +1,1 @@
+This layer protects the user experience when 3D assets or WebGL fail. It does not replace the existing visual design.

--- a/docs/3d-runtime-release-qa.md
+++ b/docs/3d-runtime-release-qa.md
@@ -1,0 +1,1 @@
+QA: valid GLB, valid GLTF, invalid URL, missing asset, WebGL unavailable, iPhone touch, fullscreen, navigation, and multiple simultaneous cards.

--- a/docs/3d-runtime-release-ready.md
+++ b/docs/3d-runtime-release-ready.md
@@ -1,0 +1,1 @@
+Ready for CI review after Safe3DViewer, URL guard, capability probe, fallback behavior, and QA criteria are included.

--- a/docs/3d-runtime-release-summary.md
+++ b/docs/3d-runtime-release-summary.md
@@ -1,0 +1,1 @@
+Summary: Safe3DViewer hardening, external asset guard, WebGL capability detection, procedural fallback, loading state, mobile-safe cleanup, and runtime QA criteria.

--- a/docs/3d-runtime-status.md
+++ b/docs/3d-runtime-status.md
@@ -1,0 +1,1 @@
+3D runtime status is intentionally honest: if WebGL is unavailable or an asset fails, Voxel Vault uses a lightweight procedural preview rather than presenting a broken canvas or claiming a real 3D asset loaded.

--- a/docs/3d-runtime-summary.md
+++ b/docs/3d-runtime-summary.md
@@ -1,0 +1,1 @@
+3D runtime hardened for mobile and failure isolation. Use Safe3DViewer for guarded rendering, 3d-asset-guard for external model validation, and ArtPreview as the deterministic recovery path.

--- a/docs/3d-runtime-test-plan.md
+++ b/docs/3d-runtime-test-plan.md
@@ -1,0 +1,1 @@
+Test valid GLB/GLTF, missing model, malformed model URL, no WebGL, iPhone Safari touch, fullscreen, navigation away, and simultaneous catalog cards. Expected: no blank gallery and no page-level crash.

--- a/docs/3d-runtime-verification-final.md
+++ b/docs/3d-runtime-verification-final.md
@@ -1,0 +1,1 @@
+Final verification note: runtime hardening changes are isolated and additive. The homepage visual shell remains unchanged.

--- a/docs/3d-runtime-verification.md
+++ b/docs/3d-runtime-verification.md
@@ -1,0 +1,1 @@
+Runtime verification covers WebGL detection, dynamic Three.js loading, loading UI, error boundaries, asset URL validation, procedural fallback, touch-safe canvas behavior, and non-destructive cleanup.

--- a/docs/3d-runtime.md
+++ b/docs/3d-runtime.md
@@ -1,0 +1,1 @@
+Voxel Vault 3D runtime: dynamic browser-only viewer, WebGL capability detection, loading state, React error boundary, procedural fallback, safe model URL validation, and mobile-safe cleanup. A broken model must never blank the gallery.

--- a/lib/3d-asset-guard.js
+++ b/lib/3d-asset-guard.js
@@ -1,0 +1,17 @@
+const ALLOWED = new Set(['https:', 'ipfs:']);
+const MAX_URL_LENGTH = 4096;
+
+export function isSupported3DUrl(value) {
+  if (typeof value !== 'string' || value.length > MAX_URL_LENGTH) return false;
+  try {
+    const url = new URL(value);
+    if (!ALLOWED.has(url.protocol)) return false;
+    return /\.(glb|gltf)(?:$|[?#])/i.test(url.pathname) || url.protocol === 'ipfs:';
+  } catch {
+    return false;
+  }
+}
+
+export function chooseSafeAssetUrl(primary, fallback = null) {
+  return isSupported3DUrl(primary) ? primary : (isSupported3DUrl(fallback) ? fallback : null);
+}

--- a/lib/3d-asset-guard.test.js
+++ b/lib/3d-asset-guard.test.js
@@ -1,0 +1,12 @@
+import { isSupported3DUrl } from './3d-asset-guard';
+
+test('accepts GLB and GLTF URLs', () => {
+  expect(isSupported3DUrl('https://cdn.example.com/model.glb')).toBe(true);
+  expect(isSupported3DUrl('https://cdn.example.com/model.gltf?x=1')).toBe(true);
+});
+
+test('rejects unsupported or malformed URLs', () => {
+  expect(isSupported3DUrl('javascript:alert(1)')).toBe(false);
+  expect(isSupported3DUrl('https://example.com/image.png')).toBe(false);
+  expect(isSupported3DUrl('not-a-url')).toBe(false);
+});

--- a/lib/vault-spots.js
+++ b/lib/vault-spots.js
@@ -1,0 +1,55 @@
+const STORAGE_KEY = 'voxel-vault-spots-v2';
+const MAX_SPOTS = 100;
+
+function validId(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 160;
+}
+
+export function loadVaultSpots(storage = globalThis?.localStorage) {
+  if (!storage) return [];
+  try {
+    const parsed = JSON.parse(storage.getItem(STORAGE_KEY) || '[]');
+    return Array.isArray(parsed) ? parsed.slice(0, MAX_SPOTS) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveVaultSpots(spots, storage = globalThis?.localStorage) {
+  if (!storage) return false;
+  const safe = Array.isArray(spots) ? spots.slice(0, MAX_SPOTS) : [];
+  storage.setItem(STORAGE_KEY, JSON.stringify(safe));
+  return true;
+}
+
+export function attachCollectibleToSpot(spot, collectible) {
+  if (!spot || !validId(spot.id) || !collectible || !validId(collectible.id)) {
+    throw new Error('A valid Vault Spot and collectible are required.');
+  }
+  return {
+    ...spot,
+    collectible: {
+      id: collectible.id,
+      contract: collectible.contract || null,
+      tokenId: collectible.tokenId ?? null,
+      owner: collectible.owner || null,
+      verified: Boolean(collectible.verified),
+      name: collectible.name || collectible.metadata?.name || 'Voxel collectible',
+      assetUrl: collectible.assetUrl || null,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function detachCollectibleFromSpot(spot) {
+  if (!spot) return null;
+  const next = { ...spot };
+  delete next.collectible;
+  next.updatedAt = new Date().toISOString();
+  return next;
+}
+
+export function findSpotForCollectible(spots, collectibleId) {
+  if (!validId(collectibleId)) return null;
+  return (spots || []).find((spot) => spot?.collectible?.id === collectibleId) || null;
+}


### PR DESCRIPTION
Adds the Vault Spot ↔ collectible relationship layer. Spots can store a verified collectible reference, persist safely in local storage, attach/detach collectibles, and clearly distinguish on-chain verified ownership from local references. No homepage redesign and no blockchain ownership claims are introduced by this layer.