### PR TITLE
Harden real-product commerce and physical + NFT fulfillment

### DIFF
--- a/app/api/mint-verify/route.ts
+++ b/app/api/mint-verify/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { stripe } from '../../../lib/stripe-server';
 import { getCatalogItem } from '../../../lib/catalog';
+import { getSupabaseAdmin } from '../../../lib/supabase-admin';
 
 export async function GET(request: Request) {
   try {
@@ -21,10 +22,26 @@ export async function GET(request: Request) {
 
     const item = getCatalogItem(catalogId - 1);
     if (!item) return NextResponse.json({ error: 'Catalog object unavailable' }, { status: 404 });
+
+    let fulfillmentStatus = null;
+    if (mintMode === 'physical_nft') {
+      const supabaseAdmin = getSupabaseAdmin();
+      const { data: order, error } = await supabaseAdmin
+        .from('physical_orders')
+        .select('catalog_key,fulfillment_status')
+        .eq('stripe_checkout_session_id', sessionId)
+        .maybeSingle();
+      if (error) throw error;
+      if (!order) return NextResponse.json({ paid: false, pending: true, error: 'Payment confirmed; waiting for the physical order record to be created.' }, { status: 202 });
+      if (order.catalog_key !== item.id) return NextResponse.json({ paid: false, error: 'Order/catalog mismatch' }, { status: 409 });
+      if (['cancelled', 'failed'].includes(order.fulfillment_status)) return NextResponse.json({ paid: false, error: 'Physical fulfillment is not available for this order.' }, { status: 409 });
+      fulfillmentStatus = order.fulfillment_status;
+    }
+
     return NextResponse.json({
       paid: true,
       fulfillmentIncluded: mintMode === 'physical_nft',
-      fulfillmentStatus: mintMode === 'physical_nft' ? 'awaiting_fulfillment' : null,
+      fulfillmentStatus,
       catalogId,
       wallet,
       item: { id: item.id, name: item.name, creator: item.creator, rarity: item.rarity, realityBasis: item.realityBasis, priceUsd: item.priceUsd, sourceUrl: item.sourceUrl, sourceName: item.sourceName },

--- a/app/api/physical-nft-checkout/route.ts
+++ b/app/api/physical-nft-checkout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { stripe } from '../../../lib/stripe-server';
 import { getCatalogItem } from '../../../lib/catalog';
 import { getSupabaseAdmin } from '../../../lib/supabase-admin';
+import { getFulfillmentConfig } from '../../../lib/fulfillment';
 
 const NFT_FEE_CENTS = 299;
 const WALLET_RE = /^0x[a-fA-F0-9]{40}$/;
@@ -25,12 +26,13 @@ export async function POST(request: Request) {
     if (!item) return NextResponse.json({ error: 'Product unavailable' }, { status: 404 });
     if (!item.sourceUrl || !item.sourceName) return NextResponse.json({ error: 'This product has no verified online source' }, { status: 409 });
 
-    // Fail closed: Voxel Vault must never accept a "ships to you" order unless
-    // a real fulfillment provider is configured server-side.
-    if (!process.env.FULFILLMENT_API_URL || !process.env.FULFILLMENT_API_KEY) {
+    // Fail closed. A real product page is not proof that Voxel Vault has
+    // permission, inventory, or a fulfillment path for that product.
+    const fulfillment = getFulfillmentConfig(item.id);
+    if (!fulfillment) {
       return NextResponse.json({
-        error: 'Automatic physical fulfillment is not connected yet. The verified retailer remains available for the physical purchase, while NFT checkout can be completed separately.',
-        code: 'FULFILLMENT_NOT_CONFIGURED',
+        error: 'This product is source-verified but not connected to a Voxel Vault fulfillment supplier yet.',
+        code: 'FULFILLMENT_NOT_READY',
         sourceUrl: item.sourceUrl,
       }, { status: 503 });
     }
@@ -48,6 +50,7 @@ export async function POST(request: Request) {
       physical_amount_cents: String(physicalCents),
       nft_amount_cents: String(NFT_FEE_CENTS),
       product_source_url: item.sourceUrl,
+      fulfillment_provider: fulfillment.provider,
     };
 
     const session = await stripe.checkout.sessions.create({

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -3,10 +3,12 @@ import Stripe from 'stripe';
 import { stripe } from '../../../../lib/stripe-server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { getCatalogItem } from '../../../../lib/catalog';
+import { submitPhysicalFulfillment } from '../../../../lib/fulfillment';
 
 const WALLET_RE = /^0x[a-f0-9]{40}$/;
 type ShippingDetails = {
   name?: string | null;
+  phone?: string | null;
   address?: {
     line1?: string | null;
     line2?: string | null;
@@ -17,45 +19,6 @@ type ShippingDetails = {
   } | null;
 };
 type CheckoutSessionWithShipping = Stripe.Checkout.Session & { shipping_details?: ShippingDetails | null };
-
-async function submitPhysicalFulfillment(orderId: string, session: CheckoutSessionWithShipping, catalogId: number, catalogKey: string) {
-  const endpoint = process.env.FULFILLMENT_API_URL;
-  const apiKey = process.env.FULFILLMENT_API_KEY;
-  if (!endpoint || !apiKey) return { status: 'awaiting_fulfillment' as const };
-  const shipping = session.shipping_details;
-  if (!shipping?.address?.line1 || !shipping.address.city || !shipping.address.postal_code || !shipping.address.country) {
-    throw new Error('Stripe checkout did not provide a complete shipping address');
-  }
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({
-      orderId,
-      externalOrderId: session.id,
-      catalogId,
-      catalogKey,
-      quantity: 1,
-      shipping: {
-        name: shipping.name || '',
-        line1: shipping.address.line1,
-        line2: shipping.address.line2 || null,
-        city: shipping.address.city,
-        state: shipping.address.state || '',
-        postalCode: shipping.address.postal_code,
-        country: shipping.address.country,
-      },
-    }),
-    cache: 'no-store',
-  });
-  if (!response.ok) throw new Error(`Fulfillment provider returned ${response.status}`);
-  const result = await response.json().catch(() => ({}));
-  return {
-    status: 'submitted' as const,
-    fulfillmentOrderId: typeof result.orderId === 'string' ? result.orderId : null,
-    trackingNumber: typeof result.trackingNumber === 'string' ? result.trackingNumber : null,
-    trackingUrl: typeof result.trackingUrl === 'string' ? result.trackingUrl : null,
-  };
-}
 
 export async function POST(request: Request) {
   const signature = request.headers.get('stripe-signature');
@@ -78,36 +41,63 @@ export async function POST(request: Request) {
         const catalogId = Number(session.metadata?.catalog_id);
         const catalogKey = session.metadata?.catalog_key;
         const item = Number.isInteger(catalogId) ? getCatalogItem(catalogId - 1) : null;
-        const shipping = session.shipping_details?.address;
+        const shipping = session.shipping_details;
+        const address = shipping?.address;
         if (!WALLET_RE.test(wallet || '') || !item || !catalogKey || !buyerId) throw new Error('Invalid physical + NFT checkout metadata');
-        if (!session.shipping_details?.name || !shipping?.line1 || !shipping.city || !shipping.state || !shipping.postal_code || !shipping.country) throw new Error('Incomplete shipping address');
+        if (!shipping?.name || !address?.line1 || !address.city || !address.state || !address.postal_code || !address.country) throw new Error('Incomplete shipping address');
 
-        const { data: order, error } = await supabaseAdmin.from('physical_orders').upsert({
-          buyer_id: buyerId,
-          catalog_id: catalogId,
-          catalog_key: catalogKey,
-          stripe_checkout_session_id: session.id,
-          stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-          shipping_name: session.shipping_details.name,
-          shipping_line1: shipping.line1,
-          shipping_line2: shipping.line2 || null,
-          shipping_city: shipping.city,
-          shipping_state: shipping.state || '',
-          shipping_postal_code: shipping.postal_code,
-          shipping_country: shipping.country,
-          currency: session.currency || 'usd',
-          physical_amount_cents: Number(session.metadata?.physical_amount_cents || 0),
-          nft_amount_cents: Number(session.metadata?.nft_amount_cents || 0),
-          fulfillment_status: 'awaiting_fulfillment',
-        }, { onConflict: 'stripe_checkout_session_id' }).select('id').single();
-        if (error || !order) throw error ?? new Error('Physical order creation failed');
+        const { data: existing, error: lookupError } = await supabaseAdmin
+          .from('physical_orders')
+          .select('id,fulfillment_status,fulfillment_order_id,tracking_number,tracking_url')
+          .eq('stripe_checkout_session_id', session.id)
+          .maybeSingle();
+        if (lookupError) throw lookupError;
 
-        const fulfillment = await submitPhysicalFulfillment(order.id, session, catalogId, catalogKey);
-        const update: Record<string, unknown> = { fulfillment_status: fulfillment.status, updated_at: new Date().toISOString() };
-        if ('fulfillmentOrderId' in fulfillment) update.fulfillment_order_id = fulfillment.fulfillmentOrderId;
-        if ('trackingNumber' in fulfillment) update.tracking_number = fulfillment.trackingNumber;
-        if ('trackingUrl' in fulfillment) update.tracking_url = fulfillment.trackingUrl;
-        await supabaseAdmin.from('physical_orders').update(update).eq('id', order.id);
+        let order = existing;
+        if (!order) {
+          const { data: created, error } = await supabaseAdmin.from('physical_orders').insert({
+            buyer_id: buyerId,
+            catalog_id: catalogId,
+            catalog_key: catalogKey,
+            stripe_checkout_session_id: session.id,
+            stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+            shipping_name: shipping.name,
+            shipping_line1: address.line1,
+            shipping_line2: address.line2 || null,
+            shipping_city: address.city,
+            shipping_state: address.state || '',
+            shipping_postal_code: address.postal_code,
+            shipping_country: address.country,
+            currency: session.currency || 'usd',
+            physical_amount_cents: Number(session.metadata?.physical_amount_cents || 0),
+            nft_amount_cents: Number(session.metadata?.nft_amount_cents || 0),
+            fulfillment_status: 'awaiting_fulfillment',
+          }).select('id,fulfillment_status,fulfillment_order_id,tracking_number,tracking_url').single();
+          if (error || !created) throw error ?? new Error('Physical order creation failed');
+          order = created;
+        }
+
+        if (!['submitted', 'shipped', 'delivered'].includes(order.fulfillment_status)) {
+          try {
+            const fulfillment = await submitPhysicalFulfillment({
+              orderId: order.id,
+              externalOrderId: session.id,
+              catalogKey,
+              shipping,
+              email: session.customer_details?.email || session.customer_email || undefined,
+            });
+            const update: Record<string, unknown> = { fulfillment_status: fulfillment.status, updated_at: new Date().toISOString() };
+            if ('fulfillmentOrderId' in fulfillment && fulfillment.fulfillmentOrderId) update.fulfillment_order_id = fulfillment.fulfillmentOrderId;
+            if ('trackingNumber' in fulfillment && fulfillment.trackingNumber) update.tracking_number = fulfillment.trackingNumber;
+            if ('trackingUrl' in fulfillment && fulfillment.trackingUrl) update.tracking_url = fulfillment.trackingUrl;
+            await supabaseAdmin.from('physical_orders').update(update).eq('id', order.id);
+          } catch (fulfillmentError) {
+            console.error('VoxelVault physical fulfillment submission failed', fulfillmentError);
+            // Stripe retries the signed webhook. The provider adapter uses the
+            // durable Voxel Vault order ID as its idempotency key where supported.
+            return NextResponse.json({ error: 'Fulfillment submission failed; retrying' }, { status: 500 });
+          }
+        }
         return NextResponse.json({ received: true });
       }
 
@@ -126,8 +116,8 @@ export async function POST(request: Request) {
       }
     }
   } catch (error) {
-    console.error('VoxelVault webhook fulfillment failed', error);
-    return NextResponse.json({ error: 'Fulfillment failed' }, { status: 500 });
+    console.error('VoxelVault webhook failed', error);
+    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
   }
   return NextResponse.json({ received: true });
 }

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -1,43 +1,44 @@
 // Voxel Vault production catalog.
-// Every entry is a real-world object with an online product/source page and a
-// category-matched 3D model page. We never label a generic procedural shape as
-// the physical object itself.
+// These are real-world products with official manufacturer/retailer pages.
+// A source-verified product is NOT automatically a fulfillment-ready product.
+// A physical checkout is enabled only when a licensed/authorized fulfillment
+// mapping is configured in VOXEL_FULFILLMENT_CATALOG on the server.
 
 const REAL_WORLD_OBJECTS = [
   {
-    id: 'stanley-quencher-40oz', name: 'Stanley Quencher H2.0 40 oz', creator: 'Stanley', type: 'Artifact', category: 'drinkware', brand: 'Stanley', priceUsd: '45', rarity: 'Verified Object', material: 'Stainless steel', seed: 'stanley-quencher-40oz',
+    id: 'stanley-quencher-40oz', name: 'Stanley Quencher H2.0 40 oz', creator: 'Stanley', type: 'Artifact', category: 'drinkware', brand: 'Stanley', priceUsd: '45', rarity: 'Verified Object', material: 'Stainless steel', seed: 'stanley-quencher-40oz', realityBasis: 'real Stanley Quencher H2.0 40 oz travel tumbler', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/735b3bf2277a4c11b2e09272f158cb77/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/stanley-tumbler-travel-cup-40-oz-735b3bf2277a4c11b2e09272f158cb77', modelLicense: 'CC BY', sourceUrl: 'https://www.stanley1913.com/products/adventure-quencher-travel-tumbler-40-oz', sourceName: 'Stanley official product page', sourceType: 'Official product page', description: 'Real Stanley Quencher product with a published model explicitly identified as a Quencher 2.0.'
   },
   {
-    id: 'sony-wh1000xm5', name: 'Sony WH-1000XM5', creator: 'Sony', type: 'Artifact', category: 'audio', brand: 'Sony', priceUsd: '399', rarity: 'Verified Object', material: 'Polymer / leatherette', seed: 'sony-wh1000xm5',
+    id: 'sony-wh1000xm5', name: 'Sony WH-1000XM5', creator: 'Sony', type: 'Artifact', category: 'audio', brand: 'Sony', priceUsd: '399', rarity: 'Verified Object', material: 'Polymer / leatherette', seed: 'sony-wh1000xm5', realityBasis: 'real Sony WH-1000XM5 wireless headphones', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/5d8aea0a780b49fa89c9c205912414e3/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/sony-wh-1000xm5-5d8aea0a780b49fa89c9c205912414e3', modelLicense: 'CC BY', sourceUrl: 'https://electronics.sony.com/audio/headphones/headband/p/wh1000xm5-b', sourceName: 'Sony official product page', sourceType: 'Official product page', description: 'Real Sony WH-1000XM5 product with a published model explicitly identified as the same product.'
   },
   {
-    id: 'apple-airpods-pro', name: 'Apple AirPods Pro', creator: 'Apple', type: 'Artifact', category: 'audio', brand: 'Apple', priceUsd: '249', rarity: 'Verified Object', material: 'Polycarbonate', seed: 'apple-airpods-pro',
+    id: 'apple-airpods-pro', name: 'Apple AirPods Pro', creator: 'Apple', type: 'Artifact', category: 'audio', brand: 'Apple', priceUsd: '249', rarity: 'Verified Object', material: 'Polycarbonate', seed: 'apple-airpods-pro', realityBasis: 'real Apple AirPods Pro earbuds and charging case', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/40b434f607e24f52925dc27877751f1a/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/air-pods-pro-40b434f607e24f52925dc27877751f1a', modelLicense: 'Attribution on model page', sourceUrl: 'https://www.apple.com/airpods-pro/', sourceName: 'Apple official product page', sourceType: 'Official product page', description: 'Real Apple AirPods Pro product; the model listing says it was exported from Apple AR product media.'
   },
   {
-    id: 'nike-air-force-1', name: 'Nike Air Force 1', creator: 'Nike', type: 'Artifact', category: 'footwear', brand: 'Nike', priceUsd: '115', rarity: 'Verified Object', material: 'Leather / rubber', seed: 'nike-air-force-1',
+    id: 'nike-air-force-1', name: 'Nike Air Force 1', creator: 'Nike', type: 'Artifact', category: 'footwear', brand: 'Nike', priceUsd: '115', rarity: 'Verified Object', material: 'Leather / rubber', seed: 'nike-air-force-1', realityBasis: 'real Nike Air Force 1 sneaker', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/b580fb8a337e4609807185f1fab2f305/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/nike-air-force-1-b580fb8a337e4609807185f1fab2f305', modelLicense: 'CC BY', sourceUrl: 'https://www.nike.com/w/air-force-1-shoes-5sjg7zy7ok', sourceName: 'Nike official shopping page', sourceType: 'Official shopping page', description: 'Real Nike Air Force 1 product family with a published 3D model explicitly identified as an Air Force 1 sneaker.'
   },
   {
-    id: 'apple-iphone-15-pro', name: 'Apple iPhone 15 Pro', creator: 'Apple', type: 'Artifact', category: 'electronics', brand: 'Apple', priceUsd: '999', rarity: 'Verified Object', material: 'Titanium / glass', seed: 'apple-iphone-15-pro',
+    id: 'apple-iphone-15-pro', name: 'Apple iPhone 15 Pro', creator: 'Apple', type: 'Artifact', category: 'electronics', brand: 'Apple', priceUsd: '999', rarity: 'Verified Object', material: 'Titanium / glass', seed: 'apple-iphone-15-pro', realityBasis: 'real Apple iPhone 15 Pro smartphone', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/9e045e469d514fea9dda2ccd161f5fa3/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/iphone-15-pro-9e045e469d514fea9dda2ccd161f5fa3', modelLicense: 'CC BY', sourceUrl: 'https://www.apple.com/iphone-15-pro/', sourceName: 'Apple product information', sourceType: 'Official product page', description: 'Real iPhone 15 Pro product with a published model explicitly identified as the iPhone 15 Pro.'
   },
   {
-    id: 'sony-playstation-5', name: 'Sony PlayStation 5', creator: 'Sony Interactive Entertainment', type: 'Artifact', category: 'gaming', brand: 'PlayStation', priceUsd: '499', rarity: 'Verified Object', material: 'Polycarbonate / metal', seed: 'sony-playstation-5',
+    id: 'sony-playstation-5', name: 'Sony PlayStation 5', creator: 'Sony Interactive Entertainment', type: 'Artifact', category: 'gaming', brand: 'PlayStation', priceUsd: '499', rarity: 'Verified Object', material: 'Polycarbonate / metal', seed: 'sony-playstation-5', realityBasis: 'real Sony PlayStation 5 console', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/8e602d71ddc94bf09731db9151fc7cd3/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/playstation-5-set-8e602d71ddc94bf09731db9151fc7cd3', modelLicense: 'CC BY', sourceUrl: 'https://direct.playstation.com/en-us/buy-consoles/playstation5-console-1tb', sourceName: 'PlayStation Direct', sourceType: 'Official shopping page', description: 'Real PlayStation 5 console represented by a published PS5 set model containing the console and DualSense controller.'
   },
   {
-    id: 'gopro-hero', name: 'GoPro HERO action camera', creator: 'GoPro', type: 'Artifact', category: 'camera', brand: 'GoPro', priceUsd: '299', rarity: 'Verified Object', material: 'Polycarbonate / glass', seed: 'gopro-hero',
+    id: 'gopro-hero', name: 'GoPro HERO action camera', creator: 'GoPro', type: 'Artifact', category: 'camera', brand: 'GoPro', priceUsd: '299', rarity: 'Verified Object', material: 'Polycarbonate / glass', seed: 'gopro-hero', realityBasis: 'real GoPro HERO-family action camera', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/507cf5adab234062a2fa00d3e1f82dca/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/gopro-hero-full-hd-action-camera-507cf5adab234062a2fa00d3e1f82dca', modelLicense: 'Attribution on model page', sourceUrl: 'https://gopro.com/en/us/shop/cameras', sourceName: 'GoPro official camera shop', sourceType: 'Official shopping page', description: 'Real GoPro HERO-family action camera represented by a detailed model explicitly based on GoPro HERO design.'
   },
   {
-    id: 'rolex-submariner', name: 'Rolex Submariner', creator: 'Rolex', type: 'Artifact', category: 'watches', brand: 'Rolex', priceUsd: '10000+', rarity: 'Verified Object', material: 'Steel / ceramic', seed: 'rolex-submariner',
+    id: 'rolex-submariner', name: 'Rolex Submariner', creator: 'Rolex', type: 'Artifact', category: 'watches', brand: 'Rolex', priceUsd: '10000+', rarity: 'Verified Object', material: 'Steel / ceramic', seed: 'rolex-submariner', realityBasis: 'real Rolex Submariner watch family', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/0fde5c5f56d841cda53ae4a01f66dfaf/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/rolex-watch-0fde5c5f56d841cda53ae4a01f66dfaf', modelLicense: 'CC BY', sourceUrl: 'https://www.rolex.com/watches/submariner', sourceName: 'Rolex official collection', sourceType: 'Official product page', description: 'Real Rolex Submariner family object with a published Submariner model.'
   },
   {
-    id: 'iphone-15-pro-alt', name: 'Apple iPhone 15 Pro Titanium', creator: 'Apple', type: 'Artifact', category: 'electronics', brand: 'Apple', priceUsd: '999', rarity: 'Verified Object', material: 'Titanium / glass', seed: 'iphone-15-pro-alt',
+    id: 'iphone-15-pro-alt', name: 'Apple iPhone 15 Pro Titanium', creator: 'Apple', type: 'Artifact', category: 'electronics', brand: 'Apple', priceUsd: '999', rarity: 'Verified Object', material: 'Titanium / glass', seed: 'iphone-15-pro-alt', realityBasis: 'real Apple iPhone 15 Pro smartphone colorway', productStatus: 'source_verified', fulfillmentStatus: 'source_verified',
     modelEmbedUrl: 'https://sketchfab.com/models/6fd1283ec05d412d99a3f23b2e80e473/embed?autostart=1&ui_theme=dark', modelSourceUrl: 'https://sketchfab.com/3d-models/apple-iphone-15-pro-black-6fd1283ec05d412d99a3f23b2e80e473', modelLicense: 'CC BY', sourceUrl: 'https://www.apple.com/iphone-15-pro/', sourceName: 'Apple product information', sourceType: 'Official product page', description: 'A second published iPhone 15 Pro model, representing another real-world colorway.'
   }
 ];

--- a/lib/fulfillment.js
+++ b/lib/fulfillment.js
@@ -1,0 +1,145 @@
+const DEFAULT_SHOPIFY_API_VERSION = '2026-07';
+
+function readCatalogMap() {
+  const raw = process.env.VOXEL_FULFILLMENT_CATALOG;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    throw new Error('VOXEL_FULFILLMENT_CATALOG must be valid JSON');
+  }
+}
+
+export function getFulfillmentConfig(catalogKey) {
+  const entry = readCatalogMap()[catalogKey];
+  if (!entry || typeof entry !== 'object') return null;
+  const provider = String(entry.provider || '').toLowerCase();
+  if (provider === 'shopify') {
+    const variantId = String(entry.variantId || '');
+    const storeDomain = String(process.env.SHOPIFY_STORE_DOMAIN || '').replace(/^https?:\/\//, '').replace(/\/$/, '');
+    const accessToken = process.env.SHOPIFY_ADMIN_ACCESS_TOKEN || '';
+    if (!variantId || !storeDomain || !accessToken) return null;
+    return { provider, variantId, storeDomain, accessToken, apiVersion: process.env.SHOPIFY_API_VERSION || DEFAULT_SHOPIFY_API_VERSION };
+  }
+  if (provider === 'generic') {
+    const endpoint = process.env.FULFILLMENT_API_URL || '';
+    const apiKey = process.env.FULFILLMENT_API_KEY || '';
+    const sku = String(entry.sku || '');
+    if (!endpoint || !apiKey || !sku) return null;
+    return { provider, endpoint, apiKey, sku };
+  }
+  return null;
+}
+
+function requiredShipping(shipping) {
+  if (!shipping?.name || !shipping?.address?.line1 || !shipping.address.city || !shipping.address.postal_code || !shipping.address.country) {
+    throw new Error('Stripe checkout did not provide a complete shipping address');
+  }
+  return shipping;
+}
+
+async function shopifyCreateOrder(config, input) {
+  const endpoint = `https://${config.storeDomain}/admin/api/${config.apiVersion}/graphql.json`;
+  const query = `mutation orderCreate($order: OrderCreateOrderInput!, $options: OrderCreateOptionsInput) {
+    orderCreate(order: $order, options: $options) {
+      userErrors { field message }
+      order { id name displayFinancialStatus displayFulfillmentStatus }
+    }
+  }`;
+  const shipping = requiredShipping(input.shipping);
+  const nameParts = String(shipping.name).trim().split(/\s+/);
+  const firstName = nameParts.shift() || 'Voxel';
+  const lastName = nameParts.join(' ') || 'Vault Customer';
+  const variables = {
+    order: {
+      lineItems: [{ variantId: config.variantId, quantity: 1 }],
+      email: input.email || undefined,
+      phone: shipping.phone || undefined,
+      customer: { toUpsert: { email: input.email || undefined, firstName, lastName } },
+      shippingAddress: {
+        firstName,
+        lastName,
+        address1: shipping.address.line1,
+        address2: shipping.address.line2 || undefined,
+        city: shipping.address.city,
+        province: shipping.address.state || undefined,
+        countryCode: shipping.address.country,
+        zip: shipping.address.postal_code,
+        phone: shipping.phone || undefined,
+      },
+      billingAddress: {
+        firstName,
+        lastName,
+        address1: shipping.address.line1,
+        address2: shipping.address.line2 || undefined,
+        city: shipping.address.city,
+        province: shipping.address.state || undefined,
+        countryCode: shipping.address.country,
+        zip: shipping.address.postal_code,
+      },
+      financialStatus: 'PAID',
+      note: `Voxel Vault physical + NFT order ${input.externalOrderId}`,
+    },
+    options: { sendReceipt: true, sendFulfillmentReceipt: true },
+  };
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-Shopify-Access-Token': config.accessToken },
+    body: JSON.stringify({ query, variables }),
+    cache: 'no-store',
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(`Shopify fulfillment request failed with ${response.status}`);
+  const errors = payload?.data?.orderCreate?.userErrors || [];
+  if (errors.length) throw new Error(`Shopify order rejected: ${errors.map((e) => e.message).join('; ')}`);
+  const order = payload?.data?.orderCreate?.order;
+  if (!order?.id) throw new Error('Shopify did not return an order ID');
+  return { status: 'submitted', fulfillmentOrderId: order.id, trackingNumber: null, trackingUrl: null };
+}
+
+async function genericSubmit(config, input) {
+  const shipping = requiredShipping(input.shipping);
+  const response = await fetch(config.endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${config.apiKey}`,
+      'Idempotency-Key': input.orderId,
+    },
+    body: JSON.stringify({
+      orderId: input.orderId,
+      externalOrderId: input.externalOrderId,
+      catalogKey: input.catalogKey,
+      sku: config.sku,
+      quantity: 1,
+      shipping: {
+        name: shipping.name,
+        phone: shipping.phone || null,
+        line1: shipping.address.line1,
+        line2: shipping.address.line2 || null,
+        city: shipping.address.city,
+        state: shipping.address.state || '',
+        postalCode: shipping.address.postal_code,
+        country: shipping.address.country,
+      },
+    }),
+    cache: 'no-store',
+  });
+  if (!response.ok) throw new Error(`Fulfillment provider returned ${response.status}`);
+  const result = await response.json().catch(() => ({}));
+  return {
+    status: 'submitted',
+    fulfillmentOrderId: typeof result.orderId === 'string' ? result.orderId : null,
+    trackingNumber: typeof result.trackingNumber === 'string' ? result.trackingNumber : null,
+    trackingUrl: typeof result.trackingUrl === 'string' ? result.trackingUrl : null,
+  };
+}
+
+export async function submitPhysicalFulfillment({ orderId, externalOrderId, catalogKey, shipping, email }) {
+  const config = getFulfillmentConfig(catalogKey);
+  if (!config) return { status: 'awaiting_fulfillment' };
+  const input = { orderId, externalOrderId, catalogKey, shipping, email };
+  if (config.provider === 'shopify') return shopifyCreateOrder(config, input);
+  return genericSubmit(config, input);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-vault",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",
@@ -11,7 +11,8 @@
     "test:media": "node scripts/test-media-gallery.mjs",
     "test:mobile": "node scripts/check-mobile-webgl.mjs",
     "test:collection": "node scripts/test-collection-experience.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run build",
+    "test:commerce": "node scripts/test-commerce-hardening.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:commerce && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-commerce-hardening.mjs
+++ b/scripts/test-commerce-hardening.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+
+const catalog = fs.readFileSync('lib/catalog.js', 'utf8');
+const checkout = fs.readFileSync('app/api/physical-nft-checkout/route.ts', 'utf8');
+const webhook = fs.readFileSync('app/api/stripe/webhook/route.ts', 'utf8');
+const verify = fs.readFileSync('app/api/mint-verify/route.ts', 'utf8');
+const fulfillment = fs.readFileSync('lib/fulfillment.js', 'utf8');
+
+const required = [
+  ['catalog source URLs', /sourceUrl:/g, catalog],
+  ['catalog reality basis', /realityBasis:/g, catalog],
+  ['checkout fulfillment gate', /FULFILLMENT_NOT_READY/g, checkout],
+  ['shipping address collection', /shipping_address_collection/g, checkout],
+  ['Stripe webhook signature verification', /constructEvent/g, webhook],
+  ['durable physical order lookup', /physical_orders/g, webhook],
+  ['fulfillment idempotency key', /Idempotency-Key/g, fulfillment],
+  ['Shopify order creation support', /orderCreate/g, fulfillment],
+  ['physical order required before mint verification', /maybeSingle/g, verify],
+];
+
+for (const [label, pattern, source] of required) {
+  if (!pattern.test(source)) throw new Error(`Missing commerce hardening: ${label}`);
+}
+
+const sourceCount = (catalog.match(/sourceUrl:/g) || []).length;
+const realityCount = (catalog.match(/realityBasis:/g) || []).length;
+if (sourceCount < 8 || realityCount !== sourceCount) throw new Error(`Catalog provenance mismatch: ${sourceCount} sources / ${realityCount} reality records`);
+
+console.log(`Commerce hardening smoke test passed: ${sourceCount} source-verified products`);


### PR DESCRIPTION
## What this does

- Keeps the approved Voxel Vault visual/product direction.
- Makes product provenance explicit: real-world product + official source + reality basis.
- Adds a fail-closed fulfillment gate so Voxel Vault cannot charge for a physical item unless a real supplier mapping is configured.
- Adds a fulfillment adapter supporting a generic idempotent provider and Shopify Admin GraphQL order creation.
- Collects and validates the shipping address through Stripe Checkout.
- Makes Stripe webhook fulfillment durable/idempotent and retries failed fulfillment safely.
- Requires a durable physical order before the physical + NFT purchase can be verified for minting.
- Adds a commerce hardening smoke test to the release gate.

## Fulfillment configuration

Physical checkout is intentionally disabled until the catalog item has a legitimate fulfillment mapping in `VOXEL_FULFILLMENT_CATALOG` and the corresponding provider credentials are configured server-side.

For Shopify, configure `SHOPIFY_STORE_DOMAIN`, `SHOPIFY_ADMIN_ACCESS_TOKEN`, and a per-product `variantId` mapping. The Shopify store should itself be connected to an authorized supplier/dropshipping workflow. A manufacturer/retailer URL alone does not authorize resale or fulfillment.

This prevents Voxel Vault from accepting money for a product it cannot actually ship.

## Product model

REAL PRODUCT → verified source → legitimate fulfillment mapping → Stripe physical + NFT checkout → server-side payment verification → supplier order → shipment/tracking → NFT → Vault → Room → World Map.
