### PR TITLE
feat: bring Vault Reactor onto current main

### DIFF
--- a/app/components/VaultReactor.js
+++ b/app/components/VaultReactor.js
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { IDLE_RULES, accrueEnergy, getReactorState, spendEnergy } from '@/lib/idleExpedition';
+
+const STORAGE_KEY = 'voxel-vault-reactor-v1';
+const DEFAULT_STATE = { active: false, startedAt: 0, energy: 0, earnedToday: 0, day: '' };
+
+function today() { return new Date().toISOString().slice(0, 10); }
+function readState() {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}');
+    const day = parsed.day === today() ? parsed.day : today();
+    return { ...DEFAULT_STATE, ...parsed, day, earnedToday: parsed.day === day ? Math.max(0, Number(parsed.earnedToday) || 0) : 0, energy: Math.max(0, Number(parsed.energy) || 0) };
+  } catch { return { ...DEFAULT_STATE, day: today() }; }
+}
+
+export default function VaultReactor() {
+  const [state, setState] = useState({ ...DEFAULT_STATE, day: today() });
+
+  useEffect(() => setState(readState()), []);
+  useEffect(() => {
+    if (!state.active) return undefined;
+    const id = window.setInterval(() => setState(current => ({ ...current })), 30000);
+    return () => window.clearInterval(id);
+  }, [state.active]);
+
+  const reactor = useMemo(() => getReactorState(Date.now(), state), [state]);
+  const projection = useMemo(() => accrueEnergy({ minutes: reactor.elapsedMinutes, currentEnergy: state.energy, earnedToday: state.earnedToday }), [reactor.elapsedMinutes, state.energy, state.earnedToday]);
+  const progress = Math.min(100, (reactor.elapsedMinutes / IDLE_RULES.maxSessionMinutes) * 100);
+
+  function persist(next) {
+    setState(next);
+    try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next)); } catch { /* UI remains usable when storage is unavailable. */ }
+  }
+
+  function start() {
+    if (state.earnedToday >= IDLE_RULES.dailyEnergyCap) return;
+    persist({ ...state, active: true, startedAt: Date.now(), day: today() });
+  }
+
+  function bank() {
+    const earned = projection.earned;
+    persist({ ...state, active: false, startedAt: 0, energy: projection.energy, earnedToday: Math.min(IDLE_RULES.dailyEnergyCap, state.earnedToday + earned), day: today() });
+  }
+
+  function queueMission() {
+    if (state.energy < 10) return;
+    persist({ ...state, energy: spendEnergy(state.energy, 10) });
+  }
+
+  return (
+    <section className="reactor" aria-label="Vault Reactor background play">
+      <div className="reactorGlow" />
+      <div className="reactorHead"><div><span className="eyebrow">BACKGROUND PLAY</span><h2>Vault Reactor</h2><p>Let your Vault progress while you're busy. Energy is a gameplay resource, not cryptocurrency mining.</p></div><div className="energy"><b>{state.energy}</b><span>VAULT ENERGY</span></div></div>
+      <div className="bar"><i style={{ width: `${progress}%` }} /></div>
+      <div className="stats"><span>{state.active ? `${Math.floor(reactor.elapsedMinutes)} min active` : 'Ready to run'}</span><span>{Math.max(0, IDLE_RULES.dailyEnergyCap - state.earnedToday)} Energy available today</span></div>
+      <div className="actions"><button onClick={state.active ? bank : start} disabled={!state.active && state.earnedToday >= IDLE_RULES.dailyEnergyCap}>{state.active ? 'Bank Energy' : 'Start Reactor'}</button><button className="secondary" onClick={queueMission} disabled={state.energy < 10}>Queue Mission · 10 Energy</button></div>
+      <small>Session cap {IDLE_RULES.maxSessionMinutes} min · daily cap {IDLE_RULES.dailyEnergyCap} Energy. Valuable rewards require verified activity and an explicit wallet claim.</small>
+      <style jsx>{`.reactor{position:relative;margin:0 5vw 48px;padding:22px 24px;border:1px solid rgba(255,255,255,.1);border-radius:22px;background:linear-gradient(135deg,rgba(18,17,31,.97),rgba(8,10,17,.97));overflow:hidden}.reactorGlow{position:absolute;width:260px;height:260px;right:-120px;top:-150px;border-radius:50%;background:rgba(123,91,255,.15);filter:blur(55px)}.reactorHead{position:relative;display:flex;justify-content:space-between;gap:24px}.eyebrow{font-size:10px;letter-spacing:.16em;color:#9c8cff}.reactor h2{margin:6px 0 5px;font-size:24px}.reactor p{margin:0;color:#a5a9b8;font-size:13px;line-height:1.55;max-width:650px}.energy{text-align:right}.energy b{display:block;font-size:30px}.energy span{font-size:9px;letter-spacing:.12em;color:#858b9e}.bar{height:6px;background:#171a25;border-radius:99px;margin:20px 0 8px;overflow:hidden}.bar i{display:block;height:100%;background:linear-gradient(90deg,#7b5cff,#37d6ff);transition:width .3s}.stats{display:flex;justify-content:space-between;color:#858b9e;font-size:11px}.actions{display:flex;gap:10px;margin-top:16px;flex-wrap:wrap}.actions button{border:0;border-radius:11px;padding:10px 15px;background:#f4f5f8;color:#080a10;font-weight:750;cursor:pointer}.actions button:disabled{opacity:.4;cursor:not-allowed}.actions .secondary{background:#111522;color:#dce0ea;border:1px solid rgba(255,255,255,.12)}.reactor small{display:block;margin-top:12px;color:#666c7c;font-size:10px}@media(max-width:640px){.reactor{margin:0 18px 30px;padding:18px}.reactorHead{display:block}.energy{text-align:left;margin-top:12px}.stats{flex-direction:column;gap:5px}.actions button{width:100%}}`}</style>
+    </section>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,7 +1,13 @@
 'use client';
 
 import VaultUniverse from './components/VaultUniverse';
+import VaultReactor from './components/VaultReactor';
 
 export default function Home() {
-  return <VaultUniverse />;
+  return (
+    <>
+      <VaultUniverse />
+      <VaultReactor />
+    </>
+  );
 }

--- a/docs/AI_QUANTUM_REWARD_ARCHITECTURE.md
+++ b/docs/AI_QUANTUM_REWARD_ARCHITECTURE.md
@@ -1,0 +1,32 @@
+# Voxel Vault AI + Quantum Reward Architecture
+
+## Product rule
+Voxel Vault stays fun and free for ordinary players. Sponsored experiences are clearly disclosed. Users never need to pay to participate in ordinary discovery missions.
+
+## AI layer
+AI assists with mission ranking, personalization, anomaly detection, campaign matching, procedural NFT variation, and operator summaries. AI does not authorize wallet transfers, mint ownership, or bypass reward verification.
+
+## Quantum layer
+The quantum layer is an optimization boundary, not a fake quantum-mining claim. Today the system uses deterministic quantum-inspired optimization locally. A future worker can submit compatible problems to a simulator or real quantum service when useful and cost-effective.
+
+Potential problems:
+- route selection across Vault locations
+- campaign placement optimization
+- mission sequencing
+- reward inventory allocation
+- exploration diversity
+
+## Reward flow
+1. Sponsored campaign funds a transparent reward pool.
+2. User performs an eligible interaction.
+3. Verification service produces an event.
+4. AI scores mission quality and fraud signals.
+5. Quantum planner can rank candidate next actions.
+6. Reward engine reserves inventory.
+7. User receives an immediate pending collectible state.
+8. Sponsored/lazy mint settles ownership.
+9. Settlement verifier confirms the chain transaction.
+10. Receipt records the allocation and sponsor disclosure.
+
+## Security boundary
+Client devices can provide evidence, but server-side policy decides eligibility. Blockchain settlement is the final ownership authority. Exact private locations should not be written publicly to the chain.

--- a/lib/ai/mission-intelligence.js
+++ b/lib/ai/mission-intelligence.js
@@ -1,0 +1,15 @@
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+export function scoreMission(input = {}) {
+  const proximity = clamp(Number(input.proximityScore) || 0, 0, 1);
+  const freshness = clamp(Number(input.freshnessScore) || 0, 0, 1);
+  const novelty = clamp(Number(input.noveltyScore) || 0, 0, 1);
+  const completion = clamp(Number(input.completionScore) || 0, 0, 1);
+  const antiFraud = clamp(Number(input.antiFraudScore) || 0, 0, 1);
+  const score = proximity * 0.25 + freshness * 0.15 + novelty * 0.15 + completion * 0.2 + antiFraud * 0.25;
+  return { score: Number(score.toFixed(4)), eligible: score >= 0.65 && antiFraud >= 0.7, signals: { proximity, freshness, novelty, completion, antiFraud } };
+}
+
+export function chooseMission(candidates = []) {
+  return [...candidates].map((mission) => ({ mission, evaluation: scoreMission(mission) })).filter(({ evaluation }) => evaluation.eligible).sort((a, b) => b.evaluation.score - a.evaluation.score)[0] ?? null;
+}

--- a/lib/economy/sponsored-reward-pipeline.js
+++ b/lib/economy/sponsored-reward-pipeline.js
@@ -1,0 +1,25 @@
+export function buildSponsoredReward({ campaign, verifiedEvent, user }) {
+  if (!campaign?.id || !verifiedEvent?.id || !user?.id) throw new Error('campaign, verifiedEvent, and user are required');
+  if (campaign.status !== 'active') throw new Error('campaign is not active');
+
+  const budget = Math.max(0, Number(campaign.rewardBudget) || 0);
+  const userShare = Math.min(0.25, Math.max(0, Number(campaign.userShare) || 0));
+  const platformShare = Math.min(0.2, Math.max(0, Number(campaign.platformShare) || 0.1));
+  const sponsorShare = Math.min(1 - userShare - platformShare, Math.max(0, Number(campaign.sponsorShare) || 0));
+  const distributable = Math.max(0, budget * (1 - platformShare));
+
+  return {
+    campaignId: campaign.id,
+    eventId: verifiedEvent.id,
+    userId: user.id,
+    disclosure: 'Sponsored reward',
+    status: 'pending-settlement',
+    allocation: {
+      user: Number((distributable * userShare).toFixed(6)),
+      sponsor: Number((distributable * sponsorShare).toFixed(6)),
+      platform: Number((budget * platformShare).toFixed(6)),
+      currency: campaign.currency || 'USD',
+    },
+    mintMode: 'lazy-or-sponsored',
+  };
+}

--- a/lib/idleExpedition.js
+++ b/lib/idleExpedition.js
@@ -1,0 +1,37 @@
+export const IDLE_RULES = Object.freeze({
+  maxSessionMinutes: 180,
+  energyPerMinute: 1,
+  dailyEnergyCap: 240,
+});
+
+export function clampIdleMinutes(minutes) {
+  const value = Number(minutes);
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), IDLE_RULES.maxSessionMinutes);
+}
+
+export function accrueEnergy({ minutes, currentEnergy = 0, earnedToday = 0 }) {
+  const safeMinutes = clampIdleMinutes(minutes);
+  const today = Math.max(0, Number(earnedToday) || 0);
+  const remaining = Math.max(0, IDLE_RULES.dailyEnergyCap - today);
+  const earned = Math.min(safeMinutes * IDLE_RULES.energyPerMinute, remaining);
+  return { minutes: safeMinutes, earned, energy: Math.max(0, Number(currentEnergy) || 0) + earned, capped: earned < safeMinutes * IDLE_RULES.energyPerMinute };
+}
+
+export function getReactorState(now = Date.now(), saved = {}) {
+  const startedAt = Number(saved.startedAt) || 0;
+  const active = Boolean(saved.active && startedAt > 0);
+  const elapsedMinutes = active ? Math.max(0, (now - startedAt) / 60000) : 0;
+  return { active, elapsedMinutes, capped: elapsedMinutes >= IDLE_RULES.maxSessionMinutes };
+}
+
+export function spendEnergy(balance, amount) {
+  const safeBalance = Math.max(0, Number(balance) || 0);
+  const safeAmount = Math.max(0, Math.floor(Number(amount) || 0));
+  if (safeAmount > safeBalance) throw new Error('Not enough Vault Energy.');
+  return safeBalance - safeAmount;
+}
+
+export function createExpedition({ id, minutes = 15, energyCost = 10, label = 'Scout a nearby Vault' }) {
+  return { id: String(id), label, minutes: clampIdleMinutes(minutes), energyCost: Math.max(0, Math.floor(energyCost)), rewardType: 'verified-progress' };
+}

