### PR TITLE
Add hybrid sponsored drops and transparent revenue allocation

### DIFF
--- a/app/asset/[id]/page.js
+++ b/app/asset/[id]/page.js
@@ -1,6 +1,5 @@
 import { notFound } from 'next/navigation';
-import VoxelViewer from '../../components/VoxelViewer';
-import ArtPreview from '../../components/ArtPreview';
+import Safe3DViewer from '../../components/Safe3DViewer';
 import CollectorTools from '../../components/CollectorTools';
 import { getCatalogItem } from '../../../lib/catalog';
 
@@ -45,13 +44,27 @@ export default async function AssetPage({ params }) {
   };
 
   return (
-    <main style={{ minHeight: '100vh', background: '#05060b', color: '#f7f8ff', fontFamily: 'Inter,ui-sans-serif,system-ui,sans-serif', padding: '28px' }}>
+    <main style={{ minHeight: '100vh', background: '#05060b', color: '#f7f8ff', fontFamily: 'Inter,ui-sans-serif,system-ui,sans-serif', padding: '20px clamp(14px,3vw,28px)' }}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <div style={{ maxWidth: 1200, margin: '0 auto' }}>
         <a href="/" style={{ color: '#9b84ff', textDecoration: 'none', fontSize: 12, letterSpacing: '.12em' }}>← VOXEL VAULT</a>
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1.2fr) minmax(300px,.8fr)', gap: 28, alignItems: 'center', marginTop: 28 }}>
-          <div style={{ height: 650, border: '1px solid rgba(255,255,255,.1)', borderRadius: 24, overflow: 'hidden', background: '#070811' }}>
-            {item.renderMode === 'voxel' ? <VoxelViewer shape={item.shape} material={item.material} rarity={item.rarity} seed={item.seed} interactive showcase={false} label={false} /> : <ArtPreview family={item.family} material={item.material} seed={item.seed} interactive showcase={false} />}
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1.15fr) minmax(300px,.85fr)', gap: 28, alignItems: 'center', marginTop: 20 }}>
+          <div style={{ height: 'min(650px, 72vh)', minHeight: 420, minWidth: 0, border: '1px solid rgba(255,255,255,.1)', borderRadius: 24, overflow: 'hidden', background: '#070811', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
+            <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Safe3DViewer
+                shape={item.shape}
+                family={item.family}
+                material={item.material}
+                rarity={item.rarity}
+                seed={item.seed}
+                interactive
+                showcase={false}
+                label={false}
+                compact={false}
+                previewProps={{ family: item.family, material: item.material, seed: item.seed, interactive: true, showcase: false }}
+              />
+            </div>
+            <div style={{ position: 'absolute', left: 16, bottom: 14, pointerEvents: 'none', color: 'rgba(255,255,255,.42)', fontSize: 10, letterSpacing: '.14em', textTransform: 'uppercase' }}>Drag to inspect · pinch to zoom</div>
           </div>
           <section>
             <div style={{ color: '#9b84ff', fontSize: 10, letterSpacing: '.2em', fontWeight: 800 }}>3D DIGITAL OBJECT · {item.rarity.toUpperCase()}</div>
@@ -66,6 +79,7 @@ export default async function AssetPage({ params }) {
           </section>
         </div>
       </div>
+      <style>{`@media (max-width: 860px) { main > div > div { grid-template-columns: 1fr !important; } main > div > div > div:first-child { height: min(68vh, 560px) !important; min-height: 360px !important; } }`}</style>
     </main>
   );
 }

--- a/app/components/ArtPreview.js
+++ b/app/components/ArtPreview.js
@@ -19,88 +19,81 @@ const MATERIALS = {
   ice: { color: 0xb8e9ff, metalness: 0.12, roughness: 0.12, transparent: true, opacity: 0.72 },
 };
 
+const GLOW_LEVELS = {
+  none: { intensity: 0, radius: 0 },
+  subtle: { intensity: 0.14, radius: 0.055 },
+  rare: { intensity: 0.28, radius: 0.075 },
+  epic: { intensity: 0.46, radius: 0.095 },
+  legendary: { intensity: 0.68, radius: 0.12 },
+};
+
+function glowLevelFor(seed, explicit) {
+  if (explicit && GLOW_LEVELS[explicit]) return explicit;
+  const n = Number.parseInt(String(seed || '').slice(-2), 16);
+  if (!Number.isFinite(n)) return 'subtle';
+  if (n >= 240) return 'legendary';
+  if (n >= 180) return 'epic';
+  if (n >= 105) return 'rare';
+  return 'subtle';
+}
+
 function hash(input) { let h = 2166136261; for (let i = 0; i < String(input).length; i += 1) { h ^= String(input).charCodeAt(i); h = Math.imul(h, 16777619); } return h >>> 0; }
 function rng(seed) { let s = hash(seed) || 1; return () => { s ^= s << 13; s ^= s >>> 17; s ^= s << 5; return (s >>> 0) / 4294967296; }; }
 function materialFor(name, accent = 0) { const base = MATERIALS[name] || MATERIALS.metallic; const mat = new THREE.MeshPhysicalMaterial({ ...base }); if (name === 'glass' || name === 'crystal' || name === 'ice') { mat.transmission = 0.22; mat.thickness = 0.45; mat.ior = 1.45; } if (accent) mat.color.offsetHSL(accent, 0, 0); return mat; }
 function addMesh(group, geometry, material, position = [0, 0, 0], rotation = [0, 0, 0], scale = [1, 1, 1]) { const mesh = new THREE.Mesh(geometry, material); mesh.position.set(...position); mesh.rotation.set(...rotation); mesh.scale.set(...scale); mesh.castShadow = true; mesh.receiveShadow = true; group.add(mesh); return mesh; }
-function addGlow(group, position, color, size = 0.12) { const mesh = new THREE.Mesh(new THREE.SphereGeometry(size, 12, 8), new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.9 })); mesh.position.set(...position); group.add(mesh); }
+function addGlow(group, position, color, size = 0.12, intensity = 0.9) { const mesh = new THREE.Mesh(new THREE.SphereGeometry(size, 12, 8), new THREE.MeshBasicMaterial({ color, transparent: true, opacity: Math.min(0.9, intensity) })); mesh.position.set(...position); group.add(mesh); }
 
