### PR TITLE
Reconcile full Voxel Vault experience and harden claim confirmation

### DIFF
--- a/app/api/drops/confirm/route.js
+++ b/app/api/drops/confirm/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { markClaimConfirmed } from '../../../../lib/claimAuthority.js';
+import { verifyClaimTransaction } from '../../../../lib/claimChainVerifier.js';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const verification = await verifyClaimTransaction({
+      transactionHash: body.transactionHash,
+      walletAddress: body.walletAddress,
+      claimTicket: body.claimTicket,
+    });
+
+    const result = await markClaimConfirmed({
+      dropId: body.dropId,
+      walletAddress: body.walletAddress,
+      claimTicket: body.claimTicket,
+      tokenId: verification.tokenId,
+    });
+
+    return NextResponse.json({
+      ...result,
+      verification,
+      ownershipGranted: true,
+      status: 'confirmed',
+    });
+  } catch (error) {
+    return NextResponse.json({ error: error?.message || 'Authoritative claim confirmation failed', ownershipGranted: false }, { status: 400 });
+  }
+}

--- a/app/api/drops/submit/route.js
+++ b/app/api/drops/submit/route.js
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { markClaimSubmitted } from '../../../../lib/claimAuthority.js';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const result = await markClaimSubmitted({
+      dropId: body.dropId,
+      walletAddress: body.walletAddress,
+      claimTicket: body.claimTicket,
+      transactionHash: body.transactionHash,
+    });
+    return NextResponse.json({ ...result, ownershipGranted: false, status: 'submitted' });
+  } catch (error) {
+    return NextResponse.json({ error: error?.message || 'Claim submission failed', ownershipGranted: false }, { status: 400 });
+  }
+}

