### PR TITLE
feat: background Vault Reactor and legitimate idle progression

### DIFF
--- a/app/api/rewards/verify/route.js
+++ b/app/api/rewards/verify/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { authorizeClaim } from '../../../../lib/claimAuthority.js';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { missionId, dropId, walletAddress, distanceMeters, requireInZone = false } = body || {};
+    if (!missionId || !dropId || !walletAddress) {
+      return NextResponse.json({ ok: false, error: 'missionId, dropId, and walletAddress are required' }, { status: 400 });
+    }
+    const authorization = await authorizeClaim({ dropId, walletAddress, distanceMeters, requireInZone });
+    if (!authorization.authorized) {
+      return NextResponse.json({ ok: false, reason: authorization.reason, claimTicket: authorization.claimTicket || null }, { status: 409 });
+    }
+    return NextResponse.json({
+      ok: true,
+      missionId,
+      stage: 'verified',
+      proof: { id: authorization.claimTicket, verified: true, source: 'server-claim-authority' },
+      next: 'eligibility_then_wallet-confirmed-claim',
+      ownership: 'not granted until chain confirmation',
+    });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error?.message || 'Verification failed' }, { status: 400 });
+  }
+}

--- a/app/components/VaultReactor.js
+++ b/app/components/VaultReactor.js
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { accrueEnergy, createExpedition, getReactorState, spendEnergy } from '../../lib/idleExpedition';
+
+const STORAGE_KEY = 'voxel-vault-reactor-v2';
+const DEFAULT = { active: false, startedAt: 0, energy: 0, earnedToday: 0, lastDay: new Date().toISOString().slice(0, 10), completed: [] };
+const EXPEDITIONS = [
+  createExpedition({ id: 'scan-15', minutes: 15, energyCost: 10, label: 'Scout a hidden Vault route' }),
+  createExpedition({ id: 'catalog-30', minutes: 30, energyCost: 20, label: 'Curate three collectibles' }),
+  createExpedition({ id: 'hunt-60', minutes: 60, energyCost: 35, label: 'Run a long-form scavenger mission' }),
+];
+
+function loadState() {
+  if (typeof window === 'undefined') return DEFAULT;
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+    if (!parsed) return DEFAULT;
+    const today = new Date().toISOString().slice(0, 10);
+    return parsed.lastDay === today ? { ...DEFAULT, ...parsed } : { ...DEFAULT, ...parsed, earnedToday: 0, lastDay: today };
+  } catch { return DEFAULT; }
+}
+
+export default function VaultReactor() {
+  const [state, setState] = useState(DEFAULT);
+  const [now, setNow] = useState(Date.now());
+  const [message, setMessage] = useState('');
+
+  useEffect(() => setState(loadState()), []);
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+  useEffect(() => {
+    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const reactor = useMemo(() => getReactorState(now, state), [now, state]);
+  const preview = accrueEnergy({ minutes: reactor.elapsedMinutes, currentEnergy: state.energy, earnedToday: state.earnedToday });
+  const displayedEnergy = state.energy + Math.max(0, preview.earned);
+  const minutes = Math.min(Math.floor(reactor.elapsedMinutes), 180);
+
+  function start() {
+    setMessage('Reactor online. Your Vault can progress while you are away.');
+    setState(s => ({ ...s, active: true, startedAt: Date.now() }));
+  }
+
+  function stop() {
+    const gained = accrueEnergy({ minutes: reactor.elapsedMinutes, currentEnergy: state.energy, earnedToday: state.earnedToday });
+    setState(s => ({ ...s, active: false, startedAt: 0, energy: gained.energy, earnedToday: s.earnedToday + gained.earned }));
+    setMessage(gained.earned ? `+${gained.earned} Vault Energy banked.` : 'Daily Reactor cap reached.');
+  }
+
+  function launch(expedition) {
+    try {
+      const next = spendEnergy(displayedEnergy, expedition.energyCost);
+      setState(s => ({ ...s, active: false, startedAt: 0, energy: next, completed: [...new Set([...s.completed, expedition.id])] }));
+      setMessage(`${expedition.label} launched. Rewards remain subject to verified hunt/claim rules.`);
+    } catch (error) { setMessage(error.message); }
+  }
+
+  return (
+    <section className="reactorShell" aria-labelledby="reactor-title">
+      <div className="reactorHead"><div><div className="reactorEyebrow">✦ BACKGROUND MODE</div><h2 id="reactor-title">Vault Reactor</h2><p>Leave it running while you work, study, or step away. It earns capped Vault Energy, not fake browser crypto.</p></div><div className={`reactorOrb ${state.active ? 'on' : ''}`} aria-label={state.active ? 'Reactor active' : 'Reactor idle'} /></div>
+      <div className="reactorStats"><div><b>{Math.floor(displayedEnergy)}</b><span>Energy</span></div><div><b>{minutes}m</b><span>Session</span></div><div><b>{state.earnedToday}/240</b><span>Daily cap</span></div></div>
+      <div className="reactorActions"><button onClick={state.active ? stop : start}>{state.active ? 'Bank & pause' : 'Start background run'}</button><small>Runs locally and visibly. No hidden CPU mining, wallet signing, or secret charges.</small></div>
+      <div className="expeditionGrid">{EXPEDITIONS.map(expedition => <button key={expedition.id} disabled={state.completed.includes(expedition.id) || displayedEnergy < expedition.energyCost} onClick={() => launch(expedition)}><span>{state.completed.includes(expedition.id) ? '✓ Completed' : `−${expedition.energyCost} Energy`}</span><b>{expedition.label}</b><small>{expedition.minutes} min mission · verified reward path</small></button>)}</div>
+      {message && <div className="reactorMessage" role="status">{message}</div>}
+      <style jsx>{` .reactorShell{margin:0 5vw 90px;padding:28px;border:1px solid rgba(255,255,255,.1);border-radius:26px;background:linear-gradient(145deg,rgba(18,16,35,.9),rgba(8,9,17,.96));box-shadow:0 24px 80px rgba(0,0,0,.25)}.reactorHead{display:flex;justify-content:space-between;gap:24px;align-items:center}.reactorEyebrow{font-size:11px;letter-spacing:.16em;color:#9b7cff;font-weight:800}.reactorShell h2{font-size:30px;margin:6px 0}.reactorShell p{color:#9da3b5;max-width:650px;margin:0;line-height:1.6}.reactorOrb{width:58px;height:58px;border-radius:50%;border:1px solid rgba(155,124,255,.4);background:radial-gradient(circle,#bba7ff 0 4%,rgba(155,124,255,.2) 12%,transparent 65%);box-shadow:0 0 34px rgba(155,124,255,.14)}.reactorOrb.on{animation:pulse 2s ease-in-out infinite;box-shadow:0 0 46px rgba(155,124,255,.32)}.reactorStats{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:24px 0}.reactorStats div{padding:16px;border-radius:16px;background:rgba(255,255,255,.035);border:1px solid rgba(255,255,255,.07)}.reactorStats b{display:block;font-size:23px}.reactorStats span{font-size:11px;color:#858da0;text-transform:uppercase;letter-spacing:.1em}.reactorActions{display:flex;align-items:center;gap:14px;flex-wrap:wrap}.reactorActions button{border:0;border-radius:999px;padding:12px 18px;background:#f4f4f7;color:#080910;font-weight:800;cursor:pointer}.reactorActions small{color:#737b8d}.expeditionGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.expeditionGrid button{text-align:left;padding:17px;border-radius:17px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);cursor:pointer}.expeditionGrid button:disabled{opacity:.42;cursor:not-allowed}.expeditionGrid span,.expeditionGrid small{display:block;color:#8d95a8;font-size:11px}.expeditionGrid b{display:block;margin:8px 0;color:#fff}.reactorMessage{margin-top:16px;color:#c9c2ff;font-size:13px}@keyframes pulse{50%{transform:scale(1.04);opacity:.8}}@media(max-width:720px){.reactorShell{margin:0 18px 60px;padding:20px}.reactorStats{grid-template-columns:1fr}.expeditionGrid{grid-template-columns:1fr}.reactorHead{align-items:flex-start}.reactorOrb{flex:none}}`}</style>
+    </section>
+  );
+}

--- a/app/components/VaultReactor.js
+++ b/app/components/VaultReactor.js
@@ -2,9 +2,10 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { accrueEnergy, createExpedition, getReactorState, spendEnergy } from '../../lib/idleExpedition';
+import { makeEligibility, queueMission } from '../../lib/rewardLoop';
 
-const STORAGE_KEY = 'voxel-vault-reactor-v2';
-const DEFAULT = { active: false, startedAt: 0, energy: 0, earnedToday: 0, lastDay: new Date().toISOString().slice(0, 10), completed: [] };
+const STORAGE_KEY = 'voxel-vault-reactor-v3';
+const DEFAULT = { active: false, startedAt: 0, energy: 0, earnedToday: 0, lastDay: new Date().toISOString().slice(0, 10), queue: [], completed: [] };
 const EXPEDITIONS = [
   createExpedition({ id: 'scan-15', minutes: 15, energyCost: 10, label: 'Scout a hidden Vault route' }),
   createExpedition({ id: 'catalog-30', minutes: 30, energyCost: 20, label: 'Curate three collectibles' }),
@@ -27,46 +28,39 @@ export default function VaultReactor() {
   const [message, setMessage] = useState('');
 
   useEffect(() => setState(loadState()), []);
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-  useEffect(() => {
-    if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  }, [state]);
+  useEffect(() => { const timer = setInterval(() => setNow(Date.now()), 1000); return () => clearInterval(timer); }, []);
+  useEffect(() => { if (typeof window !== 'undefined') localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }, [state]);
 
   const reactor = useMemo(() => getReactorState(now, state), [now, state]);
   const preview = accrueEnergy({ minutes: reactor.elapsedMinutes, currentEnergy: state.energy, earnedToday: state.earnedToday });
   const displayedEnergy = state.energy + Math.max(0, preview.earned);
   const minutes = Math.min(Math.floor(reactor.elapsedMinutes), 180);
 
-  function start() {
-    setMessage('Reactor online. Your Vault can progress while you are away.');
-    setState(s => ({ ...s, active: true, startedAt: Date.now() }));
-  }
-
+  function start() { setMessage('Reactor online. Progress is visible and capped.'); setState(s => ({ ...s, active: true, startedAt: Date.now() })); }
   function stop() {
     const gained = accrueEnergy({ minutes: reactor.elapsedMinutes, currentEnergy: state.energy, earnedToday: state.earnedToday });
     setState(s => ({ ...s, active: false, startedAt: 0, energy: gained.energy, earnedToday: s.earnedToday + gained.earned }));
     setMessage(gained.earned ? `+${gained.earned} Vault Energy banked.` : 'Daily Reactor cap reached.');
   }
-
-  function launch(expedition) {
+  function queue(expedition) {
     try {
-      const next = spendEnergy(displayedEnergy, expedition.energyCost);
-      setState(s => ({ ...s, active: false, startedAt: 0, energy: next, completed: [...new Set([...s.completed, expedition.id])] }));
-      setMessage(`${expedition.label} launched. Rewards remain subject to verified hunt/claim rules.`);
+      const nextEnergy = spendEnergy(displayedEnergy, expedition.energyCost);
+      const nextQueue = queueMission(state.queue, expedition, displayedEnergy);
+      setState(s => ({ ...s, active: false, startedAt: 0, energy: nextEnergy, queue: nextQueue }));
+      setMessage('Mission queued. Complete the real-world activity to unlock server verification.');
     } catch (error) { setMessage(error.message); }
   }
 
   return (
     <section className="reactorShell" aria-labelledby="reactor-title">
-      <div className="reactorHead"><div><div className="reactorEyebrow">✦ BACKGROUND MODE</div><h2 id="reactor-title">Vault Reactor</h2><p>Leave it running while you work, study, or step away. It earns capped Vault Energy, not fake browser crypto.</p></div><div className={`reactorOrb ${state.active ? 'on' : ''}`} aria-label={state.active ? 'Reactor active' : 'Reactor idle'} /></div>
+      <div className="reactorHead"><div><div className="reactorEyebrow">✦ BACKGROUND MODE · VERIFIED REWARDS</div><h2 id="reactor-title">Vault Reactor</h2><p>Busy? Leave the Reactor running. Bank capped Energy, queue missions, complete verified activity, then unlock authentic NFT claims through the existing server and wallet flow.</p></div><div className={`reactorOrb ${state.active ? 'on' : ''}`} /></div>
+      <div className="flow"><span>BUSY</span><i>→</i><span className="hot">REACTOR</span><i>→</i><span>ENERGY</span><i>→</i><span>MISSION</span><i>→</i><span>VERIFY</span><i>→</i><span>NFT CLAIM</span></div>
       <div className="reactorStats"><div><b>{Math.floor(displayedEnergy)}</b><span>Energy</span></div><div><b>{minutes}m</b><span>Session</span></div><div><b>{state.earnedToday}/240</b><span>Daily cap</span></div></div>
-      <div className="reactorActions"><button onClick={state.active ? stop : start}>{state.active ? 'Bank & pause' : 'Start background run'}</button><small>Runs locally and visibly. No hidden CPU mining, wallet signing, or secret charges.</small></div>
-      <div className="expeditionGrid">{EXPEDITIONS.map(expedition => <button key={expedition.id} disabled={state.completed.includes(expedition.id) || displayedEnergy < expedition.energyCost} onClick={() => launch(expedition)}><span>{state.completed.includes(expedition.id) ? '✓ Completed' : `−${expedition.energyCost} Energy`}</span><b>{expedition.label}</b><small>{expedition.minutes} min mission · verified reward path</small></button>)}</div>
+      <div className="reactorActions"><button onClick={state.active ? stop : start}>{state.active ? 'Bank & pause' : 'Start background run'}</button><small>No hidden CPU mining. No background wallet signing. Energy is gameplay only.</small></div>
+      <div className="expeditionGrid">{EXPEDITIONS.map(expedition => <button key={expedition.id} disabled={state.queue.some(x => x.id === expedition.id) || displayedEnergy < expedition.energyCost} onClick={() => queue(expedition)}><span>{state.queue.some(x => x.id === expedition.id) ? '✓ Queued' : `−${expedition.energyCost} Energy`}</span><b>{expedition.label}</b><small>{expedition.minutes} min · verified activity required</small></button>)}</div>
+      {state.queue.length > 0 && <div className="missionList"><b>Mission queue</b>{state.queue.map(item => { const eligibility = makeEligibility(item, { minimumScore: 1 }); return <div className="mission" key={item.id}><span>{item.label}</span><strong>{eligibility.stage === 'verified' ? '✓ Verified' : 'Awaiting activity'}</strong></div>; })}</div>}
       {message && <div className="reactorMessage" role="status">{message}</div>}
-      <style jsx>{` .reactorShell{margin:0 5vw 90px;padding:28px;border:1px solid rgba(255,255,255,.1);border-radius:26px;background:linear-gradient(145deg,rgba(18,16,35,.9),rgba(8,9,17,.96));box-shadow:0 24px 80px rgba(0,0,0,.25)}.reactorHead{display:flex;justify-content:space-between;gap:24px;align-items:center}.reactorEyebrow{font-size:11px;letter-spacing:.16em;color:#9b7cff;font-weight:800}.reactorShell h2{font-size:30px;margin:6px 0}.reactorShell p{color:#9da3b5;max-width:650px;margin:0;line-height:1.6}.reactorOrb{width:58px;height:58px;border-radius:50%;border:1px solid rgba(155,124,255,.4);background:radial-gradient(circle,#bba7ff 0 4%,rgba(155,124,255,.2) 12%,transparent 65%);box-shadow:0 0 34px rgba(155,124,255,.14)}.reactorOrb.on{animation:pulse 2s ease-in-out infinite;box-shadow:0 0 46px rgba(155,124,255,.32)}.reactorStats{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:24px 0}.reactorStats div{padding:16px;border-radius:16px;background:rgba(255,255,255,.035);border:1px solid rgba(255,255,255,.07)}.reactorStats b{display:block;font-size:23px}.reactorStats span{font-size:11px;color:#858da0;text-transform:uppercase;letter-spacing:.1em}.reactorActions{display:flex;align-items:center;gap:14px;flex-wrap:wrap}.reactorActions button{border:0;border-radius:999px;padding:12px 18px;background:#f4f4f7;color:#080910;font-weight:800;cursor:pointer}.reactorActions small{color:#737b8d}.expeditionGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.expeditionGrid button{text-align:left;padding:17px;border-radius:17px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);cursor:pointer}.expeditionGrid button:disabled{opacity:.42;cursor:not-allowed}.expeditionGrid span,.expeditionGrid small{display:block;color:#8d95a8;font-size:11px}.expeditionGrid b{display:block;margin:8px 0;color:#fff}.reactorMessage{margin-top:16px;color:#c9c2ff;font-size:13px}@keyframes pulse{50%{transform:scale(1.04);opacity:.8}}@media(max-width:720px){.reactorShell{margin:0 18px 60px;padding:20px}.reactorStats{grid-template-columns:1fr}.expeditionGrid{grid-template-columns:1fr}.reactorHead{align-items:flex-start}.reactorOrb{flex:none}}`}</style>
+      <style jsx>{` .reactorShell{margin:0 5vw 90px;padding:28px;border:1px solid rgba(255,255,255,.1);border-radius:26px;background:linear-gradient(145deg,rgba(18,16,35,.94),rgba(8,9,17,.98));box-shadow:0 24px 80px rgba(0,0,0,.25)}.reactorHead{display:flex;justify-content:space-between;gap:24px;align-items:center}.reactorEyebrow{font-size:11px;letter-spacing:.14em;color:#9b7cff;font-weight:800}.reactorShell h2{font-size:30px;margin:6px 0}.reactorShell p{color:#9da3b5;max-width:720px;margin:0;line-height:1.6}.reactorOrb{width:58px;height:58px;border-radius:50%;border:1px solid rgba(155,124,255,.4);background:radial-gradient(circle,#bba7ff 0 4%,rgba(155,124,255,.2) 12%,transparent 65%);box-shadow:0 0 34px rgba(155,124,255,.14);flex:none}.reactorOrb.on{animation:pulse 2s ease-in-out infinite;box-shadow:0 0 46px rgba(155,124,255,.32)}.flow{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:22px 0;color:#7f8799;font-size:10px;letter-spacing:.08em}.flow i{opacity:.35}.flow .hot{color:#c9bdff}.reactorStats{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin:20px 0}.reactorStats div{padding:16px;border-radius:16px;background:rgba(255,255,255,.035);border:1px solid rgba(255,255,255,.07)}.reactorStats b{display:block;font-size:23px}.reactorStats span{font-size:11px;color:#858da0;text-transform:uppercase;letter-spacing:.1em}.reactorActions{display:flex;align-items:center;gap:14px;flex-wrap:wrap}.reactorActions button{border:0;border-radius:999px;padding:12px 18px;background:#f4f4f7;color:#080910;font-weight:800;cursor:pointer}.reactorActions small{color:#737b8d}.expeditionGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:20px}.expeditionGrid button{text-align:left;padding:17px;border-radius:17px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);cursor:pointer}.expeditionGrid button:disabled{opacity:.42;cursor:not-allowed}.expeditionGrid span,.expeditionGrid small{display:block;color:#8d95a8;font-size:11px}.expeditionGrid b{display:block;margin:8px 0;color:#fff}.missionList{margin-top:18px;border-top:1px solid rgba(255,255,255,.07);padding-top:16px}.mission{display:flex;justify-content:space-between;gap:12px;padding:12px 0;color:#b0b7c7;font-size:13px}.mission strong{color:#8e96a9;font-size:11px}.reactorMessage{margin-top:16px;color:#c9c2ff;font-size:13px}@keyframes pulse{50%{transform:scale(1.04);opacity:.8}}@media(max-width:720px){.reactorShell{margin:0 18px 60px;padding:20px}.reactorStats{grid-template-columns:1fr}.expeditionGrid{grid-template-columns:1fr}.reactorHead{align-items:flex-start}.flow{gap:5px}.reactorOrb{flex:none}}`}</style>
     </section>
   );
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,7 +1,13 @@
 'use client';
 
 import VaultUniverse from './components/VaultUniverse';
+import VaultReactor from './components/VaultReactor';
 
 export default function Home() {
-  return <VaultUniverse />;
+  return (
+    <>
+      <VaultUniverse />
+      <VaultReactor />
+    </>
+  );
 }

--- a/docs/BACKGROUND-PLAY-PLAN.md
+++ b/docs/BACKGROUND-PLAY-PLAN.md
@@ -1,0 +1,55 @@
+# Voxel Vault Background Play + Legitimate Rewards Roadmap
+
+## Product direction
+
+Voxel Vault should remain useful when a collector is busy. The app can run a visible, battery-aware background progression loop that accumulates **Vault Energy** and unlocks verified missions. It must never pretend that a phone browser is mining cryptocurrency.
+
+## Priority 0 — trust and safety
+
+- No hidden CPU/GPU crypto mining.
+- No wallet signing in the background.
+- No secret transactions.
+- No guaranteed financial return.
+- Every on-chain reward must originate from a verified claim/event path.
+- Energy is a gameplay resource, not cryptocurrency.
+- Hard session and daily caps protect battery, abuse surface, and reward inflation.
+
+## Priority 1 — Background Play
+
+- Vault Reactor: visible idle progression while the user is away.
+- Pause/bank controls.
+- Daily cap and session cap.
+- Local persistence with explicit status.
+- Mobile-safe, no continuous render loop while backgrounded.
+
+## Priority 2 — Verified Missions
+
+- Spend Energy to queue scavenger, curation, discovery, and creator missions.
+- Mission completion must be verified by the existing hunt/claim authority before any NFT or crypto reward is issued.
+- Prevent duplicate completion IDs and replayed claims.
+
+## Priority 3 — Real NFT progression
+
+- Energy can unlock access, metadata packs, hunt tickets, cosmetic traits, and eligible drops.
+- Authentic NFTs are minted or transferred only through the existing contract/payment paths.
+- Reward receipts expose the source event and claim state.
+
+## Priority 4 — Sustainable reinvestment
+
+- Optional purchases can fund platform operations and sponsored drops.
+- Clearly disclose sponsorship and revenue allocation.
+- Never market Energy as a token or investment.
+
+## Priority 5 — Advanced automation
+
+- Notification reminders for completed background missions.
+- Server-verified queued work.
+- Rate limits and abuse scoring.
+- Analytics for energy inflation, mission completion, and reward liability.
+- Kill switch for reward issuance.
+
+## Release gates
+
+PLAN → REVIEW EVERYTHING → IMPLEMENT → UNIT TEST → BUILD → SECURITY REVIEW → VERCEL PREVIEW → BROWSER/VISUAL QA → FIX → RETEST → APPROVE PR → MERGE MAIN → VERCEL PRODUCTION → VERIFY LIVE SHA → PRODUCTION SMOKE TEST → MONITOR → ROLLBACK OR GREEN.
+
+**Absolute rule: Green build never means finished.**

--- a/lib/idleExpedition.js
+++ b/lib/idleExpedition.js
@@ -1,0 +1,52 @@
+export const IDLE_RULES = Object.freeze({
+  maxSessionMinutes: 180,
+  energyPerMinute: 1,
+  dailyEnergyCap: 240,
+  streakBonus: 0.1,
+});
+
+export function clampIdleMinutes(minutes) {
+  const value = Number(minutes);
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), IDLE_RULES.maxSessionMinutes);
+}
+
+export function accrueEnergy({ minutes, currentEnergy = 0, earnedToday = 0 }) {
+  const safeMinutes = clampIdleMinutes(minutes);
+  const remaining = Math.max(0, IDLE_RULES.dailyEnergyCap - Math.max(0, Number(earnedToday) || 0));
+  const earned = Math.min(safeMinutes * IDLE_RULES.energyPerMinute, remaining);
+  return {
+    minutes: safeMinutes,
+    earned,
+    energy: Math.max(0, Number(currentEnergy) || 0) + earned,
+    capped: earned < safeMinutes * IDLE_RULES.energyPerMinute,
+  };
+}
+
+export function getReactorState(now = Date.now(), saved = {}) {
+  const startedAt = Number(saved.startedAt) || 0;
+  const active = Boolean(saved.active && startedAt > 0);
+  const elapsedMinutes = active ? Math.max(0, (now - startedAt) / 60000) : 0;
+  return { active, elapsedMinutes, capped: elapsedMinutes >= IDLE_RULES.maxSessionMinutes };
+}
+
+export function spendEnergy(balance, amount) {
+  const safeBalance = Math.max(0, Number(balance) || 0);
+  const safeAmount = Math.max(0, Math.floor(Number(amount) || 0));
+  if (safeAmount > safeBalance) throw new Error('Not enough Vault Energy.');
+  return safeBalance - safeAmount;
+}
+
+export function createExpedition({ id, minutes = 15, energyCost = 10, label = 'Scout a nearby Vault' }) {
+  return {
+    id: String(id),
+    label,
+    minutes: clampIdleMinutes(minutes),
+    energyCost: Math.max(0, Math.floor(energyCost)),
+    rewardType: 'verified-progress',
+  };
+}
+
+export function isClaimableExpedition(expedition, completedIds = []) {
+  return Boolean(expedition?.id) && !completedIds.includes(expedition.id);
+}

--- a/lib/rewardLoop.js
+++ b/lib/rewardLoop.js
@@ -1,0 +1,41 @@
+export const REWARD_STAGES = Object.freeze([
+  'busy', 'reactor', 'energy', 'mission-queued', 'verified', 'eligible', 'claimable', 'claimed', 'reinvested', 'recycled'
+]);
+
+export function createMissionQueue() { return []; }
+
+export function queueMission(queue, mission, energy) {
+  if (!mission?.id) throw new Error('Mission id is required.');
+  if (queue.some(item => item.id === mission.id)) throw new Error('Mission is already queued.');
+  if (energy < mission.energyCost) throw new Error('Not enough Vault Energy.');
+  return [...queue, { ...mission, stage: 'mission-queued', queuedAt: Date.now() }];
+}
+
+export function markVerified(queue, missionId, proof) {
+  if (!proof?.verified || !proof?.id) throw new Error('Verified proof is required.');
+  return queue.map(item => item.id === missionId ? { ...item, stage: 'verified', proofId: proof.id, verifiedAt: Date.now() } : item);
+}
+
+export function makeEligibility(item, rules = {}) {
+  const minimumScore = Number(rules.minimumScore ?? 1);
+  const score = Number(item?.score ?? 0);
+  const verified = item?.stage === 'verified' && Boolean(item?.proofId);
+  return { eligible: verified && score >= minimumScore, stage: verified && score >= minimumScore ? 'eligible' : item?.stage ?? 'mission-queued' };
+}
+
+export function createClaimIntent(item, walletAddress) {
+  if (!item || item.stage !== 'eligible') throw new Error('Mission is not eligible for a claim.');
+  if (!walletAddress) throw new Error('Wallet confirmation is required.');
+  return { missionId: item.id, proofId: item.proofId, walletAddress, stage: 'claimable', createdAt: Date.now() };
+}
+
+export function recordClaim(intent, txHash) {
+  if (!intent?.proofId || !txHash) throw new Error('Verified transaction hash is required.');
+  return { ...intent, txHash, stage: 'claimed', claimedAt: Date.now() };
+}
+
+export function recordReinvestment(claim, allocation) {
+  if (!claim?.txHash) throw new Error('Only claimed rewards can be reinvested.');
+  const amount = Math.max(0, Number(allocation) || 0);
+  return { ...claim, reinvestment: amount, stage: 'reinvested', reinvestedAt: Date.now() };
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-vault",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -10,7 +10,8 @@
     "test:rewards": "node scripts/test-rewards-engine.mjs",
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run build",
+    "test:idle": "node scripts/test-idle-expedition.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:idle && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-vault",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -11,7 +11,8 @@
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
     "test:idle": "node scripts/test-idle-expedition.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:idle && npm run build",
+    "test:reward-loop": "node scripts/test-reward-loop.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:idle && npm run test:reward-loop && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-idle-expedition.mjs
+++ b/scripts/test-idle-expedition.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { IDLE_RULES, accrueEnergy, clampIdleMinutes, createExpedition, getReactorState, spendEnergy } from '../lib/idleExpedition.js';
+
+assert.equal(clampIdleMinutes(-5), 0);
+assert.equal(clampIdleMinutes(999), IDLE_RULES.maxSessionMinutes);
+assert.deepEqual(accrueEnergy({ minutes: 15, currentEnergy: 2, earnedToday: 0 }), { minutes: 15, earned: 15, energy: 17, capped: false });
+assert.equal(accrueEnergy({ minutes: 999, currentEnergy: 0, earnedToday: 235 }).earned, 5);
+assert.equal(accrueEnergy({ minutes: 15, currentEnergy: 0, earnedToday: 240 }).earned, 0);
+assert.equal(getReactorState(1000, { active: true, startedAt: 1000 }).elapsedMinutes, 0);
+assert.equal(getReactorState(601000, { active: true, startedAt: 1000 }).elapsedMinutes, 10);
+assert.equal(spendEnergy(25, 10), 15);
+assert.throws(() => spendEnergy(5, 6), /Not enough Vault Energy/);
+assert.deepEqual(createExpedition({ id: 'x', minutes: 20, energyCost: 8 }).rewardType, 'verified-progress');
+console.log('Idle Expedition tests passed');

--- a/scripts/test-reward-loop.mjs
+++ b/scripts/test-reward-loop.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { createMissionQueue, queueMission, markVerified, makeEligibility, createClaimIntent, recordClaim, recordReinvestment } from '../lib/rewardLoop.js';
+
+const mission = { id: 'hunt-1', energyCost: 10, score: 3 };
+let queue = createMissionQueue();
+queue = queueMission(queue, mission, 20);
+assert.equal(queue[0].stage, 'mission-queued');
+assert.throws(() => queueMission(queue, mission, 20), /already queued/);
+queue = markVerified(queue, 'hunt-1', { id: 'proof-1', verified: true });
+const eligibility = makeEligibility(queue[0], { minimumScore: 2 });
+assert.equal(eligibility.eligible, true);
+const intent = createClaimIntent({ ...queue[0], stage: 'eligible' }, '0x123');
+assert.equal(intent.stage, 'claimable');
+const claimed = recordClaim(intent, '0xtx');
+assert.equal(claimed.stage, 'claimed');
+const reinvested = recordReinvestment(claimed, 25);
+assert.equal(reinvested.stage, 'reinvested');
+assert.equal(reinvested.reinvestment, 25);
+assert.throws(() => createClaimIntent(queue[0], '0x123'), /not eligible/);
+console.log('Reward loop tests passed');


### PR DESCRIPTION
## Goal
Add a fun, visible background-play loop for collectors who are busy while preserving the existing Voxel Vault experience.

## Included
- Vault Reactor background progression UI
- capped Vault Energy, not cryptocurrency
- 180-minute session cap and 240 daily energy cap
- explicit start/pause/bank controls
- local persistence
- deterministic idle-expedition engine
- regression tests added to release suite
- release/security roadmap documenting the legitimate reward model

## Trust model
This release explicitly does **not** perform hidden browser crypto mining, background wallet signing, or secret transactions. Authentic NFT/crypto rewards remain tied to verified existing hunt/claim/payment paths. Energy is a gameplay resource only.

## Release gate
PLAN → REVIEW EVERYTHING → IMPLEMENT → UNIT TEST → BUILD → SECURITY REVIEW → VERCEL PREVIEW → BROWSER/VISUAL QA → FIX → RETEST → APPROVE → MERGE MAIN → VERCEL PRODUCTION → VERIFY LIVE SHA → PRODUCTION SMOKE TEST → MONITOR → ROLLBACK OR GREEN.

Green build never means finished.