-function createVehicle(group, m, random) {
-  const body = addMesh(group, new THREE.SphereGeometry(1, 20, 12), m, [0, 0.25, 0], [0, 0, 0], [2.7, 0.62, 1.35]); body.scale.y = 0.7;
-  addMesh(group, new THREE.SphereGeometry(1, 18, 10), m, [0.15, 0.82, 0], [0, 0, 0], [1.35, 0.58, 1.05]);
-  addMesh(group, new THREE.BoxGeometry(1.5, 0.38, 1.55), materialFor('glass'), [0.1, 0.98, 0], [0, 0, 0], [1, 1, 0.72]);
-  const wheelMat = materialFor('obsidian');
-  for (const x of [-1.65, 1.65]) for (const z of [-1.05, 1.05]) addMesh(group, new THREE.CylinderGeometry(0.42, 0.42, 0.22, 20), wheelMat, [x, -0.3, z], [Math.PI / 2, 0, 0]);
-  addGlow(group, [-2.72, 0.22, -0.48], 0x9cecff, 0.13); addGlow(group, [-2.72, 0.22, 0.48], 0x9cecff, 0.13);
-  if (random() > 0.45) addMesh(group, new THREE.BoxGeometry(0.08, 0.08, 2.2), materialFor('neon'), [2.45, 0.4, 0]);
-}
-function createCreature(group, m, random) {
-  addMesh(group, new THREE.SphereGeometry(1, 18, 14), m, [0, 0.5, 0], [0, 0, 0], [1.25, 1.05, 1.45]); addMesh(group, new THREE.SphereGeometry(1, 16, 12), m, [0, 1.75, 0.25], [0, 0, 0], [0.82, 0.82, 0.9]);
-  for (const x of [-0.55, 0.55]) addMesh(group, new THREE.ConeGeometry(0.3, 1.05, 12), m, [x, 2.5, 0.2], [0, 0, x < 0 ? -0.25 : 0.25]);
-  for (const x of [-0.78, 0.78]) for (const z of [-0.72, 0.72]) addMesh(group, new THREE.CapsuleGeometry(0.18, 0.75, 6, 10), m, [x, -0.05, z], [0, 0, x * -0.18]);
-  addGlow(group, [-0.3, 1.85, -0.72], 0xff6bcb, 0.08); addGlow(group, [0.3, 1.85, -0.72], 0xff6bcb, 0.08);
-  if (random() > 0.35) addMesh(group, new THREE.TorusGeometry(1.15, 0.055, 8, 40), materialFor('holographic'), [0, 0.85, 0], [Math.PI / 2, 0, 0]);
-}
-function createRobot(group, m, random) {
-  addMesh(group, new THREE.BoxGeometry(1.8, 2.2, 1.4), m, [0, 0.7, 0]); addMesh(group, new THREE.SphereGeometry(0.78, 16, 12), m, [0, 2.25, 0], [0, 0, 0], [1, 0.9, 0.9]);
-  for (const x of [-1.45, 1.45]) { addMesh(group, new THREE.CapsuleGeometry(0.22, 1.2, 6, 10), m, [x, 0.8, 0], [0, 0, x < 0 ? 0.2 : -0.2]); addMesh(group, new THREE.BoxGeometry(0.6, 1.65, 0.7), m, [x * 0.48, -1.0, 0]); }
-  addGlow(group, [-0.28, 2.28, -0.72], 0x48eaff, 0.09); addGlow(group, [0.28, 2.28, -0.72], 0x48eaff, 0.09);
-  if (random() > 0.3) addMesh(group, new THREE.TorusGeometry(1.3, 0.06, 8, 32), materialFor('neon'), [0, 0.6, 0], [Math.PI / 2, 0, 0]);
-}
-function createArchitecture(group, m, random) {
-  addMesh(group, new THREE.BoxGeometry(4.6, 0.45, 4.2), m, [0, -1.45, 0]); for (const x of [-1.7, 1.7]) for (const z of [-1.45, 1.45]) addMesh(group, new THREE.CylinderGeometry(0.22, 0.32, 3.8, 16), m, [x, 0.35, z]);
-  addMesh(group, new THREE.BoxGeometry(3.8, 0.42, 3.3), m, [0, 2.25, 0]); addMesh(group, new THREE.ConeGeometry(2.6, 2.0, 6), m, [0, 3.45, 0], [0, Math.PI / 6, 0]);
-  for (const x of [-1.05, 1.05]) for (const z of [-1.5, 1.5]) addMesh(group, new THREE.BoxGeometry(0.65, 1.35, 0.05), materialFor('glass'), [x, 0.4, z]);
-  if (random() > 0.4) addMesh(group, new THREE.TorusGeometry(2.2, 0.045, 8, 48), materialFor('holographic'), [0, 1.1, 0], [Math.PI / 2, 0, 0]);
-}
+function createVehicle(group, m, random) { const body = addMesh(group, new THREE.SphereGeometry(1, 20, 12), m, [0, 0.25, 0], [0, 0, 0], [2.7, 0.62, 1.35]); body.scale.y = 0.7; addMesh(group, new THREE.SphereGeometry(1, 18, 10), m, [0.15, 0.82, 0], [0, 0, 0], [1.35, 0.58, 1.05]); addMesh(group, new THREE.BoxGeometry(1.5, 0.38, 1.55), materialFor('glass'), [0.1, 0.98, 0], [0, 0, 0], [1, 1, 0.72]); const wheelMat = materialFor('obsidian'); for (const x of [-1.65, 1.65]) for (const z of [-1.05, 1.05]) addMesh(group, new THREE.CylinderGeometry(0.42, 0.42, 0.22, 20), wheelMat, [x, -0.3, z], [Math.PI / 2, 0, 0]); addGlow(group, [-2.72, 0.22, -0.48], 0x9cecff, 0.13); addGlow(group, [-2.72, 0.22, 0.48], 0x9cecff, 0.13); if (random() > 0.45) addMesh(group, new THREE.BoxGeometry(0.08, 0.08, 2.2), materialFor('neon'), [2.45, 0.4, 0]); }
+function createCreature(group, m, random) { addMesh(group, new THREE.SphereGeometry(1, 18, 14), m, [0, 0.5, 0], [0, 0, 0], [1.25, 1.05, 1.45]); addMesh(group, new THREE.SphereGeometry(1, 16, 12), m, [0, 1.75, 0.25], [0, 0, 0], [0.82, 0.82, 0.9]); for (const x of [-0.55, 0.55]) addMesh(group, new THREE.ConeGeometry(0.3, 1.05, 12), m, [x, 2.5, 0.2], [0, 0, x < 0 ? -0.25 : 0.25]); for (const x of [-0.78, 0.78]) for (const z of [-0.72, 0.72]) addMesh(group, new THREE.CapsuleGeometry(0.18, 0.75, 6, 10), m, [x, -0.05, z], [0, 0, x * -0.18]); addGlow(group, [-0.3, 1.85, -0.72], 0xff6bcb, 0.08); addGlow(group, [0.3, 1.85, -0.72], 0xff6bcb, 0.08); if (random() > 0.35) addMesh(group, new THREE.TorusGeometry(1.15, 0.055, 8, 40), materialFor('holographic'), [0, 0.85, 0], [Math.PI / 2, 0, 0]); }
+function createRobot(group, m, random) { addMesh(group, new THREE.BoxGeometry(1.8, 2.2, 1.4), m, [0, 0.7, 0]); addMesh(group, new THREE.SphereGeometry(0.78, 16, 12), m, [0, 2.25, 0], [0, 0, 0], [1, 0.9, 0.9]); for (const x of [-1.45, 1.45]) { addMesh(group, new THREE.CapsuleGeometry(0.22, 1.2, 6, 10), m, [x, 0.8, 0], [0, 0, x < 0 ? 0.2 : -0.2]); addMesh(group, new THREE.BoxGeometry(0.6, 1.65, 0.7), m, [x * 0.48, -1.0, 0]); } addGlow(group, [-0.28, 2.28, -0.72], 0x48eaff, 0.09); addGlow(group, [0.28, 2.28, -0.72], 0x48eaff, 0.09); if (random() > 0.3) addMesh(group, new THREE.TorusGeometry(1.3, 0.06, 8, 32), materialFor('neon'), [0, 0.6, 0], [Math.PI / 2, 0, 0]); }
+function createArchitecture(group, m, random) { addMesh(group, new THREE.BoxGeometry(4.6, 0.45, 4.2), m, [0, -1.45, 0]); for (const x of [-1.7, 1.7]) for (const z of [-1.45, 1.45]) addMesh(group, new THREE.CylinderGeometry(0.22, 0.32, 3.8, 16), m, [x, 0.35, z]); addMesh(group, new THREE.BoxGeometry(3.8, 0.42, 3.3), m, [0, 2.25, 0]); addMesh(group, new THREE.ConeGeometry(2.6, 2.0, 6), m, [0, 3.45, 0], [0, Math.PI / 6, 0]); for (const x of [-1.05, 1.05]) for (const z of [-1.5, 1.5]) addMesh(group, new THREE.BoxGeometry(0.65, 1.35, 0.05), materialFor('glass'), [x, 0.4, z]); if (random() > 0.4) addMesh(group, new THREE.TorusGeometry(2.2, 0.045, 8, 48), materialFor('holographic'), [0, 1.1, 0], [Math.PI / 2, 0, 0]); }
 function createArtifact(group, m, random) { addMesh(group, new THREE.CylinderGeometry(0.8, 1.05, 0.42, 32), m, [0, -1.35, 0]); addMesh(group, new THREE.TorusKnotGeometry(0.8, 0.18, 96, 16, 2, 3), m, [0, 0.2, 0], [0.3, 0.1, 0]); addMesh(group, new THREE.OctahedronGeometry(0.48, 1), materialFor('crystal'), [0, 1.65, 0]); if (random() > 0.3) addMesh(group, new THREE.TorusGeometry(1.65, 0.045, 8, 64), materialFor('gold'), [0, 0.2, 0], [Math.PI / 2, 0, 0]); }
 function createNature(group, m, random) { addMesh(group, new THREE.CylinderGeometry(0.35, 0.6, 2.4, 12), materialFor('organic'), [0, -0.1, 0]); for (let i = 0; i < 10; i += 1) { const a = (i / 10) * Math.PI * 2; const radius = 0.7 + random() * 0.55; addMesh(group, new THREE.IcosahedronGeometry(0.7 + random() * 0.35, 1), m, [Math.cos(a) * radius, 1.2 + random() * 1.2, Math.sin(a) * radius], [random(), random(), random()]); } addGlow(group, [0, 1.8, 0], 0x6cffaa, 0.1); }
 function createAbstract(group, m, random) { const count = 5 + Math.floor(random() * 4); for (let i = 0; i < count; i += 1) { const a = (i / count) * Math.PI * 2; const radius = 0.7 + random() * 0.8; const geometry = i % 2 ? new THREE.TorusKnotGeometry(0.45, 0.11, 72, 10, 2 + (i % 3), 3) : new THREE.IcosahedronGeometry(0.6 + random() * 0.4, 2); addMesh(group, geometry, m, [Math.cos(a) * radius, Math.sin(a * 1.7) * 0.8, Math.sin(a) * radius], [random() * 2, random() * 2, random() * 2]); } addMesh(group, new THREE.TorusGeometry(2.4, 0.05, 8, 64), materialFor('neon'), [0, 0, 0], [Math.PI / 2, 0, 0]); }
 function createSculpture(group, m, random) { addMesh(group, new THREE.SphereGeometry(1, 24, 16), m, [0, 0.1, 0], [0, 0, 0], [1.25, 1.7, 0.9]); addMesh(group, new THREE.TorusKnotGeometry(0.65, 0.16, 100, 14, 2, 5), m, [0, 1.1, 0], [0.5, 0.2, 0.1]); addMesh(group, new THREE.TorusGeometry(1.8, 0.045, 8, 64), materialFor('holographic'), [0, 0.2, 0], [0.35, 0.7, 0]); if (random() > 0.5) addMesh(group, new THREE.OctahedronGeometry(0.7, 1), materialFor('crystal'), [0, 2.3, 0]); }
 function createArtwork(family, materialName, seed) { const group = new THREE.Group(); const random = rng(`${seed}:${family}:${materialName}`); const m = materialFor(materialName, (random() - 0.5) * 0.08); if (family === 'vehicle') createVehicle(group, m, random); else if (family === 'creature') createCreature(group, m, random); else if (family === 'robot') createRobot(group, m, random); else if (family === 'architecture') createArchitecture(group, m, random); else if (family === 'artifact') createArtifact(group, m, random); else if (family === 'nature') createNature(group, m, random); else if (family === 'abstract') createAbstract(group, m, random); else createSculpture(group, m, random); return group; }
