### PR TITLE
Fix canonical 3D NFT presentation

### DIFF
--- a/app/components/CanonicalNFTMedia.js
+++ b/app/components/CanonicalNFTMedia.js
@@ -13,12 +13,15 @@ export default function CanonicalNFTMedia({ item, interactive = false, className
     material: item?.material,
     seed: item?.seed,
     rarity: item?.rarity,
+    shape: item?.shape,
     interactive,
     showcase: !interactive,
     compact: !interactive,
     label: false,
   };
 
+  // A canonical collectible is always presented as a 3D NFT. A verified/licensed
+  // model takes priority; otherwise ArtPreview supplies the deterministic digital twin.
   if (media.modelUri) {
     return (
       <div className={`flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden ${className}`}>
@@ -36,21 +39,12 @@ export default function CanonicalNFTMedia({ item, interactive = false, className
     );
   }
 
-  if (media.previewUri) {
-    return (
-      <div className={`flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden ${className}`}>
-        <img
-          src={media.previewUri}
-          alt={item?.name || 'Voxel Vault collectible'}
-          className="block max-h-full max-w-full object-contain object-center"
-          loading={interactive ? 'eager' : 'lazy'}
-          decoding="async"
-          fetchPriority={interactive ? 'high' : 'auto'}
-          referrerPolicy="no-referrer"
-        />
+  return (
+    <div className={`relative flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden ${className}`}>
+      <ArtPreview {...previewProps} />
+      <div className="pointer-events-none absolute left-4 top-4 rounded-full border border-violet-300/20 bg-black/45 px-3 py-1 text-[9px] font-black uppercase tracking-[.18em] text-violet-200 backdrop-blur-md">
+        3D NFT Twin
       </div>
-    );
-  }
-
-  return fallback || <ArtPreview {...previewProps} />;
+    </div>
+  );
 }

--- a/lib/media/assetResolver.js
+++ b/lib/media/assetResolver.js
@@ -2,7 +2,17 @@ export function resolveNFTMedia(item = {}) {
   const ai = item.ai?.asset || item.aiAsset || item.asset || {};
   const modelUri = firstString(ai.modelUri, item.modelUri, item.glb, item.gltf, item.assetUrl);
   const previewUri = firstString(ai.previewUri, item.previewUri, item.image, item.imageUrl, item.imageUri);
-  return { modelUri, previewUri, kind: modelUri ? '3d' : previewUri ? '2d' : 'procedural', ready: Boolean(modelUri || previewUri) };
+
+  // Every canonical collectible gets a 3D representation. When a verified/licensed
+  // GLB/GLTF is unavailable, the client uses its deterministic procedural digital twin.
+  // This keeps the NFT experience 3D without pretending a generated twin is an exact scan.
+  return {
+    modelUri,
+    previewUri,
+    kind: modelUri ? '3d-model' : '3d-twin',
+    ready: Boolean(modelUri || previewUri),
+    has3DTwin: true,
+  };
 }
 
 function firstString(...values) {


### PR DESCRIPTION
Make the canonical collectible media layer consistently present every Voxel Vault collectible as a 3D NFT twin. Verified/licensed GLB/GLTF assets remain preferred; otherwise the deterministic procedural ArtPreview is used instead of falling back to a flat product image. This keeps the premium layout 3D-first while preserving the real-world product truth boundary.