### PR TITLE
Polish 3D NFT presentation and permanent twin access

### DIFF
--- a/app/components/RealWorld3DNFT.js
+++ b/app/components/RealWorld3DNFT.js
@@ -24,15 +24,15 @@ export default function RealWorld3DNFT({ item, hero = false }) {
         <span style={preview ? { backgroundImage: `url(${preview})`, backgroundSize: 'cover', backgroundPosition: 'center' } : undefined}>◆</span>
         <div><small>LIVE 3D</small><b>DRAG · ORBIT · ZOOM</b></div>
       </div>
-      <div className="vv3-nftBadge" aria-hidden="true">
-        <span>ORIGINAL VAULT ARTWORK</span>
-        <small>PERMANENT 3D PRESENTATION</small>
+      <div className="vv3-nftBadge" aria-hidden="true" style={{position:'absolute',left:16,bottom:62,zIndex:4,display:'flex',flexDirection:'column',gap:3,padding:'8px 11px',borderRadius:10,border:'1px solid rgba(169,146,255,.28)',background:'rgba(7,9,16,.72)',backdropFilter:'blur(12px)',boxShadow:'0 10px 28px rgba(0,0,0,.28)'}}>
+        <span style={{fontSize:9,fontWeight:900,letterSpacing:'.16em',color:'#d8d0ff'}}>ORIGINAL VAULT ARTWORK</span>
+        <small style={{fontSize:8,letterSpacing:'.12em',color:'#8d96ad'}}>PERMANENT 3D PRESENTATION</small>
       </div>
       <Product3DTwin item={item} hero={hero} />
       <figcaption className="vv3-twinFooter" id={titleId}>
         <div className="vv3-twinName"><small>{item?.creator || 'Voxel Vault'}</small><strong>{item?.name || 'Collectible object'}</strong></div>
         <div className="vv3-twinPrice"><small>PHYSICAL + DIGITAL</small>{price && <strong>{price}</strong>}</div>
-        <a className="vv3-twinOpen" href={twinUrl} aria-label={`Open permanent 3D NFT for ${item?.name || 'this collectible'}`}>OPEN 3D NFT ↗</a>
+        <a className="vv3-twinOpen" href={twinUrl} aria-label={`Open permanent 3D NFT for ${item?.name || 'this collectible'}`} style={{display:'inline-flex',alignItems:'center',justifyContent:'center',gap:6,padding:'8px 10px',borderRadius:9,border:'1px solid rgba(169,146,255,.34)',background:'rgba(141,107,255,.1)',color:'#e8e3ff',fontSize:10,fontWeight:850,letterSpacing:'.08em',textDecoration:'none',whiteSpace:'nowrap'}}>OPEN 3D NFT ↗</a>
       </figcaption>
     </figure>
   );

--- a/app/components/RealWorld3DNFT.js
+++ b/app/components/RealWorld3DNFT.js
@@ -11,6 +11,7 @@ export default function RealWorld3DNFT({ item, hero = false }) {
   const price = item?.customerPriceUsd ? `$${item.customerPriceUsd}` : null;
   const preview = item?.previewUri;
   const titleId = `twin-${item?.id || 'object'}`;
+  const twinUrl = `/twin?asset=${encodeURIComponent(item?.id || '')}`;
 
   return (
     <figure className={`vv3-modelFrame ${hero ? 'vv3-modelFrameHero' : ''}`} aria-labelledby={titleId}>
@@ -23,10 +24,15 @@ export default function RealWorld3DNFT({ item, hero = false }) {
         <span style={preview ? { backgroundImage: `url(${preview})`, backgroundSize: 'cover', backgroundPosition: 'center' } : undefined}>◆</span>
         <div><small>LIVE 3D</small><b>DRAG · ORBIT · ZOOM</b></div>
       </div>
+      <div className="vv3-nftBadge" aria-hidden="true">
+        <span>ORIGINAL VAULT ARTWORK</span>
+        <small>PERMANENT 3D PRESENTATION</small>
+      </div>
       <Product3DTwin item={item} hero={hero} />
       <figcaption className="vv3-twinFooter" id={titleId}>
         <div className="vv3-twinName"><small>{item?.creator || 'Voxel Vault'}</small><strong>{item?.name || 'Collectible object'}</strong></div>
         <div className="vv3-twinPrice"><small>PHYSICAL + DIGITAL</small>{price && <strong>{price}</strong>}</div>
+        <a className="vv3-twinOpen" href={twinUrl} aria-label={`Open permanent 3D NFT for ${item?.name || 'this collectible'}`}>OPEN 3D NFT ↗</a>
       </figcaption>
     </figure>
   );


### PR DESCRIPTION
Targeted polish pass on the already-real dropship catalog and original procedural 3D NFT system. Adds a stronger in-card NFT identity treatment and a direct permanent `/twin?asset=` action so the 3D collectible is visually central and easy to open. Keeps supplier sourcing, 45% Vault markup, and fulfillment safeguards unchanged. The catalog already contains real CJdropshipping listings with supplier SKUs and source URLs, while the mintable 3D artwork remains original Voxel Vault procedural artwork.