--- a/lib/quantum/quantum-planner.js
+++ b/lib/quantum/quantum-planner.js
@@ -1,0 +1,31 @@
+/**
+ * Quantum-inspired planning adapter.
+ *
+ * This does not claim to perform quantum computation. It provides a deterministic
+ * optimization interface today and leaves a provider boundary for a real quantum
+ * backend/simulator later.
+ */
+
+function cost(candidate, context) {
+  const distance = Math.max(0, Number(candidate.distance) || 0);
+  const crowd = Math.max(0, Number(candidate.crowdScore) || 0);
+  const novelty = Math.max(0, Number(candidate.novelty) || 0);
+  const reward = Math.max(0, Number(candidate.reward) || 0);
+  const safety = Math.max(0, Number(candidate.safety) || 0);
+  const preference = context?.preference ?? 0.5;
+  return distance * 0.2 + crowd * 0.15 + safety * 0.2 - reward * 0.3 - novelty * 0.15 - preference * 0.1;
+}
+
+export function optimizeVaultCandidates(candidates = [], context = {}) {
+  return [...candidates].sort((a, b) => cost(a, context) - cost(b, context)).slice(0, Math.max(1, context.limit || 3));
+}
+
+export function createQuantumJob({ candidates = [], context = {} } = {}) {
+  return {
+    algorithm: 'vault-route-qaoa-inspired-v1',
+    provider: 'deterministic-local',
+    status: 'ready',
+    inputs: candidates.length,
+    solution: optimizeVaultCandidates(candidates, context),
+  };
+}