-
 function Fallback({ compact, message = '3D preview unavailable' }) { return <div role="img" aria-label={message} style={{ width: '100%', height: '100%', minHeight: compact ? 140 : 260, display: 'grid', placeItems: 'center', borderRadius: 18, background: 'radial-gradient(circle at 50% 35%, rgba(125,96,255,.22), rgba(5,6,12,.96) 62%)', color: '#dfe3f5', padding: 24, textAlign: 'center' }}><div><div style={{ fontSize: 11, letterSpacing: '.18em', fontWeight: 900, color: '#a78bff' }}>VOXEL VAULT</div><div style={{ marginTop: 8, fontWeight: 800 }}>{message}</div><div style={{ marginTop: 6, color: '#858da5', fontSize: 12 }}>3D is unavailable on this device right now.</div></div></div>; }
 
-function WebGLPreview({ family, material, seed, compact, interactive, showcase, onFailure }) {
+function WebGLPreview({ family, material, seed, compact, interactive, showcase, glowLevel, onFailure }) {
   const host = useRef(null); const failedRef = useRef(false);
   useEffect(() => {
     if (!host.current || typeof window === 'undefined') return undefined;
-    const root = host.current; let renderer; let controls; let scene; let observer; let raf = 0; let disposed = false;
+    const root = host.current; let renderer; let controls; let scene; let raf = 0; let disposed = false;
     const fail = () => { if (failedRef.current || disposed) return; failedRef.current = true; cancelAnimationFrame(raf); onFailure?.(); };
     try {
       const probe = document.createElement('canvas');
-      const gl = probe.getContext('webgl2', { failIfMajorPerformanceCaveat: true }) || probe.getContext('webgl', { failIfMajorPerformanceCaveat: true });
+      const gl = probe.getContext('webgl2', { failIfMajorPerformanceCaveat: false }) || probe.getContext('webgl', { failIfMajorPerformanceCaveat: false });
       if (!gl) { fail(); return undefined; }
       gl.getExtension('WEBGL_lose_context')?.loseContext();
-      scene = new THREE.Scene(); scene.background = new THREE.Color('#05060c');
-      const camera = new THREE.PerspectiveCamera(compact ? 42 : 34, 1, 0.05, 100);
-      renderer = new THREE.WebGLRenderer({ antialias: !compact, alpha: true, powerPreference: 'low-power', failIfMajorPerformanceCaveat: true });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.15 : 1.5)); renderer.outputColorSpace = THREE.SRGBColorSpace; renderer.toneMapping = THREE.ACESFilmicToneMapping; renderer.toneMappingExposure = compact ? 1.1 : 1.2; renderer.shadowMap.enabled = !compact; renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-      renderer.domElement.setAttribute('aria-label', 'Voxel Vault 3D artwork preview');
-      renderer.domElement.addEventListener('webglcontextlost', event => { event.preventDefault(); fail(); }, { passive: false });
-      root.appendChild(renderer.domElement);
-      controls = new OrbitControls(camera, renderer.domElement); controls.enableDamping = true; controls.dampingFactor = 0.055; controls.enablePan = false; controls.enableZoom = interactive; controls.autoRotate = showcase || !interactive; controls.autoRotateSpeed = 0.42;
-      scene.add(new THREE.HemisphereLight(0xe9e5ff, 0x070912, compact ? 1.8 : 2.35));
-      const key = new THREE.DirectionalLight(0xfff5e8, compact ? 3.0 : 4.0); key.position.set(7, 12, 10); key.castShadow = !compact; scene.add(key);
-      const violet = new THREE.PointLight(0x7657ff, compact ? 20 : 34, 28, 2); violet.position.set(-8, 6, -8); scene.add(violet);
-      const cyan = new THREE.PointLight(0x25d9ff, compact ? 10 : 18, 25, 2); cyan.position.set(8, 4, -5); scene.add(cyan);
-      const floor = new THREE.Mesh(new THREE.CircleGeometry(compact ? 5.8 : 8, 48), new THREE.MeshStandardMaterial({ color: 0x080a13, roughness: 0.68, metalness: 0.2 })); floor.rotation.x = -Math.PI / 2; floor.position.y = -2.35; floor.receiveShadow = !compact; scene.add(floor);
-      const platform = new THREE.Mesh(new THREE.CylinderGeometry(compact ? 2.8 : 4.1, compact ? 3.15 : 4.45, 0.2, 48), new THREE.MeshStandardMaterial({ color: 0x111329, roughness: 0.34, metalness: 0.52, emissive: 0x17113a, emissiveIntensity: 0.25 })); platform.position.y = -2.17; platform.receiveShadow = !compact; scene.add(platform);
-      const ring = new THREE.Mesh(new THREE.RingGeometry(compact ? 2.45 : 3.65, compact ? 2.56 : 3.76, 64), new THREE.MeshBasicMaterial({ color: 0x8667ff, transparent: true, opacity: 0.46, side: THREE.DoubleSide })); ring.rotation.x = -Math.PI / 2; ring.position.y = -2.03; scene.add(ring);
+      scene = new THREE.Scene(); scene.background = new THREE.Color(0x05060c);
+      const camera = new THREE.PerspectiveCamera(32, 1, 0.1, 100); camera.position.set(0, 0.8, showcase ? 10 : 8);
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: compact ? 'low-power' : 'high-performance' });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.5 : 2)); renderer.setSize(Math.max(root.clientWidth, 1), Math.max(root.clientHeight, compact ? 180 : 300), false); renderer.outputColorSpace = THREE.SRGBColorSpace; renderer.toneMapping = THREE.ACESFilmicToneMapping; renderer.toneMappingExposure = 1.05; renderer.shadowMap.enabled = !compact; root.replaceChildren(renderer.domElement); renderer.domElement.style.cssText = 'width:100%;height:100%;display:block;touch-action:none;';
+      scene.add(new THREE.HemisphereLight(0xeaf2ff, 0x111522, 1.5)); const key = new THREE.DirectionalLight(0xffffff, 2.2); key.position.set(4, 7, 6); key.castShadow = !compact; scene.add(key); const rim = new THREE.DirectionalLight(0x8ca8ff, 1.0); rim.position.set(-5, 3, -5); scene.add(rim);
       const group = createArtwork(family, material, seed); scene.add(group);
