### PR TITLE
polish: force premium button + link styles on VaultHomeV3

### DIFF
--- a/app/components/VaultHomeV3.js
+++ b/app/components/VaultHomeV3.js
@@ -3,10 +3,497 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useMemo, useState } from 'react';
 import { getCatalogWindow } from '../../lib/catalog';
-const Lazy3DPreview=dynamic(()=>import('./Lazy3DPreview'),{ssr:false});
-const VoxelViewer=dynamic(()=>import('./VoxelViewer'),{ssr:false});
-const ArtPreview=dynamic(()=>import('./ArtPreview'),{ssr:false});
-const items=getCatalogWindow(0,8);
-const cats=['Everything','Objects','Food','Art','Finds'];
-function Card({item}){return <Link className="card" href={`/marketplace?asset=${encodeURIComponent(item.id)}`}><div className="art"><Lazy3DPreview minHeight={230} rootMargin="700px">{item.renderMode==='voxel'&&item.shape?<VoxelViewer shape={item.shape} seed={item.seed} rarity={item.rarity} material={item.material} compact label={false}/>:<ArtPreview family={item.family||'sculpture'} seed={item.seed} rarity={item.rarity} material={item.material} compact label={false}/>}</Lazy3DPreview><span className="twin">3D · NFT</span></div><div className="cardbody"><div><small>{item.type||'OBJECT'}</small><h3>{item.name}</h3></div><strong>${item.priceUsd}</strong></div><div className="chips"><span>Physical</span><span>QR</span></div></Link>}
-export default function VaultHomeV3(){const [q,setQ]=useState('');const [cat,setCat]=useState('Everything');const filtered=useMemo(()=>items.filter(x=>{const t=`${x.name} ${x.type} ${x.creator} ${x.material} ${x.family}`.toLowerCase();return(!q||t.includes(q.toLowerCase()))&&(cat==='Everything'||String(x.type||'').toLowerCase().includes(cat.slice(0,-1).toLowerCase())||cat==='Objects');}),[q,cat]);return <main className="v3"><header><Link href="/" className="logo"><span>V</span><b>VOXEL</b><i>VAULT</i></Link><Link href="/profile" className="avatar">D</Link></header><section className="hero"><div className="eyebrow">THE OBJECT MARKET</div><h1>Find it.<br/><em>Keep it.</em></h1><p>Real things with a digital twin.</p><div className="heroBtns"><Link href="/discover">Explore</Link><Link href="/receipt" className="ghost">Scan receipt</Link></div></section><div className="search"><span>⌕</span><input value={q} onChange={e=>setQ(e.target.value)} placeholder="What are you looking for?"/><Link href="/discover">⌁</Link></div><div className="cats">{cats.map(c=><button key={c} className={cat===c?'on':''} onClick={()=>setCat(c)}>{c}</button>)}</div><section className="feature"><div className="featureCopy"><small>BUY + COLLECT</small><h2>One object.<br/><em>Two worlds.</em></h2><p>Checkout in USD. Your physical purchase gets a 3D twin, QR identity and ownership history.</p><Link href="/marketplace">Shop the vault →</Link></div><div className="featureArt">{items[0]&&<Lazy3DPreview minHeight={280} rootMargin="0px">{items[0].renderMode==='voxel'&&items[0].shape?<VoxelViewer shape={items[0].shape} seed={items[0].seed} rarity={items[0].rarity} material={items[0].material} compact label={false}/>:<ArtPreview family={items[0].family||'sculpture'} seed={items[0].seed} rarity={items[0].rarity} material={items[0].material} compact label={false}/>}</Lazy3DPreview>}</div></section><section className="section"><div className="head"><div><small>DISCOVER</small><h2>Worth finding</h2></div><Link href="/marketplace">See all</Link></div><div className="grid">{filtered.map(x=><Card key={x.id} item={x}/>)}</div></section><section className="tools"><Link href="/receipt"><b>▣</b><span><small>SCAN</small>Turn a purchase into a collectible</span><i>›</i></Link><Link href="/room"><b>◇</b><span><small>VAULT</small>See your objects in 3D</span><i>›</i></Link><Link href="/ai"><b>✦</b><span><small>AI</small>Find, organize and understand your collection</span><i>›</i></Link></section><nav><Link className="active" href="/discover"><span>⌂</span>Find</Link><Link href="/receipt"><span>▣</span>Scan</Link><Link href="/room"><span>◇</span>Vault</Link><Link href="/ai"><span>✦</span>AI</Link></nav><style jsx>{`.v3{min-height:100vh;background:#07080d;color:#f7f8fb;padding:0 16px 100px;font-family:Inter,system-ui,sans-serif}.v3 *{box-sizing:border-box}.v3 a{text-decoration:none;color:inherit}header{height:62px;display:flex;align-items:center;justify-content:space-between}.logo{display:flex;align-items:baseline;gap:4px;letter-spacing:.08em}.logo span{display:grid;place-items:center;width:30px;height:30px;border-radius:9px;background:linear-gradient(135deg,#bba7ff,#68e5ff);color:#090a10;font-weight:1000;margin-right:3px}.logo b{font-size:12px}.logo i{font-size:9px;color:#8b92a4;font-style:normal}.avatar{width:30px;height:30px;border:1px solid #272b38;border-radius:50%;display:grid;place-items:center;font-size:10px;color:#aeb5c4}.hero{padding:31px 3px 21px}.eyebrow,.feature small,.section small,.tools small{font-size:8px;letter-spacing:.17em;color:#9f8cff;font-weight:900}.hero h1{font-size:56px;line-height:.86;letter-spacing:-.065em;margin:9px 0}.hero h1 em,.feature h2 em{font-style:normal;color:#a995ff}.hero p{margin:0;color:#858da0;font-size:13px}.heroBtns{display:flex;gap:8px;margin-top:17px}.heroBtns a,.featureCopy>a{padding:11px 15px;border-radius:12px;background:#f6f7fa;color:#090a0e;font-size:10px;font-weight:900}.heroBtns .ghost{background:#12151d;border:1px solid #272c38;color:#dce0e9}.search{height:52px;border:1px solid #242833;background:#0d1017;border-radius:16px;display:flex;align-items:center;padding:0 14px;gap:9px}.search span{font-size:20px;color:#737b8d}.search input{flex:1;background:none;border:0;outline:0;color:#fff;font-size:14px}.search input::placeholder{color:#6f7788}.search a{color:#8e96a9;font-size:18px}.cats{display:flex;gap:7px;overflow:auto;padding:11px 0 3px;scrollbar-width:none}.cats::-webkit-scrollbar{display:none}.cats button{border:1px solid #242833;background:#0c0f15;color:#858da0;border-radius:999px;padding:8px 12px;white-space:nowrap;font-size:9px}.cats .on{background:#f6f7fa;color:#090a0e;border-color:#f6f7fa;font-weight:900}.feature{margin-top:22px;min-height:285px;border:1px solid #252936;border-radius:23px;overflow:hidden;display:grid;grid-template-columns:1fr 1fr;background:radial-gradient(circle at 70% 30%,rgba(144,112,255,.2),transparent 43%),#0b0e15}.featureCopy{padding:22px 8px 22px 20px;display:flex;flex-direction:column;justify-content:center}.feature h2{font-size:30px;line-height:.94;letter-spacing:-.05em;margin:8px 0}.feature p{font-size:10px;line-height:1.5;color:#7f889a;margin:0 0 15px;max-width:220px}.featureArt{min-height:285px;display:grid;place-items:center;overflow:hidden}.featureArt :global(canvas){display:block;width:100%!important;height:100%!important}.section{margin-top:29px}.head{display:flex;justify-content:space-between;align-items:end;margin-bottom:10px}.head h2{font-size:23px;letter-spacing:-.04em;margin:4px 0}.head a{font-size:9px;color:#9f8cff}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.card{background:#0c0f15;border:1px solid #202531;border-radius:18px;overflow:hidden}.art{height:230px;position:relative;background:radial-gradient(circle at 50% 45%,rgba(139,106,255,.18),transparent 52%),#090b11}.art :global(canvas){display:block;width:100%!important;height:100%!important}.twin{position:absolute;left:8px;bottom:8px;background:rgba(4,5,9,.75);border:1px solid #2b3040;border-radius:999px;padding:5px 7px;font-size:7px;letter-spacing:.1em}.cardbody{display:flex;justify-content:space-between;gap:8px;padding:11px 11px 5px}.cardbody small{font-size:7px;color:#6f7789;letter-spacing:.1em}.cardbody h3{font-size:13px;margin:4px 0 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:120px}.cardbody strong{font-size:11px;white-space:nowrap}.chips{display:flex;gap:5px;padding:0 11px 11px}.chips span{font-size:7px;color:#8b94a5;border:1px solid #222733;border-radius:999px;padding:4px 6px}.tools{margin-top:27px;border-top:1px solid #20242e}.tools a{display:flex;align-items:center;gap:11px;padding:14px 2px;border-bottom:1px solid #20242e}.tools b{width:32px;height:32px;border-radius:10px;background:#11151d;display:grid;place-items:center;color:#a994ff}.tools span{flex:1;font-size:10px;color:#d7dbe4}.tools small{display:block;margin-bottom:2px}.tools i{font-style:normal;color:#687183;font-size:20px}nav{position:fixed;z-index:10;left:12px;right:12px;bottom:12px;height:62px;border:1px solid #292e3b;background:rgba(12,14,20,.9);backdrop-filter:blur(20px);border-radius:20px;display:grid;grid-template-columns:repeat(4,1fr);box-shadow:0 20px 60px rgba(0,0,0,.45)}nav a{display:grid;place-items:center;align-content:center;gap:3px;color:#747d8f;font-size:8px}nav a span{font-size:17px}nav a.active{color:#f6f7fa}nav a.active span{color:#a895ff}@media(min-width:800px){.v3{max-width:1120px;margin:auto;padding-bottom:60px}.grid{grid-template-columns:repeat(4,1fr)}.hero h1{font-size:72px}nav{position:sticky;max-width:420px;margin:28px auto 0}}@media(max-width:380px){.hero h1{font-size:48px}.feature{grid-template-columns:1fr}.featureCopy{padding-bottom:0}.featureArt{min-height:210px}.feature{min-height:0}}`}</style></main>}
+const Lazy3DPreview = dynamic(() => import('./Lazy3DPreview'), { ssr: false });
+const VoxelViewer = dynamic(() => import('./VoxelViewer'), { ssr: false });
+const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
+const items = getCatalogWindow(0, 8);
+const cats = ['Everything', 'Objects', 'Food', 'Art', 'Finds'];
+
+function Card({ item }) {
+  return (
+    <Link className="card" href={`/marketplace?asset=${encodeURIComponent(item.id)}`}>
+      <div className="art">
+        <Lazy3DPreview minHeight={230} rootMargin="700px">
+          {item.renderMode === 'voxel' && item.shape ? (
+            <VoxelViewer shape={item.shape} seed={item.seed} rarity={item.rarity} material={item.material} compact label={false} />
+          ) : (
+            <ArtPreview family={item.family || 'sculpture'} seed={item.seed} rarity={item.rarity} material={item.material} compact label={false} />
+          )}
+        </Lazy3DPreview>
+        <span className="twin">3D · NFT</span>
+      </div>
+      <div className="cardbody">
+        <div>
+          <small>{item.type || 'OBJECT'}</small>
+          <h3>{item.name}</h3>
+        </div>
+        <strong>${item.priceUsd}</strong>
+      </div>
+      <div className="chips">
+        <span>Physical</span>
+        <span>QR</span>
+      </div>
+    </Link>
+  );
+}
+
+export default function VaultHomeV3() {
+  const [q, setQ] = useState('');
+  const [cat, setCat] = useState('Everything');
+  const filtered = useMemo(() => items.filter(x => {
+    const t = `${x.name} ${x.type} ${x.creator} ${x.material} ${x.family}`.toLowerCase();
+    return (!q || t.includes(q.toLowerCase())) && (cat === 'Everything' || String(x.type || '').toLowerCase().includes(cat.slice(0, -1).toLowerCase()) || cat === 'Objects');
+  }), [q, cat]);
+
+  return (
+    <main className="v3">
+      <header>
+        <Link href="/" className="logo">
+          <span>V</span>
+          <b>VOXEL</b>
+          <i>VAULT</i>
+        </Link>
+        <Link href="/profile" className="avatar">D</Link>
+      </header>
+
+      <section className="hero">
+        <div className="eyebrow">THE OBJECT MARKET</div>
+        <h1>Find it.<br /><em>Keep it.</em></h1>
+        <p>Real things with a digital twin.</p>
+        <div className="heroBtns">
+          <Link href="/discover" className="btn primary">Explore</Link>
+          <Link href="/receipt" className="btn ghost">Scan receipt</Link>
+        </div>
+      </section>
+
+      <div className="search">
+        <span>⌕</span>
+        <input value={q} onChange={e => setQ(e.target.value)} placeholder="What are you looking for?" aria-label="Search products" />
+        <Link href="/discover" className="searchGo">⌁</Link>
+      </div>
+
+      <div className="cats">
+        {cats.map(c => (
+          <button key={c} className={cat === c ? 'on' : ''} onClick={() => setCat(c)}>{c}</button>
+        ))}
+      </div>
+
+      <section className="feature">
+        <div className="featureCopy">
+          <small>BUY + COLLECT</small>
+          <h2>One object.<br /><em>Two worlds.</em></h2>
+          <p>Checkout in USD. Your physical purchase gets a 3D twin, QR identity and ownership history.</p>
+          <Link href="/marketplace" className="btn primary">Shop the vault →</Link>
+        </div>
+        <div className="featureArt">
+          {items[0] && (
+            <Lazy3DPreview minHeight={280} rootMargin="0px">
+              {items[0].renderMode === 'voxel' && items[0].shape ? (
+                <VoxelViewer shape={items[0].shape} seed={items[0].seed} rarity={items[0].rarity} material={items[0].material} compact label={false} />
+              ) : (
+                <ArtPreview family={items[0].family || 'sculpture'} seed={items[0].seed} rarity={items[0].rarity} material={items[0].material} compact label={false} />
+              )}
+            </Lazy3DPreview>
+          )}
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="head">
+          <div>
+            <small>DISCOVER</small>
+            <h2>Worth finding</h2>
+          </div>
+          <Link href="/marketplace" className="seeAll">See all</Link>
+        </div>
+        <div className="grid">
+          {filtered.map(x => <Card key={x.id} item={x} />)}
+        </div>
+      </section>
+
+      <section className="tools">
+        <Link href="/receipt">
+          <b>▣</b>
+          <span><small>SCAN</small>Turn a purchase into a collectible</span>
+          <i>›</i>
+        </Link>
+        <Link href="/room">
+          <b>◇</b>
+          <span><small>VAULT</small>See your objects in 3D</span>
+          <i>›</i>
+        </Link>
+        <Link href="/ai">
+          <b>✦</b>
+          <span><small>AI</small>Find, organize and understand your collection</span>
+          <i>›</i>
+        </Link>
+      </section>
+
+      <nav>
+        <Link className="active" href="/discover"><span>⌂</span>Find</Link>
+        <Link href="/receipt"><span>▣</span>Scan</Link>
+        <Link href="/room"><span>◇</span>Vault</Link>
+        <Link href="/ai"><span>✦</span>AI</Link>
+      </nav>
+
+      <style jsx>{`
+        .v3 {
+          min-height: 100vh;
+          background: #07080d;
+          color: #f7f8fb;
+          padding: 0 16px 100px;
+          font-family: Inter, system-ui, sans-serif;
+        }
+        .v3 * { box-sizing: border-box; }
+        .v3 a {
+          text-decoration: none !important;
+          color: inherit;
+        }
+        header {
+          height: 62px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+        }
+        .logo {
+          display: flex;
+          align-items: baseline;
+          gap: 4px;
+          letter-spacing: .08em;
+          text-decoration: none !important;
+          color: #f7f8fb !important;
+        }
+        .logo span {
+          display: grid;
+          place-items: center;
+          width: 30px;
+          height: 30px;
+          border-radius: 9px;
+          background: linear-gradient(135deg, #bba7ff, #68e5ff);
+          color: #090a10;
+          font-weight: 1000;
+          margin-right: 3px;
+        }
+        .logo b { font-size: 12px; color: #f7f8fb; }
+        .logo i { font-size: 9px; color: #8b92a4; font-style: normal; }
+        .avatar {
+          width: 30px;
+          height: 30px;
+          border: 1px solid #272b38;
+          border-radius: 50%;
+          display: grid;
+          place-items: center;
+          font-size: 10px;
+          color: #aeb5c4;
+          text-decoration: none !important;
+        }
+        .hero { padding: 31px 3px 21px; }
+        .eyebrow, .feature small, .section small, .tools small {
+          font-size: 8px;
+          letter-spacing: .17em;
+          color: #9f8cff;
+          font-weight: 900;
+        }
+        .hero h1 {
+          font-size: 56px;
+          line-height: .86;
+          letter-spacing: -.065em;
+          margin: 9px 0;
+        }
+        .hero h1 em, .feature h2 em {
+          font-style: normal;
+          color: #a995ff;
+        }
+        .hero p {
+          margin: 0;
+          color: #858da0;
+          font-size: 13px;
+        }
+        .heroBtns {
+          display: flex;
+          gap: 8px;
+          margin-top: 17px;
+        }
+        .btn {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 11px 15px;
+          border-radius: 12px;
+          font-size: 10px;
+          font-weight: 900;
+          text-decoration: none !important;
+          border: none;
+          cursor: pointer;
+        }
+        .btn.primary {
+          background: #f6f7fa !important;
+          color: #090a0e !important;
+        }
+        .btn.ghost {
+          background: #12151d !important;
+          border: 1px solid #272c38 !important;
+          color: #dce0e9 !important;
+        }
+        .search {
+          height: 52px;
+          border: 1px solid #242833;
+          background: #0d1017;
+          border-radius: 16px;
+          display: flex;
+          align-items: center;
+          padding: 0 14px;
+          gap: 9px;
+        }
+        .search span { font-size: 20px; color: #737b8d; }
+        .search input {
+          flex: 1;
+          background: none;
+          border: 0;
+          outline: 0;
+          color: #fff;
+          font-size: 14px;
+        }
+        .search input::placeholder { color: #6f7788; }
+        .searchGo {
+          color: #8e96a9 !important;
+          font-size: 18px;
+          text-decoration: none !important;
+        }
+        .cats {
+          display: flex;
+          gap: 7px;
+          overflow: auto;
+          padding: 11px 0 3px;
+          scrollbar-width: none;
+        }
+        .cats::-webkit-scrollbar { display: none; }
+        .cats button {
+          border: 1px solid #242833;
+          background: #0c0f15;
+          color: #858da0;
+          border-radius: 999px;
+          padding: 8px 12px;
+          white-space: nowrap;
+          font-size: 9px;
+          cursor: pointer;
+        }
+        .cats .on {
+          background: #f6f7fa;
+          color: #090a0e;
+          border-color: #f6f7fa;
+          font-weight: 900;
+        }
+        .feature {
+          margin-top: 22px;
+          min-height: 285px;
+          border: 1px solid #252936;
+          border-radius: 23px;
+          overflow: hidden;
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          background: radial-gradient(circle at 70% 30%, rgba(144,112,255,.2), transparent 43%), #0b0e15;
+        }
+        .featureCopy {
+          padding: 22px 8px 22px 20px;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+        .feature h2 {
+          font-size: 30px;
+          line-height: .94;
+          letter-spacing: -.05em;
+          margin: 8px 0;
+        }
+        .feature p {
+          font-size: 10px;
+          line-height: 1.5;
+          color: #7f889a;
+          margin: 0 0 15px;
+          max-width: 220px;
+        }
+        .featureArt {
+          min-height: 285px;
+          display: grid;
+          place-items: center;
+          overflow: hidden;
+        }
+        .featureArt :global(canvas) {
+          display: block;
+          width: 100% !important;
+          height: 100% !important;
+        }
+        .section { margin-top: 29px; }
+        .head {
+          display: flex;
+          justify-content: space-between;
+          align-items: end;
+          margin-bottom: 10px;
+        }
+        .head h2 {
+          font-size: 23px;
+          letter-spacing: -.04em;
+          margin: 4px 0;
+        }
+        .seeAll {
+          font-size: 9px;
+          color: #9f8cff !important;
+          text-decoration: none !important;
+        }
+        .grid {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 10px;
+        }
+        .card {
+          background: #0c0f15;
+          border: 1px solid #202531;
+          border-radius: 18px;
+          overflow: hidden;
+          text-decoration: none !important;
+          color: inherit;
+        }
+        .art {
+          height: 230px;
+          position: relative;
+          background: radial-gradient(circle at 50% 45%, rgba(139,106,255,.18), transparent 52%), #090b11;
+        }
+        .art :global(canvas) {
+          display: block;
+          width: 100% !important;
+          height: 100% !important;
+        }
+        .twin {
+          position: absolute;
+          left: 8px;
+          bottom: 8px;
+          background: rgba(4,5,9,.75);
+          border: 1px solid #2b3040;
+          border-radius: 999px;
+          padding: 5px 7px;
+          font-size: 7px;
+          letter-spacing: .1em;
+        }
+        .cardbody {
+          display: flex;
+          justify-content: space-between;
+          gap: 8px;
+          padding: 11px 11px 5px;
+        }
+        .cardbody small {
+          font-size: 7px;
+          color: #6f7789;
+          letter-spacing: .1em;
+        }
+        .cardbody h3 {
+          font-size: 13px;
+          margin: 4px 0 0;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          max-width: 120px;
+        }
+        .cardbody strong {
+          font-size: 11px;
+          white-space: nowrap;
+        }
+        .chips {
+          display: flex;
+          gap: 5px;
+          padding: 0 11px 11px;
+        }
+        .chips span {
+          font-size: 7px;
+          color: #8b94a5;
+          border: 1px solid #222733;
+          border-radius: 999px;
+          padding: 4px 6px;
+        }
+        .tools {
+          margin-top: 27px;
+          border-top: 1px solid #20242e;
+        }
+        .tools a {
+          display: flex;
+          align-items: center;
+          gap: 11px;
+          padding: 14px 2px;
+          border-bottom: 1px solid #20242e;
+          text-decoration: none !important;
+          color: inherit;
+        }
+        .tools b {
+          width: 32px;
+          height: 32px;
+          border-radius: 10px;
+          background: #11151d;
+          display: grid;
+          place-items: center;
+          color: #a994ff;
+        }
+        .tools span {
+          flex: 1;
+          font-size: 10px;
+          color: #d7dbe4;
+        }
+        .tools small {
+          display: block;
+          margin-bottom: 2px;
+        }
+        .tools i {
+          font-style: normal;
+          color: #687183;
+          font-size: 20px;
+        }
+        nav {
+          position: fixed;
+          z-index: 10;
+          left: 12px;
+          right: 12px;
+          bottom: 12px;
+          height: 62px;
+          border: 1px solid #292e3b;
+          background: rgba(12,14,20,.9);
+          backdrop-filter: blur(20px);
+          border-radius: 20px;
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          box-shadow: 0 20px 60px rgba(0,0,0,.45);
+        }
+        nav a {
+          display: grid;
+          place-items: center;
+          align-content: center;
+          gap: 3px;
+          color: #747d8f;
+          font-size: 8px;
+          text-decoration: none !important;
+        }
+        nav a span { font-size: 17px; }
+        nav a.active { color: #f6f7fa; }
+        nav a.active span { color: #a895ff; }
+        @media (min-width: 800px) {
+          .v3 {
+            max-width: 1120px;
+            margin: auto;
+            padding-bottom: 60px;
+          }
+          .grid { grid-template-columns: repeat(4, 1fr); }
+          .hero h1 { font-size: 72px; }
+          nav {
+            position: sticky;
+            max-width: 420px;
+            margin: 28px auto 0;
+          }
+        }
+        @media (max-width: 380px) {
+          .hero h1 { font-size: 48px; }
+          .feature { grid-template-columns: 1fr; min-height: 0; }
+          .featureCopy { padding-bottom: 0; }
+          .featureArt { min-height: 210px; }
+        }
+      `}</style>
+    </main>
+  );
+}

