### PR TITLE
Polish the canonical 3D NFT experience

### DIFF
--- a/app/components/CanonicalNFTMedia.js
+++ b/app/components/CanonicalNFTMedia.js
@@ -5,8 +5,9 @@ import { resolveNFTMedia } from '../../lib/media/assetResolver';
 
 const Safe3DViewer = dynamic(() => import('./Safe3DViewer'), { ssr: false });
 const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
+const NFT3DStage = dynamic(() => import('./NFT3DStage'), { ssr: false });
 
-export default function CanonicalNFTMedia({ item, interactive = false, className = '', fallback = null }) {
+export default function CanonicalNFTMedia({ item, interactive = false, className = '' }) {
   const media = resolveNFTMedia(item);
   const previewProps = {
     family: item?.family,
@@ -15,36 +16,32 @@ export default function CanonicalNFTMedia({ item, interactive = false, className
     rarity: item?.rarity,
     shape: item?.shape,
     interactive,
-    showcase: !interactive,
-    compact: !interactive,
+    showcase: true,
+    compact: false,
     label: false,
   };
 
-  // A canonical collectible is always presented as a 3D NFT. A verified/licensed
-  // model takes priority; otherwise ArtPreview supplies the deterministic digital twin.
-  if (media.modelUri) {
-    return (
-      <div className={`flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden ${className}`}>
-        <Safe3DViewer
-          assetUrl={media.modelUri}
-          previewProps={{ ...previewProps, imageUrl: media.previewUri || undefined }}
-          interactive={interactive}
-          shape={item?.shape}
-          family={item?.family}
-          material={item?.material}
-          rarity={item?.rarity}
-          seed={item?.seed}
-        />
-      </div>
-    );
-  }
-
   return (
-    <div className={`relative flex h-full min-h-[280px] w-full items-center justify-center overflow-hidden ${className}`}>
-      <ArtPreview {...previewProps} />
-      <div className="pointer-events-none absolute left-4 top-4 rounded-full border border-violet-300/20 bg-black/45 px-3 py-1 text-[9px] font-black uppercase tracking-[.18em] text-violet-200 backdrop-blur-md">
-        3D NFT Twin
+    <NFT3DStage title={item?.name || 'Digital Twin'} status={media.modelUri ? 'VERIFIED 3D ASSET' : 'LIVE DIGITAL TWIN'}>
+      <div className={`relative flex min-h-[320px] items-center justify-center ${className}`}>
+        {media.modelUri ? (
+          <Safe3DViewer
+            assetUrl={media.modelUri}
+            previewProps={{ ...previewProps, imageUrl: media.previewUri || undefined, alt: item?.name || 'Real-world object' }}
+            interactive={interactive}
+            shape={item?.shape}
+            family={item?.family}
+            material={item?.material}
+            rarity={item?.rarity}
+            seed={item?.seed}
+          />
+        ) : (
+          <ArtPreview {...previewProps} />
+        )}
+        <div className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border border-white/10 bg-black/55 px-3 py-1.5 text-[8px] font-black uppercase tracking-[.18em] text-white/60 backdrop-blur-md">
+          3D collectible · NFT
+        </div>
       </div>
-    </div>
+    </NFT3DStage>
   );
 }

--- a/app/components/NFT3DStage.js
+++ b/app/components/NFT3DStage.js
@@ -1,0 +1,23 @@
+'use client';
+
+import React from 'react';
+
+export default function NFT3DStage({ children, title = '3D NFT', status = 'LIVE DIGITAL TWIN' }) {
+  return (
+    <section className="relative w-full overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_50%_35%,rgba(139,92,246,.18),transparent_42%),linear-gradient(145deg,#0b0d18,#03040a)] shadow-[0_30px_90px_rgba(0,0,0,.42)]">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(255,255,255,.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.035)_1px,transparent_1px)] bg-[size:32px_32px] opacity-40" />
+      <div className="relative flex items-center justify-between px-4 pt-4 sm:px-5">
+        <div>
+          <div className="text-[9px] font-black uppercase tracking-[.24em] text-violet-300">{status}</div>
+          <div className="mt-1 text-sm font-semibold text-white">{title}</div>
+        </div>
+        <div className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-2.5 py-1 text-[8px] font-black uppercase tracking-[.18em] text-emerald-200">NFT</div>
+      </div>
+      <div className="relative px-2 pb-2 pt-1 sm:px-3">{children}</div>
+      <div className="relative flex items-center justify-between border-t border-white/10 px-4 py-3 text-[9px] font-bold uppercase tracking-[.16em] text-white/40 sm:px-5">
+        <span>Interactive digital collectible</span>
+        <span>Physical + NFT</span>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Improve the 3D NFT presentation without changing the core product direction. Add a premium 3D stage, clearer NFT identity, stronger framing, and consistent physical + NFT messaging. Verified 3D assets remain preferred; deterministic digital twins remain the fallback. Keep failures isolated from the storefront.