### PR TITLE
Fix null product pricing in real-world catalog

### DIFF
--- a/lib/realWorldCatalog.js
+++ b/lib/realWorldCatalog.js
@@ -11,14 +11,17 @@ const items=[
 ];
 
 function priceWithMarkup(basePrice, markupPercent=25) {
-  if (!Number.isFinite(Number(basePrice))) return null;
-  return (Math.ceil(Number(basePrice) * (1 + markupPercent / 100) * 100) / 100).toFixed(2);
+  if (basePrice === null || basePrice === undefined || basePrice === '') return null;
+  const numeric=Number(basePrice);
+  if (!Number.isFinite(numeric)) return null;
+  return (Math.ceil(numeric * (1 + markupPercent / 100) * 100) / 100).toFixed(2);
 }
 
 export const REAL_WORLD_CATALOG=items.map((item,index)=>{
   const markupPercent=25;
-  const basePriceUsd=Number.isFinite(Number(item.sourcePriceUsd)) ? Number(item.sourcePriceUsd) : null;
-  const customerPriceUsd=basePriceUsd === null ? null : priceWithMarkup(basePriceUsd,markupPercent);
+  const hasNumericSourcePrice=item.sourcePriceUsd !== null && item.sourcePriceUsd !== undefined && item.sourcePriceUsd !== '' && Number.isFinite(Number(item.sourcePriceUsd));
+  const basePriceUsd=hasNumericSourcePrice ? Number(item.sourcePriceUsd) : null;
+  const customerPriceUsd=hasNumericSourcePrice ? priceWithMarkup(basePriceUsd,markupPercent) : null;
   return {
     ...item,
     id:item.id||`real-object-${index+1}`,


### PR DESCRIPTION
Fixes JavaScript Number(null) coercion so products with no numeric source price cannot become a fake $0.00. Numeric products keep the configured 25% Vault markup; unknown prices render as Price on request.