### PR TITLE
feat: make minted Voxel Vault NFTs permanently 3D

### DIFF
--- a/app/api/mint-verify/route.ts
+++ b/app/api/mint-verify/route.ts
@@ -38,13 +38,26 @@ export async function GET(request: Request) {
       fulfillmentStatus = order.fulfillment_status;
     }
 
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io';
     return NextResponse.json({
       paid: true,
       fulfillmentIncluded: mintMode === 'physical_nft',
       fulfillmentStatus,
       catalogId,
       wallet,
-      item: { id: item.id, name: item.name, creator: item.creator, rarity: item.rarity, realityBasis: item.realityBasis, priceUsd: item.priceUsd, sourceUrl: item.sourceUrl, sourceName: item.sourceName },
+      item: {
+        id: item.id,
+        name: item.name,
+        creator: item.creator,
+        rarity: item.rarity,
+        realityBasis: item.realityBasis,
+        material: item.material,
+        priceUsd: item.priceUsd,
+        sourceUrl: item.sourceUrl,
+        sourceName: item.sourceName,
+        nftAnimationUrl: `${appUrl}/twin?asset=${catalogId}`,
+        nftImageUrl: `${appUrl}/api/og?asset=${catalogId}`,
+      },
       sessionId,
     });
   } catch (error) {

--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -12,6 +12,7 @@ export async function GET(request) {
   const subtitle = item
     ? `${item.rarity} · ${item.realityBasis} · ${item.material}`
     : 'A 3D-first digital object marketplace';
+  const price = item?.priceUsd ? `$${item.priceUsd}` : '3D NFT';
 
   return new ImageResponse(
     (
@@ -24,10 +25,10 @@ export async function GET(request) {
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', position: 'relative' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <div style={{ fontSize: 18, color: '#73798b' }}>3D DIGITAL OBJECT · REAL OWNERSHIP</div>
+            <div style={{ fontSize: 18, color: '#73798b' }}>ORIGINAL 3D DIGITAL TWIN · REAL-WORLD REFERENCE</div>
             <div style={{ fontSize: 24, color: '#fff' }}>Inspect the object in real 3D before collecting.</div>
           </div>
-          {item && <div style={{ display: 'flex', fontSize: 30, fontWeight: 800 }}>{item.price} ETH</div>}
+          <div style={{ display: 'flex', fontSize: 30, fontWeight: 800 }}>{price}</div>
         </div>
       </div>
     ),

--- a/app/api/physical-nft-checkout/route.ts
+++ b/app/api/physical-nft-checkout/route.ts
@@ -47,10 +47,16 @@ export async function POST(request: Request) {
         sourceUrl: item.sourceUrl,
       }, { status: 503 });
     }
+    if (fulfillment.costUsd === null) {
+      return NextResponse.json({
+        error: 'Supplier cost is not configured for this SKU. Checkout is intentionally locked until the dropship cost is known.',
+        code: 'FULFILLMENT_COST_NOT_CONFIGURED',
+      }, { status: 503 });
+    }
 
-    const physicalCents = customerPriceCents(item.priceUsd);
-    const basePriceCents = customerPriceCents(item.priceUsd) === null ? null : Math.round(Number(item.priceUsd) * 100);
-    if (physicalCents === null || physicalCents < 50 || basePriceCents === null) return NextResponse.json({ error: 'Product price is not configured for checkout' }, { status: 500 });
+    const physicalCents = customerPriceCents(fulfillment.costUsd);
+    const basePriceCents = Math.round(Number(fulfillment.costUsd) * 100);
+    if (physicalCents === null || physicalCents < 50 || !Number.isFinite(basePriceCents) || basePriceCents < 50) return NextResponse.json({ error: 'Supplier price is not configured for checkout' }, { status: 500 });
 
     const markupPercent = getMarkupPercent();
     const grossMerchandiseMarginCents = physicalCents - basePriceCents;
@@ -65,6 +71,7 @@ export async function POST(request: Request) {
       source_cost_cents: String(basePriceCents),
       gross_merchandise_margin_cents: String(grossMerchandiseMarginCents),
       markup_percent: String(markupPercent),
+      markup_basis: 'configured_supplier_cost',
       nft_amount_cents: String(NFT_FEE_CENTS),
       product_source_url: item.sourceUrl,
       fulfillment_provider: fulfillment.provider,
@@ -76,8 +83,10 @@ export async function POST(request: Request) {
       billing_address_collection: 'required',
       shipping_address_collection: { allowed_countries: ['US'] },
       phone_number_collection: { enabled: true },
-      line_items: [{ quantity: 1, price_data: { currency: 'usd', unit_amount: physicalCents, product_data: { name: item.name, description: `Verified real-world product from ${item.sourceName}. Voxel Vault retail price includes a ${markupPercent}% store markup.` } } },
-        { quantity: 1, price_data: { currency: 'usd', unit_amount: NFT_FEE_CENTS, product_data: { name: `${item.name} · Voxel Vault Digital Twin`, description: 'One digital collectible for your Vault, Room, and world placement.' } } }],
+      line_items: [
+        { quantity: 1, price_data: { currency: 'usd', unit_amount: physicalCents, product_data: { name: item.name, description: `Real-world product fulfilled through the configured supplier. Voxel Vault retail price includes a ${markupPercent}% store markup.` } } },
+        { quantity: 1, price_data: { currency: 'usd', unit_amount: NFT_FEE_CENTS, product_data: { name: `${item.name} · Voxel Vault Digital Twin`, description: 'Original interactive digital collectible for your Vault, Room, and world placement.' } } },
+      ],
       metadata,
       payment_intent_data: { metadata },
       success_url: `${appUrl}/mint?catalog=${id}&session_id={CHECKOUT_SESSION_ID}&physical=1`,

--- a/app/mint/page.js
+++ b/app/mint/page.js
@@ -7,12 +7,16 @@ import { getWallet, mintCollectible } from '../../lib/blockchain';
 function metadataUri(item) {
   const payload = {
     name: item.name,
-    description: `Voxel Vault digital twin inspired by a ${item.realityBasis}. Purchased in USD through Voxel Vault.`,
-    external_url: 'https://voxelvault.io',
+    description: `Voxel Vault original 3D digital twin of a ${item.realityBasis}. Purchased in USD through Voxel Vault.`,
+    image: item.nftImageUrl,
+    animation_url: item.nftAnimationUrl,
+    external_url: item.nftAnimationUrl,
     attributes: [
       { trait_type: 'Creator', value: item.creator },
       { trait_type: 'Rarity', value: item.rarity },
       { trait_type: 'Reality basis', value: item.realityBasis },
+      { trait_type: 'Material', value: item.material || 'Digital material study' },
+      { trait_type: '3D asset', value: 'Voxel Vault native procedural twin' },
       { trait_type: 'Purchase', value: 'USD verified' },
       { trait_type: 'Identity', value: `VV-${item.id}` },
     ],
@@ -53,7 +57,7 @@ export default function MintPage() {
       const response = await fetch(`/api/mint-verify?session_id=${encodeURIComponent(sessionId)}&wallet=${encodeURIComponent(wallet)}`);
       const data = await response.json();
       if (!response.ok || !data.paid) throw new Error(data.error || 'Payment is not confirmed yet.');
-      setItem(data.item); setCatalogId(String(data.catalogId)); setPaid(true); setMessage('Payment verified. Your NFT is ready to mint.');
+      setItem(data.item); setCatalogId(String(data.catalogId)); setPaid(true); setMessage('Payment verified. Your original 3D NFT is ready to mint.');
     } catch (error) { setMessage(error.message || 'Could not verify payment.'); }
     finally { setBusy(false); }
   }
@@ -92,7 +96,7 @@ export default function MintPage() {
 
   async function mintNow() {
     if (!item || !paid) return;
-    setBusy(true); setMessage('Minting your digital twin… confirm the wallet transaction.');
+    setBusy(true); setMessage('Minting your original 3D digital twin… confirm the wallet transaction.');
     try {
       const result = await mintCollectible({ uri: metadataUri(item), royaltyBps: 500 });
       const entry = { id: item.id, name: item.name, creator: item.creator, rarity: item.rarity, priceUsd: item.priceUsd, wallet, tokenId: result.tokenId, hash: result.hash, explorerTx: result.explorerTx, createdAt: new Date().toISOString() };
@@ -107,18 +111,18 @@ export default function MintPage() {
 
   return <main className="page">
     <header><Link href="/" className="brand">VOXEL VAULT</Link><Link href="/" className="back">Back</Link></header>
-    <section className="hero"><small>PHYSICAL + DIGITAL</small><h1>Buy it.<br /><em>Own both.</em></h1><p>Choose a verified real-world product, keep its digital twin in your Vault, and place the collectible in your Room or the world map.</p></section>
+    <section className="hero"><small>PHYSICAL + DIGITAL</small><h1>Buy it.<br /><em>Own both.</em></h1><p>Choose a verified real-world product, keep its original Voxel Vault 3D twin in your Vault, and place the collectible in your Room or the world.</p></section>
     <section className="panel">
       <div className="step"><b>01</b><strong>Connect your wallet</strong><button onClick={connect} disabled={busy}>{wallet ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}` : 'Connect'}</button></div>
       <div className="step"><b>02</b><strong>Physical + NFT</strong><button onClick={startPhysicalAndNftCheckout} disabled={busy || !catalogId}>{catalogId ? 'Buy + ship + NFT' : 'Choose an object first'}</button></div>
       <div className="step"><b>03</b><strong>Digital-only checkout</strong><button onClick={startCheckout} disabled={busy || !catalogId}>{catalogId ? 'Buy NFT' : 'Choose an object first'}</button></div>
       <div className="step"><b>04</b><strong>Verify payment</strong><button onClick={verify} disabled={busy || !sessionId || !wallet}>Verify</button></div>
-      <div className="step"><b>05</b><strong>Mint the digital twin</strong><button onClick={mintNow} disabled={busy || !paid}>{paid ? 'Mint NFT' : 'Locked until paid'}</button></div>
+      <div className="step"><b>05</b><strong>Mint the original 3D twin</strong><button onClick={mintNow} disabled={busy || !paid}>{paid ? 'Mint NFT' : 'Locked until paid'}</button></div>
     </section>
-    {item && <section className="object"><small>REAL-WORLD OBJECT</small><h2>{item.name}</h2><p>by {item.creator} · {item.rarity}</p><div className="facts"><span>${item.priceUsd}</span><span>Source verified</span><span>VV-{item.id}</span></div>{mint && <a href={mint.explorerTx} target="_blank" rel="noreferrer">View confirmed transaction ↗</a>}</section>}
+    {item && <section className="object"><small>REAL-WORLD OBJECT · ORIGINAL 3D TWIN</small><h2>{item.name}</h2><p>by {item.creator} · {item.rarity}</p><div className="facts"><span>${item.priceUsd}</span><span>Source verified</span><span>Native 3D media</span><span>VV-{item.id}</span></div><Link href={`/twin?asset=${catalogId}`} className="twinLink">Inspect the permanent 3D twin ↗</Link>{mint && <a href={mint.explorerTx} target="_blank" rel="noreferrer">View confirmed transaction ↗</a>}</section>}
     {history.length > 0 && <section className="history"><small>YOUR HISTORY</small><h2>Collected objects.</h2>{history.slice(0, 8).map((entry, index) => <article key={`${entry.hash}-${index}`}><div><strong>{entry.name}</strong><span>{entry.creator} · {entry.createdAt.slice(0, 10)}</span></div><b>{entry.tokenId ? `#${entry.tokenId}` : 'Minted'}</b></article>)}</section>}
     {message && <p className="message" role="status">{message}</p>}
     <footer><Link href="/terms">Terms</Link><Link href="/privacy">Privacy</Link></footer>
-    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f7f8fb;padding:0 16px 45px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page *{box-sizing:border-box}header{height:62px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,255,255,.08)}.brand{color:#fff;text-decoration:none;font-size:11px;font-weight:950;letter-spacing:.16em}.back{color:#858ea1;text-decoration:none;font-size:10px}.hero{padding:44px 0 25px}.hero small,.panel+section small,.history>small{color:#a895ff;font-size:9px;font-weight:900;letter-spacing:.17em}.hero h1{font-size:clamp(52px,13vw,80px);line-height:.86;letter-spacing:-.07em;margin:10px 0}.hero em{font-style:normal;color:#a894ff}.hero p{max-width:460px;color:#858ea1;font-size:13px;line-height:1.5}.panel,.object,.history{border:1px solid rgba(255,255,255,.09);border-radius:22px;background:rgba(255,255,255,.035);padding:10px}.step{display:grid;grid-template-columns:30px 1fr auto;gap:10px;align-items:center;padding:14px 8px;border-bottom:1px solid rgba(255,255,255,.07)}.step:last-child{border-bottom:0}.step b{color:#727b8e;font-size:9px}.step strong{font-size:12px}.step button{border:1px solid rgba(255,255,255,.12);background:#f5f6f9;color:#08090d;border-radius:10px;padding:9px 10px;font-size:9px;font-weight:900}.step button:disabled{opacity:.45}.object{margin-top:12px;padding:20px;background:linear-gradient(135deg,rgba(143,112,255,.14),rgba(255,255,255,.025))}.object h2,.history h2{font-size:26px;letter-spacing:-.04em;margin:8px 0 3px}.object p{color:#7e8799;font-size:10px}.facts{display:flex;gap:7px;flex-wrap:wrap;margin:15px 0}.facts span{border:1px solid rgba(255,255,255,.1);border-radius:999px;padding:7px 9px;color:#dce1ea;font-size:8px}.object a{color:#a894ff;text-decoration:none;font-size:9px}.history{margin-top:12px}.history h2{margin-bottom:12px}.history article{display:flex;justify-content:space-between;gap:12px;padding:11px 0;border-top:1px solid rgba(255,255,255,.07)}.history article div{min-width:0}.history strong,.history span{display:block}.history strong{font-size:11px}.history span{font-size:8px;color:#737c8e;margin-top:3px}.history article>b{font-size:9px;color:#67eeb0}.message{color:#9aa3b5;font-size:10px;line-height:1.5;padding:10px 2px}.page footer{display:flex;justify-content:center;gap:18px;margin-top:24px}.page footer a{color:#5f687a;text-decoration:none;font-size:9px}@media(min-width:700px){.page{max-width:760px;margin:0 auto;padding-left:24px;padding-right:24px}}`}</style>
+    <style jsx>{`.page{min-height:100vh;background:#05060b;color:#f7f8fb;padding:0 16px 45px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.page *{box-sizing:border-box}header{height:62px;display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid rgba(255,255,255,.08)}.brand{color:#fff;text-decoration:none;font-size:11px;font-weight:950;letter-spacing:.16em}.back{color:#858ea1;text-decoration:none;font-size:10px}.hero{padding:44px 0 25px}.hero small,.panel+section small,.history>small{color:#a895ff;font-size:9px;font-weight:900;letter-spacing:.17em}.hero h1{font-size:clamp(52px,13vw,80px);line-height:.86;letter-spacing:-.07em;margin:10px 0}.hero em{font-style:normal;color:#a894ff}.hero p{max-width:460px;color:#858ea1;font-size:13px;line-height:1.5}.panel,.object,.history{border:1px solid rgba(255,255,255,.09);border-radius:22px;background:rgba(255,255,255,.035);padding:10px}.step{display:grid;grid-template-columns:30px 1fr auto;gap:10px;align-items:center;padding:14px 8px;border-bottom:1px solid rgba(255,255,255,.07)}.step:last-child{border-bottom:0}.step b{color:#727b8e;font-size:9px}.step strong{font-size:12px}.step button{border:1px solid rgba(255,255,255,.12);background:#f5f6f9;color:#08090d;border-radius:10px;padding:9px 10px;font-size:9px;font-weight:900}.step button:disabled{opacity:.45}.object{margin-top:12px;padding:20px;background:linear-gradient(135deg,rgba(143,112,255,.14),rgba(255,255,255,.025))}.object h2,.history h2{font-size:26px;letter-spacing:-.04em;margin:8px 0 3px}.object p{color:#7e8799;font-size:10px}.facts{display:flex;gap:7px;flex-wrap:wrap;margin:15px 0}.facts span{border:1px solid rgba(255,255,255,.1);border-radius:999px;padding:7px 9px;color:#dce1ea;font-size:8px}.object a,.twinLink{display:inline-block;color:#a894ff;text-decoration:none;font-size:9px;margin-right:12px}.history{margin-top:12px}.history h2{margin-bottom:12px}.history article{display:flex;justify-content:space-between;gap:12px;padding:11px 0;border-top:1px solid rgba(255,255,255,.07)}.history article div{min-width:0}.history strong,.history span{display:block}.history strong{font-size:11px}.history span{font-size:8px;color:#737c8e;margin-top:3px}.history article>b{font-size:9px;color:#67eeb0}.message{color:#9aa3b5;font-size:10px;line-height:1.5;padding:10px 2px}.page footer{display:flex;justify-content:center;gap:18px;margin-top:24px}.page footer a{color:#5f687a;text-decoration:none;font-size:9px}@media(min-width:700px){.page{max-width:760px;margin:0 auto;padding-left:24px;padding-right:24px}}`}</style>
   </main>;
 }

--- a/app/twin/page.js
+++ b/app/twin/page.js
@@ -1,0 +1,34 @@
+'use client';
+
+import { Suspense, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { getCatalogItem } from '../../lib/catalog';
+
+const Product3DTwin = dynamic(() => import('../components/Product3DTwin'), { ssr: false });
+
+function TwinExperience(){
+  const params = useSearchParams();
+  const catalogId = Number(params.get('asset') || 1);
+  const item = useMemo(() => getCatalogItem(catalogId - 1), [catalogId]);
+  const validId = item ? catalogId : 1;
+  const resolved = item || getCatalogItem(0);
+
+  return <main className="vv-twinPage">
+    <header className="vv-twinNav"><Link href="/" className="vv-twinBrand">VOXEL VAULT</Link><span>ON-CHAIN 3D TWIN</span><Link href={`/mint?catalog=${validId}`} className="vv-twinCollect">Collect ↗</Link></header>
+    <section className="vv-twinStage">
+      <div className="vv-twinStageGrid" aria-hidden="true" />
+      <div className="vv-twinStageMeta"><span>ORIGINAL VOXEL VAULT DIGITAL ASSET</span><span>INTERACTIVE · 3D · NFT READY</span></div>
+      <div className="vv-twinViewer"><Product3DTwin item={resolved} hero /></div>
+      <div className="vv-twinCaption"><div><small>REAL-WORLD REFERENCE</small><h1>{resolved.name}</h1><p>{resolved.realityBasis}</p></div><div className="vv-twinFacts"><span>{resolved.creator}</span><span>{resolved.material}</span><span>{resolved.rarity}</span></div></div>
+    </section>
+    <section className="vv-twinInfo"><div><small>WHAT YOU ARE COLLECTING</small><h2>A real 3D collectible, not a flat product card.</h2></div><p>This is the permanent interactive 3D presentation target for the Voxel Vault NFT. The storefront may link to published model sources for product inspection, while the collectible itself is rendered by Voxel Vault's native 3D twin engine.</p></section>
+    <footer><Link href="/terms">Terms</Link><Link href="/privacy">Privacy</Link><Link href={`/mint?catalog=${validId}`}>Mint / collect</Link></footer>
+    <style jsx>{`.vv-twinPage{min-height:100vh;background:#05060b;color:#f7f8fb;padding:0 18px 42px;font-family:Inter,ui-sans-serif,system-ui,sans-serif}.vv-twinNav{height:64px;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:16px;border-bottom:1px solid rgba(255,255,255,.08);font-size:8px;font-weight:900;letter-spacing:.14em;color:#6f788b}.vv-twinNav>a{color:#fff;text-decoration:none}.vv-twinBrand{font-size:11px;letter-spacing:.16em}.vv-twinCollect{text-align:right;color:#b7a8ff!important}.vv-twinStage{position:relative;max-width:1180px;margin:24px auto 0;min-height:690px;border:1px solid rgba(255,255,255,.1);border-radius:28px;overflow:hidden;background:radial-gradient(circle at 50% 42%,rgba(119,104,255,.14),transparent 42%),linear-gradient(180deg,#0b0d16,#05060b);box-shadow:0 35px 100px rgba(0,0,0,.45)}.vv-twinStageGrid{position:absolute;inset:0;background-image:linear-gradient(rgba(255,255,255,.035) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.035) 1px,transparent 1px);background-size:42px 42px;mask-image:radial-gradient(circle at 50% 48%,#000,transparent 75%)}.vv-twinStageMeta{position:absolute;z-index:4;left:22px;right:22px;top:20px;display:flex;justify-content:space-between;gap:12px;color:#81899b;font-size:8px;font-weight:900;letter-spacing:.13em}.vv-twinViewer{position:absolute;inset:58px 18px 170px;min-height:430px}.vv-twinViewer>div{height:100%!important}.vv-twinCaption{position:absolute;z-index:4;left:22px;right:22px;bottom:22px;display:flex;justify-content:space-between;gap:20px;align-items:end}.vv-twinCaption small,.vv-twinInfo small{color:#a895ff;font-size:8px;font-weight:900;letter-spacing:.15em}.vv-twinCaption h1{margin:7px 0 3px;font-size:clamp(30px,5vw,54px);line-height:.95;letter-spacing:-.05em}.vv-twinCaption p{margin:0;color:#7e8799;font-size:10px}.vv-twinFacts{display:flex;gap:7px;flex-wrap:wrap;justify-content:flex-end}.vv-twinFacts span{border:1px solid rgba(255,255,255,.11);background:rgba(5,6,11,.65);border-radius:999px;padding:8px 10px;color:#d9deea;font-size:8px;font-weight:800}.vv-twinInfo{max-width:1180px;margin:18px auto 0;padding:25px;border:1px solid rgba(255,255,255,.08);border-radius:22px;background:rgba(255,255,255,.025);display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,1fr);gap:28px}.vv-twinInfo h2{margin:8px 0 0;max-width:650px;font-size:clamp(26px,4vw,44px);line-height:.98;letter-spacing:-.05em}.vv-twinInfo p{margin:0;color:#7d8698;font-size:11px;line-height:1.65;align-self:end}.vv-twinPage footer{max-width:1180px;margin:18px auto 0;display:flex;justify-content:center;gap:18px}.vv-twinPage footer a{color:#667084;text-decoration:none;font-size:9px}@media(max-width:700px){.vv-twinNav{grid-template-columns:1fr auto}.vv-twinNav>span{display:none}.vv-twinStage{min-height:610px;border-radius:20px}.vv-twinStageMeta{font-size:7px}.vv-twinStageMeta span:last-child{display:none}.vv-twinViewer{inset:58px 8px 185px}.vv-twinCaption{display:block;left:16px;right:16px;bottom:16px}.vv-twinFacts{justify-content:flex-start;margin-top:10px}.vv-twinInfo{grid-template-columns:1fr;padding:20px}.vv-twinInfo p{font-size:10px}}`}</style>
+  </main>;
+}
+
+export default function TwinPage(){
+  return <Suspense fallback={<main style={{minHeight:'100vh',display:'grid',placeItems:'center',background:'#05060b',color:'#fff'}}>Loading 3D twin…</main>}><TwinExperience/></Suspense>;
+}

--- a/docs/dropship-revenue-setup.md
+++ b/docs/dropship-revenue-setup.md
@@ -1,0 +1,46 @@
+# Voxel Vault dropship revenue setup
+
+Physical checkout is deliberately fail-closed until a real fulfillment mapping exists for the exact SKU.
+
+## Revenue model
+
+- `VOXEL_MARKUP_PERCENT` controls the store markup. Default: `25`.
+- The customer pays the supplier cost plus that markup, plus the configured NFT fee.
+- The checkout records the supplier cost and gross merchandise margin in Stripe metadata.
+- No Stripe Connect application fee or transfer split is created by the physical checkout route, so the payment belongs to the Stripe account configured for this Voxel Vault project. Stripe processing fees, refunds, taxes, shipping costs, supplier costs, and other business expenses still reduce net profit.
+
+## Supplier mapping
+
+Configure `VOXEL_FULFILLMENT_CATALOG` as JSON in the Vercel production environment. Each entry must point to a real fulfillment SKU and include its supplier cost.
+
+Example:
+
+```json
+{
+  "my-supplier-product": {
+    "provider": "generic",
+    "sku": "SUPPLIER-SKU-123",
+    "costUsd": 18.50
+  }
+}
+```
+
+For Shopify fulfillment, use:
+
+```json
+{
+  "my-supplier-product": {
+    "provider": "shopify",
+    "variantId": "gid://shopify/ProductVariant/123456789",
+    "costUsd": 18.50
+  }
+}
+```
+
+The checkout will refuse to sell a physical item when `costUsd` is missing. This prevents the storefront from guessing a supplier cost from a public retail page and accidentally destroying the intended margin.
+
+## Important sourcing rule
+
+A product page proves that an item exists. It does **not** prove that Voxel Vault has permission to resell it, use its branding, or use a third-party 3D model in a commercial NFT. Only connect suppliers and 3D assets that you are authorized to use commercially.
+
+The storefront can display a published third-party 3D viewer for product inspection, while the mintable NFT experience uses Voxel Vault's own native 3D twin engine.

--- a/lib/fulfillment.js
+++ b/lib/fulfillment.js
@@ -11,23 +11,29 @@ function readCatalogMap() {
   }
 }
 
+function readCostUsd(entry) {
+  const value = Number(entry?.costUsd);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
 export function getFulfillmentConfig(catalogKey) {
   const entry = readCatalogMap()[catalogKey];
   if (!entry || typeof entry !== 'object') return null;
   const provider = String(entry.provider || '').toLowerCase();
+  const costUsd = readCostUsd(entry);
   if (provider === 'shopify') {
     const variantId = String(entry.variantId || '');
     const storeDomain = String(process.env.SHOPIFY_STORE_DOMAIN || '').replace(/^https?:\/\//, '').replace(/\/$/, '');
     const accessToken = process.env.SHOPIFY_ADMIN_ACCESS_TOKEN || '';
     if (!variantId || !storeDomain || !accessToken) return null;
-    return { provider, variantId, storeDomain, accessToken, apiVersion: process.env.SHOPIFY_API_VERSION || DEFAULT_SHOPIFY_API_VERSION };
+    return { provider, variantId, storeDomain, accessToken, apiVersion: process.env.SHOPIFY_API_VERSION || DEFAULT_SHOPIFY_API_VERSION, costUsd };
   }
   if (provider === 'generic') {
     const endpoint = process.env.FULFILLMENT_API_URL || '';
     const apiKey = process.env.FULFILLMENT_API_KEY || '';
     const sku = String(entry.sku || '');
     if (!endpoint || !apiKey || !sku) return null;
-    return { provider, endpoint, apiKey, sku };
+    return { provider, endpoint, apiKey, sku, costUsd };
   }
   return null;
 }


### PR DESCRIPTION
Hardens the already-polished native 3D storefront without replacing the current visual system.

- Adds a permanent `/twin?asset=` 3D presentation route for every catalog object.
- Mint metadata now carries `image` and `animation_url` pointing to Voxel Vault-owned routes.
- Keeps the NFT media target on the native Voxel Vault 3D twin engine rather than a third-party embedded viewer.
- Adds supplier `costUsd` mapping so physical checkout markup is calculated from the actual dropship cost.
- Locks physical checkout when supplier cost is unknown, preventing accidental margin loss.
- Records markup basis and gross merchandise margin in Stripe metadata.
- Fixes NFT social preview pricing.
- Documents the fulfillment/revenue configuration.

This preserves gross merchandise margin at checkout, while Stripe fees, taxes, shipping, refunds, and supplier costs still determine net profit.