### PR TITLE
Harden physical product + NFT checkout and fulfillment

### DIFF
--- a/app/api/mint-verify/route.ts
+++ b/app/api/mint-verify/route.ts
@@ -12,18 +12,22 @@ export async function GET(request: Request) {
 
     const session = await stripe.checkout.sessions.retrieve(sessionId);
     const metadataWallet = session.metadata?.wallet?.toLowerCase();
+    const mintMode = session.metadata?.mint_mode;
     const catalogId = Number(session.metadata?.catalog_id);
-    if (session.metadata?.mint_mode !== 'usd' || metadataWallet !== wallet || session.payment_status !== 'paid') {
+    if (!['usd', 'physical_nft'].includes(String(mintMode)) || metadataWallet !== wallet || session.payment_status !== 'paid') {
       return NextResponse.json({ paid: false }, { status: 402 });
     }
     if (!Number.isInteger(catalogId) || catalogId < 1) return NextResponse.json({ error: 'Invalid mint object' }, { status: 400 });
 
     const item = getCatalogItem(catalogId - 1);
+    if (!item) return NextResponse.json({ error: 'Catalog object unavailable' }, { status: 404 });
     return NextResponse.json({
       paid: true,
+      fulfillmentIncluded: mintMode === 'physical_nft',
+      fulfillmentStatus: mintMode === 'physical_nft' ? 'awaiting_fulfillment' : null,
       catalogId,
       wallet,
-      item: { id: item.id, name: item.name, creator: item.creator, rarity: item.rarity, realityBasis: item.realityBasis, priceUsd: item.priceUsd },
+      item: { id: item.id, name: item.name, creator: item.creator, rarity: item.rarity, realityBasis: item.realityBasis, priceUsd: item.priceUsd, sourceUrl: item.sourceUrl, sourceName: item.sourceName },
       sessionId,
     });
   } catch (error) {

--- a/app/api/physical-nft-checkout/route.ts
+++ b/app/api/physical-nft-checkout/route.ts
@@ -1,12 +1,20 @@
 import { NextResponse } from 'next/server';
 import { stripe } from '../../../lib/stripe-server';
 import { getCatalogItem } from '../../../lib/catalog';
+import { getSupabaseAdmin } from '../../../lib/supabase-admin';
 
 const NFT_FEE_CENTS = 299;
 const WALLET_RE = /^0x[a-fA-F0-9]{40}$/;
 
 export async function POST(request: Request) {
   try {
+    const supabaseAdmin = getSupabaseAdmin();
+    const auth = request.headers.get('authorization');
+    const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+    if (!token) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
+    if (authError || !user) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+
     const { catalogId, wallet } = await request.json();
     const id = Number(catalogId);
     const normalizedWallet = String(wallet || '').toLowerCase();
@@ -17,11 +25,11 @@ export async function POST(request: Request) {
     if (!item) return NextResponse.json({ error: 'Product unavailable' }, { status: 404 });
     if (!item.sourceUrl || !item.sourceName) return NextResponse.json({ error: 'This product has no verified online source' }, { status: 409 });
 
-    // Physical fulfillment is deliberately fail-closed. A product cannot be presented as
-    // "ships to you" until a real fulfillment adapter is configured and verified.
+    // Fail closed: Voxel Vault must never accept a "ships to you" order unless
+    // a real fulfillment provider is configured server-side.
     if (!process.env.FULFILLMENT_API_URL || !process.env.FULFILLMENT_API_KEY) {
       return NextResponse.json({
-        error: 'Physical fulfillment is not configured yet. Use the verified retailer link for the physical product; NFT checkout remains available separately.',
+        error: 'Automatic physical fulfillment is not connected yet. The verified retailer remains available for the physical purchase, while NFT checkout can be completed separately.',
         code: 'FULFILLMENT_NOT_CONFIGURED',
         sourceUrl: item.sourceUrl,
       }, { status: 503 });
@@ -31,37 +39,46 @@ export async function POST(request: Request) {
     if (!Number.isFinite(physicalCents) || physicalCents < 50) return NextResponse.json({ error: 'Product price is not configured for checkout' }, { status: 500 });
 
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxelvault.io';
+    const metadata = {
+      mint_mode: 'physical_nft',
+      catalog_id: String(id),
+      catalog_key: item.id,
+      wallet: normalizedWallet,
+      buyer_id: user.id,
+      physical_amount_cents: String(physicalCents),
+      nft_amount_cents: String(NFT_FEE_CENTS),
+      product_source_url: item.sourceUrl,
+    };
+
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
+      customer_email: user.email || undefined,
+      billing_address_collection: 'required',
       shipping_address_collection: { allowed_countries: ['US'] },
+      phone_number_collection: { enabled: true },
       line_items: [{
         quantity: 1,
         price_data: {
           currency: 'usd',
-          unit_amount: physicalCents + NFT_FEE_CENTS,
+          unit_amount: physicalCents,
           product_data: {
-            name: `${item.name} + Voxel Vault Digital Twin`,
-            description: `Physical ${item.name} fulfillment plus one Voxel Vault digital collectible. Physical fulfillment is submitted only after verified payment.`,
+            name: item.name,
+            description: `Verified real-world product from ${item.sourceName}.`,
+          },
+        },
+      }, {
+        quantity: 1,
+        price_data: {
+          currency: 'usd',
+          unit_amount: NFT_FEE_CENTS,
+          product_data: {
+            name: `${item.name} · Voxel Vault Digital Twin`,
+            description: 'One digital collectible for your Vault, Room, and world placement.',
           },
         },
       }],
-      metadata: {
-        mint_mode: 'physical_nft',
-        catalog_id: String(id),
-        catalog_key: item.id,
-        wallet: normalizedWallet,
-        physical_amount_cents: String(physicalCents),
-        nft_amount_cents: String(NFT_FEE_CENTS),
-        product_source_url: item.sourceUrl,
-      },
-      payment_intent_data: {
-        metadata: {
-          mint_mode: 'physical_nft',
-          catalog_id: String(id),
-          catalog_key: item.id,
-          wallet: normalizedWallet,
-        },
-      },
+      metadata,
+      payment_intent_data: { metadata },
       success_url: `${appUrl}/mint?catalog=${id}&session_id={CHECKOUT_SESSION_ID}&physical=1`,
       cancel_url: `${appUrl}/mint?catalog=${id}&cancelled=1`,
     });

--- a/app/api/physical-nft-checkout/route.ts
+++ b/app/api/physical-nft-checkout/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '../../../lib/stripe-server';
+import { getCatalogItem } from '../../../lib/catalog';
+
+const NFT_FEE_CENTS = 299;
+const WALLET_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export async function POST(request: Request) {
+  try {
+    const { catalogId, wallet } = await request.json();
+    const id = Number(catalogId);
+    const normalizedWallet = String(wallet || '').toLowerCase();
+    if (!Number.isInteger(id) || id < 1) return NextResponse.json({ error: 'Invalid product' }, { status: 400 });
+    if (!WALLET_RE.test(normalizedWallet)) return NextResponse.json({ error: 'Connect a valid wallet first' }, { status: 400 });
+
+    const item = getCatalogItem(id - 1);
+    if (!item) return NextResponse.json({ error: 'Product unavailable' }, { status: 404 });
+    if (!item.sourceUrl || !item.sourceName) return NextResponse.json({ error: 'This product has no verified online source' }, { status: 409 });
+
+    // Physical fulfillment is deliberately fail-closed. A product cannot be presented as
+    // "ships to you" until a real fulfillment adapter is configured and verified.
+    if (!process.env.FULFILLMENT_API_URL || !process.env.FULFILLMENT_API_KEY) {
+      return NextResponse.json({
+        error: 'Physical fulfillment is not configured yet. Use the verified retailer link for the physical product; NFT checkout remains available separately.',
+        code: 'FULFILLMENT_NOT_CONFIGURED',
+        sourceUrl: item.sourceUrl,
+      }, { status: 503 });
+    }
+
+    const physicalCents = Math.round(Number(item.priceUsd) * 100);
+    if (!Number.isFinite(physicalCents) || physicalCents < 50) return NextResponse.json({ error: 'Product price is not configured for checkout' }, { status: 500 });
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxelvault.io';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      shipping_address_collection: { allowed_countries: ['US'] },
+      line_items: [{
+        quantity: 1,
+        price_data: {
+          currency: 'usd',
+          unit_amount: physicalCents + NFT_FEE_CENTS,
+          product_data: {
+            name: `${item.name} + Voxel Vault Digital Twin`,
+            description: `Physical ${item.name} fulfillment plus one Voxel Vault digital collectible. Physical fulfillment is submitted only after verified payment.`,
+          },
+        },
+      }],
+      metadata: {
+        mint_mode: 'physical_nft',
+        catalog_id: String(id),
+        catalog_key: item.id,
+        wallet: normalizedWallet,
+        physical_amount_cents: String(physicalCents),
+        nft_amount_cents: String(NFT_FEE_CENTS),
+        product_source_url: item.sourceUrl,
+      },
+      payment_intent_data: {
+        metadata: {
+          mint_mode: 'physical_nft',
+          catalog_id: String(id),
+          catalog_key: item.id,
+          wallet: normalizedWallet,
+        },
+      },
+      success_url: `${appUrl}/mint?catalog=${id}&session_id={CHECKOUT_SESSION_ID}&physical=1`,
+      cancel_url: `${appUrl}/mint?catalog=${id}&cancelled=1`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (error) {
+    console.error('physical + NFT checkout failed', error);
+    return NextResponse.json({ error: 'Unable to start physical + NFT checkout' }, { status: 500 });
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -2,6 +2,35 @@ import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { stripe } from '../../../../lib/stripe-server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
+import { getCatalogItem } from '../../../../lib/catalog';
+
+const WALLET_RE = /^0x[a-f0-9]{40}$/;
+
+async function submitPhysicalFulfillment(orderId: string, session: Stripe.Checkout.Session, catalogId: number, catalogKey: string) {
+  const endpoint = process.env.FULFILLMENT_API_URL;
+  const apiKey = process.env.FULFILLMENT_API_KEY;
+  if (!endpoint || !apiKey) return { status: 'awaiting_fulfillment' as const };
+  const shipping = session.shipping_details;
+  if (!shipping?.address?.line1 || !shipping.address.city || !shipping.address.postal_code || !shipping.address.country) {
+    throw new Error('Stripe checkout did not provide a complete shipping address');
+  }
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ orderId, externalOrderId: session.id, catalogId, catalogKey, quantity: 1, shipping: {
+      name: shipping.name || '', line1: shipping.address.line1, line2: shipping.address.line2 || null,
+      city: shipping.address.city, state: shipping.address.state || '', postalCode: shipping.address.postal_code,
+      country: shipping.address.country,
+    } }),
+    cache: 'no-store',
+  });
+  if (!response.ok) throw new Error(`Fulfillment provider returned ${response.status}`);
+  const result = await response.json().catch(() => ({}));
+  return { status: 'submitted' as const,
+    fulfillmentOrderId: typeof result.orderId === 'string' ? result.orderId : null,
+    trackingNumber: typeof result.trackingNumber === 'string' ? result.trackingNumber : null,
+    trackingUrl: typeof result.trackingUrl === 'string' ? result.trackingUrl : null };
+}
 
 export async function POST(request: Request) {
   const signature = request.headers.get('stripe-signature');
@@ -11,13 +40,47 @@ export async function POST(request: Request) {
   let event: Stripe.Event;
   try { event = stripe.webhooks.constructEvent(payload, signature, secret); }
   catch { return NextResponse.json({ error: 'Invalid signature' }, { status: 400 }); }
+
   try {
     const supabaseAdmin = getSupabaseAdmin();
     if (event.type === 'checkout.session.completed' || event.type === 'checkout.session.async_payment_succeeded') {
       const session = event.data.object as Stripe.Checkout.Session;
+      if (session.payment_status !== 'paid') return NextResponse.json({ received: true });
+
+      if (session.metadata?.mint_mode === 'physical_nft') {
+        const wallet = session.metadata?.wallet?.toLowerCase();
+        const buyerId = session.metadata?.buyer_id || null;
+        const catalogId = Number(session.metadata?.catalog_id);
+        const catalogKey = session.metadata?.catalog_key;
+        const item = Number.isInteger(catalogId) ? getCatalogItem(catalogId - 1) : null;
+        const shipping = session.shipping_details?.address;
+        if (!WALLET_RE.test(wallet || '') || !item || !catalogKey || !buyerId) throw new Error('Invalid physical + NFT checkout metadata');
+        if (!session.shipping_details?.name || !shipping?.line1 || !shipping.city || !shipping.state || !shipping.postal_code || !shipping.country) throw new Error('Incomplete shipping address');
+
+        const { data: order, error } = await supabaseAdmin.from('physical_orders').upsert({
+          buyer_id: buyerId, catalog_id: catalogId, catalog_key: catalogKey,
+          stripe_checkout_session_id: session.id,
+          stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+          shipping_name: session.shipping_details.name, shipping_line1: shipping.line1, shipping_line2: shipping.line2 || null,
+          shipping_city: shipping.city, shipping_state: shipping.state || '', shipping_postal_code: shipping.postal_code,
+          shipping_country: shipping.country, currency: session.currency || 'usd',
+          physical_amount_cents: Number(session.metadata?.physical_amount_cents || 0), nft_amount_cents: Number(session.metadata?.nft_amount_cents || 0),
+          fulfillment_status: 'awaiting_fulfillment',
+        }, { onConflict: 'stripe_checkout_session_id' }).select('id').single();
+        if (error || !order) throw error ?? new Error('Physical order creation failed');
+
+        const fulfillment = await submitPhysicalFulfillment(order.id, session, catalogId, catalogKey);
+        const update: Record<string, unknown> = { fulfillment_status: fulfillment.status, updated_at: new Date().toISOString() };
+        if ('fulfillmentOrderId' in fulfillment) update.fulfillment_order_id = fulfillment.fulfillmentOrderId;
+        if ('trackingNumber' in fulfillment) update.tracking_number = fulfillment.trackingNumber;
+        if ('trackingUrl' in fulfillment) update.tracking_url = fulfillment.trackingUrl;
+        await supabaseAdmin.from('physical_orders').update(update).eq('id', order.id);
+        return NextResponse.json({ received: true });
+      }
+
       const assetId = session.metadata?.asset_id;
       const buyerId = session.metadata?.buyer_id;
-      if (assetId && buyerId && session.payment_status === 'paid') {
+      if (assetId && buyerId) {
         const { data: asset, error: assetError } = await supabaseAdmin.from('assets').select('id,seller_id,price_cents,currency').eq('id', assetId).eq('status', 'published').single();
         if (assetError || !asset) throw assetError ?? new Error('Asset not found');
         const amount = session.amount_total ?? asset.price_cents;

--- a/app/mint/page.js
+++ b/app/mint/page.js
@@ -8,7 +8,7 @@ function metadataUri(item) {
   const payload = {
     name: item.name,
     description: `Voxel Vault digital twin inspired by a ${item.realityBasis}. Purchased in USD through Voxel Vault.`,
-    external_url: 'https://voxel-vault.vercel.app',
+    external_url: 'https://voxelvault.io',
     attributes: [
       { trait_type: 'Creator', value: item.creator },
       { trait_type: 'Rarity', value: item.rarity },
@@ -70,6 +70,26 @@ export default function MintPage() {
     } catch (error) { setMessage(error.message || 'Could not start checkout.'); setBusy(false); }
   }
 
+  async function startPhysicalAndNftCheckout() {
+    if (!catalogId) return;
+    if (!wallet) { await connect(); return; }
+    setBusy(true); setMessage('Preparing physical delivery + digital twin checkout…');
+    try {
+      const response = await fetch('/api/physical-nft-checkout', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ catalogId: Number(catalogId), wallet }) });
+      const data = await response.json();
+      if (!response.ok || !data.url) {
+        if (data.sourceUrl) {
+          setMessage('Automated fulfillment is not connected yet. Opening the verified retailer so the physical product can be purchased safely.');
+          window.open(data.sourceUrl, '_blank', 'noopener,noreferrer');
+          setBusy(false);
+          return;
+        }
+        throw new Error(data.error || 'Physical checkout unavailable.');
+      }
+      window.location.assign(data.url);
+    } catch (error) { setMessage(error.message || 'Could not start physical + NFT checkout.'); setBusy(false); }
+  }
+
   async function mintNow() {
     if (!item || !paid) return;
     setBusy(true); setMessage('Minting your digital twin… confirm the wallet transaction.');
@@ -87,17 +107,18 @@ export default function MintPage() {
 
   return <main className="page">
     <header><Link href="/" className="brand">VOXEL VAULT</Link><Link href="/" className="back">Back</Link></header>
-    <section className="hero"><small>USD → NFT</small><h1>Buy it.<br /><em>Mint it.</em></h1><p>Pay in USD first. We verify the payment. Then the NFT can be minted to your wallet.</p></section>
+    <section className="hero"><small>PHYSICAL + DIGITAL</small><h1>Buy it.<br /><em>Own both.</em></h1><p>Choose a verified real-world product, keep its digital twin in your Vault, and place the collectible in your Room or the world map.</p></section>
     <section className="panel">
       <div className="step"><b>01</b><strong>Connect your wallet</strong><button onClick={connect} disabled={busy}>{wallet ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}` : 'Connect'}</button></div>
-      <div className="step"><b>02</b><strong>Pay in USD</strong><button onClick={startCheckout} disabled={busy || !catalogId}>{catalogId ? 'Pay + mint NFT' : 'Choose an object first'}</button></div>
-      <div className="step"><b>03</b><strong>Verify payment</strong><button onClick={verify} disabled={busy || !sessionId || !wallet}>Verify</button></div>
-      <div className="step"><b>04</b><strong>Mint the digital twin</strong><button onClick={mintNow} disabled={busy || !paid}>{paid ? 'Mint NFT' : 'Locked until paid'}</button></div>
+      <div className="step"><b>02</b><strong>Physical + NFT</strong><button onClick={startPhysicalAndNftCheckout} disabled={busy || !catalogId}>{catalogId ? 'Buy + ship + NFT' : 'Choose an object first'}</button></div>
+      <div className="step"><b>03</b><strong>Digital-only checkout</strong><button onClick={startCheckout} disabled={busy || !catalogId}>{catalogId ? 'Buy NFT' : 'Choose an object first'}</button></div>
+      <div className="step"><b>04</b><strong>Verify payment</strong><button onClick={verify} disabled={busy || !sessionId || !wallet}>Verify</button></div>
+      <div className="step"><b>05</b><strong>Mint the digital twin</strong><button onClick={mintNow} disabled={busy || !paid}>{paid ? 'Mint NFT' : 'Locked until paid'}</button></div>
     </section>
-    {item && <section className="object"><small>READY TO MINT</small><h2>{item.name}</h2><p>by {item.creator} · {item.rarity}</p><div className="facts"><span>${item.priceUsd}</span><span>USD verified</span><span>VV-{item.id}</span></div>{mint && <a href={mint.explorerTx} target="_blank" rel="noreferrer">View confirmed transaction ↗</a>}</section>}
+    {item && <section className="object"><small>REAL-WORLD OBJECT</small><h2>{item.name}</h2><p>by {item.creator} · {item.rarity}</p><div className="facts"><span>${item.priceUsd}</span><span>Source verified</span><span>VV-{item.id}</span></div>{mint && <a href={mint.explorerTx} target="_blank" rel="noreferrer">View confirmed transaction ↗</a>}</section>}
     {history.length > 0 && <section className="history"><small>YOUR HISTORY</small><h2>Collected objects.</h2>{history.slice(0, 8).map((entry, index) => <article key={`${entry.hash}-${index}`}><div><strong>{entry.name}</strong><span>{entry.creator} · {entry.createdAt.slice(0, 10)}</span></div><b>{entry.tokenId ? `#${entry.tokenId}` : 'Minted'}</b></article>)}</section>}
     {message && <p className="message" role="status">{message}</p>}
     <footer><Link href="/terms">Terms</Link><Link href="/privacy">Privacy</Link></footer>
-    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f7f8fb;padding:0 16px 45px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page *{box-sizing:border-box}header{height:62px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,255,255,.08)}.brand{color:#fff;text-decoration:none;font-size:11px;font-weight:950;letter-spacing:.16em}.back{color:#858ea1;text-decoration:none;font-size:10px}.hero{padding:44px 0 25px}.hero small,.panel+section small,.history>small{color:#a895ff;font-size:9px;font-weight:900;letter-spacing:.17em}.hero h1{font-size:clamp(52px,13vw,80px);line-height:.86;letter-spacing:-.07em;margin:10px 0}.hero em{font-style:normal;color:#a894ff}.hero p{max-width:420px;color:#858ea1;font-size:13px;line-height:1.5}.panel,.object,.history{border:1px solid rgba(255,255,255,.09);border-radius:22px;background:rgba(255,255,255,.035);padding:10px}.step{display:grid;grid-template-columns:30px 1fr auto;gap:10px;align-items:center;padding:14px 8px;border-bottom:1px solid rgba(255,255,255,.07)}.step:last-child{border-bottom:0}.step b{color:#727b8e;font-size:9px}.step strong{font-size:12px}.step button{border:1px solid rgba(255,255,255,.12);background:#f5f6f9;color:#08090d;border-radius:10px;padding:9px 10px;font-size:9px;font-weight:900}.step button:disabled{opacity:.45}.object{margin-top:12px;padding:20px;background:linear-gradient(135deg,rgba(143,112,255,.14),rgba(255,255,255,.025))}.object h2,.history h2{font-size:26px;letter-spacing:-.04em;margin:8px 0 3px}.object p{color:#7e8799;font-size:10px}.facts{display:flex;gap:7px;flex-wrap:wrap;margin:15px 0}.facts span{border:1px solid rgba(255,255,255,.1);border-radius:999px;padding:7px 9px;color:#dce1ea;font-size:8px}.object a{color:#a894ff;text-decoration:none;font-size:9px}.history{margin-top:12px}.history h2{margin-bottom:12px}.history article{display:flex;justify-content:space-between;gap:12px;padding:11px 0;border-top:1px solid rgba(255,255,255,.07)}.history article div{min-width:0}.history strong,.history span{display:block}.history strong{font-size:11px}.history span{font-size:8px;color:#737c8e;margin-top:3px}.history article>b{font-size:9px;color:#67eeb0}.message{color:#9aa3b5;font-size:10px;line-height:1.5;padding:10px 2px}.page footer{display:flex;justify-content:center;gap:18px;margin-top:24px}.page footer a{color:#5f687a;text-decoration:none;font-size:9px}@media(min-width:700px){.page{max-width:760px;margin:0 auto;padding-left:24px;padding-right:24px}}`}</style>
+    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f7f8fb;padding:0 16px 45px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page *{box-sizing:border-box}header{height:62px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,255,255,.08)}.brand{color:#fff;text-decoration:none;font-size:11px;font-weight:950;letter-spacing:.16em}.back{color:#858ea1;text-decoration:none;font-size:10px}.hero{padding:44px 0 25px}.hero small,.panel+section small,.history>small{color:#a895ff;font-size:9px;font-weight:900;letter-spacing:.17em}.hero h1{font-size:clamp(52px,13vw,80px);line-height:.86;letter-spacing:-.07em;margin:10px 0}.hero em{font-style:normal;color:#a894ff}.hero p{max-width:460px;color:#858ea1;font-size:13px;line-height:1.5}.panel,.object,.history{border:1px solid rgba(255,255,255,.09);border-radius:22px;background:rgba(255,255,255,.035);padding:10px}.step{display:grid;grid-template-columns:30px 1fr auto;gap:10px;align-items:center;padding:14px 8px;border-bottom:1px solid rgba(255,255,255,.07)}.step:last-child{border-bottom:0}.step b{color:#727b8e;font-size:9px}.step strong{font-size:12px}.step button{border:1px solid rgba(255,255,255,.12);background:#f5f6f9;color:#08090d;border-radius:10px;padding:9px 10px;font-size:9px;font-weight:900}.step button:disabled{opacity:.45}.object{margin-top:12px;padding:20px;background:linear-gradient(135deg,rgba(143,112,255,.14),rgba(255,255,255,.025))}.object h2,.history h2{font-size:26px;letter-spacing:-.04em;margin:8px 0 3px}.object p{color:#7e8799;font-size:10px}.facts{display:flex;gap:7px;flex-wrap:wrap;margin:15px 0}.facts span{border:1px solid rgba(255,255,255,.1);border-radius:999px;padding:7px 9px;color:#dce1ea;font-size:8px}.object a{color:#a894ff;text-decoration:none;font-size:9px}.history{margin-top:12px}.history h2{margin-bottom:12px}.history article{display:flex;justify-content:space-between;gap:12px;padding:11px 0;border-top:1px solid rgba(255,255,255,.07)}.history article div{min-width:0}.history strong,.history span{display:block}.history strong{font-size:11px}.history span{font-size:8px;color:#737c8e;margin-top:3px}.history article>b{font-size:9px;color:#67eeb0}.message{color:#9aa3b5;font-size:10px;line-height:1.5;padding:10px 2px}.page footer{display:flex;justify-content:center;gap:18px;margin-top:24px}.page footer a{color:#5f687a;text-decoration:none;font-size:9px}@media(min-width:700px){.page{max-width:760px;margin:0 auto;padding-left:24px;padding-right:24px}}`}</style>
   </main>;
 }

--- a/supabase/migrations/002_physical_fulfillment.sql
+++ b/supabase/migrations/002_physical_fulfillment.sql
@@ -1,0 +1,35 @@
+-- Physical product + NFT order ledger.
+-- Stripe captures the buyer's shipping address. An order is only marked shipped
+-- after a configured fulfillment adapter confirms submission/tracking.
+create table if not exists public.physical_orders (
+  id uuid primary key default gen_random_uuid(),
+  buyer_id uuid not null references auth.users(id) on delete restrict,
+  catalog_id integer not null,
+  catalog_key text not null,
+  stripe_checkout_session_id text unique not null,
+  stripe_payment_intent_id text unique,
+  shipping_name text not null,
+  shipping_line1 text not null,
+  shipping_line2 text,
+  shipping_city text not null,
+  shipping_state text not null,
+  shipping_postal_code text not null,
+  shipping_country text not null,
+  currency text not null default 'usd',
+  physical_amount_cents integer not null check (physical_amount_cents >= 0),
+  nft_amount_cents integer not null check (nft_amount_cents >= 0),
+  fulfillment_status text not null default 'awaiting_fulfillment' check (fulfillment_status in ('awaiting_fulfillment','submitted','shipped','delivered','cancelled','failed')),
+  fulfillment_order_id text,
+  tracking_number text,
+  tracking_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.physical_orders enable row level security;
+create policy "buyers view own physical orders" on public.physical_orders for select using (buyer_id = auth.uid());
+create index if not exists physical_orders_buyer_id_idx on public.physical_orders(buyer_id);
+create index if not exists physical_orders_fulfillment_status_idx on public.physical_orders(fulfillment_status);
+
+-- Optional automated fulfillment adapter. Configure server-side only:
+-- FULFILLMENT_API_URL, FULFILLMENT_API_KEY. Without these, orders remain awaiting_fulfillment.


### PR DESCRIPTION
Harden the physical-product + NFT purchase path: authenticate the buyer server-side, bind the checkout session to the authenticated user, collect billing/shipping/phone details, verify physical+NFT payment, and preserve fail-closed fulfillment so Voxel Vault never charges for an order it cannot automatically fulfill. The catalog remains source-backed real-world products, while the existing Vault/Room/map NFT flow stays intact.