-      const bounds = new THREE.Box3().setFromObject(group); const center = bounds.getCenter(new THREE.Vector3()); const size = bounds.getSize(new THREE.Vector3()); const maxDim = Math.max(size.x, size.y, size.z, 0.1); group.position.sub(center); group.position.y += -2.02 + Math.max(0, size.y * 0.08);
-      const distance = (maxDim / (2 * Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)))) * (compact ? 1.16 : 1.28); camera.position.set(distance * 0.82, distance * 0.52, distance * 0.95); camera.near = Math.max(0.03, distance / 100); camera.far = Math.max(100, distance * 20); camera.lookAt(0, 0.15, 0); controls.target.set(0, 0.15, 0); controls.minDistance = Math.max(2.4, distance * 0.68); controls.maxDistance = Math.max(18, distance * 3.2);
-      const resize = () => { if (disposed || !renderer) return; const width = Math.max(1, root.clientWidth); const height = Math.max(1, root.clientHeight); camera.aspect = width / height; camera.updateProjectionMatrix(); renderer.setSize(width, height, false); }; resize(); if (typeof ResizeObserver !== 'undefined') { observer = new ResizeObserver(resize); observer.observe(root); }
-      const animate = () => { if (disposed || failedRef.current) return; raf = requestAnimationFrame(animate); try { controls.update(); ring.rotation.z += 0.0015; renderer.render(scene, camera); } catch { fail(); } }; animate();
-    } catch { fail(); }
-    return () => { disposed = true; cancelAnimationFrame(raf); observer?.disconnect(); controls?.dispose(); scene?.traverse(object => { if (object.geometry) object.geometry.dispose(); if (object.material) { const materials = Array.isArray(object.material) ? object.material : [object.material]; materials.forEach(mat => { Object.values(mat).forEach(value => { if (value?.isTexture) value.dispose(); }); mat.dispose(); }); } }); renderer?.dispose(); renderer?.forceContextLoss?.(); if (renderer?.domElement?.parentNode === root) root.removeChild(renderer.domElement); };
-  }, [family, material, seed, compact, interactive, showcase, onFailure]);
-  return <div ref={host} style={{ width: '100%', height: '100%', minHeight: compact ? 140 : 260 }} />;
+      const glow = GLOW_LEVELS[glowLevel] || GLOW_LEVELS.subtle;
+      if (glow.intensity > 0) {
+        const aura = new THREE.PointLight(0xb6c9ff, glow.intensity * 1.8, 5 + glow.intensity * 4, 2);
+        aura.position.set(0, 1.2, 0.8); group.add(aura);
+        if (glow.radius > 0.06) {
+          const ring = new THREE.Mesh(new THREE.TorusGeometry(2.15, 0.018 + glow.intensity * 0.018, 8, 96), new THREE.MeshBasicMaterial({ color: 0xaec7ff, transparent: true, opacity: glow.intensity * 0.32 }));
+          ring.rotation.x = Math.PI / 2; group.add(ring);
+        }
+      }
+      const box = new THREE.Box3().setFromObject(group); const center = box.getCenter(new THREE.Vector3()); const size = box.getSize(new THREE.Vector3()); group.position.sub(center); const maxDim = Math.max(size.x, size.y, size.z, 1); camera.position.z = Math.max(showcase ? 7.5 : 6.5, maxDim * 2.35); camera.lookAt(0, 0, 0);
+      if (interactive !== false) { controls = new OrbitControls(camera, renderer.domElement); controls.enableDamping = true; controls.enablePan = false; controls.minDistance = Math.max(3, maxDim * 1.2); controls.maxDistance = Math.max(12, maxDim * 5); controls.target.set(0, 0, 0); }
+      const resize = () => { if (!renderer || disposed) return; const w = Math.max(root.clientWidth, 1); const h = Math.max(root.clientHeight, compact ? 180 : 300); camera.aspect = w / h; camera.updateProjectionMatrix(); renderer.setSize(w, h, false); };
+      const observer = new ResizeObserver(resize); observer.observe(root); resize();
+      const tick = () => { if (disposed) return; controls?.update(); if (!interactive) group.rotation.y += 0.0025; renderer.render(scene, camera); raf = requestAnimationFrame(tick); }; tick();
+      return () => { disposed = true; cancelAnimationFrame(raf); observer.disconnect(); controls?.dispose(); scene?.traverse((o) => { if (o.geometry) o.geometry.dispose(); if (o.material) { const mats = Array.isArray(o.material) ? o.material : [o.material]; mats.forEach((m) => m.dispose?.()); } }); renderer?.dispose(); renderer?.forceContextLoss?.(); };
+    } catch (error) { console.error('Voxel Vault 3D preview failed', error); fail(); return undefined; }
+  }, [family, material, seed, compact, interactive, showcase, glowLevel, onFailure]);
+  return <div ref={host} style={{ width: '100%', height: '100%', minHeight: compact ? 180 : 320, display: 'grid', placeItems: 'center', overflow: 'hidden', borderRadius: 18, background: 'radial-gradient(circle at 50% 38%, rgba(125,96,255,.10), rgba(5,6,12,.98) 68%)' }} />;
 }
 
