### PR TITLE
Make real-world 3D NFTs resilient and storefront-native

### DIFF
--- a/app/components/RealWorld3DNFT.js
+++ b/app/components/RealWorld3DNFT.js
@@ -5,15 +5,20 @@ import dynamic from 'next/dynamic';
 const CanonicalNFTMedia = dynamic(() => import('./CanonicalNFTMedia'), { ssr: false });
 
 export default function RealWorld3DNFT({ item, hero = false }) {
+  // External reference models remain provenance data. They are never required to
+  // render the storefront, because corporate networks can block third-party embeds.
+  // The NFT presentation therefore uses the local deterministic digital twin first.
+  const storefrontTwin = { ...item, modelUri: null, glb: null, gltf: null, assetUrl: null };
+
   return (
     <div className={`vv3-modelFrame ${hero ? 'vv3-modelFrameHero' : ''}`}>
       <div className="vv3-grid" aria-hidden="true" />
-      <CanonicalNFTMedia item={item} interactive className="relative z-[1] h-full w-full" />
+      <CanonicalNFTMedia item={storefrontTwin} interactive className="relative z-[1] h-full w-full" />
       <div className="pointer-events-none absolute left-4 top-4 z-10 rounded-full border border-violet-300/25 bg-black/55 px-3 py-1 text-[9px] font-black uppercase tracking-[.18em] text-violet-100 backdrop-blur-md">
         <span aria-hidden="true">◆</span> 3D NFT TWIN
       </div>
       <div className="pointer-events-none absolute bottom-4 left-4 right-4 z-10 flex items-center justify-between gap-3 text-[9px] font-black uppercase tracking-[.14em] text-white/60">
-        <span>{item.modelUri ? 'VERIFIED 3D ASSET' : 'DIGITAL TWIN'}</span>
+        <span>VOXEL 3D DIGITAL TWIN</span>
         <span>REAL-WORLD OBJECT</span>
       </div>
     </div>

--- a/app/components/RealWorld3DNFT.js
+++ b/app/components/RealWorld3DNFT.js
@@ -1,0 +1,21 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const CanonicalNFTMedia = dynamic(() => import('./CanonicalNFTMedia'), { ssr: false });
+
+export default function RealWorld3DNFT({ item, hero = false }) {
+  return (
+    <div className={`vv3-modelFrame ${hero ? 'vv3-modelFrameHero' : ''}`}>
+      <div className="vv3-grid" aria-hidden="true" />
+      <CanonicalNFTMedia item={item} interactive className="relative z-[1] h-full w-full" />
+      <div className="pointer-events-none absolute left-4 top-4 z-10 rounded-full border border-violet-300/25 bg-black/55 px-3 py-1 text-[9px] font-black uppercase tracking-[.18em] text-violet-100 backdrop-blur-md">
+        <span aria-hidden="true">◆</span> 3D NFT TWIN
+      </div>
+      <div className="pointer-events-none absolute bottom-4 left-4 right-4 z-10 flex items-center justify-between gap-3 text-[9px] font-black uppercase tracking-[.14em] text-white/60">
+        <span>{item.modelUri ? 'VERIFIED 3D ASSET' : 'DIGITAL TWIN'}</span>
+        <span>REAL-WORLD OBJECT</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/RealWorldCommerceHome.js
+++ b/app/components/RealWorldCommerceHome.js
@@ -1,13 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
-import dynamic from 'next/dynamic';
 import { REAL_WORLD_CATALOG } from '../../lib/realWorldCatalog';
+import RealWorld3DNFT from './RealWorld3DNFT';
 import './VaultHomeV3.css';
-
-const ArtPreview = dynamic(() => import('./ArtPreview'), { ssr: false });
 
 function Icon({ name, size = 18 }) {
   const paths = {
@@ -22,77 +18,6 @@ function Brand() {
   return <Link href="/" className="vv3-brand" aria-label="Voxel Vault home"><span className="vv3-brandMark"><i/><i/><i/></span><span>VOXEL <b>VAULT</b></span></Link>;
 }
 
-function Automatic3D({ item, hero = false }) {
-  const host = useRef(null);
-  const timer = useRef(null);
-  const [visible, setVisible] = useState(hero);
-  const [externalLoaded, setExternalLoaded] = useState(false);
-  const [externalFailed, setExternalFailed] = useState(false);
-  const [imageFailed, setImageFailed] = useState(false);
-
-  useEffect(() => {
-    if (hero || !host.current || typeof IntersectionObserver === 'undefined') {
-      if (!hero) setVisible(true);
-      return undefined;
-    }
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setVisible(true);
-        observer.disconnect();
-      }
-    }, { rootMargin: '350px' });
-    observer.observe(host.current);
-    return () => observer.disconnect();
-  }, [hero]);
-
-  useEffect(() => {
-    if (!visible || !item.modelEmbedUrl || externalLoaded) return undefined;
-    timer.current = window.setTimeout(() => setExternalFailed(true), 10000);
-    return () => { if (timer.current) window.clearTimeout(timer.current); };
-  }, [visible, item.modelEmbedUrl, externalLoaded]);
-
-  const modelUrl = item.modelEmbedUrl?.replace('autostart=1', 'autostart=0');
-  const hasExternalTwin = Boolean(modelUrl) && visible && !externalFailed;
-  const twinStatus = externalLoaded ? 'VERIFIED 3D REFERENCE' : 'VOXEL 3D DIGITAL TWIN';
-
-  return <div ref={host} className="vv3-modelFrame" style={{ minHeight: hero ? 420 : 260 }}>
-    <div className="vv3-grid"/>
-
-    {visible && <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
-      <ArtPreview
-        family={item.family || 'artifact'}
-        material={item.material || 'metallic'}
-        seed={item.seed}
-        rarity={item.rarity}
-        interactive
-        showcase
-        compact={!hero}
-        label={false}
-      />
-    </div>}
-
-    {!imageFailed && <Image src={item.previewUri} alt={`${item.name} physical product reference`} fill priority={hero} sizes={hero ? '(max-width: 900px) 100vw, 50vw' : '(max-width: 900px) 100vw, 33vw'} quality={78} style={{ objectFit: 'cover', opacity: visible ? 0.08 : 0.9, zIndex: 0 }} onError={() => setImageFailed(true)} />}
-
-    {hasExternalTwin && <iframe
-      title={`${item.name} verified 3D reference`}
-      src={modelUrl}
-      style={{ position: 'absolute', inset: 0, zIndex: 2, width: '100%', height: '100%', minHeight: hero ? 420 : 260, border: 0, display: externalLoaded ? 'block' : 'none', background: 'transparent' }}
-      allow="autoplay; fullscreen; xr-spatial-tracking"
-      allowFullScreen
-      loading="lazy"
-      referrerPolicy="strict-origin-when-cross-origin"
-      onLoad={() => { setExternalLoaded(true); if (timer.current) window.clearTimeout(timer.current); }}
-      onError={() => setExternalFailed(true)}
-    />}
-
-    <div className="vv3-3dBadge" style={{ zIndex: 4 }}><Icon name="cube" size={13}/> 3D NFT · {twinStatus}</div>
-    <div style={{ position: 'absolute', bottom: 12, left: 12, right: 12, zIndex: 4, display: 'flex', justifyContent: 'space-between', gap: 8, pointerEvents: 'none' }}>
-      <span style={{ borderRadius: 999, padding: '6px 9px', background: 'rgba(5,6,12,.66)', border: '1px solid rgba(255,255,255,.1)', backdropFilter: 'blur(12px)', color: 'rgba(255,255,255,.82)', fontSize: 8, fontWeight: 900, letterSpacing: '.12em' }}>REAL-WORLD OBJECT</span>
-      <span style={{ borderRadius: 999, padding: '6px 9px', background: 'rgba(5,6,12,.66)', border: '1px solid rgba(255,255,255,.1)', backdropFilter: 'blur(12px)', color: 'rgba(255,255,255,.62)', fontSize: 8, fontWeight: 800, letterSpacing: '.1em' }}>{externalLoaded ? 'SOURCE MODEL' : 'DIGITAL TWIN'}</span>
-    </div>
-  </div>;
-}
-
 function BuyBoth({ item }) {
   const ready = Boolean(item.fulfillmentReady && item.purchaseAssetId);
   const margin = Number(item.targetMarginPercent || 0);
@@ -104,11 +29,11 @@ function BuyBoth({ item }) {
 
 function Card({ item, index }) {
   return <article className="vv3-objectCard">
-    <div className="vv3-objectVisual"><Automatic3D item={item}/><span className="vv3-cardIndex">{String(index + 1).padStart(2, '0')}</span><span className="vv3-liveBadge"><i/> REAL OBJECT</span></div>
+    <div className="vv3-objectVisual"><RealWorld3DNFT item={item}/><span className="vv3-cardIndex">{String(index + 1).padStart(2, '0')}</span><span className="vv3-liveBadge"><i/> REAL OBJECT</span></div>
     <div className="vv3-objectDetails"><div><small>{item.type}</small><h3>{item.name}</h3></div><strong>${item.priceUsd}</strong></div>
     <div className="vv3-objectMeta"><span>{item.sourceName}</span><span>3D NFT TWIN</span></div>
     <BuyBoth item={item}/>
-    <div style={{ padding: '0 14px 14px', fontSize: 10, color: 'rgba(255,255,255,.5)', lineHeight: 1.5 }}>Real product source is shown for identity and provenance. Voxel Vault checkout remains on-site; the physical sale is enabled only after an authorized supplier/SKU is connected. Pricing is supplier cost plus the configured Vault margin.</div>
+    <div style={{ padding: '0 14px 14px', fontSize: 10, color: 'rgba(255,255,255,.5)', lineHeight: 1.5 }}>Real product source is shown for identity and provenance. Voxel Vault checkout stays on-site and is enabled only after an authorized supplier/SKU is connected. Pricing can include the configured Vault margin.</div>
   </article>;
 }
 
@@ -117,7 +42,7 @@ export default function RealWorldCommerceHome() {
   return <main className="vv3-home">
     <div className="vv3-noise" aria-hidden="true"/>
     <header className="vv3-header"><div className="vv3-topbar"><Brand/><nav className="vv3-desktopNav" aria-label="Primary navigation"><Link href="/discover">Discover</Link><Link href="/marketplace">Marketplace</Link><Link href="/room">My vault</Link><Link href="/ai">Intelligence</Link></nav><Link className="vv3-headerCta" href="#collection">Shop physical + NFT <Icon name="arrow" size={15}/></Link></div></header>
-    <section className="vv3-hero"><div className="vv3-heroGlow" aria-hidden="true"/><div className="vv3-heroCopy"><div className="vv3-eyebrow"><i/> PHYSICAL + DIGITAL COLLECTION</div><h1>Real objects.<br/><em>3D NFTs.</em></h1><p>Buy the physical product and its 3D digital twin together. The product ships to you; the NFT lives in your Vault, Room, and World.</p><div className="vv3-heroActions"><Link className="vv3-primaryCta" href="#collection">Shop both <Icon name="arrow" size={17}/></Link><Link className="vv3-textCta" href="/room"><span><Icon name="cube" size={14}/></span> Open Vault</Link></div><div className="vv3-proofRow"><span><Icon name="shield" size={16}/><b>Real product</b></span><span><Icon name="cube" size={16}/><b>Automatic 3D twin</b></span><span><Icon name="shield" size={16}/><b>Verified NFT</b></span></div></div><div className="vv3-heroVisual"><div className="vv3-visualTop"><span><i/> 3D NFT</span><small>AUTOMATIC DIGITAL TWIN</small></div><Automatic3D item={hero} hero/><div className="vv3-featureMeta"><div><small>PHYSICAL + DIGITAL</small><strong>{hero.name}</strong><span>{hero.creator} · ${hero.priceUsd}</span></div></div><BuyBoth item={hero}/></div></section>
+    <section className="vv3-hero"><div className="vv3-heroGlow" aria-hidden="true"/><div className="vv3-heroCopy"><div className="vv3-eyebrow"><i/> PHYSICAL + DIGITAL COLLECTION</div><h1>Real objects.<br/><em>3D NFTs.</em></h1><p>Buy the physical product and its 3D digital twin together. The product ships to you; the NFT lives in your Vault, Room, and World.</p><div className="vv3-heroActions"><Link className="vv3-primaryCta" href="#collection">Shop both <Icon name="arrow" size={17}/></Link><Link className="vv3-textCta" href="/room"><span><Icon name="cube" size={14}/></span> Open Vault</Link></div><div className="vv3-proofRow"><span><Icon name="shield" size={16}/><b>Real product</b></span><span><Icon name="cube" size={16}/><b>Automatic 3D twin</b></span><span><Icon name="shield" size={16}/><b>Verified NFT</b></span></div></div><div className="vv3-heroVisual"><div className="vv3-visualTop"><span><i/> 3D NFT</span><small>AUTOMATIC DIGITAL TWIN</small></div><RealWorld3DNFT item={hero} hero/><div className="vv3-featureMeta"><div><small>PHYSICAL + DIGITAL</small><strong>{hero.name}</strong><span>{hero.creator} · ${hero.priceUsd}</span></div></div><BuyBoth item={hero}/></div></section>
     <section className="vv3-signalBar"><span>REAL PRODUCTS</span><i/><span>3D DIGITAL TWINS</span><i/><span>ONE CHECKOUT</span><i/><span>NFT + VAULT + WORLD</span></section>
     <section className="vv3-collection" id="collection"><div className="vv3-collectionHead"><div><div className="vv3-sectionLabel"><span>01</span> SHOP THE COLLECTION</div><h2>Buy the object.<br/><em>Own the twin.</em></h2></div><p>Every listing is tied to a real-world source from a real manufacturer or retailer. The customer stays in Voxel Vault. The physical item and its digital collectible are treated as one object identity.</p></div><div className="vv3-objectGrid">{REAL_WORLD_CATALOG.map((item, i) => <Card key={item.id} item={item} index={i}/>)}</div></section>
     <section className="vv3-finalCta"><div><small>VOXEL VAULT</small><h2>Physical in your hands. Digital in your world.</h2><p>Buy both, keep the digital twin in your Vault, place it in your Room, and make it discoverable in the World.</p></div><Link className="vv3-primaryCta" href="/room">Open My Room <Icon name="arrow" size={17}/></Link></section>


### PR DESCRIPTION
Fix the real-product storefront so third-party model embeds are never required for the NFT experience. Real products remain tied to their manufacturer/retailer source for identity and provenance, while Voxel Vault renders a local deterministic 3D digital twin inside the existing premium layout. This removes a major failure mode on work/corporate networks and keeps the NFT visible automatically. Physical checkout remains gated by authorized supplier/SKU fulfillment mapping.