--- a/app/components/ObjectsWorthFindingExperience.js
+++ b/app/components/ObjectsWorthFindingExperience.js
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+function distanceMeters(a, b) {
+  if (!a || !b) return null;
+  const R = 6371000;
+  const rad = (v) => (v * Math.PI) / 180;
+  const dLat = rad(b.lat - a.lat);
+  const dLng = rad(b.lng - a.lng);
+  const x = Math.sin(dLat / 2) ** 2 + Math.cos(rad(a.lat)) * Math.cos(rad(b.lat)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(x));
+}
+
+export default function ObjectsWorthFindingExperience() {
+  const [objects, setObjects] = useState([]);
+  const [position, setPosition] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/hunts')
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || 'Unable to load nearby objects');
+        if (!cancelled) setObjects(data.hunts || []);
+      })
+      .catch((error) => !cancelled && setStatus(error.message || 'Unable to load nearby objects'))
+      .finally(() => !cancelled && setLoading(false));
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => !cancelled && setPosition({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        () => !cancelled && setStatus('Location is optional. You can still explore the object catalog.'),
+        { enableHighAccuracy: true, timeout: 12000, maximumAge: 30000 },
+      );
+    }
+    return () => { cancelled = true; };
+  }, []);
+
+  const ranked = useMemo(() => objects
+    .map((object) => {
+      const coords = Number.isFinite(object.lat) && Number.isFinite(object.lng)
+        ? { lat: object.lat, lng: object.lng }
+        : null;
+      return { ...object, distance: distanceMeters(position, coords) };
+    })
+    .sort((a, b) => {
+      if (a.distance == null && b.distance == null) return 0;
+      if (a.distance == null) return 1;
+      if (b.distance == null) return -1;
+      return a.distance - b.distance;
+    }), [objects, position]);
+
+  return (
+    <main className="objectsRoot">
+      <nav className="objectsNav">
+        <Link className="brand" href="/">V<span>V</span>OXELVAULT</Link>
+        <div className="links">
+          <Link href="/discover">Discover</Link>
+          <Link href="/objects-worth-finding" className="active">Objects Worth Finding</Link>
+          <Link href="/marketplace">Marketplace</Link>
+          <Link href="/trade">Trade</Link>
+        </div>
+        <Link className="pill" href="/play">Play</Link>
+      </nav>
+
+      <header className="hero">
+        <div className="eyebrow"><i /> WALK · DISCOVER · COLLECT · EARN</div>
+        <h1>Objects worth <em>finding.</em></h1>
+        <p>Real-world discovery for digital objects with real ownership. Walk toward a signal, get close, collect explicitly, and let the Vault handle the blockchain underneath.</p>
+        <div className="actions">
+          <Link className="primary" href="/hunt">Open collection experience</Link>
+          <Link className="secondary" href="/discover">Explore the Atlas</Link>
+        </div>
+      </header>
+
+      <section className="signalBar">
+        <div><span className="dot" /> {position ? 'LOCATION READY' : 'LOCATION OPTIONAL'}</div>
+        <strong>{loading ? 'Scanning the object catalog…' : `${ranked.length} objects available`}</strong>
+      </section>
+
+      <section className="grid">
+        {!loading && ranked.length === 0 && <div className="empty">No objects are currently published. Check back when the next drop appears.</div>}
+        {ranked.map((object, index) => (
+          <article className={`card ${index === 0 && object.distance != null ? 'near' : ''}`} key={object.id || object.name}>
+            <div className="cardTop">
+              <span>{object.mode || 'NATURAL'}</span>
+              <span>{object.active ? 'LIVE' : 'STANDBY'}</span>
+            </div>
+            <div className="glyph">✦</div>
+            <h2>{object.name || 'Unnamed Object'}</h2>
+            <p>{object.description || 'A collectible signal waiting to be discovered.'}</p>
+            <div className="meta">
+              <span>{object.difficulty || 'STANDARD'}</span>
+              <span>{object.stopCount || object.stops?.length || 1} collection point{(object.stopCount || object.stops?.length || 1) === 1 ? '' : 's'}</span>
+              <span>{object.distance != null ? `${Math.round(object.distance)} m away` : 'Distance hidden until you approach'}</span>
+            </div>
+            <Link className="cardAction" href="/hunt">View object →</Link>
+          </article>
+        ))}
+      </section>
+
+      <section className="promise">
+        <div>
+          <div className="eyebrow">THE COLLECTION RULE</div>
+          <h2>Close enough to discover.<br /><em>Never close enough to fake ownership.</em></h2>
+        </div>
+        <div className="steps">
+          <span><b>01</b> SIGNED PROXIMITY</span>
+          <span><b>02</b> DURABLE RESERVATION</span>
+          <span><b>03</b> SUBMITTED TRANSACTION</span>
+          <span><b>04</b> VERIFIED CHAIN RECEIPT</span>
+          <span><b>05</b> ATOMIC CONFIRMATION</span>
+        </div>
+      </section>
+
+      {status && <div className="status">● {status}<button type="button" onClick={() => setStatus('')}>×</button></div>}
+
+      <style jsx>{`
+        .objectsRoot{min-height:100vh;background:#05060b;color:#f7f8ff;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.objectsRoot *{box-sizing:border-box}
+        .objectsNav{height:76px;display:flex;align-items:center;justify-content:space-between;padding:0 5vw;border-bottom:1px solid rgba(255,255,255,.08);background:rgba(5,6,11,.88);backdrop-filter:blur(18px);position:sticky;top:0;z-index:20}.brand{font-size:17px;font-weight:950;letter-spacing:.15em;color:#fff;text-decoration:none}.brand span{color:#9b7cff}.links{display:flex;gap:22px}.links a{font-size:12px;color:#9299ab;text-decoration:none}.links a:hover,.links a.active{color:#fff}.pill{border:1px solid rgba(255,255,255,.15);border-radius:999px;padding:10px 15px;color:#fff;text-decoration:none;font-size:12px;font-weight:850}
+        .hero{max-width:1120px;margin:auto;padding:82px 5vw 42px}.eyebrow{font-size:10px;letter-spacing:.18em;color:#8f96a9;font-weight:900}.eyebrow i{display:inline-block;width:7px;height:7px;border-radius:50%;background:#55e6ff;box-shadow:0 0 14px #55e6ff;margin-right:8px}.hero h1{font-size:clamp(52px,8vw,96px);line-height:.9;letter-spacing:-.055em;margin:15px 0 20px;font-weight:950}.hero h1 em,.promise h2 em{font-family:Georgia,serif;font-weight:400;color:#ad99ff}.hero p{max-width:700px;color:#a8aec0;line-height:1.7;font-size:16px}.actions{display:flex;gap:10px;margin-top:28px;flex-wrap:wrap}.primary,.secondary{padding:13px 18px;border-radius:999px;text-decoration:none;font-size:13px;font-weight:850}.primary{background:#fff;color:#05060b}.secondary{border:1px solid rgba(255,255,255,.16);color:#fff}
+        .signalBar{max-width:1120px;margin:auto;padding:15px 5vw;display:flex;justify-content:space-between;gap:15px;border-top:1px solid rgba(255,255,255,.08);border-bottom:1px solid rgba(255,255,255,.08);color:#8e95a8;font-size:10px;letter-spacing:.1em}.signalBar strong{color:#d7dbea;letter-spacing:0}.dot{display:inline-block;width:7px;height:7px;border-radius:50%;background:#55e6ff;box-shadow:0 0 10px #55e6ff;margin-right:7px}
+        .grid{max-width:1120px;margin:auto;padding:26px 5vw 78px;display:grid;grid-template-columns:repeat(3,1fr);gap:13px}.card{min-height:300px;padding:20px;border:1px solid rgba(255,255,255,.09);border-radius:22px;background:linear-gradient(145deg,rgba(255,255,255,.035),rgba(255,255,255,.012));position:relative;overflow:hidden}.card.near{border-color:rgba(85,230,255,.35);box-shadow:inset 0 0 45px rgba(85,230,255,.035)}.cardTop{display:flex;justify-content:space-between;font-size:9px;letter-spacing:.14em;color:#7f879b}.glyph{width:58px;height:58px;border-radius:18px;display:grid;place-items:center;margin:28px 0 16px;border:1px solid rgba(155,124,255,.3);background:radial-gradient(circle,rgba(155,124,255,.18),transparent 68%);color:#55e6ff;font-size:24px}.card h2{font-size:25px;margin:0 0 8px}.card p{font-size:12px;line-height:1.55;color:#9299ab;min-height:58px}.meta{display:flex;gap:7px;flex-wrap:wrap;margin:15px 0}.meta span{font-size:9px;color:#aeb4c5;border:1px solid rgba(255,255,255,.09);border-radius:999px;padding:5px 7px}.cardAction{display:inline-block;margin-top:5px;color:#fff;text-decoration:none;font-size:12px;font-weight:850}.empty{grid-column:1/-1;padding:60px 20px;text-align:center;border:1px dashed rgba(255,255,255,.12);border-radius:20px;color:#7f879b}
+        .promise{max-width:1120px;margin:0 auto 80px;padding:28px;border-radius:24px;border:1px solid rgba(85,230,255,.18);background:radial-gradient(circle at 85% 20%,rgba(85,230,255,.07),transparent 35%),rgba(7,10,17,.9);display:grid;grid-template-columns:1.1fr .9fr;gap:35px}.promise h2{font-size:31px;line-height:1.05;margin:10px 0}.steps{display:grid;gap:7px}.steps span{padding:10px 0;border-bottom:1px solid rgba(255,255,255,.07);font-size:10px;letter-spacing:.09em;color:#a9afc0}.steps b{color:#55e6ff;margin-right:10px}.status{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:50;max-width:94vw;background:#11141e;border:1px solid rgba(255,255,255,.14);border-radius:999px;padding:11px 14px;color:#cdd2df;font-size:12px}.status button{border:0;background:transparent;color:#8e94a7;margin-left:8px;cursor:pointer}
+        @media(max-width:900px){.grid{grid-template-columns:1fr 1fr}.promise{grid-template-columns:1fr}.links{display:none}}@media(max-width:600px){.grid{grid-template-columns:1fr}.hero{padding-top:60px}.signalBar{align-items:flex-start;flex-direction:column}.card{min-height:270px}}
+      `}</style>
+    </main>
+  );
+}