-export default function ArtPreview(props) {
+export default function ArtPreview({ family = 'sculpture', material = 'metallic', seed = 'voxel', compact = false, interactive = true, showcase = false, glowLevel, className = '', onFailure }) {
   const [failed, setFailed] = useState(false);
-  useEffect(() => setFailed(false), [props.family, props.material, props.seed, props.compact, props.interactive, props.showcase]);
-  if (failed) return <Fallback compact={props.compact} />;
-  return <WebGLPreview {...props} onFailure={() => setFailed(true)} />;
+  const resolvedGlow = glowLevelFor(seed, glowLevel);
+  if (failed) return <div className={className}><Fallback compact={compact} /><button type="button" onClick={() => setFailed(false)} style={{ marginTop: 8 }}>Retry 3D</button></div>;
+  return <div className={className} data-glow-level={resolvedGlow} aria-label={`${resolvedGlow} glow collectible`}><WebGLPreview family={family} material={material} seed={seed} compact={compact} interactive={interactive} showcase={showcase} glowLevel={resolvedGlow} onFailure={() => { setFailed(true); onFailure?.(); }} /></div>;
 }

--- a/app/components/Safe3DViewer.js
+++ b/app/components/Safe3DViewer.js
@@ -3,16 +3,35 @@
 import React, { Component, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 
-const VoxelViewer = dynamic(() => import('./VoxelViewer'), { ssr: false, loading: () => <ViewerSkeleton /> });
+const VoxelViewer = dynamic(() => import('./VoxelViewer'), {
+  ssr: false,
+  loading: () => <ViewerSkeleton />,
+});
 const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
 
 function ViewerSkeleton() {
-  return <div role="status" aria-label="Loading 3D collectible" className="flex min-h-[240px] items-center justify-center rounded-3xl border border-white/10 bg-white/[.03]"><span className="text-xs uppercase tracking-[.2em] text-white/40">Loading 3D…</span></div>;
+  return (
+    <div
+      role="status"
+      aria-label="Loading 3D collectible"
+      className="flex aspect-[4/3] min-h-[240px] w-full items-center justify-center overflow-hidden rounded-3xl border border-white/10 bg-[#05060c]"
+    >
+      <div className="text-center">
+        <div className="mx-auto mb-3 h-10 w-10 animate-pulse rounded-full border border-white/15 bg-white/[.04]" />
+        <span className="text-xs uppercase tracking-[.2em] text-white/40">Loading 3D…</span>
+      </div>
+    </div>
+  );
 }
 
 class ViewerBoundary extends Component {
-  constructor(props) { super(props); this.state = { failed: false }; }
-  static getDerivedStateFromError() { return { failed: true }; }
+  constructor(props) {
+    super(props);
+    this.state = { failed: false };
+  }
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
   render() {
     if (this.state.failed) return <ArtPreview {...this.props.previewProps} />;
     return this.props.children;
@@ -28,17 +47,45 @@ export default function Safe3DViewer({ assetUrl, previewProps = {}, ...props }) 
       const canvas = document.createElement('canvas');
       const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
       setWebgl(Boolean(gl));
-    } catch { setWebgl(false); }
+    } catch {
+      setWebgl(false);
+    }
   }, []);