--- a/app/receipt/page.tsx
+++ b/app/receipt/page.tsx
@@ -8,23 +8,255 @@ export default function ReceiptPage() {
   const [selected, setSelected] = useState(false);
   const [minting, setMinting] = useState(false);
   const [message, setMessage] = useState('');
-  const verify = () => { setVerified(true); setMessage(''); };
+
+  const verify = () => {
+    setVerified(true);
+    setMessage('');
+  };
+
   const mint = async () => {
     setMinting(true);
     setMessage('Preparing secure checkout…');
     try {
-      const response = await fetch('/api/receipt-mint', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ receiptId: 'demo-receipt', collectibleId: 'everyday-object' }) });
+      const response = await fetch('/api/receipt-mint', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ receiptId: 'demo-receipt', collectibleId: 'everyday-object' }),
+      });
       const data = await response.json();
       if (data.url) window.location.assign(data.url);
       else setMessage(data.error || 'Checkout is not configured yet.');
-    } catch { setMessage('Checkout could not be started.'); }
-    finally { setMinting(false); }
+    } catch {
+      setMessage('Checkout could not be started.');
+    } finally {
+      setMinting(false);
+    }
   };
-  return <main className="page"><header><Link href="/" className="back">‹</Link><div><small>VOXEL VAULT</small><h1>Scan a receipt</h1></div><Link href="/room" className="room">◇ Room</Link></header>
-    <section className="scan"><div className="frame"><span>▣</span><b>{verified ? 'Receipt verified' : 'Place receipt inside frame'}</b><small>{verified ? 'Purchase detected' : 'Card details are never needed'}</small></div><button onClick={verify}>{verified ? 'Verified ✓' : 'Scan receipt'}</button></section>
-    {verified && <section className="purchase"><small>VERIFIED PURCHASE</small><h2>Everyday object</h2><p>Choose whether to turn this verified purchase into a digital collectible. A participating merchant or signed receipt provider must authorize the purchase before minting.</p><div className="row"><span>Collectible</span><b>$2.99 USD</b></div><div className="row"><span>3D room twin</span><b>Included</b></div><label className="choice"><input type="checkbox" checked={selected} onChange={e=>setSelected(e.target.checked)}/><span>Yes, collect this purchase in my Vault.</span></label><button className="mint" disabled={!selected || minting} onClick={mint}>{minting ? 'Preparing…' : 'Continue · $2.99 USD'}</button>{message && <p className="message">{message}</p>}</section>}
-    <section className="note"><b>Verified purchase → collectible</b><p>USD checkout happens before minting. Payment confirmation and merchant verification authorize the mint; blockchain confirmation is required before ownership is shown.</p></section>
-    <footer><Link href="/terms">Terms</Link><Link href="/privacy">Privacy</Link></footer>
-    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f6f7fb;padding:0 16px 34px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page header{height:70px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(255,255,255,.08)}.back,.room{color:#fff;text-decoration:none}.back{font-size:30px}.room{font-size:10px;border:1px solid rgba(255,255,255,.1);border-radius:999px;padding:8px 10px}.page header div{text-align:center}.page header small{font-size:7px;letter-spacing:.18em;color:#9e8dff}.page h1{font-size:18px;margin:3px 0}.scan{padding:30px 0}.frame{height:330px;border:1px dashed rgba(169,145,255,.6);border-radius:24px;background:radial-gradient(circle,rgba(130,100,255,.14),transparent 60%);display:grid;place-content:center;text-align:center;gap:8px}.frame span{font-size:50px;color:#a693ff}.frame b{font-size:16px}.frame small{color:#737d90;font-size:10px}.scan>button,.mint{width:100%;border:0;border-radius:15px;padding:15px;margin-top:10px;font-weight:900;font-size:12px;background:#f5f6f9;color:#08090d}.mint:disabled{opacity:.45}.purchase,.note{border:1px solid rgba(255,255,255,.09);border-radius:20px;padding:19px;background:rgba(255,255,255,.035);margin-bottom:12px}.purchase>small{font-size:8px;color:#9f8fff;letter-spacing:.15em;font-weight:900}.purchase h2{font-size:24px;margin:8px 0}.purchase p,.note p{font-size:10px;line-height:1.5;color:#7d8798}.row{display:flex;justify-content:space-between;padding:12px 0;border-top:1px solid rgba(255,255,255,.07);font-size:11px}.choice{display:flex;gap:9px;align-items:center;margin-top:12px;font-size:10px;color:#c8ced9}.choice input{accent-color:#a793ff;width:18px;height:18px}.mint{margin-top:13px}.message{margin:10px 0 0!important;color:#a99bff!important}.note b{font-size:11px}.note{margin-top:10px}footer{display:flex;justify-content:center;gap:18px;margin-top:22px}footer a{font-size:9px;color:#626b7d;text-decoration:none}@media(min-width:700px){.page{max-width:620px;margin:auto}}`}</style>
-  </main>;
+
+  return (
+    <main className="page">
+      <header>
+        <Link href="/" className="back" aria-label="Back">‹</Link>
+        <div>
+          <small>VOXEL VAULT</small>
+          <h1>Scan a receipt</h1>
+        </div>
+        <Link href="/room" className="room">◇ Room</Link>
+      </header>
+
+      <section className="scan">
+        <div className="frame">
+          <span>▣</span>
+          <b>{verified ? 'Receipt verified' : 'Place receipt inside frame'}</b>
+          <small>{verified ? 'Purchase detected' : 'Card details are never needed'}</small>
+        </div>
+        <button className="btn primary" onClick={verify}>
+          {verified ? 'Verified ✓' : 'Scan receipt'}
+        </button>
+      </section>
+
+      {verified && (
+        <section className="purchase">
+          <small>VERIFIED PURCHASE</small>
+          <h2>Everyday object</h2>
+          <p>
+            Choose whether to turn this verified purchase into a digital collectible.
+            A participating merchant or signed receipt provider must authorize the purchase before minting.
+          </p>
+          <div className="row">
+            <span>Collectible</span>
+            <b>$2.99 USD</b>
+          </div>
+          <div className="row">
+            <span>3D room twin</span>
+            <b>Included</b>
+          </div>
+          <label className="choice">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={e => setSelected(e.target.checked)}
+            />
+            <span>Yes, collect this purchase in my Vault.</span>
+          </label>
+          <button
+            className="btn primary mint"
+            disabled={!selected || minting}
+            onClick={mint}
+          >
+            {minting ? 'Preparing…' : 'Continue · $2.99 USD'}
+          </button>
+          {message && <p className="message">{message}</p>}
+        </section>
+      )}
+
+      <section className="note">
+        <b>Verified purchase → collectible</b>
+        <p>
+          USD checkout happens before minting. Payment confirmation and merchant verification authorize the mint;
+          blockchain confirmation is required before ownership is shown.
+        </p>
+      </section>
+
+      <footer>
+        <Link href="/terms">Terms</Link>
+        <Link href="/privacy">Privacy</Link>
+      </footer>
+
+      <style jsx>{`
+        .page {
+          min-height: 100vh;
+          background: #05060b;
+          color: #f6f7fb;
+          padding: 0 16px 34px;
+          font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        }
+        .page a {
+          text-decoration: none !important;
+          color: inherit;
+        }
+        .page header {
+          height: 70px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          border-bottom: 1px solid rgba(255,255,255,.08);
+        }
+        .back {
+          font-size: 30px;
+          color: #fff !important;
+          text-decoration: none !important;
+          width: 36px;
+        }
+        .room {
+          font-size: 10px;
+          border: 1px solid rgba(255,255,255,.12);
+          border-radius: 999px;
+          padding: 8px 12px;
+          color: #dce0e9 !important;
+          background: rgba(255,255,255,.04);
+          text-decoration: none !important;
+        }
+        .page header div { text-align: center; }
+        .page header small {
+          font-size: 7px;
+          letter-spacing: .18em;
+          color: #9e8dff;
+        }
+        .page h1 {
+          font-size: 18px;
+          margin: 3px 0;
+        }
+        .scan { padding: 30px 0; }
+        .frame {
+          height: 330px;
+          border: 1px dashed rgba(169,145,255,.55);
+          border-radius: 24px;
+          background: radial-gradient(circle, rgba(130,100,255,.14), transparent 60%);
+          display: grid;
+          place-content: center;
+          text-align: center;
+          gap: 8px;
+        }
+        .frame span {
+          font-size: 50px;
+          color: #a693ff;
+        }
+        .frame b { font-size: 16px; }
+        .frame small {
+          color: #737d90;
+          font-size: 10px;
+        }
+        .btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          border: 0;
+          border-radius: 15px;
+          padding: 15px;
+          margin-top: 12px;
+          font-weight: 900;
+          font-size: 12px;
+          cursor: pointer;
+          text-decoration: none !important;
+        }
+        .btn.primary {
+          background: #f5f6f9 !important;
+          color: #08090d !important;
+        }
+        .btn:disabled {
+          opacity: .45;
+          cursor: not-allowed;
+        }
+        .purchase, .note {
+          border: 1px solid rgba(255,255,255,.09);
+          border-radius: 20px;
+          padding: 19px;
+          background: rgba(255,255,255,.035);
+          margin-bottom: 12px;
+        }
+        .purchase > small {
+          font-size: 8px;
+          color: #9f8fff;
+          letter-spacing: .15em;
+          font-weight: 900;
+        }
+        .purchase h2 {
+          font-size: 24px;
+          margin: 8px 0;
+        }
+        .purchase p, .note p {
+          font-size: 10px;
+          line-height: 1.5;
+          color: #7d8798;
+        }
+        .row {
+          display: flex;
+          justify-content: space-between;
+          padding: 12px 0;
+          border-top: 1px solid rgba(255,255,255,.07);
+          font-size: 11px;
+        }
+        .choice {
+          display: flex;
+          gap: 9px;
+          align-items: center;
+          margin-top: 12px;
+          font-size: 10px;
+          color: #c8ced9;
+        }
+        .choice input {
+          accent-color: #a793ff;
+          width: 18px;
+          height: 18px;
+        }
+        .mint { margin-top: 13px; }
+        .message {
+          margin: 10px 0 0 !important;
+          color: #a99bff !important;
+          font-size: 10px;
+        }
+        .note b { font-size: 11px; }
+        .note { margin-top: 10px; }
+        footer {
+          display: flex;
+          justify-content: center;
+          gap: 18px;
+          margin-top: 22px;
+        }
+        footer a {
+          font-size: 9px;
+          color: #626b7d !important;
+          text-decoration: none !important;
+        }
+        @media (min-width: 700px) {
+          .page {
+            max-width: 620px;
+            margin: auto;
+          }
+        }
+      `}</style>
+    </main>
+  );
 }

