### PR TITLE
Reconcile Voxel Vault vNext collection architecture

### DIFF
--- a/app/api/drops/claim/route.js
+++ b/app/api/drops/claim/route.js
@@ -44,6 +44,7 @@ function ensureDemoDrop(dropId) {
   });
   seedMemoryDrop({
     ...drop,
+    // Demo-only coordinates stay in ephemeral memory. They are never persisted by claimAuthority.
     lat: raw.lat,
     lng: raw.lng,
     collectible: createUniversalCollectible(raw.collectible),
@@ -57,7 +58,8 @@ export async function POST(request) {
     const dropId = body.dropId;
     const walletAddress = body.walletAddress;
     const distanceMeters = body.distanceMeters;
-    const requireInZone = Boolean(body.requireInZone);
+    const requireInZone = body.requireInZone !== false;
+    const proximityProof = body.proximityProof || null;
 
     if (!dropId) return NextResponse.json({ error: 'dropId is required' }, { status: 400 });
     if (!walletAddress) return NextResponse.json({ error: 'walletAddress is required' }, { status: 400 });
@@ -67,32 +69,39 @@ export async function POST(request) {
     const result = await authorizeClaim({
       dropId,
       walletAddress,
+      // Distance is retained only for UX/telemetry. It never authorizes a claim.
       distanceMeters: Number.isFinite(Number(distanceMeters)) ? Number(distanceMeters) : null,
       requireInZone,
+      proximityProof,
     });
 
     if (!result.authorized) {
       return NextResponse.json(
         {
           ...result,
-          error: result.reason === 'already_claimed' ? 'This wallet already claimed this drop' : 'Claim denied',
+          error:
+            result.reason === 'already_claimed'
+              ? 'This wallet already claimed this drop'
+              : result.reason === 'claim_reserved'
+                ? 'This drop is already reserved for this wallet'
+                : 'Claim denied',
         },
         { status: result.reason === 'already_claimed' ? 409 : 403 }
       );
     }
 
-    // Authorized ticket only — UI must not show "You own this" until chain confirms.
     return NextResponse.json({
       ...result,
       ownershipGranted: false,
+      cameraRequired: false,
       message:
-        'Server authorized a claim ticket. Sign a wallet transaction next. Ownership is only real after chain confirmation.',
+        'Claim reserved. Camera is not required. Ownership and any reward are only real after authoritative chain confirmation.',
     });
   } catch (error) {
     const message = error?.message || 'Claim failed';
     const status =
       message.includes('not found') ? 404
-        : message.includes('not currently active') || message.includes('exhausted') || message.includes('Outside')
+        : message.includes('not currently active') || message.includes('exhausted') || message.includes('Outside') || message.includes('Proximity proof')
           ? 403
           : 400;
     return NextResponse.json({ error: message, ownershipGranted: false }, { status });

--- a/config/collectionExperience.js
+++ b/config/collectionExperience.js
@@ -1,0 +1,42 @@
+export const COLLECTION_EXPERIENCE = Object.freeze({
+  primaryLoop: Object.freeze(['walk', 'discover', 'collect', 'earn']),
+  cameraRequired: false,
+  arPeekEnabled: true,
+  locationRequiredForProximityDrops: true,
+  microInteractionOptional: true,
+  defaultInteractionMs: 800,
+  phonePosition: 'natural',
+  privacy: Object.freeze({
+    rawGpsPublic: false,
+    rawGpsOnChain: false,
+    coarseSpatialDiscovery: true,
+    cameraIndependentOfLocation: true,
+  }),
+  states: Object.freeze([
+    'discovered',
+    'eligible',
+    'reserved',
+    'authorized',
+    'submitted',
+    'confirmed',
+    'owned',
+    'rewarded',
+  ]),
+});
+
+export function canCollectWithoutCamera() {
+  return COLLECTION_EXPERIENCE.cameraRequired === false;
+}
+
+export function getCollectionPresentation({ distanceMeters, rarity = 'common', sponsored = false } = {}) {
+  const distance = Number.isFinite(Number(distanceMeters)) ? Math.max(0, Number(distanceMeters)) : null;
+  return {
+    mode: 'walk',
+    cameraRequired: false,
+    showArPeek: COLLECTION_EXPERIENCE.arPeekEnabled,
+    distanceMeters: distance,
+    rarity,
+    sponsored,
+    primaryAction: distance !== null && distance <= 12 ? 'COLLECT' : 'APPROACH',
+  };
+}

--- a/docs/VOXEL-VAULT-VNEXT-CANONICAL.md
+++ b/docs/VOXEL-VAULT-VNEXT-CANONICAL.md
@@ -1,0 +1,200 @@
+# Voxel Vault vNext — Canonical Architecture
+
+Status: canonical planning and implementation contract
+Date: 2026-08-21
+
+## North star
+
+**Walk. Discover. Collect. Earn.**
+
+The majority of the player experience is a proximity-based discovery loop. The player does not need to hold up a camera to participate.
+
+## Player experience
+
+1. Open the app.
+2. See nearby signals and optional route guidance.
+3. Walk toward a drop.
+4. Enter the collection zone.
+5. Tap **COLLECT**.
+6. Complete a tiny optional micro-interaction when the drop calls for one.
+7. Receive the collectible and any eligible reward after authoritative settlement.
+
+### Camera policy
+
+- Camera is **never required** for ordinary collection.
+- Camera/AR is an optional enhancement called **Peek**.
+- The default collection interaction keeps the phone in a natural position.
+- Location permission may be requested for proximity discovery; camera permission is independent.
+- A camera-denied user must still be able to discover and collect ordinary compatible drops.
+
+## Two drop economies
+
+### Natural Vaults
+
+AI-assisted, unbranded collectibles that keep the world populated when no sponsor is active.
+
+AI may propose rarity, lore, visual direction, mutations, quests and spawn candidates. Deterministic rules and trusted services decide eligibility and ownership.
+
+### Sponsored Hunts
+
+Businesses fund real-world discovery campaigns. A sponsor purchases a campaign, not intrusive banner inventory. The campaign defines its collectible, discovery zone, schedule, supply and economic rules.
+
+The canonical economic model for sponsored campaigns is **50% player / 25% platform / 20% global pool / 5% creator**, but percentages must live in one canonical campaign schema and be validated server-side and on-chain before any production deployment.
+
+## Trust boundaries
+
+### Client
+
+Responsible for:
+
+- rendering the world
+- requesting permissions
+- showing distance as UX
+- collecting sensor inputs
+- initiating explicit user actions
+
+The client is **not authoritative** for ownership, money, claim counts or proximity eligibility.
+
+### AI
+
+AI is assistive. It may recommend, generate, score and explain. It must not independently authorize irreversible ownership or treasury actions.
+
+### Proximity service
+
+A trusted proximity service/oracle converts sensor/location evidence into a short-lived signed proof. Raw GPS must not be written to public chain state.
+
+### Backend
+
+Responsible for authentication, rate limits, reservations, voucher issuance, state transitions and observability.
+
+### Blockchain
+
+Responsible for final ownership, replay protection, campaign escrow accounting and settlement events.
+
+## Claim state machine
+
+```text
+DISCOVERED
+   ↓
+ELIGIBLE
+   ↓
+RESERVED
+   ↓
+AUTHORIZED
+   ↓
+SUBMITTED
+   ↓
+CONFIRMED
+   ↓
+OWNED
+   ↓
+REWARDED
+```
+
+Failure states must be recoverable. A failed transaction must not permanently consume a user claim merely because an authorization request succeeded.
+
+## Privacy
+
+- Never put raw latitude/longitude on-chain.
+- Prefer coarse spatial identifiers for public discovery.
+- Keep precise location ephemeral and purpose-limited.
+- Camera permission is separate from location permission.
+- Do not expose another user's precise location through APIs, logs or analytics.
+
+## 3D policy
+
+3D is progressive enhancement:
+
+- lightweight marker first
+- lazy GLB preview second
+- full interactive 3D only when useful
+- graceful non-WebGL fallback always
+
+## AI branches
+
+- World Director
+- Quest Master
+- Vault Artist
+- Anti-Cheat scoring
+- Pricing intelligence
+- Concierge route recommendations
+- Brand campaign assistant
+- Moderation
+- Weather and environment mutations
+
+## Quantum-ready branches
+
+Quantum functionality must be optional infrastructure, never a production availability dependency.
+
+- QRNG adapter
+- route optimization research adapter
+- post-quantum cryptography migration layer
+- Qiskit research sandbox
+
+If a quantum provider disappears, the game must continue normally.
+
+## Revenue architecture
+
+Campaign budget and platform revenue are separate accounting concepts.
+
+```text
+Sponsor funding
+      ↓
+Campaign escrow
+      ↓
+Claim settlement
+ ┌────┼─────┬─────┐
+Player Platform Global Creator
+```
+
+Every settlement needs an auditable receipt and an explicit accounting state.
+
+## Reconciliation rule
+
+A feature is only marked **implemented** when source code, configuration, tests and deployment behavior support it. A plan, README or generated scaffold does not make a feature production-ready.
+
+## Release gates
+
+Before a production release:
+
+- no known critical security findings
+- build succeeds
+- contract compilation succeeds
+- unit tests succeed
+- claim/reward invariants are tested
+- mobile/WebGL checks succeed
+- camera-denied collection path succeeds
+- location-denied fallback is honest and non-destructive
+- 3D failure fallback succeeds
+- ownership UI only changes after authoritative confirmation
+- deployment is inspected after build
+
+## Build order
+
+### Slice A — reconciliation and player shell
+
+Freeze this document, normalize drop/claim states, make camera optional, remove unsafe client-authoritative language, consolidate stale planning documents.
+
+### Slice B — authoritative collection
+
+Build reservation state transitions and signed proximity proof interfaces without putting raw GPS on-chain.
+
+### Slice C — sponsored economy
+
+Implement campaign escrow and settlement only after contract invariants and economic rules are finalized and tested.
+
+### Slice D — gasless ownership
+
+Integrate a real ERC-4337 provider/paymaster behind a stable collection service interface.
+
+### Slice E — natural world
+
+Add AI-assisted natural vault generation, weather mutations and adaptive quests.
+
+### Slice F — creator and brand tools
+
+Self-serve sponsored campaign creation, asset validation, reporting and receipts.
+
+### Slice G — advanced systems
+
+Fusion, Reactor, guild convergence, lineage/indexing, AR Peek, quantum-ready adapters and route optimization.

--- a/hooks/useNearbyClaim.js
+++ b/hooks/useNearbyClaim.js
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createClaimIntent } from '@/lib/collect/claimPolicy';
 
+/** Proximity discovery intentionally does not request or use camera access. */
 export function useNearbyClaim({ drop, wallet, enabled = true } = {}) {
   const [position, setPosition] = useState(null);
   const [permission, setPermission] = useState('unknown');
@@ -10,7 +11,10 @@ export function useNearbyClaim({ drop, wallet, enabled = true } = {}) {
   useEffect(() => {
     if (!enabled || typeof navigator === 'undefined' || !navigator.geolocation) return undefined;
     const watchId = navigator.geolocation.watchPosition(
-      ({ coords }) => { setPermission('granted'); setPosition({ lat: coords.latitude, lng: coords.longitude }); },
+      ({ coords }) => {
+        setPermission('granted');
+        setPosition({ lat: coords.latitude, lng: coords.longitude });
+      },
       () => setPermission('denied'),
       { enableHighAccuracy: true, maximumAge: 10000, timeout: 10000 },
     );
@@ -24,5 +28,13 @@ export function useNearbyClaim({ drop, wallet, enabled = true } = {}) {
     dropLocation: drop?.location,
   }), [drop?.id, drop?.location?.lat, drop?.location?.lng, wallet, position?.lat, position?.lng]);
 
-  return { position, permission, intent, nearby: Boolean(intent.eligible), requestLocation: () => navigator.geolocation?.getCurrentPosition(() => {}, () => {}) };
+  return {
+    position,
+    permission,
+    intent,
+    nearby: Boolean(intent.eligible),
+    cameraRequired: false,
+    arAvailable: true,
+    requestLocation: () => navigator.geolocation?.getCurrentPosition(() => {}, () => {}),
+  };
 }

--- a/lib/claimAuthority.js
+++ b/lib/claimAuthority.js
@@ -1,18 +1,15 @@
 /**
  * Server-side claim authority for Voxel Vault drops.
  * Client distance is UX only. Authoritative proximity requires a short-lived signed proof.
+ * Durable claim storage is required for production reservation/confirmation authority.
  */
 
 import { createHash, randomBytes } from 'node:crypto';
 import { verifyProximityProof } from './proximityProof.js';
 import { isDropDiscoverable } from './dropEngine.js';
+import { assertProductionStorage, reservationExpiresAt, isReservationActive, DEFAULT_TTL_SECONDS } from './claimReservation.js';
 
-const memory = {
-  drops: new Map(),
-  claims: new Map(), // key: `${dropId}:${wallet}`
-  trades: new Map(),
-};
-
+const memory = { drops: new Map(), claims: new Map(), trades: new Map() };
 let supabase = null;
 let supabaseTried = false;
 
@@ -25,23 +22,19 @@ async function getSupabase() {
     if (!url || !key) return null;
     const { createClient } = await import('@supabase/supabase-js');
     supabase = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-    return supabase;
-  } catch {
-    return null;
-  }
+  } catch {}
+  return supabase;
 }
 
 function normalizeWallet(address) {
   if (typeof address !== 'string' || !address.trim()) throw new Error('Wallet connection is required');
   return address.trim().toLowerCase();
 }
-
 function ticketFor(dropId, wallet) {
-  const nonce = randomBytes(8).toString('hex');
-  const payload = `${dropId}:${wallet}:${nonce}:${Date.now()}`;
-  const hash = createHash('sha256').update(payload).digest('hex').slice(0, 32);
-  return `vvclaim_${hash}`;
+  const nonce = randomBytes(16).toString('hex');
+  return `vvclaim_${createHash('sha256').update(`${dropId}:${wallet}:${nonce}:${Date.now()}`).digest('hex').slice(0, 40)}`;
 }
+function requireConfiguredStorage(db) { assertProductionStorage(db); return db; }
 
 export function seedMemoryDrop(drop) {
   if (!drop?.id) return;
@@ -51,10 +44,7 @@ export function seedMemoryDrop(drop) {
 export async function upsertDrop(drop) {
   const db = await getSupabase();
   const row = {
-    id: drop.id,
-    name: drop.name,
-    status: drop.status || 'active',
-    quantity: drop.quantity || 1,
+    id: drop.id, name: drop.name, status: drop.status || 'active', quantity: drop.quantity || 1,
     claimed_count: drop.claimedCount || 0,
     public_zone_id: drop.discovery?.publicZoneId || drop.publicZoneId || null,
     radius_meters: drop.discovery?.radiusMeters || drop.radiusMeters || 50,
@@ -63,24 +53,11 @@ export async function upsertDrop(drop) {
     max_claims_per_wallet: drop.claimRules?.maxClaimsPerWallet || 1,
     collectible: drop.collectible || {},
   };
-
-  memory.drops.set(drop.id, {
-    id: row.id,
-    name: row.name,
-    status: row.status,
-    quantity: row.quantity,
-    claimedCount: row.claimed_count,
-    discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
-    schedule: { startAt: row.start_at, endAt: row.end_at },
-    claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet },
-    collectible: row.collectible,
-  });
-
-  if (db) {
-    const { error } = await db.from('voxel_drops').upsert(row);
-    if (error) throw new Error(`Drop persist failed: ${error.message}`);
-  }
-
+  memory.drops.set(drop.id, { id: row.id, name: row.name, status: row.status, quantity: row.quantity,
+    claimedCount: row.claimed_count, discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
+    schedule: { startAt: row.start_at, endAt: row.end_at }, claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet },
+    collectible: row.collectible });
+  if (db) { const { error } = await db.from('voxel_drops').upsert(row); if (error) throw new Error(`Drop persist failed: ${error.message}`); }
   return memory.drops.get(drop.id);
 }
 
@@ -89,19 +66,9 @@ export async function getDrop(dropId) {
   if (db) {
     const { data, error } = await db.from('voxel_drops').select('*').eq('id', dropId).maybeSingle();
     if (error) throw new Error(error.message);
-    if (data) {
-      return {
-        id: data.id,
-        name: data.name,
-        status: data.status,
-        quantity: data.quantity,
-        claimedCount: data.claimed_count,
-        discovery: { publicZoneId: data.public_zone_id, radiusMeters: data.radius_meters },
-        schedule: { startAt: data.start_at, endAt: data.end_at },
-        claimRules: { maxClaimsPerWallet: data.max_claims_per_wallet },
-        collectible: data.collectible,
-      };
-    }
+    if (data) return { id: data.id, name: data.name, status: data.status, quantity: data.quantity, claimedCount: data.claimed_count,
+      discovery: { publicZoneId: data.public_zone_id, radiusMeters: data.radius_meters },
+      schedule: { startAt: data.start_at, endAt: data.end_at }, claimRules: { maxClaimsPerWallet: data.max_claims_per_wallet }, collectible: data.collectible };
   }
   return memory.drops.get(dropId) || null;
 }
@@ -110,255 +77,112 @@ export async function listDrops() {
   const db = await getSupabase();
   if (db) {
     const { data, error } = await db.from('voxel_drops').select('*').in('status', ['active', 'scheduled']);
-    if (!error && data?.length) {
-      return data.map((row) => ({
-        id: row.id,
-        name: row.name,
-        status: row.status,
-        quantity: row.quantity,
-        claimedCount: row.claimed_count,
-        discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
-        schedule: { startAt: row.start_at, endAt: row.end_at },
-        claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet },
-        collectible: row.collectible,
-      }));
-    }
+    if (!error && data?.length) return data.map((row) => ({ id: row.id, name: row.name, status: row.status, quantity: row.quantity,
+      claimedCount: row.claimed_count, discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
+      schedule: { startAt: row.start_at, endAt: row.end_at }, claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet }, collectible: row.collectible }));
   }
   return [...memory.drops.values()].filter((d) => ['active', 'scheduled'].includes(d.status));
 }
 
-/**
- * Reserve a claim. Reservation does not consume supply. Final settlement must happen
- * after authoritative chain confirmation, which prevents failed transactions from
- * permanently consuming a drop.
- */
-export async function authorizeClaim({
-  dropId,
-  walletAddress,
-  distanceMeters = null,
-  requireInZone = false,
-  proximityProof = null,
-} = {}) {
+export async function authorizeClaim({ dropId, walletAddress, distanceMeters = null, requireInZone = false, proximityProof = null,
+  reservationTtlSeconds = DEFAULT_TTL_SECONDS } = {}) {
   const wallet = normalizeWallet(walletAddress);
+  const db = await getSupabase();
+  if (requireInZone) {
+    const proximity = verifyProximityProof(proximityProof, wallet, dropId);
+    if (!proximity.valid) throw new Error(`Proximity proof rejected: ${proximity.reason}`);
+  }
+  if (requireInZone) requireConfiguredStorage(db);
   const drop = await getDrop(dropId);
   if (!drop) throw new Error('Drop not found');
   if (!isDropDiscoverable(drop)) throw new Error('Drop is not currently active');
-
   if (drop.claimedCount >= drop.quantity) throw new Error('Drop is exhausted');
 
-  let proximity = null;
-  if (requireInZone) {
-    proximity = verifyProximityProof(proximityProof, wallet, dropId);
-    if (!proximity.valid) throw new Error(`Proximity proof rejected: ${proximity.reason}`);
+  const expiresAt = reservationExpiresAt(Date.now(), reservationTtlSeconds);
+  const claimKey = `${drop.id}:${wallet}`;
+  if (!db) {
+    if (memory.claims.has(claimKey)) {
+      const existing = memory.claims.get(claimKey);
+      if (existing.status === 'reserved' && isReservationActive(existing.status, existing.expiresAt)) return { authorized: false, reason: 'claim_reserved', claimTicket: existing.claimTicket, status: existing.status, expiresAt: existing.expiresAt, storage: 'memory' };
+      if (existing.status === 'confirmed' || existing.status === 'submitted') return { authorized: false, reason: existing.status === 'confirmed' ? 'already_claimed' : 'claim_submitted', claimTicket: existing.claimTicket, status: existing.status, storage: 'memory' };
+      memory.claims.delete(claimKey);
+    }
+    const claimTicket = ticketFor(drop.id, wallet);
+    const record = { dropId: drop.id, walletAddress: wallet, status: 'reserved', claimTicket, clientDistanceMeters: Number.isFinite(distanceMeters) ? Number(distanceMeters) : null, createdAt: new Date().toISOString(), expiresAt };
+    memory.claims.set(claimKey, record);
+    return { authorized: true, claimTicket, dropId: drop.id, walletAddress: wallet, status: 'reserved', expiresAt, collectible: drop.collectible || null, serverValidation: true, storage: 'memory' };
   }
 
-  const claimKey = `${drop.id}:${wallet}`;
-  const db = await getSupabase();
-
-  if (db) {
-    const { data: existing } = await db
-      .from('voxel_claims')
-      .select('id,status,claim_ticket')
-      .eq('drop_id', drop.id)
-      .eq('wallet_address', wallet)
-      .maybeSingle();
-    if (existing && ['reserved', 'authorized', 'submitted', 'confirmed'].includes(existing.status)) {
-      return {
-        authorized: false,
-        reason: existing.status === 'confirmed' ? 'already_claimed' : 'claim_reserved',
-        claimTicket: existing.claim_ticket,
-        status: existing.status,
-        serverValidation: true,
-        storage: 'supabase',
-      };
-    }
-  } else if (memory.claims.has(claimKey)) {
-    const existing = memory.claims.get(claimKey);
-    if (['reserved', 'authorized', 'submitted', 'confirmed'].includes(existing.status)) {
-      return {
-        authorized: false,
-        reason: existing.status === 'confirmed' ? 'already_claimed' : 'claim_reserved',
-        claimTicket: existing.claimTicket,
-        status: existing.status,
-        serverValidation: true,
-        storage: 'memory',
-      };
-    }
+  const { data: existing, error: existingError } = await db.from('voxel_claims').select('id,status,claim_ticket,expires_at').eq('drop_id', drop.id).eq('wallet_address', wallet).maybeSingle();
+  if (existingError) throw new Error(existingError.message);
+  if (existing) {
+    if (existing.status === 'confirmed') return { authorized: false, reason: 'already_claimed', claimTicket: existing.claim_ticket, status: existing.status, storage: 'supabase' };
+    if (existing.status === 'submitted') return { authorized: false, reason: 'claim_submitted', claimTicket: existing.claim_ticket, status: existing.status, storage: 'supabase' };
+    if (isReservationActive(existing.status, existing.expires_at)) return { authorized: false, reason: 'claim_reserved', claimTicket: existing.claim_ticket, status: existing.status, expiresAt: existing.expires_at, storage: 'supabase' };
+    const { error: releaseError } = await db.from('voxel_claims').update({ status: 'expired' }).eq('id', existing.id).eq('status', existing.status);
+    if (releaseError) throw new Error(releaseError.message);
   }
 
   const claimTicket = ticketFor(drop.id, wallet);
-  const record = {
-    dropId: drop.id,
-    walletAddress: wallet,
-    status: 'reserved',
-    claimTicket,
-    clientDistanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null,
-    proximityProof: proximity ? { spatialCell: proximity.spatialCell, scoreBps: proximity.scoreBps, expiresAt: proximity.expiresAt } : null,
-    createdAt: new Date().toISOString(),
-    security: {
-      locationCheck: requireInZone ? 'signed-proximity-proof' : 'not-required',
-      clientDistanceIsUxOnly: true,
-      serverValidationRequired: true,
-      replayProtectionRequired: true,
-      ownership: 'not-granted-until-chain-confirmation',
-    },
-  };
-
-  memory.claims.set(claimKey, record);
-
-  if (db) {
-    const { error: claimErr } = await db.from('voxel_claims').insert({
-      drop_id: drop.id,
-      wallet_address: wallet,
-      status: 'reserved',
-      claim_ticket: claimTicket,
-      client_distance_meters: record.clientDistanceMeters,
-    });
-    if (claimErr) {
-      if (String(claimErr.message).includes('duplicate') || claimErr.code === '23505') {
-        return { authorized: false, reason: 'claim_reserved', serverValidation: true, storage: 'supabase' };
-      }
-      throw new Error(claimErr.message);
-    }
+  const { data: inserted, error: insertError } = await db.from('voxel_claims').insert({
+    drop_id: drop.id, wallet_address: wallet, status: 'reserved', claim_ticket: claimTicket,
+    client_distance_meters: Number.isFinite(distanceMeters) ? Number(distanceMeters) : null, expires_at: expiresAt,
+  }).select('id,claim_ticket,status,expires_at').single();
+  if (insertError) {
+    if (insertError.code === '23505') return { authorized: false, reason: 'claim_reserved', serverValidation: true, storage: 'supabase' };
+    throw new Error(insertError.message);
   }
-
-  return {
-    authorized: true,
-    claimTicket,
-    dropId: drop.id,
-    walletAddress: wallet,
-    status: 'reserved',
-    collectible: drop.collectible || null,
-    security: record.security,
-    nextStep: 'explicit_wallet_action_then_authoritative_chain_settlement',
-    serverValidation: true,
-    storage: db ? 'supabase' : 'memory',
-  };
+  return { authorized: true, claimTicket: inserted.claim_ticket, dropId: drop.id, walletAddress: wallet, status: 'reserved', expiresAt: inserted.expires_at,
+    collectible: drop.collectible || null, security: { locationCheck: requireInZone ? 'signed-proximity-proof' : 'not-required', clientDistanceIsUxOnly: true,
+      ownership: 'not-granted-until-chain-confirmation' }, nextStep: 'explicit_collect_then_authoritative_chain_confirmation', serverValidation: true, storage: 'supabase' };
 }
 
 export async function markClaimSubmitted({ dropId, walletAddress, claimTicket, transactionHash } = {}) {
   const wallet = normalizeWallet(walletAddress);
   if (!claimTicket || !transactionHash) throw new Error('Claim ticket and transaction hash are required');
-  const key = `${dropId}:${wallet}`;
-  const record = memory.claims.get(key);
-  if (record && record.claimTicket === claimTicket) {
-    record.status = 'submitted';
-    record.transactionHash = transactionHash;
-    memory.claims.set(key, record);
-  }
-  const db = await getSupabase();
-  if (db) {
-    const { error } = await db
-      .from('voxel_claims')
-      .update({ status: 'submitted', transaction_hash: transactionHash })
-      .eq('drop_id', dropId)
-      .eq('wallet_address', wallet)
-      .eq('claim_ticket', claimTicket);
-    if (error) throw new Error(error.message);
-  }
-  return { status: 'submitted', dropId, walletAddress: wallet, claimTicket, transactionHash };
+  const db = requireConfiguredStorage(await getSupabase());
+  const { data, error } = await db.from('voxel_claims').update({ status: 'submitted', transaction_hash: transactionHash }).eq('drop_id', dropId).eq('wallet_address', wallet).eq('claim_ticket', claimTicket).eq('status', 'reserved').select('id,status').single();
+  if (error || !data) throw new Error(error?.message || 'Claim reservation is not available for submission');
+  return { status: data.status, dropId, walletAddress: wallet, claimTicket, transactionHash };
 }
 
 export async function markClaimConfirmed({ dropId, walletAddress, claimTicket, tokenId = null } = {}) {
   const wallet = normalizeWallet(walletAddress);
   if (!claimTicket) throw new Error('Claim ticket is required');
-  const key = `${dropId}:${wallet}`;
-  const record = memory.claims.get(key);
-  if (record && record.claimTicket === claimTicket) {
-    if (record.status === 'confirmed') return { status: 'confirmed', alreadyFinalized: true };
-    record.status = 'confirmed';
-    record.tokenId = tokenId;
-    memory.claims.set(key, record);
-  }
+  const db = requireConfiguredStorage(await getSupabase());
+  const { data, error } = await db.from('voxel_claims').select('id,status,transaction_hash,expires_at').eq('drop_id', dropId).eq('wallet_address', wallet).eq('claim_ticket', claimTicket).maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('Claim reservation not found');
+  if (data.status === 'confirmed') return { status: 'confirmed', alreadyFinalized: true };
+  if (data.status !== 'submitted') throw new Error('Claim must be submitted before confirmation');
+  if (!data.transaction_hash) throw new Error('Transaction hash is required before confirmation');
+  if (isReservationActive(data.status, data.expires_at) === false && data.status !== 'submitted') throw new Error('Claim reservation expired');
 
-  const drop = await getDrop(dropId);
-  if (!drop) throw new Error('Drop not found');
-  if (drop.claimedCount >= drop.quantity) throw new Error('Drop exhausted');
-
-  const db = await getSupabase();
-  if (db) {
-    const { data: claim, error: claimError } = await db
-      .from('voxel_claims')
-      .select('status')
-      .eq('drop_id', dropId)
-      .eq('wallet_address', wallet)
-      .eq('claim_ticket', claimTicket)
-      .maybeSingle();
-    if (claimError) throw new Error(claimError.message);
-    if (!claim) throw new Error('Claim reservation not found');
-    if (claim.status === 'confirmed') return { status: 'confirmed', alreadyFinalized: true };
-    const { error } = await db
-      .from('voxel_claims')
-      .update({ status: 'confirmed', token_id: tokenId == null ? null : String(tokenId) })
-      .eq('drop_id', dropId)
-      .eq('wallet_address', wallet)
-      .eq('claim_ticket', claimTicket);
-    if (error) throw new Error(error.message);
-  }
-
-  drop.claimedCount = (drop.claimedCount || 0) + 1;
-  if (drop.claimedCount >= drop.quantity) drop.status = 'exhausted';
-  memory.drops.set(dropId, drop);
-  if (db) {
-    const { error } = await db.from('voxel_drops').update({ claimed_count: drop.claimedCount, status: drop.status }).eq('id', dropId);
-    if (error) throw new Error(error.message);
-  }
+  // Chain receipt/event verification belongs here before this function is exposed to the public API.
+  // This function deliberately refuses to accept tokenId as proof of ownership.
+  // The next adapter will verify the actual receipt against the configured contract/network.
+  const { data: confirmed, error: confirmError } = await db.from('voxel_claims').update({ status: 'confirmed', token_id: tokenId == null ? null : String(tokenId) }).eq('id', data.id).eq('status', 'submitted').select('id,status').single();
+  if (confirmError || !confirmed) throw new Error(confirmError?.message || 'Claim confirmation race lost');
   return { status: 'confirmed', dropId, walletAddress: wallet, claimTicket, tokenId };
 }
 
 export async function releaseClaimReservation({ dropId, walletAddress, claimTicket } = {}) {
   const wallet = normalizeWallet(walletAddress);
-  const key = `${dropId}:${wallet}`;
-  memory.claims.delete(key);
-  const db = await getSupabase();
-  if (db) {
-    const { error } = await db
-      .from('voxel_claims')
-      .delete()
-      .eq('drop_id', dropId)
-      .eq('wallet_address', wallet)
-      .eq('claim_ticket', claimTicket)
-      .in('status', ['reserved', 'authorized']);
-    if (error) throw new Error(error.message);
-  }
+  const db = requireConfiguredStorage(await getSupabase());
+  const { error } = await db.from('voxel_claims').update({ status: 'released' }).eq('drop_id', dropId).eq('wallet_address', wallet).eq('claim_ticket', claimTicket).in('status', ['reserved']);
+  if (error) throw new Error(error.message);
   return { released: true, dropId, walletAddress: wallet };
 }
 
 export async function saveTradeOffer(offer) {
   const db = await getSupabase();
   memory.trades.set(offer.id, offer);
-  if (db) {
-    const { error } = await db.from('voxel_trade_offers').upsert({
-      id: offer.id,
-      state: offer.state,
-      offerer: offer.offerer,
-      recipient: offer.recipient,
-      offered: offer.offered,
-      requested: offer.requested,
-      expires_at: offer.expiresAt,
-      updated_at: new Date().toISOString(),
-    });
-    if (error) throw new Error(error.message);
-  }
+  if (db) { const { error } = await db.from('voxel_trade_offers').upsert({ id: offer.id, state: offer.state, offerer: offer.offerer, recipient: offer.recipient, offered: offer.offered, requested: offer.requested, expires_at: offer.expiresAt, updated_at: new Date().toISOString() }); if (error) throw new Error(error.message); }
   return offer;
 }
 
 export async function getTradeOffer(id) {
   const db = await getSupabase();
-  if (db) {
-    const { data } = await db.from('voxel_trade_offers').select('*').eq('id', id).maybeSingle();
-    if (data) {
-      return {
-        id: data.id,
-        state: data.state,
-        offerer: data.offerer,
-        recipient: data.recipient,
-        offered: data.offered,
-        requested: data.requested,
-        expiresAt: data.expires_at,
-        createdAt: data.created_at,
-      };
-    }
-  }
+  if (db) { const { data } = await db.from('voxel_trade_offers').select('*').eq('id', id).maybeSingle(); if (data) return { id: data.id, state: data.state, offerer: data.offerer, recipient: data.recipient, offered: data.offered, requested: data.requested, expiresAt: data.expires_at, createdAt: data.created_at }; }
   return memory.trades.get(id) || null;
 }

--- a/lib/claimAuthority.js
+++ b/lib/claimAuthority.js
@@ -1,10 +1,11 @@
 /**
  * Server-side claim authority for Voxel Vault drops.
- * Client distance is UX only. This module is the gate before any mint/transfer intent.
+ * Client distance is UX only. Authoritative proximity requires a short-lived signed proof.
  */
 
 import { createHash, randomBytes } from 'node:crypto';
-import { isDropDiscoverable, isWithinDropZone } from './dropEngine.js';
+import { verifyProximityProof } from './proximityProof.js';
+import { isDropDiscoverable } from './dropEngine.js';
 
 const memory = {
   drops: new Map(),
@@ -42,13 +43,9 @@ function ticketFor(dropId, wallet) {
   return `vvclaim_${hash}`;
 }
 
-/** Seed demo drops into memory when no DB row exists (dev / unconfigured). */
 export function seedMemoryDrop(drop) {
   if (!drop?.id) return;
-  memory.drops.set(drop.id, {
-    ...drop,
-    claimedCount: drop.claimedCount || 0,
-  });
+  memory.drops.set(drop.id, { ...drop, claimedCount: drop.claimedCount || 0 });
 }
 
 export async function upsertDrop(drop) {
@@ -61,8 +58,6 @@ export async function upsertDrop(drop) {
     claimed_count: drop.claimedCount || 0,
     public_zone_id: drop.discovery?.publicZoneId || drop.publicZoneId || null,
     radius_meters: drop.discovery?.radiusMeters || drop.radiusMeters || 50,
-    lat: drop.lat ?? null,
-    lng: drop.lng ?? null,
     start_at: drop.schedule?.startAt || drop.startAt || null,
     end_at: drop.schedule?.endAt || drop.endAt || null,
     max_claims_per_wallet: drop.claimRules?.maxClaimsPerWallet || 1,
@@ -78,8 +73,6 @@ export async function upsertDrop(drop) {
     discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
     schedule: { startAt: row.start_at, endAt: row.end_at },
     claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet },
-    lat: row.lat,
-    lng: row.lng,
     collectible: row.collectible,
   });
 
@@ -106,8 +99,6 @@ export async function getDrop(dropId) {
         discovery: { publicZoneId: data.public_zone_id, radiusMeters: data.radius_meters },
         schedule: { startAt: data.start_at, endAt: data.end_at },
         claimRules: { maxClaimsPerWallet: data.max_claims_per_wallet },
-        lat: data.lat,
-        lng: data.lng,
         collectible: data.collectible,
       };
     }
@@ -129,8 +120,6 @@ export async function listDrops() {
         discovery: { publicZoneId: row.public_zone_id, radiusMeters: row.radius_meters },
         schedule: { startAt: row.start_at, endAt: row.end_at },
         claimRules: { maxClaimsPerWallet: row.max_claims_per_wallet },
-        lat: row.lat,
-        lng: row.lng,
         collectible: row.collectible,
       }));
     }
@@ -139,13 +128,16 @@ export async function listDrops() {
 }
 
 /**
- * Authorize a claim. Returns a claim ticket — not ownership.
+ * Reserve a claim. Reservation does not consume supply. Final settlement must happen
+ * after authoritative chain confirmation, which prevents failed transactions from
+ * permanently consuming a drop.
  */
 export async function authorizeClaim({
   dropId,
   walletAddress,
   distanceMeters = null,
   requireInZone = false,
+  proximityProof = null,
 } = {}) {
   const wallet = normalizeWallet(walletAddress);
   const drop = await getDrop(dropId);
@@ -154,9 +146,10 @@ export async function authorizeClaim({
 
   if (drop.claimedCount >= drop.quantity) throw new Error('Drop is exhausted');
 
+  let proximity = null;
   if (requireInZone) {
-    if (!Number.isFinite(distanceMeters)) throw new Error('Distance required for zone check');
-    if (!isWithinDropZone(drop, distanceMeters)) throw new Error('Outside public drop zone');
+    proximity = verifyProximityProof(proximityProof, wallet, dropId);
+    if (!proximity.valid) throw new Error(`Proximity proof rejected: ${proximity.reason}`);
   }
 
   const claimKey = `${drop.id}:${wallet}`;
@@ -169,10 +162,10 @@ export async function authorizeClaim({
       .eq('drop_id', drop.id)
       .eq('wallet_address', wallet)
       .maybeSingle();
-    if (existing) {
+    if (existing && ['reserved', 'authorized', 'submitted', 'confirmed'].includes(existing.status)) {
       return {
         authorized: false,
-        reason: 'already_claimed',
+        reason: existing.status === 'confirmed' ? 'already_claimed' : 'claim_reserved',
         claimTicket: existing.claim_ticket,
         status: existing.status,
         serverValidation: true,
@@ -181,26 +174,30 @@ export async function authorizeClaim({
     }
   } else if (memory.claims.has(claimKey)) {
     const existing = memory.claims.get(claimKey);
-    return {
-      authorized: false,
-      reason: 'already_claimed',
-      claimTicket: existing.claimTicket,
-      status: existing.status,
-      serverValidation: true,
-      storage: 'memory',
-    };
+    if (['reserved', 'authorized', 'submitted', 'confirmed'].includes(existing.status)) {
+      return {
+        authorized: false,
+        reason: existing.status === 'confirmed' ? 'already_claimed' : 'claim_reserved',
+        claimTicket: existing.claimTicket,
+        status: existing.status,
+        serverValidation: true,
+        storage: 'memory',
+      };
+    }
   }
 
   const claimTicket = ticketFor(drop.id, wallet);
   const record = {
     dropId: drop.id,
     walletAddress: wallet,
-    status: 'authorized',
+    status: 'reserved',
     claimTicket,
     clientDistanceMeters: Number.isFinite(distanceMeters) ? distanceMeters : null,
+    proximityProof: proximity ? { spatialCell: proximity.spatialCell, scoreBps: proximity.scoreBps, expiresAt: proximity.expiresAt } : null,
     createdAt: new Date().toISOString(),
     security: {
-      locationCheck: 'client-supplied-distance-is-UX-only',
+      locationCheck: requireInZone ? 'signed-proximity-proof' : 'not-required',
+      clientDistanceIsUxOnly: true,
       serverValidationRequired: true,
       replayProtectionRequired: true,
       ownership: 'not-granted-until-chain-confirmation',
@@ -208,33 +205,21 @@ export async function authorizeClaim({
   };
 
   memory.claims.set(claimKey, record);
-  drop.claimedCount = (drop.claimedCount || 0) + 1;
-  memory.drops.set(drop.id, drop);
 
   if (db) {
     const { error: claimErr } = await db.from('voxel_claims').insert({
       drop_id: drop.id,
       wallet_address: wallet,
-      status: 'authorized',
+      status: 'reserved',
       claim_ticket: claimTicket,
       client_distance_meters: record.clientDistanceMeters,
     });
     if (claimErr) {
-      // Unique violation = replay
       if (String(claimErr.message).includes('duplicate') || claimErr.code === '23505') {
-        return {
-          authorized: false,
-          reason: 'already_claimed',
-          serverValidation: true,
-          storage: 'supabase',
-        };
+        return { authorized: false, reason: 'claim_reserved', serverValidation: true, storage: 'supabase' };
       }
       throw new Error(claimErr.message);
     }
-    await db
-      .from('voxel_drops')
-      .update({ claimed_count: drop.claimedCount })
-      .eq('id', drop.id);
   }
 
   return {
@@ -242,17 +227,101 @@ export async function authorizeClaim({
     claimTicket,
     dropId: drop.id,
     walletAddress: wallet,
-    status: 'authorized',
+    status: 'reserved',
     collectible: drop.collectible || null,
     security: record.security,
-    nextStep: 'wallet_signature_then_chain_settlement',
+    nextStep: 'explicit_wallet_action_then_authoritative_chain_settlement',
     serverValidation: true,
     storage: db ? 'supabase' : 'memory',
-    note:
-      db
-        ? 'Claim authorized by server. Ownership is not granted until a chain transaction confirms.'
-        : 'Claim authorized in ephemeral server memory (Supabase not configured). Not multi-instance durable.',
   };
+}
+
+export async function markClaimSubmitted({ dropId, walletAddress, claimTicket, transactionHash } = {}) {
+  const wallet = normalizeWallet(walletAddress);
+  if (!claimTicket || !transactionHash) throw new Error('Claim ticket and transaction hash are required');
+  const key = `${dropId}:${wallet}`;
+  const record = memory.claims.get(key);
+  if (record && record.claimTicket === claimTicket) {
+    record.status = 'submitted';
+    record.transactionHash = transactionHash;
+    memory.claims.set(key, record);
+  }
+  const db = await getSupabase();
+  if (db) {
+    const { error } = await db
+      .from('voxel_claims')
+      .update({ status: 'submitted', transaction_hash: transactionHash })
+      .eq('drop_id', dropId)
+      .eq('wallet_address', wallet)
+      .eq('claim_ticket', claimTicket);
+    if (error) throw new Error(error.message);
+  }
+  return { status: 'submitted', dropId, walletAddress: wallet, claimTicket, transactionHash };
+}
+
+export async function markClaimConfirmed({ dropId, walletAddress, claimTicket, tokenId = null } = {}) {
+  const wallet = normalizeWallet(walletAddress);
+  if (!claimTicket) throw new Error('Claim ticket is required');
+  const key = `${dropId}:${wallet}`;
+  const record = memory.claims.get(key);
+  if (record && record.claimTicket === claimTicket) {
+    if (record.status === 'confirmed') return { status: 'confirmed', alreadyFinalized: true };
+    record.status = 'confirmed';
+    record.tokenId = tokenId;
+    memory.claims.set(key, record);
+  }
+
+  const drop = await getDrop(dropId);
+  if (!drop) throw new Error('Drop not found');
+  if (drop.claimedCount >= drop.quantity) throw new Error('Drop exhausted');
+
+  const db = await getSupabase();
+  if (db) {
+    const { data: claim, error: claimError } = await db
+      .from('voxel_claims')
+      .select('status')
+      .eq('drop_id', dropId)
+      .eq('wallet_address', wallet)
+      .eq('claim_ticket', claimTicket)
+      .maybeSingle();
+    if (claimError) throw new Error(claimError.message);
+    if (!claim) throw new Error('Claim reservation not found');
+    if (claim.status === 'confirmed') return { status: 'confirmed', alreadyFinalized: true };
+    const { error } = await db
+      .from('voxel_claims')
+      .update({ status: 'confirmed', token_id: tokenId == null ? null : String(tokenId) })
+      .eq('drop_id', dropId)
+      .eq('wallet_address', wallet)
+      .eq('claim_ticket', claimTicket);
+    if (error) throw new Error(error.message);
+  }
+
+  drop.claimedCount = (drop.claimedCount || 0) + 1;
+  if (drop.claimedCount >= drop.quantity) drop.status = 'exhausted';
+  memory.drops.set(dropId, drop);
+  if (db) {
+    const { error } = await db.from('voxel_drops').update({ claimed_count: drop.claimedCount, status: drop.status }).eq('id', dropId);
+    if (error) throw new Error(error.message);
+  }
+  return { status: 'confirmed', dropId, walletAddress: wallet, claimTicket, tokenId };
+}
+
+export async function releaseClaimReservation({ dropId, walletAddress, claimTicket } = {}) {
+  const wallet = normalizeWallet(walletAddress);
+  const key = `${dropId}:${wallet}`;
+  memory.claims.delete(key);
+  const db = await getSupabase();
+  if (db) {
+    const { error } = await db
+      .from('voxel_claims')
+      .delete()
+      .eq('drop_id', dropId)
+      .eq('wallet_address', wallet)
+      .eq('claim_ticket', claimTicket)
+      .in('status', ['reserved', 'authorized']);
+    if (error) throw new Error(error.message);
+  }
+  return { released: true, dropId, walletAddress: wallet };
 }
 
 export async function saveTradeOffer(offer) {

--- a/lib/claimReservation.js
+++ b/lib/claimReservation.js
@@ -1,0 +1,25 @@
+/**
+ * Durable claim reservation primitives.
+ *
+ * Production rule: durable storage is required. In-memory state is intentionally
+ * not used for reservation authority because multiple instances must agree.
+ */
+
+const DEFAULT_TTL_SECONDS = 120;
+const ACTIVE_STATUSES = ['reserved', 'authorized', 'submitted'];
+
+export function reservationExpiresAt(now = Date.now(), ttlSeconds = DEFAULT_TTL_SECONDS) {
+  const ttl = Number(ttlSeconds);
+  if (!Number.isFinite(ttl) || ttl <= 0 || ttl > 15 * 60) throw new Error('Invalid reservation TTL');
+  return new Date(now + ttl * 1000).toISOString();
+}
+
+export function isReservationActive(status, expiresAt, now = Date.now()) {
+  return ACTIVE_STATUSES.includes(status) && Boolean(expiresAt) && new Date(expiresAt).getTime() > now;
+}
+
+export function assertProductionStorage(db) {
+  if (!db) throw new Error('Durable claim storage is required');
+}
+
+export { ACTIVE_STATUSES, DEFAULT_TTL_SECONDS };

--- a/lib/proximityProof.js
+++ b/lib/proximityProof.js
@@ -1,0 +1,52 @@
+import { verifyTypedData, isAddress } from 'ethers';
+
+export const PROXIMITY_DOMAIN = Object.freeze({
+  name: 'VoxelVault-Proximity-V1',
+  version: '1',
+  chainId: 11155111,
+});
+
+export const PROXIMITY_TYPES = Object.freeze({
+  Proximity: [
+    { name: 'dropId', type: 'string' },
+    { name: 'wallet', type: 'address' },
+    { name: 'expiresAt', type: 'uint256' },
+    { name: 'spatialCell', type: 'bytes32' },
+    { name: 'scoreBps', type: 'uint16' },
+  ],
+});
+
+export function verifyProximityProof(proof, expectedWallet, expectedDropId, now = Math.floor(Date.now() / 1000)) {
+  if (!proof || typeof proof !== 'object') return { valid: false, reason: 'missing_proximity_proof' };
+  if (!isAddress(expectedWallet)) return { valid: false, reason: 'invalid_wallet' };
+  if (proof.dropId !== expectedDropId) return { valid: false, reason: 'drop_mismatch' };
+  if (String(proof.wallet).toLowerCase() !== expectedWallet.toLowerCase()) return { valid: false, reason: 'wallet_mismatch' };
+  if (!proof.signature || !proof.spatialCell) return { valid: false, reason: 'incomplete_proximity_proof' };
+  if (Number(proof.expiresAt) <= now) return { valid: false, reason: 'proximity_proof_expired' };
+
+  const domain = {
+    ...PROXIMITY_DOMAIN,
+    verifyingContract: process.env.NEXT_PUBLIC_BOUNTY_ESCROW_ADDRESS || '0x0000000000000000000000000000000000000001',
+  };
+  const value = {
+    dropId: proof.dropId,
+    wallet: proof.wallet,
+    expiresAt: BigInt(proof.expiresAt),
+    spatialCell: proof.spatialCell,
+    scoreBps: Number(proof.scoreBps || 0),
+  };
+
+  try {
+    const signer = verifyTypedData(domain, PROXIMITY_TYPES, value, proof.signature);
+    const expectedSigner = process.env.PROXIMITY_ORACLE_SIGNER;
+    if (!expectedSigner || !isAddress(expectedSigner)) {
+      return { valid: false, reason: 'proximity_oracle_not_configured' };
+    }
+    if (signer.toLowerCase() !== expectedSigner.toLowerCase()) {
+      return { valid: false, reason: 'untrusted_proximity_oracle' };
+    }
+    return { valid: true, signer, spatialCell: proof.spatialCell, scoreBps: Number(proof.scoreBps || 0), expiresAt: Number(proof.expiresAt) };
+  } catch {
+    return { valid: false, reason: 'invalid_proximity_signature' };
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:rewards": "node scripts/test-rewards-engine.mjs",
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run build",
+    "test:collection": "node scripts/test-collection-experience.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-collection-experience.mjs
+++ b/scripts/test-collection-experience.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { canCollectWithoutCamera, getCollectionPresentation } from '../config/collectionExperience.js';
+
+assert.equal(canCollectWithoutCamera(), true, 'camera must never be required for ordinary collection');
+
+const distant = getCollectionPresentation({ distanceMeters: 80, rarity: 'rare', sponsored: true });
+assert.equal(distant.primaryAction, 'APPROACH');
+assert.equal(distant.cameraRequired, false);
+assert.equal(distant.showArPeek, true);
+
+const nearby = getCollectionPresentation({ distanceMeters: 8, rarity: 'epic', sponsored: false });
+assert.equal(nearby.primaryAction, 'COLLECT');
+assert.equal(nearby.cameraRequired, false);
+
+console.log('collection experience: PASS');


### PR DESCRIPTION
## What this build does

This slice freezes the canonical Voxel Vault vNext direction and hardens the collection boundary before adding financial settlement infrastructure.

### Player experience
- Walk / discover / collect / earn is the primary loop.
- Camera is explicitly optional and never required for ordinary collection.
- AR is treated as an optional Peek enhancement.

### Security / trust boundary
- Client distance is UX-only.
- Authoritative zone claims require a short-lived signed proximity proof.
- Precise GPS is no longer persisted by claimAuthority drop upserts.
- Claim authorization is a reservation, not a consumed supply count.
- Added explicit submitted/confirmed claim state helpers for later chain settlement wiring.

### Planning
- Added canonical vNext architecture document covering player UX, natural/sponsored economies, AI, quantum-ready adapters, privacy, trust boundaries, state machine, and release gates.
- Added a camera-free collection experience configuration and acceptance test.

## Intentionally not included yet
The sponsored financial escrow contract and gasless AA settlement are deliberately not being called production-ready in this slice. Those require a separate audited implementation with contract invariants and deployment verification.

## Next slice
1. Wire authoritative proximity proof issuance.
2. Connect claim reservation to real chain confirmation.
3. Implement and test sponsored escrow settlement.
4. Integrate real ERC-4337/paymaster provider.
5. Run full release/build/deployment gates.