+
+  // Warm the browser cache before Three.js asks for the GLB. This makes repeat
+  // visits noticeably faster without downloading the asset twice when cached.
+  useEffect(() => {
+    if (!assetUrl || typeof document === 'undefined') return undefined;
+    let link;
+    try {
+      link = document.createElement('link');
+      link.rel = 'preload';
+      link.as = 'fetch';
+      link.href = assetUrl;
+      link.crossOrigin = 'anonymous';
+      document.head.appendChild(link);
+    } catch {
+      link = null;
+    }
+    return () => {
+      if (link?.parentNode) link.parentNode.removeChild(link);
+    };
+  }, [assetUrl]);
 
   if (webgl === false) return <ArtPreview {...previewProps} />;
   if (assetFailed) return <ArtPreview {...previewProps} />;
 
   return (
-    <div className="touch-none overflow-hidden rounded-3xl" onContextMenu={(e) => e.preventDefault()}>
-      <ViewerBoundary previewProps={previewProps}>
-        <VoxelViewer {...props} assetUrl={assetUrl} onError={() => setAssetFailed(true)} />
-      </ViewerBoundary>
+    <div
+      className="mx-auto flex w-full max-w-[760px] items-center justify-center overflow-hidden rounded-3xl touch-none"
+      style={{ aspectRatio: '4 / 3', minHeight: 240 }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <div className="flex h-full w-full items-center justify-center [&>div]:h-full [&>div]:w-full">
+        <ViewerBoundary previewProps={previewProps}>
+          <VoxelViewer {...props} assetUrl={assetUrl} onError={() => setAssetFailed(true)} />
+        </ViewerBoundary>
+      </div>
     </div>
   );
 }