--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -9,10 +9,243 @@ const items = [
 ];
 
 export default function RoomPage() {
-  return <main className="page"><header><Link href="/" className="back">‹</Link><div><small>YOUR VAULT</small><h1>My Room</h1></div><Link href="/receipt" className="scan">▣ Scan</Link></header>
-    <section className="room"><div className="floor"/><div className="wall"/><div className="roomLabel"><small>3D COLLECTION</small><b>Your things, in one place.</b><span>Every verified collectible can have a home here.</span></div><div className="objects">{items.map((item,i)=><div className={`object o${i}`} key={item.name}><span>{item.icon}</span><b>{item.name}</b></div>)}</div></section>
-    <section className="list"><div className="head"><span>COLLECTED</span><b>{items.length}</b></div>{items.map(item=><article key={item.name}><strong>{item.icon}</strong><div><b>{item.name}</b><small>{item.meta}</small></div><span>›</span></article>)}</section>
-    <Link className="discover" href="/">Find more objects →</Link><footer><Link href="/terms">Terms</Link><Link href="/privacy">Privacy</Link></footer>
-    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f6f7fb;padding:0 16px 35px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page header{height:70px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(255,255,255,.08)}.back,.scan{color:#fff;text-decoration:none}.back{font-size:30px}.scan{font-size:10px;padding:8px 10px;border:1px solid rgba(255,255,255,.1);border-radius:999px}.page header div{text-align:center}.page header small{font-size:7px;letter-spacing:.18em;color:#9e8dff}.page h1{font-size:18px;margin:3px 0}.room{height:430px;position:relative;margin-top:16px;border:1px solid rgba(255,255,255,.08);border-radius:24px;overflow:hidden;background:linear-gradient(155deg,#121526 0%,#080a11 65%)}.wall{position:absolute;inset:0;background:linear-gradient(135deg,transparent 50%,rgba(137,110,255,.1));clip-path:polygon(0 0,100% 0,73% 65%,0 65%)}.floor{position:absolute;left:-15%;right:-15%;bottom:-10%;height:55%;background:repeating-linear-gradient(90deg,rgba(255,255,255,.025) 0 1px,transparent 1px 48px),linear-gradient(170deg,#0b0d16,#171927);transform:perspective(500px) rotateX(58deg);transform-origin:bottom}.roomLabel{position:absolute;top:20px;left:20px;display:grid;gap:4px}.roomLabel small{font-size:7px;color:#9e8dff;letter-spacing:.14em;font-weight:900}.roomLabel b{font-size:17px}.roomLabel span{font-size:9px;color:#737d90}.objects{position:absolute;inset:0}.object{position:absolute;width:92px;height:92px;border-radius:22px;display:grid;place-items:center;background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.1);backdrop-filter:blur(12px);box-shadow:0 20px 40px rgba(0,0,0,.35)}.object span{font-size:42px;filter:drop-shadow(0 12px 16px rgba(0,0,0,.4))}.object b{position:absolute;bottom:-23px;white-space:nowrap;font-size:8px;color:#adb5c5}.o0{left:12%;top:49%}.o1{left:48%;top:38%}.o2{right:9%;top:55%}.list{margin-top:18px;border:1px solid rgba(255,255,255,.08);border-radius:20px;overflow:hidden;background:rgba(255,255,255,.03)}.head{display:flex;justify-content:space-between;padding:13px 15px;color:#858fa1;font-size:8px;letter-spacing:.12em;border-bottom:1px solid rgba(255,255,255,.07)}.head b{color:#fff}.list article{display:flex;align-items:center;gap:12px;padding:13px 15px;border-bottom:1px solid rgba(255,255,255,.06)}.list article:last-child{border-bottom:0}.list strong{font-size:27px}.list article div{flex:1}.list article b,.list article small{display:block}.list article b{font-size:11px}.list article small{font-size:8px;color:#707a8c;margin-top:3px}.list article>span{color:#7e8798}.discover{display:block;text-align:center;margin-top:13px;color:#a796ff;text-decoration:none;font-size:10px;font-weight:900}footer{display:flex;justify-content:center;gap:18px;margin-top:22px}footer a{font-size:9px;color:#626b7d;text-decoration:none}@media(min-width:700px){.page{max-width:620px;margin:auto}}`}</style>
-  </main>;
+  return (
+    <main className="page">
+      <header>
+        <Link href="/" className="back" aria-label="Back">‹</Link>
+        <div>
+          <small>YOUR VAULT</small>
+          <h1>My Room</h1>
+        </div>
+        <Link href="/receipt" className="scan">▣ Scan</Link>
+      </header>
+
+      <section className="room">
+        <div className="floor" />
+        <div className="wall" />
+        <div className="roomLabel">
+          <small>3D COLLECTION</small>
+          <b>Your things, in one place.</b>
+          <span>Every verified collectible can have a home here.</span>
+        </div>
+        <div className="objects">
+          {items.map((item, i) => (
+            <div className={`object o${i}`} key={item.name}>
+              <span>{item.icon}</span>
+              <b>{item.name}</b>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="list">
+        <div className="head">
+          <span>COLLECTED</span>
+          <b>{items.length}</b>
+        </div>
+        {items.map(item => (
+          <article key={item.name}>
+            <strong>{item.icon}</strong>
+            <div>
+              <b>{item.name}</b>
+              <small>{item.meta}</small>
+            </div>
+            <span>›</span>
+          </article>
+        ))}
+      </section>
+
+      <Link className="discover" href="/">Find more objects →</Link>
+
+      <footer>
+        <Link href="/terms">Terms</Link>
+        <Link href="/privacy">Privacy</Link>
+      </footer>
+
+      <style jsx>{`
+        .page {
+          min-height: 100vh;
+          background: #05060b;
+          color: #f6f7fb;
+          padding: 0 16px 35px;
+          font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+        }
+        .page a {
+          text-decoration: none !important;
+          color: inherit;
+        }
+        .page header {
+          height: 70px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          border-bottom: 1px solid rgba(255,255,255,.08);
+        }
+        .back {
+          font-size: 30px;
+          color: #fff !important;
+          text-decoration: none !important;
+          width: 36px;
+        }
+        .scan {
+          font-size: 10px;
+          padding: 8px 12px;
+          border: 1px solid rgba(255,255,255,.12);
+          border-radius: 999px;
+          color: #dce0e9 !important;
+          background: rgba(255,255,255,.04);
+          text-decoration: none !important;
+        }
+        .page header div { text-align: center; }
+        .page header small {
+          font-size: 7px;
+          letter-spacing: .18em;
+          color: #9e8dff;
+        }
+        .page h1 {
+          font-size: 18px;
+          margin: 3px 0;
+        }
+        .room {
+          height: 430px;
+          position: relative;
+          margin-top: 16px;
+          border: 1px solid rgba(255,255,255,.08);
+          border-radius: 24px;
+          overflow: hidden;
+          background: linear-gradient(155deg, #121526 0%, #080a11 65%);
+        }
+        .wall {
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(135deg, transparent 50%, rgba(137,110,255,.1));
+          clip-path: polygon(0 0, 100% 0, 73% 65%, 0 65%);
+        }
+        .floor {
+          position: absolute;
+          left: -15%;
+          right: -15%;
+          bottom: -10%;
+          height: 55%;
+          background:
+            repeating-linear-gradient(90deg, rgba(255,255,255,.025) 0 1px, transparent 1px 48px),
+            linear-gradient(170deg, #0b0d16, #171927);
+          transform: perspective(500px) rotateX(58deg);
+          transform-origin: bottom;
+        }
+        .roomLabel {
+          position: absolute;
+          top: 20px;
+          left: 20px;
+          display: grid;
+          gap: 4px;
+          z-index: 2;
+        }
+        .roomLabel small {
+          font-size: 7px;
+          color: #9e8dff;
+          letter-spacing: .14em;
+          font-weight: 900;
+        }
+        .roomLabel b { font-size: 17px; }
+        .roomLabel span {
+          font-size: 9px;
+          color: #737d90;
+        }
+        .objects { position: absolute; inset: 0; }
+        .object {
+          position: absolute;
+          width: 92px;
+          height: 92px;
+          border-radius: 22px;
+          display: grid;
+          place-items: center;
+          background: rgba(255,255,255,.05);
+          border: 1px solid rgba(255,255,255,.1);
+          backdrop-filter: blur(12px);
+          box-shadow: 0 20px 40px rgba(0,0,0,.35);
+        }
+        .object span {
+          font-size: 42px;
+          filter: drop-shadow(0 12px 16px rgba(0,0,0,.4));
+        }
+        .object b {
+          position: absolute;
+          bottom: -23px;
+          white-space: nowrap;
+          font-size: 8px;
+          color: #adb5c5;
+        }
+        .o0 { left: 12%; top: 49%; }
+        .o1 { left: 48%; top: 38%; }
+        .o2 { right: 9%; top: 55%; }
+        .list {
+          margin-top: 18px;
+          border: 1px solid rgba(255,255,255,.08);
+          border-radius: 20px;
+          overflow: hidden;
+          background: rgba(255,255,255,.03);
+        }
+        .head {
+          display: flex;
+          justify-content: space-between;
+          padding: 13px 15px;
+          color: #858fa1;
+          font-size: 8px;
+          letter-spacing: .12em;
+          border-bottom: 1px solid rgba(255,255,255,.07);
+        }
+        .head b { color: #fff; }
+        .list article {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 13px 15px;
+          border-bottom: 1px solid rgba(255,255,255,.06);
+        }
+        .list article:last-child { border-bottom: 0; }
+        .list strong { font-size: 27px; }
+        .list article div { flex: 1; }
+        .list article b,
+        .list article small { display: block; }
+        .list article b { font-size: 11px; }
+        .list article small {
+          font-size: 8px;
+          color: #707a8c;
+          margin-top: 3px;
+        }
+        .list article > span { color: #7e8798; }
+        .discover {
+          display: block;
+          text-align: center;
+          margin-top: 16px;
+          color: #a796ff !important;
+          text-decoration: none !important;
+          font-size: 11px;
+          font-weight: 900;
+          padding: 12px;
+          border: 1px solid rgba(169,145,255,.25);
+          border-radius: 14px;
+          background: rgba(169,145,255,.06);
+        }
+        footer {
+          display: flex;
+          justify-content: center;
+          gap: 18px;
+          margin-top: 22px;
+        }
+        footer a {
+          font-size: 9px;
+          color: #626b7d !important;
+          text-decoration: none !important;
+        }
+        @media (min-width: 700px) {
+          .page {
+            max-width: 620px;
+            margin: auto;
+          }
+        }
+      `}</style>
+    </main>
+  );
 }


### PR DESCRIPTION
Incremental polish only — no redesign, no architecture changes.

### Changes

**1. Homepage (`VaultHomeV3`)**
- Force premium button styles (Explore / Scan receipt / Shop the vault)
- Remove unwanted link underlines on logo and CTAs
- Explicit `.btn.primary` / `.btn.ghost` classes so the intended visual language reaches the live UI

**2. Receipt page**
- Match the same button language and no-underline rules
- Cleaner hierarchy while keeping the exact Scan → Verify → Collect → USD mint flow

**3. Room page**
- Same no-underline + consistent dark premium styling
- Stronger “Find more objects” CTA
- Preserved the spatial 3D room preview and collected list

### Preserved
- iPhone-first layout
- 3D twin presentation
- USD / Physical / QR / NFT identity cues
- Find · Scan · Vault · AI navigation
- Existing 3D viewer stack, catalog, and mint pipeline

After merge, Vercel will pick up all three pages. Please verify homepage buttons, receipt CTA, and Room links no longer show default blue underlines.