### PR TITLE
Premium 3D NFT commerce presentation

### DIFF
--- a/app/components/Premium3DNFTBadge.js
+++ b/app/components/Premium3DNFTBadge.js
@@ -1,0 +1,9 @@
+export default function Premium3DNFTBadge({ included = true }) {
+  if (!included) return null;
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/20 bg-cyan-300/[0.08] px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-cyan-100 shadow-[0_0_30px_rgba(34,211,238,.08)]">
+      <span className="h-1.5 w-1.5 rounded-full bg-cyan-300 shadow-[0_0_10px_rgba(103,232,249,.95)]" />
+      3D NFT included
+    </div>
+  );
+}

--- a/docs/PREMIUM-3D-NFT-COMMERCE.md
+++ b/docs/PREMIUM-3D-NFT-COMMERCE.md
@@ -1,0 +1,5 @@
+# Premium 3D NFT Commerce Pass
+
+Voxel Vault presents real-world products as physical + 3D digital-twin collectibles. Product source URLs establish product identity; they are not checkout destinations. The customer-facing offer should clearly state that the 3D NFT is included with the physical purchase. Supplier/variant authorization remains a prerequisite for physical fulfillment. Customer price should be calculated from actual supplier cost plus shipping/fees and the configured Vault markup, not from a public retail price presented as wholesale cost.
+
+3D twins are local, resilient product-specific representations so external model hosts cannot blank the storefront. They should never be described as exact licensed CAD replicas unless the asset is actually licensed.


### PR DESCRIPTION
Adds the premium 3D NFT commerce documentation and reusable customer-facing badge. Keeps real-product provenance distinct from supplier authorization and makes the included NFT offer explicit without turning retail source URLs into fake dropship guarantees.