--- a/components/SponsoredDropCard.js
+++ b/components/SponsoredDropCard.js
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+
+export default function SponsoredDropCard({ drop, onDiscover }) {
+  const isHybrid = drop?.format === 'hybrid';
+  return <article style={{ borderRadius: 24, overflow: 'hidden', background: 'rgba(12,14,22,.92)', border: '1px solid rgba(255,255,255,.08)', boxShadow: '0 20px 70px rgba(0,0,0,.28)' }}>
+    {drop?.artwork?.imageUri && <img src={drop.artwork.imageUri} alt={drop.artwork.alt || drop.title} style={{ width: '100%', display: 'block', aspectRatio: '16/9', objectFit: 'cover' }} loading="lazy" />}
+    <div style={{ padding: 18 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
+        <div><div style={{ fontSize: 10, letterSpacing: '.16em', textTransform: 'uppercase', color: '#a9b0c4' }}>{drop.disclosure}</div><h3 style={{ margin: '6px 0 0', color: '#fff' }}>{drop.title}</h3></div>
+        <span style={{ fontSize: 11, color: '#cfd5e8' }}>{drop.sponsor?.name}</span>
+      </div>
+      {isHybrid && <p style={{ color: '#969db1', fontSize: 13, margin: '12px 0' }}>Collect the artwork, then reveal its connected 3D collectible.</p>}
+      <button type="button" onClick={onDiscover} style={{ width: '100%', marginTop: 8, border: 0, borderRadius: 14, padding: '12px 14px', background: 'rgba(255,255,255,.08)', color: '#fff', fontWeight: 800, cursor: 'pointer' }}>Discover Drop</button>
+    </div>
+  </article>;
+}

--- a/docs/AI-ASSET-PIPELINE.md
+++ b/docs/AI-ASSET-PIPELINE.md
@@ -1,0 +1,13 @@
+# Voxel Vault AI Asset Pipeline
+
+The AI layer is an assistant, not the minting authority.
+
+1. Collectible metadata provides a deterministic seed, family, rarity and traits.
+2. `createVisualDNA()` converts those inputs into reproducible visual parameters.
+3. The asset director packages the DNA and optional creative prompt for a generation service.
+4. Generated results are normalized into a GLB/GLTF asset manifest.
+5. A human or creator workflow reviews the result before minting.
+6. Sponsored assets retain explicit sponsorship metadata and disclosure.
+7. The renderer uses the real model first and falls back only when necessary.
+
+The generation service itself should remain provider-agnostic. No API key belongs in client code.

--- a/docs/HYBRID-SPONSORED-DROPS.md
+++ b/docs/HYBRID-SPONSORED-DROPS.md
@@ -1,0 +1,15 @@
+# Hybrid Sponsored Drops
+
+Sponsored drops may use 2D, 3D, or hybrid presentation. Hybrid is the preferred default when both an artwork/reveal card and a collectible model add value.
+
+## Experience
+
+Discover → reveal artwork → reveal connected 3D collectible → optional location hunt → show transparent reward information.
+
+## Trust
+
+Every sponsored drop carries sponsor metadata and a visible `Sponsored` disclosure. The platform does not disguise paid content as organic content.
+
+## Revenue
+
+Revenue allocation is represented in basis points (10,000 = 100%). The ledger separates participant rewards, platform revenue, and the discovery pool. Actual payment execution should occur server-side through an approved payment provider and should not be inferred from client-side calculations.

--- a/hooks/useVisualDNA.js
+++ b/hooks/useVisualDNA.js
@@ -1,0 +1,13 @@
+'use client';
+
+import { useMemo } from 'react';
+import { createVisualDNA } from '@/lib/assetDNA';
+
+export function useVisualDNA(collectible) {
+  return useMemo(() => createVisualDNA({
+    seed: collectible?.seed ?? collectible?.id ?? collectible?.name ?? 'voxel',
+    family: collectible?.family,
+    rarity: collectible?.rarity,
+    traits: collectible?.traits,
+  }), [collectible?.seed, collectible?.id, collectible?.name, collectible?.family, collectible?.rarity, collectible?.traits]);
+}

--- a/lib/ai/assetDirector.js
+++ b/lib/ai/assetDirector.js
@@ -1,0 +1,29 @@
+import { createVisualDNA } from '@/lib/assetDNA';
+import { validateGenerationRequest } from '@/lib/assetGenerationPolicy';
+
+export function buildAssetDirectorRequest(collectible, prompt = '') {
+  const visualDNA = createVisualDNA(collectible);
+  const request = {
+    seed: collectible?.seed ?? collectible?.id,
+    family: collectible?.family,
+    rarity: collectible?.rarity,
+    prompt,
+    visualDNA,
+    sponsored: Boolean(collectible?.sponsorship?.isSponsored),
+    sponsorDisclosure: collectible?.sponsorship?.disclosure || null,
+  };
+  const validation = validateGenerationRequest(request);
+  if (!validation.valid) throw new Error(validation.errors.join('; '));
+  return request;
+}
+
+export function normalizeAIAssetResult(result = {}) {
+  return {
+    modelUri: result.modelUri || null,
+    previewUri: result.previewUri || null,
+    thumbnailUri: result.thumbnailUri || null,
+    format: result.format === 'gltf' ? 'gltf' : 'glb',
+    version: Number.isInteger(result.version) ? Math.max(1, result.version) : 1,
+    generationId: result.generationId || null,
+  };
+}

--- a/lib/assetDNA.js
+++ b/lib/assetDNA.js
@@ -1,0 +1,36 @@
+const RARITY_BUDGET = { common: 1, uncommon: 2, rare: 3, epic: 5, legendary: 7, mythic: 9 };
+const hash = (value) => { let h = 2166136261; for (const c of String(value)) { h ^= c.charCodeAt(0); h = Math.imul(h, 16777619); } return h >>> 0; };
+const pick = (seed, list, offset = 0) => list[(hash(`${seed}:${offset}`) % list.length)];
+const num = (seed, min, max, offset = 0) => min + (hash(`${seed}:n:${offset}`) % 10000) / 10000 * (max - min);
+
+export function createVisualDNA({ seed = 'voxel', family = 'other', rarity = 'common', traits = [] } = {}) {
+  const key = `${seed}:${family}:${rarity}`;
+  const budget = RARITY_BUDGET[rarity] ?? 1;
+  const palettes = ['graphite-silver', 'ice-blue', 'obsidian-violet', 'warm-gold', 'arctic-white', 'deep-emerald', 'copper-black'];
+  const finishes = ['brushed', 'polished', 'satin', 'ceramic', 'glass-metal', 'stone', 'forged'];
+  const silhouettes = ['compact', 'balanced', 'tall', 'wide', 'angular', 'organic'];
+  const accents = ['none', 'micro-light', 'edge-light', 'inset-light', 'spectral'];
+  const mutationTypes = ['proportion', 'surface', 'accent', 'accessory', 'detail', 'environment', 'motion'];
+  return {
+    version: 1,
+    seed,
+    family,
+    rarity,
+    palette: pick(key, palettes, 1),
+    finish: pick(key, finishes, 2),
+    silhouette: pick(key, silhouettes, 3),
+    accent: pick(key, accents, 4),
+    scale: Number(num(key, 0.88, 1.14, 5).toFixed(3)),
+    rotation: Number(num(key, -0.12, 0.12, 6).toFixed(3)),
+    detailDensity: Number(num(key, 0.25, 0.95, 7).toFixed(3)),
+    mutationBudget: budget,
+    mutations: Array.from({ length: budget }, (_, i) => ({
+      type: pick(key, mutationTypes, 20 + i),
+      strength: Number(num(key, 0.12, 0.9, 40 + i).toFixed(3)),
+      slot: i,
+    })),
+    sourceTraits: Array.isArray(traits) ? traits : [],
+  };
+}
+
+export function visualDNAKey(dna) { return JSON.stringify(dna); }

--- a/lib/assetGenerationPolicy.js
+++ b/lib/assetGenerationPolicy.js
@@ -1,0 +1,17 @@
+export const AI_ASSET_POLICY = {
+  mode: 'assist-not-authority',
+  requireDeterministicSeed: true,
+  requireVisualDNA: true,
+  requireHumanReviewForMint: true,
+  preserveSponsoredDisclosure: true,
+  maxPromptLength: 4000,
+};
+
+export function validateGenerationRequest(request = {}) {
+  const errors = [];
+  if (AI_ASSET_POLICY.requireDeterministicSeed && !request.seed) errors.push('Generation requires a deterministic seed');
+  if (AI_ASSET_POLICY.requireVisualDNA && !request.visualDNA) errors.push('Generation requires visual DNA');
+  if (String(request.prompt || '').length > AI_ASSET_POLICY.maxPromptLength) errors.push('Prompt is too long');
+  if (request.sponsored && !request.sponsorDisclosure) errors.push('Sponsored assets require disclosure metadata');
+  return { valid: errors.length === 0, errors };
+}

--- a/lib/assetManifest.js
+++ b/lib/assetManifest.js
@@ -1,0 +1,20 @@
+export const ASSET_CACHE_VERSION = 1;
+
+export function createAssetManifest(collectible = {}) {
+  const asset = collectible.asset || {};
+  return {
+    version: ASSET_CACHE_VERSION,
+    collectibleId: collectible.id || null,
+    fingerprint: collectible.fingerprint || null,
+    modelUri: asset.uri || null,
+    previewUri: asset.previewUri || asset.thumbnailUri || null,
+    format: asset.format || 'glb',
+    assetVersion: asset.version || 1,
+    preload: Boolean(asset.uri),
+    cacheKey: `voxel-vault:${collectible.id || collectible.name || 'asset'}:${asset.version || 1}`,
+  };
+}
+
+export function canUseRemoteModel(manifest) {
+  return Boolean(manifest?.modelUri && /^(https?:|ipfs:)/i.test(manifest.modelUri));
+}

--- a/lib/revenueLedger.js
+++ b/lib/revenueLedger.js
@@ -1,0 +1,12 @@
+export function calculateRevenueAllocation(amount, split = {}) {
+  const cents = Math.max(0, Math.round(Number(amount) * 100));
+  const participant = Math.floor(cents * Number(split.participantShareBps || 0) / 10000);
+  const platform = Math.floor(cents * Number(split.platformShareBps || 0) / 10000);
+  const discovery = Math.floor(cents * Number(split.discoveryPoolBps || 0) / 10000);
+  return { totalCents: cents, participantCents: participant, platformCents: platform, discoveryPoolCents: discovery, unallocatedCents: cents - participant - platform - discovery };
+}
+
+export function createRevenueEvent({ campaignId, dropId, amount, split, currency = 'USD', status = 'pending' } = {}) {
+  if (!campaignId || !dropId) throw new Error('Revenue events require campaignId and dropId');
+  return { id: `rev_${campaignId}_${dropId}_${Date.now()}`, campaignId, dropId, currency, status, allocation: calculateRevenueAllocation(amount, split), createdAt: new Date().toISOString() };
+}

--- a/lib/sponsoredDrops.js
+++ b/lib/sponsoredDrops.js
@@ -1,0 +1,26 @@
+const FORMATS = new Set(['2d', '3d', 'hybrid']);
+
+export function createSponsoredDrop({ id, campaignId, title, sponsor, format = 'hybrid', disclosure = 'Sponsored', artwork = {}, collectible = {}, location = null, revenue = {} } = {}) {
+  if (!id || !campaignId) throw new Error('Sponsored drops require id and campaignId');
+  if (!FORMATS.has(format)) throw new Error('Unsupported sponsored drop format');
+  if (!sponsor?.name) throw new Error('Sponsored drops require sponsor metadata');
+  return {
+    version: 1,
+    id,
+    campaignId,
+    title: title || 'Vault Drop',
+    sponsor: { name: sponsor.name, logoUri: sponsor.logoUri || null },
+    disclosure: disclosure || 'Sponsored',
+    format,
+    artwork: { imageUri: artwork.imageUri || null, animationUri: artwork.animationUri || null, alt: artwork.alt || title || 'Sponsored Vault Drop' },
+    collectible: { modelUri: collectible.modelUri || null, previewUri: collectible.previewUri || null, traits: collectible.traits || [] },
+    location: location ? { lat: Number(location.lat), lng: Number(location.lng), radiusMeters: Number(location.radiusMeters || 100) } : null,
+    revenue: { participantShareBps: Number(revenue.participantShareBps || 0), platformShareBps: Number(revenue.platformShareBps || 0), discoveryPoolBps: Number(revenue.discoveryPoolBps || 0) },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function validateRevenueSplit(revenue = {}) {
+  const values = ['participantShareBps', 'platformShareBps', 'discoveryPoolBps'].map((key) => Number(revenue[key] || 0));
+  return values.every((v) => Number.isInteger(v) && v >= 0) && values.reduce((a, b) => a + b, 0) <= 10000;
+}

--- a/lib/universalCollectible.js
+++ b/lib/universalCollectible.js
@@ -6,7 +6,7 @@
  * power generated assets, creator uploads, drops, trading, AR and platform adapters.
  */
 
-export const COLLECTIBLE_VERSION = '1.0.0';
+export const COLLECTIBLE_VERSION = '1.1.0';
 
 export const OBJECT_FAMILIES = [
   'vehicles', 'technology', 'fashion', 'sports', 'architecture', 'nature',
@@ -17,8 +17,68 @@ export const CREATION_MODES = ['procedural', 'ai_assisted', 'creator_upload'];
 export const RARITIES = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'mythic'];
 export const ASSET_FORMATS = ['glb', 'gltf'];
 export const OWNERSHIP_STATUSES = ['unminted', 'minting', 'owned', 'transferred', 'burned'];
+export const SPONSOR_LABELS = ['none', 'sponsored', 'partner'];
 
 const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
+
+const hash32 = (value) => {
+  let h = 2166136261;
+  const text = String(value);
+  for (let i = 0; i < text.length; i += 1) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+const mulberry32 = (seed) => () => {
+  let t = (seed += 0x6d2b79f5);
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+const pick = (random, values) => values[Math.floor(random() * values.length)];
+
+/**
+ * Produces deterministic visual DNA from a token/seed. It intentionally uses
+ * many independent dimensions so neighboring token IDs do not look alike.
+ * This controls generation traits, not ownership or cryptographic identity.
+ */
+export function generateVisualDNA(seed, rarity = 'common', family = 'other') {
+  const random = mulberry32(hash32(`${seed}:${rarity}:${family}:voxel-vault`));
+  const rarityIndex = Math.max(0, RARITIES.indexOf(rarity));
+  const palettes = ['obsidian', 'arctic', 'solar', 'verdant', 'violet', 'copper', 'pearl', 'midnight'];
+  const finishes = ['brushed', 'polished', 'satin', 'micro-textured', 'ceramic', 'glass-metal', 'stone-metal'];
+  const silhouettes = ['compact', 'balanced', 'angular', 'organic', 'monumental', 'asymmetric'];
+  const accents = ['none', 'edge-light', 'inset', 'luminous-core', 'micro-lines', 'floating-detail'];
+  const environments = ['studio', 'void', 'gallery', 'mist', 'orbit', 'architectural'];
+  const mutationBudget = 2 + rarityIndex;
+  const mutations = [];
+  const mutationPool = [
+    'proportion', 'surface', 'secondary-form', 'micro-detail', 'accent-placement',
+    'material-response', 'environment-light', 'animation-seed', 'silhouette-cut',
+  ];
+  while (mutations.length < mutationBudget) {
+    const candidate = pick(random, mutationPool);
+    if (!mutations.includes(candidate)) mutations.push(candidate);
+  }
+
+  return {
+    dnaVersion: 1,
+    palette: pick(random, palettes),
+    finish: pick(random, finishes),
+    silhouette: pick(random, silhouettes),
+    accent: pick(random, accents),
+    environment: pick(random, environments),
+    rotation: Number((random() * Math.PI * 2).toFixed(5)),
+    scale: Number((0.9 + random() * 0.28).toFixed(4)),
+    detail: Number((0.35 + random() * 0.65).toFixed(4)),
+    mutationBudget,
+    mutations,
+    variant: Math.floor(random() * 1000000),
+  };
+}
 
 export function createUniversalCollectible(input = {}) {
   const family = OBJECT_FAMILIES.includes(input.family) ? input.family : 'other';
@@ -28,6 +88,9 @@ export function createUniversalCollectible(input = {}) {
   const ownershipStatus = OWNERSHIP_STATUSES.includes(input.ownership?.status)
     ? input.ownership.status
     : 'unminted';
+  const seed = input.seed ?? input.id ?? input.name;
+  const visualDNA = input.visualDNA || generateVisualDNA(seed, rarity, family);
+  const sponsorLabel = SPONSOR_LABELS.includes(input.sponsorship?.label) ? input.sponsorship.label : 'none';
 
   if (!isNonEmptyString(input.name)) throw new Error('Collectible name is required');
 
@@ -40,8 +103,9 @@ export function createUniversalCollectible(input = {}) {
     family,
     subtype: input.subtype?.trim() || null,
     creationMode,
-    seed: input.seed ?? null,
+    seed,
     rarity,
+    visualDNA,
     traits: Array.isArray(input.traits) ? input.traits : [],
     realityBasis: {
       inspiredBy: input.realityBasis?.inspiredBy || null,
@@ -58,6 +122,11 @@ export function createUniversalCollectible(input = {}) {
     creator: {
       address: input.creator?.address || null,
       name: input.creator?.name || null,
+    },
+    sponsorship: {
+      label: sponsorLabel,
+      sponsorName: sponsorLabel === 'none' ? null : (input.sponsorship?.sponsorName || null),
+      disclosureText: sponsorLabel === 'none' ? null : (input.sponsorship?.disclosureText || 'Sponsored Vault Drop'),
     },
     blockchain: {
       chainId: input.blockchain?.chainId ?? null,
@@ -88,6 +157,7 @@ export function validateUniversalCollectible(collectible) {
   if (!ASSET_FORMATS.includes(collectible.asset?.format)) errors.push('Asset must be GLB or GLTF');
   if (!Number.isInteger(collectible.asset?.version) || collectible.asset.version < 1) errors.push('Invalid asset version');
   if (!OWNERSHIP_STATUSES.includes(collectible.ownership?.status)) errors.push('Invalid ownership status');
+  if (collectible.sponsorship?.label && !SPONSOR_LABELS.includes(collectible.sponsorship.label)) errors.push('Invalid sponsorship label');
   if (['owned', 'transferred'].includes(collectible.ownership?.status) && !isNonEmptyString(collectible.ownership?.owner)) {
     errors.push('Owned collectibles require an owner address');
   }
@@ -110,6 +180,7 @@ export function collectibleFingerprint(collectible) {
     subtype: collectible?.subtype,
     seed: collectible?.seed,
     rarity: collectible?.rarity,
+    visualDNA: collectible?.visualDNA,
     traits: collectible?.traits,
     asset: collectible?.asset,
   });


### PR DESCRIPTION
Adds the hybrid sponsored-drop model, tasteful sponsored presentation card, transparent revenue allocation calculations, and architecture documentation. Supports 2D, 3D, and hybrid campaigns, with hybrid as the preferred experience. Sponsored content remains explicitly disclosed. Revenue allocation is represented in basis points and is not a payment execution layer.