--- a/app/hunt/page.js
+++ b/app/hunt/page.js
@@ -1,8 +1,8 @@
 import ScavengerHuntExperience from '../components/ScavengerHuntExperience';
 
 export const metadata = {
-  title: 'Scavenger Hunts · Voxel Vault',
-  description: 'Multi-stop scavenger jobs for 3D NFTs — find, claim, complete, mint on Ethereum.',
+  title: 'Collection Experience · Voxel Vault',
+  description: 'Collect Voxel Vault objects through the authoritative proximity and ownership flow.',
 };
 
 export default function HuntPage() {

--- a/app/objects-worth-finding/page.js
+++ b/app/objects-worth-finding/page.js
@@ -1,0 +1,10 @@
+import ObjectsWorthFindingExperience from '../components/ObjectsWorthFindingExperience';
+
+export const metadata = {
+  title: 'Objects Worth Finding · Voxel Vault',
+  description: 'Discover real-world Voxel Vault objects and collect them with verified ownership.',
+};
+
+export default function ObjectsWorthFindingPage() {
+  return <ObjectsWorthFindingExperience />;
+}

--- a/app/play/page.js
+++ b/app/play/page.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 const lanes = [
   { href: '/discover', label: 'DISCOVER', title: 'Find the signal', body: 'Explore the Atlas, nearby drops, and the world layer without requiring a camera.', icon: '⌖' },
-  { href: '/hunt', label: 'COLLECT', title: 'Walk the hunt', body: 'Move through stops, reserve a drop, then finish collection only after authoritative confirmation.', icon: '✦' },
+  { href: '/objects-worth-finding', label: 'COLLECT', title: 'Objects worth finding', body: 'Walk toward real-world signals, reserve a collectible, and finish ownership only after authoritative confirmation.', icon: '✦' },
   { href: '/marketplace', label: 'EARN', title: 'Trade the Vault', body: 'Move from owned collectibles into listings, offers, auctions, and verified ownership.', icon: '◇' },
   { href: '/trade', label: 'CONNECT', title: 'Tap to trade', body: 'Keep peer exchange separate from claim authority and on-chain ownership.', icon: '⇄' },
 ];
@@ -14,15 +14,15 @@ export default function PlayPage() {
     <main className="playRoot">
       <nav className="playNav">
         <Link className="brand" href="/">V<span>V</span>OXELVAULT</Link>
-        <div className="links"><Link href="/discover">Discover</Link><Link href="/hunt">Hunt</Link><Link href="/marketplace">Marketplace</Link><Link href="/trade">Trade</Link></div>
-        <Link className="wallet" href="/hunt">Start hunting →</Link>
+        <div className="links"><Link href="/discover">Discover</Link><Link href="/objects-worth-finding">Objects Worth Finding</Link><Link href="/marketplace">Marketplace</Link><Link href="/trade">Trade</Link></div>
+        <Link className="wallet" href="/objects-worth-finding">Start exploring →</Link>
       </nav>
 
       <section className="hero">
         <div className="eyebrow"><i /> WALK · DISCOVER · COLLECT · EARN</div>
         <h1>The Vault is <em>alive.</em></h1>
         <p>One clean game layer over the existing Voxel Vault: 3D objects, real-world discovery, durable reservations, verified chain ownership, and a marketplace underneath it all.</p>
-        <div className="heroActions"><Link className="primary" href="/hunt">Enter a hunt</Link><Link className="secondary" href="/discover">Open the Atlas</Link></div>
+        <div className="heroActions"><Link className="primary" href="/objects-worth-finding">Find an object</Link><Link className="secondary" href="/discover">Open the Atlas</Link></div>
       </section>
 
       <section className="lanes">
@@ -30,7 +30,7 @@ export default function PlayPage() {
       </section>
 
       <section className="pipeline">
-        <div><div className="eyebrow">AUTHORITATIVE COLLECTION</div><h2>Signal → reservation → ownership.</h2><p>The browser can show distance as UX, but it cannot grant ownership. Production collection now expects a signed proximity proof, a durable reservation, a submitted transaction, a server-verified receipt, and atomic confirmation.</p></div>
+        <div><div className="eyebrow">AUTHORITATIVE COLLECTION</div><h2>Signal → reservation → ownership.</h2><p>The browser can show distance as UX, but it cannot grant ownership. Production collection expects a signed proximity proof, a durable reservation, a submitted transaction, a server-verified receipt, and atomic confirmation.</p></div>
         <div className="steps"><span><b>01</b>SIGNED PROXIMITY</span><span><b>02</b>DURABLE RESERVATION</span><span><b>03</b>SUBMITTED TX</span><span><b>04</b>VERIFIED RECEIPT</span><span><b>05</b>ATOMIC CONFIRM</span></div>
       </section>
 
@@ -41,7 +41,7 @@ export default function PlayPage() {
 
       <footer><span>VOXEL VAULT · 3D COLLECTIBLES · REAL OWNERSHIP</span><Link href="/">Return to the Vault →</Link></footer>
 
-      <style jsx>{`
+      <style jsx>{` 
         .playRoot{min-height:100vh;background:#05060b;color:#f7f8ff;font-family:Inter,ui-sans-serif,system-ui,sans-serif;overflow:hidden}.playRoot *{box-sizing:border-box}
         .playNav{height:76px;display:flex;align-items:center;justify-content:space-between;padding:0 5vw;border-bottom:1px solid rgba(255,255,255,.08);background:rgba(5,6,11,.86);backdrop-filter:blur(18px);position:sticky;top:0;z-index:10}.brand{font-size:17px;font-weight:950;letter-spacing:.15em;color:#fff;text-decoration:none}.brand span{color:#9b7cff}.links{display:flex;gap:24px}.links a{color:#9299ab;text-decoration:none;font-size:13px}.links a:hover{color:#fff}.wallet{border:1px solid rgba(255,255,255,.16);padding:10px 15px;border-radius:999px;color:#fff;text-decoration:none;font-size:12px;font-weight:850}
         .hero{max-width:1100px;margin:0 auto;padding:92px 5vw 58px}.eyebrow{font-size:10px;letter-spacing:.18em;color:#8f96a9;font-weight:900}.eyebrow i{display:inline-block;width:7px;height:7px;border-radius:50%;background:#55e6ff;box-shadow:0 0 14px #55e6ff;margin-right:8px}.hero h1{font-size:clamp(54px,9vw,110px);line-height:.88;margin:14px 0 20px;font-weight:950;letter-spacing:-.05em}.hero h1 em,.world h2 em{font-family:Georgia,serif;font-weight:400;color:#ad99ff}.hero p{max-width:700px;color:#a8aec0;line-height:1.7;font-size:16px}.heroActions{display:flex;gap:10px;margin-top:28px}.primary,.secondary{padding:13px 18px;border-radius:999px;text-decoration:none;font-weight:850;font-size:13px}.primary{background:#fff;color:#05060b}.secondary{border:1px solid rgba(255,255,255,.16);color:#fff}

--- a/app/play/page.js
+++ b/app/play/page.js
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+
+const lanes = [
+  { href: '/discover', label: 'DISCOVER', title: 'Find the signal', body: 'Explore the Atlas, nearby drops, and the world layer without requiring a camera.', icon: '⌖' },
+  { href: '/hunt', label: 'COLLECT', title: 'Walk the hunt', body: 'Move through stops, reserve a drop, then finish collection only after authoritative confirmation.', icon: '✦' },
+  { href: '/marketplace', label: 'EARN', title: 'Trade the Vault', body: 'Move from owned collectibles into listings, offers, auctions, and verified ownership.', icon: '◇' },
+  { href: '/trade', label: 'CONNECT', title: 'Tap to trade', body: 'Keep peer exchange separate from claim authority and on-chain ownership.', icon: '⇄' },
+];
+
+export default function PlayPage() {
+  return (
+    <main className="playRoot">
+      <nav className="playNav">
+        <Link className="brand" href="/">V<span>V</span>OXELVAULT</Link>
+        <div className="links"><Link href="/discover">Discover</Link><Link href="/hunt">Hunt</Link><Link href="/marketplace">Marketplace</Link><Link href="/trade">Trade</Link></div>
+        <Link className="wallet" href="/hunt">Start hunting →</Link>
+      </nav>
+
+      <section className="hero">
+        <div className="eyebrow"><i /> WALK · DISCOVER · COLLECT · EARN</div>
+        <h1>The Vault is <em>alive.</em></h1>
+        <p>One clean game layer over the existing Voxel Vault: 3D objects, real-world discovery, durable reservations, verified chain ownership, and a marketplace underneath it all.</p>
+        <div className="heroActions"><Link className="primary" href="/hunt">Enter a hunt</Link><Link className="secondary" href="/discover">Open the Atlas</Link></div>
+      </section>
+
+      <section className="lanes">
+        {lanes.map((lane) => <Link className="lane" href={lane.href} key={lane.href}><span className="icon">{lane.icon}</span><div><div className="eyebrow">{lane.label}</div><h2>{lane.title}</h2><p>{lane.body}</p></div><span className="arrow">↗</span></Link>)}
+      </section>
+
+      <section className="pipeline">
+        <div><div className="eyebrow">AUTHORITATIVE COLLECTION</div><h2>Signal → reservation → ownership.</h2><p>The browser can show distance as UX, but it cannot grant ownership. Production collection now expects a signed proximity proof, a durable reservation, a submitted transaction, a server-verified receipt, and atomic confirmation.</p></div>
+        <div className="steps"><span><b>01</b>SIGNED PROXIMITY</span><span><b>02</b>DURABLE RESERVATION</span><span><b>03</b>SUBMITTED TX</span><span><b>04</b>VERIFIED RECEIPT</span><span><b>05</b>ATOMIC CONFIRM</span></div>
+      </section>
+
+      <section className="world">
+        <div><div className="eyebrow">THE WORLD LAYER</div><h2>Camera optional.<br /><em>Wonder mandatory.</em></h2><p>AR can be a Peek. The core game is simply walking toward signals, discovering objects, and collecting them without turning the sidewalk into a camera audition.</p></div>
+        <div className="orb"><span>VAULT<br />SIGNAL</span></div>
+      </section>
+
+      <footer><span>VOXEL VAULT · 3D COLLECTIBLES · REAL OWNERSHIP</span><Link href="/">Return to the Vault →</Link></footer>
+
+      <style jsx>{`
+        .playRoot{min-height:100vh;background:#05060b;color:#f7f8ff;font-family:Inter,ui-sans-serif,system-ui,sans-serif;overflow:hidden}.playRoot *{box-sizing:border-box}
+        .playNav{height:76px;display:flex;align-items:center;justify-content:space-between;padding:0 5vw;border-bottom:1px solid rgba(255,255,255,.08);background:rgba(5,6,11,.86);backdrop-filter:blur(18px);position:sticky;top:0;z-index:10}.brand{font-size:17px;font-weight:950;letter-spacing:.15em;color:#fff;text-decoration:none}.brand span{color:#9b7cff}.links{display:flex;gap:24px}.links a{color:#9299ab;text-decoration:none;font-size:13px}.links a:hover{color:#fff}.wallet{border:1px solid rgba(255,255,255,.16);padding:10px 15px;border-radius:999px;color:#fff;text-decoration:none;font-size:12px;font-weight:850}
+        .hero{max-width:1100px;margin:0 auto;padding:92px 5vw 58px}.eyebrow{font-size:10px;letter-spacing:.18em;color:#8f96a9;font-weight:900}.eyebrow i{display:inline-block;width:7px;height:7px;border-radius:50%;background:#55e6ff;box-shadow:0 0 14px #55e6ff;margin-right:8px}.hero h1{font-size:clamp(54px,9vw,110px);line-height:.88;margin:14px 0 20px;font-weight:950;letter-spacing:-.05em}.hero h1 em,.world h2 em{font-family:Georgia,serif;font-weight:400;color:#ad99ff}.hero p{max-width:700px;color:#a8aec0;line-height:1.7;font-size:16px}.heroActions{display:flex;gap:10px;margin-top:28px}.primary,.secondary{padding:13px 18px;border-radius:999px;text-decoration:none;font-weight:850;font-size:13px}.primary{background:#fff;color:#05060b}.secondary{border:1px solid rgba(255,255,255,.16);color:#fff}
+        .lanes{max-width:1100px;margin:0 auto;padding:0 5vw 80px;display:grid;grid-template-columns:1fr 1fr;gap:12px}.lane{min-height:190px;padding:24px;border:1px solid rgba(255,255,255,.09);border-radius:22px;background:linear-gradient(145deg,rgba(255,255,255,.035),rgba(255,255,255,.012));text-decoration:none;color:#fff;display:flex;gap:18px;position:relative;transition:.2s transform,.2s border-color}.lane:hover{transform:translateY(-3px);border-color:rgba(155,124,255,.45)}.icon{font-size:27px;color:#55e6ff}.lane h2{margin:7px 0 8px;font-size:25px}.lane p{color:#8f96a9;line-height:1.55;max-width:400px;font-size:13px}.arrow{position:absolute;right:20px;top:20px;color:#7d8496}
+        .pipeline{max-width:1100px;margin:0 auto 80px;padding:28px;border-radius:24px;border:1px solid rgba(85,230,255,.18);background:radial-gradient(circle at 85% 20%,rgba(85,230,255,.08),transparent 35%),rgba(7,10,17,.9);display:grid;grid-template-columns:1.1fr .9fr;gap:35px}.pipeline h2{font-size:32px;margin:10px 0}.pipeline p{color:#9299ab;line-height:1.65;font-size:13px}.steps{display:grid;gap:8px;align-content:center}.steps span{display:flex;align-items:center;gap:12px;border-bottom:1px solid rgba(255,255,255,.07);padding:10px 0;font-size:10px;letter-spacing:.1em;color:#a9afc0}.steps b{color:#55e6ff;font-size:10px}
+        .world{max-width:1100px;margin:0 auto 70px;padding:20px 5vw 60px;display:grid;grid-template-columns:1fr 280px;align-items:center;gap:30px}.world h2{font-size:42px;line-height:1;margin:10px 0}.world p{max-width:600px;color:#9299ab;line-height:1.65}.orb{width:240px;height:240px;border-radius:50%;margin:auto;display:grid;place-items:center;text-align:center;border:1px solid rgba(155,124,255,.45);background:radial-gradient(circle at 35% 30%,rgba(85,230,255,.22),rgba(155,124,255,.08) 35%,transparent 65%),#090b14;box-shadow:0 0 80px rgba(155,124,255,.12),inset 0 0 50px rgba(85,230,255,.08);font-size:11px;letter-spacing:.18em;font-weight:900;color:#d9d2ff}
+        footer{border-top:1px solid rgba(255,255,255,.08);padding:25px 5vw;display:flex;justify-content:space-between;color:#656c7d;font-size:9px;letter-spacing:.12em}footer a{color:#aeb4c5;text-decoration:none}
+        @media(max-width:760px){.links{display:none}.hero{padding-top:64px}.lanes,.pipeline,.world{grid-template-columns:1fr}.lane{min-height:160px}.orb{width:190px;height:190px}.heroActions{flex-wrap:wrap}footer{gap:15px;flex-direction:column}}
+      `}</style>
+    </main>
+  );
+}

--- a/lib/claimChainVerifier.js
+++ b/lib/claimChainVerifier.js
@@ -1,0 +1,98 @@
+/**
+ * Server-side verification of a claimed mint.
+ * Never trust a client-provided tokenId, receipt, or ownership assertion.
+ */
+import { Contract, JsonRpcProvider, isAddress } from 'ethers';
+
+const NFT_ABI = [
+  'function ownerOf(uint256 tokenId) view returns (address)',
+  'function tokenURI(uint256 tokenId) view returns (string)',
+  'event VoxelMinted(uint256 indexed tokenId, address indexed creator, string tokenURI, uint96 royaltyBps)',
+  'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)',
+];
+
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+function rpcUrl() {
+  const url = process.env.EVM_RPC_URL || process.env.NEXT_PUBLIC_EVM_RPC_URL;
+  if (!url) throw new Error('Authoritative EVM RPC is not configured');
+  return url;
+}
+
+function nftAddress() {
+  const address = process.env.VOXEL_NFT_ADDRESS || process.env.NEXT_PUBLIC_VOXEL_NFT_ADDRESS;
+  if (!address || !isAddress(address)) throw new Error('Authoritative NFT contract is not configured');
+  return address;
+}
+
+function expectedChainId() {
+  return BigInt(process.env.EVM_CHAIN_ID || process.env.NEXT_PUBLIC_EVM_CHAIN_ID || '11155111');
+}
+
+export async function verifyClaimTransaction({ transactionHash, walletAddress, claimTicket }) {
+  if (!/^0x[a-fA-F0-9]{64}$/.test(String(transactionHash || ''))) throw new Error('Invalid transaction hash');
+  if (!isAddress(walletAddress)) throw new Error('Invalid claimant wallet');
+  if (!claimTicket) throw new Error('Claim ticket is required');
+
+  const provider = new JsonRpcProvider(rpcUrl());
+  const network = await provider.getNetwork();
+  if (network.chainId !== expectedChainId()) throw new Error('Authoritative RPC is on the wrong chain');
+
+  const tx = await provider.getTransaction(transactionHash);
+  if (!tx) throw new Error('Transaction not found');
+  if (!tx.to || tx.to.toLowerCase() !== nftAddress().toLowerCase()) throw new Error('Transaction target is not the Voxel Vault NFT contract');
+  if (!tx.from || tx.from.toLowerCase() !== walletAddress.toLowerCase()) throw new Error('Transaction sender does not match claimant');
+
+  const receipt = await provider.getTransactionReceipt(transactionHash);
+  if (!receipt) throw new Error('Transaction receipt is not available yet');
+  if (receipt.status !== 1) throw new Error('Mint transaction reverted');
+
+  const nft = new Contract(nftAddress(), NFT_ABI, provider);
+  const parsedTx = nft.interface.parseTransaction({ data: tx.data, value: tx.value });
+  if (!parsedTx || parsedTx.name !== 'mint') throw new Error('Transaction is not the expected NFT mint call');
+
+  const uri = String(parsedTx.args?.[0] || '');
+  if (!uri.includes(claimTicket)) throw new Error('Claim ticket is not bound to the mint transaction');
+
+  let tokenId = null;
+  let transferFound = false;
+  let mintFound = false;
+  for (const log of receipt.logs || []) {
+    if (log.address.toLowerCase() !== nftAddress().toLowerCase()) continue;
+    if (log.topics?.[0]?.toLowerCase() === TRANSFER_TOPIC && log.topics.length >= 4) {
+      const from = `0x${log.topics[1].slice(-40)}`.toLowerCase();
+      const to = `0x${log.topics[2].slice(-40)}`.toLowerCase();
+      if (from === '0x0000000000000000000000000000000000000000' && to === walletAddress.toLowerCase()) {
+        tokenId = BigInt(log.topics[3]).toString();
+        transferFound = true;
+      }
+    }
+    try {
+      const parsed = nft.interface.parseLog(log);
+      if (parsed?.name === 'VoxelMinted') {
+        const eventTokenId = BigInt(parsed.args.tokenId).toString();
+        if (eventTokenId === tokenId && String(parsed.args.tokenURI) === uri && String(parsed.args.creator).toLowerCase() === walletAddress.toLowerCase()) mintFound = true;
+      }
+    } catch {
+      // Ignore unrelated logs emitted by the NFT contract.
+    }
+  }
+
+  if (!transferFound || !tokenId) throw new Error('No verified mint Transfer event for the claimant');
+  if (!mintFound) throw new Error('VoxelMinted event does not match the verified claimant mint');
+
+  const owner = await nft.ownerOf(tokenId);
+  if (owner.toLowerCase() !== walletAddress.toLowerCase()) throw new Error('On-chain owner does not match claimant');
+  const tokenURI = await nft.tokenURI(tokenId);
+  if (String(tokenURI) !== uri) throw new Error('On-chain token URI does not match the submitted mint');
+
+  return {
+    verified: true,
+    transactionHash,
+    tokenId,
+    owner,
+    contractAddress: nftAddress(),
+    chainId: network.chainId.toString(),
+    tokenURI,
+  };
+}

--- a/lib/claimMint.js
+++ b/lib/claimMint.js
@@ -2,15 +2,12 @@
  * Build metadata URI + mint claimed drop collectibles on Ethereum (Sepolia by default).
  */
 
-import { mintCollectible, hasNftContract, EVM_CHAIN_NAME } from './blockchain';
+import { mintCollectible, hasNftContract, EVM_CHAIN_NAME } from './blockchain.js';
 
 export function buildClaimMetadataUri({ collectible, claimTicket, dropId }) {
   const payload = {
     name: collectible?.name || 'Voxel Vault Collectible',
-    description:
-      collectible?.description ||
-      `${collectible?.name || 'Collectible'} claimed from Voxel Drop ${dropId || ''}. ` +
-        `Reality basis: ${collectible?.realityBasis?.inspiredBy || 'n/a'}.`,
+    description: collectible?.description || `${collectible?.name || 'Collectible'} claimed from Voxel Drop ${dropId || ''}. Reality basis: ${collectible?.realityBasis?.inspiredBy || 'n/a'}.`,
     image: collectible?.asset?.previewUri || collectible?.asset?.thumbnailUri || undefined,
     animation_url: collectible?.asset?.uri || undefined,
     external_url: 'https://voxel-vault.vercel.app',
@@ -23,38 +20,37 @@ export function buildClaimMetadataUri({ collectible, claimTicket, dropId }) {
       { trait_type: 'Chain', value: EVM_CHAIN_NAME },
     ].filter((a) => a.value),
   };
-
-  // data: URI keeps mint self-contained without requiring IPFS during claim.
-  // Production can replace with IPFS/Arweave upload later.
   const json = JSON.stringify(payload);
-  if (typeof window !== 'undefined' && typeof btoa === 'function') {
-    return `data:application/json;base64,${btoa(unescape(encodeURIComponent(json)))}`;
-  }
+  if (typeof window !== 'undefined' && typeof btoa === 'function') return `data:application/json;base64,${btoa(unescape(encodeURIComponent(json)))}`;
   return `data:application/json,${encodeURIComponent(json)}`;
 }
 
-/**
- * After server issues a claim ticket, mint the NFT to the claimer's wallet.
- * Gas is paid in ETH on the configured chain.
- */
+/** Mint from a server reservation, then require server-side receipt verification before final ownership state. */
 export async function mintClaimOnEthereum({ collectible, claimTicket, dropId, royaltyBps = 500 }) {
-  if (!hasNftContract()) {
-    throw new Error(
-      `NFT contract not configured. Set NEXT_PUBLIC_VOXEL_NFT_ADDRESS and connect to ${EVM_CHAIN_NAME}.`
-    );
-  }
+  if (!hasNftContract()) throw new Error(`NFT contract not configured. Set NEXT_PUBLIC_VOXEL_NFT_ADDRESS and connect to ${EVM_CHAIN_NAME}.`);
   if (!claimTicket) throw new Error('Server claim ticket is required before minting.');
+  if (!dropId) throw new Error('Drop ID is required before minting.');
 
   const uri = buildClaimMetadataUri({ collectible, claimTicket, dropId });
   const result = await mintCollectible({ uri, royaltyBps });
-  return {
-    ...result,
-    claimTicket,
-    dropId,
-    ownershipGranted: result.status === 'confirmed',
-    message:
-      result.status === 'confirmed'
-        ? `Minted on ${EVM_CHAIN_NAME}. Token ${result.tokenId || 'pending'} is owned by your wallet.`
-        : `Mint submitted on ${EVM_CHAIN_NAME}. Wait for confirmation.`,
-  };
+  const walletAddress = result.owner;
+  if (!walletAddress || !result.hash) throw new Error('Mint returned no authoritative wallet or transaction hash');
+
+  const submitResponse = await fetch('/api/drops/submit', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dropId, walletAddress, claimTicket, transactionHash: result.hash }),
+  });
+  const submitData = await submitResponse.json().catch(() => ({}));
+  if (!submitResponse.ok) return { ...result, claimTicket, dropId, ownershipGranted: false, confirmationStatus: 'submitted_unrecorded', message: 'The mint confirmed on-chain, but the durable claim record could not be updated. Ownership is not finalized in Voxel Vault.', serverError: submitData.error || 'Durable claim submission failed' };
+
+  const confirmResponse = await fetch('/api/drops/confirm', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dropId, walletAddress, claimTicket, transactionHash: result.hash }),
+  });
+  const confirmData = await confirmResponse.json().catch(() => ({}));
+  if (!confirmResponse.ok || confirmData.ownershipGranted !== true) return { ...result, claimTicket, dropId, ownershipGranted: false, confirmationStatus: 'submitted_verification_failed', message: confirmData.error || 'Chain receipt verification did not finalize the reservation.' };
+
+  return { ...result, ...confirmData.verification, claimTicket, dropId, ownershipGranted: true, confirmationStatus: 'confirmed', message: `Minted and verified on ${EVM_CHAIN_NAME}. Token ${confirmData.verification?.tokenId || result.tokenId || 'confirmed'} is owned by your wallet.` };
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
     "test:collection": "node scripts/test-collection-experience.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run build",
+    "test:claim-verifier": "node scripts/test-claim-chain-verifier.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:claim-verifier && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-claim-chain-verifier.mjs
+++ b/scripts/test-claim-chain-verifier.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { verifyClaimTransaction } from '../lib/claimChainVerifier.js';
+
+await assert.rejects(
+  verifyClaimTransaction({ transactionHash: 'not-a-hash', walletAddress: '0x0000000000000000000000000000000000000001', claimTicket: 'ticket' }),
+  /Invalid transaction hash/
+);
+
+await assert.rejects(
+  verifyClaimTransaction({ transactionHash: `0x${'1'.repeat(64)}`, walletAddress: 'not-an-address', claimTicket: 'ticket' }),
+  /Invalid claimant wallet/
+);
+
+await assert.rejects(
+  verifyClaimTransaction({ transactionHash: `0x${'1'.repeat(64)}`, walletAddress: '0x0000000000000000000000000000000000000001', claimTicket: '' }),
+  /Claim ticket is required/
+);
+
+console.log('Claim chain verifier input hardening tests passed.');


### PR DESCRIPTION
## Purpose
Preserve the existing Voxel Vault visual shell while integrating the hardened collection path and making the full product easier to enter.

## Included
- Adds a unified `/play` game hub without replacing the existing home/gallery shell.
- Adds server-side authoritative NFT receipt verification.
- Adds durable claim submission and confirmation API boundaries.
- Binds confirmation to claimant wallet, NFT contract, successful receipt, mint calldata, claim ticket, Transfer event, VoxelMinted event, ownerOf, and tokenURI.
- Prevents the client from treating a mint as finalized ownership before server verification.
- Adds adversarial verifier input tests to the release gate.
- Keeps camera optional and preserves existing Discover/Hunt/Marketplace/Trade routes.

## Hardening principle
Client distance remains UX-only. Production claim authority requires a signed proximity proof and durable storage. A missing server reservation or failed authoritative verification never becomes a local ownership success.

## Verification
Existing release gates remain intact, with the claim verifier added to `test:release`.
