### PR TITLE
Fix Stripe shipping type check

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -5,8 +5,20 @@ import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { getCatalogItem } from '../../../../lib/catalog';
 
 const WALLET_RE = /^0x[a-f0-9]{40}$/;
+type ShippingDetails = {
+  name?: string | null;
+  address?: {
+    line1?: string | null;
+    line2?: string | null;
+    city?: string | null;
+    state?: string | null;
+    postal_code?: string | null;
+    country?: string | null;
+  } | null;
+};
+type CheckoutSessionWithShipping = Stripe.Checkout.Session & { shipping_details?: ShippingDetails | null };
 
-async function submitPhysicalFulfillment(orderId: string, session: Stripe.Checkout.Session, catalogId: number, catalogKey: string) {
+async function submitPhysicalFulfillment(orderId: string, session: CheckoutSessionWithShipping, catalogId: number, catalogKey: string) {
   const endpoint = process.env.FULFILLMENT_API_URL;
   const apiKey = process.env.FULFILLMENT_API_KEY;
   if (!endpoint || !apiKey) return { status: 'awaiting_fulfillment' as const };
@@ -17,19 +29,32 @@ async function submitPhysicalFulfillment(orderId: string, session: Stripe.Checko
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({ orderId, externalOrderId: session.id, catalogId, catalogKey, quantity: 1, shipping: {
-      name: shipping.name || '', line1: shipping.address.line1, line2: shipping.address.line2 || null,
-      city: shipping.address.city, state: shipping.address.state || '', postalCode: shipping.address.postal_code,
-      country: shipping.address.country,
-    } }),
+    body: JSON.stringify({
+      orderId,
+      externalOrderId: session.id,
+      catalogId,
+      catalogKey,
+      quantity: 1,
+      shipping: {
+        name: shipping.name || '',
+        line1: shipping.address.line1,
+        line2: shipping.address.line2 || null,
+        city: shipping.address.city,
+        state: shipping.address.state || '',
+        postalCode: shipping.address.postal_code,
+        country: shipping.address.country,
+      },
+    }),
     cache: 'no-store',
   });
   if (!response.ok) throw new Error(`Fulfillment provider returned ${response.status}`);
   const result = await response.json().catch(() => ({}));
-  return { status: 'submitted' as const,
+  return {
+    status: 'submitted' as const,
     fulfillmentOrderId: typeof result.orderId === 'string' ? result.orderId : null,
     trackingNumber: typeof result.trackingNumber === 'string' ? result.trackingNumber : null,
-    trackingUrl: typeof result.trackingUrl === 'string' ? result.trackingUrl : null };
+    trackingUrl: typeof result.trackingUrl === 'string' ? result.trackingUrl : null,
+  };
 }
 
 export async function POST(request: Request) {
@@ -44,7 +69,7 @@ export async function POST(request: Request) {
   try {
     const supabaseAdmin = getSupabaseAdmin();
     if (event.type === 'checkout.session.completed' || event.type === 'checkout.session.async_payment_succeeded') {
-      const session = event.data.object as Stripe.Checkout.Session;
+      const session = event.data.object as CheckoutSessionWithShipping;
       if (session.payment_status !== 'paid') return NextResponse.json({ received: true });
 
       if (session.metadata?.mint_mode === 'physical_nft') {
@@ -58,13 +83,21 @@ export async function POST(request: Request) {
         if (!session.shipping_details?.name || !shipping?.line1 || !shipping.city || !shipping.state || !shipping.postal_code || !shipping.country) throw new Error('Incomplete shipping address');
 
         const { data: order, error } = await supabaseAdmin.from('physical_orders').upsert({
-          buyer_id: buyerId, catalog_id: catalogId, catalog_key: catalogKey,
+          buyer_id: buyerId,
+          catalog_id: catalogId,
+          catalog_key: catalogKey,
           stripe_checkout_session_id: session.id,
           stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-          shipping_name: session.shipping_details.name, shipping_line1: shipping.line1, shipping_line2: shipping.line2 || null,
-          shipping_city: shipping.city, shipping_state: shipping.state || '', shipping_postal_code: shipping.postal_code,
-          shipping_country: shipping.country, currency: session.currency || 'usd',
-          physical_amount_cents: Number(session.metadata?.physical_amount_cents || 0), nft_amount_cents: Number(session.metadata?.nft_amount_cents || 0),
+          shipping_name: session.shipping_details.name,
+          shipping_line1: shipping.line1,
+          shipping_line2: shipping.line2 || null,
+          shipping_city: shipping.city,
+          shipping_state: shipping.state || '',
+          shipping_postal_code: shipping.postal_code,
+          shipping_country: shipping.country,
+          currency: session.currency || 'usd',
+          physical_amount_cents: Number(session.metadata?.physical_amount_cents || 0),
+          nft_amount_cents: Number(session.metadata?.nft_amount_cents || 0),
           fulfillment_status: 'awaiting_fulfillment',
         }, { onConflict: 'stripe_checkout_session_id' }).select('id').single();
         if (error || !order) throw error ?? new Error('Physical order creation failed');


### PR DESCRIPTION
Fix the production TypeScript build by providing a compatible shipping_details type for the installed Stripe SDK while preserving verified shipping-address fulfillment.