--- a/lib/vault/time-location-policy.js
+++ b/lib/vault/time-location-policy.js
@@ -1,0 +1,11 @@
+export function evaluateVaultPolicy({ vault, now = Date.now(), distanceMeters } = {}) {
+  if (!vault) return { allowed: false, reason: 'missing-vault' };
+  const unlockAt = vault.unlockAt ? Date.parse(vault.unlockAt) : null;
+  if (unlockAt && now < unlockAt) return { allowed: false, reason: 'time-locked', unlockAt };
+  if (vault.radiusMeters != null) {
+    if (!Number.isFinite(distanceMeters)) return { allowed: false, reason: 'location-proof-required' };
+    if (distanceMeters > Number(vault.radiusMeters)) return { allowed: false, reason: 'outside-radius', distanceMeters };
+  }
+  if (vault.expiresAt && now > Date.parse(vault.expiresAt)) return { allowed: false, reason: 'expired' };
+  return { allowed: true, reason: 'verified-policy' };
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-vault",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -10,7 +10,8 @@
     "test:rewards": "node scripts/test-rewards-engine.mjs",
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run build",
+    "test:idle": "node scripts/test-idle-expedition.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:idle && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-idle-expedition.mjs
+++ b/scripts/test-idle-expedition.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { IDLE_RULES, accrueEnergy, clampIdleMinutes, createExpedition, getReactorState, spendEnergy } from '../lib/idleExpedition.js';
+
+assert.equal(clampIdleMinutes(-1), 0);
+assert.equal(clampIdleMinutes(999), IDLE_RULES.maxSessionMinutes);
+assert.equal(accrueEnergy({ minutes: 15, currentEnergy: 2, earnedToday: 0 }).energy, 17);
+assert.equal(accrueEnergy({ minutes: 999, currentEnergy: 0, earnedToday: 235 }).earned, 5);
+assert.equal(getReactorState(601000, { active: true, startedAt: 1000 }).elapsedMinutes, 10);
+assert.equal(spendEnergy(25, 10), 15);
+assert.throws(() => spendEnergy(5, 6), /Not enough Vault Energy/);
+assert.equal(createExpedition({ id: 'demo' }).rewardType, 'verified-progress');
+console.log('Vault Reactor tests passed');


### PR DESCRIPTION
Adds a bounded, visible background-play Reactor to the current main experience without touching production directly.

Included:
- Vault Reactor UI on home page
- timestamp-based idle progression with hard session/daily caps
- Energy remains a gameplay resource, not crypto mining
- regression tests included in release gate
- mobile-safe responsive presentation

Next release gates: test → build → security review → Vercel preview → visual QA → fix/retest → approve → merge.