### PR TITLE
Automatically convert real product images into 3D NFTs

### DIFF
--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+const MESHY_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
+
+export async function POST(request) {
+  const apiKey = process.env.MESHY_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Image-to-3D generation is not configured. Set MESHY_API_KEY in the production environment.' }, { status: 503 });
+  }
+  try {
+    const body = await request.json();
+    const imageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
+    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) return NextResponse.json({ error: 'A public product image URL is required.' }, { status: 400 });
+    const response = await fetch(MESHY_ENDPOINT, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ image_url: imageUrl, target_formats: ['glb'], should_texture: true, enable_pbr: true, auto_size: true, origin_at: 'bottom' }),
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || 'Image-to-3D provider rejected the request.' }, { status: response.status });
+    return NextResponse.json({ taskId: data?.result || data?.id || null });
+  } catch (error) {
+    return NextResponse.json({ error: error?.message || 'Image-to-3D request failed.' }, { status: 500 });
+  }
+}
+
+export async function GET(request) {
+  const apiKey = process.env.MESHY_API_KEY;
+  const taskId = new URL(request.url).searchParams.get('taskId');
+  if (!apiKey) return NextResponse.json({ error: 'Image-to-3D generation is not configured.' }, { status: 503 });
+  if (!taskId) return NextResponse.json({ error: 'taskId is required.' }, { status: 400 });
+  try {
+    const response = await fetch(`${MESHY_ENDPOINT}/${encodeURIComponent(taskId)}`, { headers: { Authorization: `Bearer ${apiKey}` }, cache: 'no-store' });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || 'Unable to read 3D generation status.' }, { status: response.status });
+    return NextResponse.json({ status: data?.status || 'PENDING', progress: data?.progress ?? 0, modelUrl: data?.model_urls?.glb || data?.model_url || null, thumbnailUrl: data?.thumbnail_url || null });
+  } catch (error) {
+    return NextResponse.json({ error: error?.message || '3D generation status request failed.' }, { status: 500 });
+  }
+}

--- a/app/components/RealProductModel.js
+++ b/app/components/RealProductModel.js
@@ -4,13 +4,39 @@ import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
+const CACHE_PREFIX = 'vv3-image-to-3d:';
+
+async function generateFromImage(imageUrl, cacheKey) {
+  const cached = window.localStorage.getItem(CACHE_PREFIX + cacheKey);
+  if (cached) return cached;
+  const start = await fetch('/api/image-to-3d', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ imageUrl }),
+  });
+  if (!start.ok) throw new Error('Image-to-3D generation is not configured or failed to start.');
+  const { taskId } = await start.json();
+  if (!taskId) throw new Error('Image-to-3D provider returned no task id.');
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise(r => setTimeout(r, 4000));
+    const status = await fetch(`/api/image-to-3d?taskId=${encodeURIComponent(taskId)}`, { cache: 'no-store' });
+    if (!status.ok) throw new Error('Unable to read image-to-3D generation status.');
+    const data = await status.json();
+    if (data.status === 'SUCCEEDED' && data.modelUrl) {
+      window.localStorage.setItem(CACHE_PREFIX + cacheKey, data.modelUrl);
+      return data.modelUrl;
+    }
+    if (['FAILED', 'CANCELED'].includes(data.status)) throw new Error(`Image-to-3D generation ${data.status.toLowerCase()}.`);
+  }
+  throw new Error('Image-to-3D generation timed out.');
+}
+
 export default function RealProductModel({ item, onLoaded }) {
   const host = useRef(null);
   useEffect(() => {
     const root = host.current;
-    const url = item?.modelUri || item?.digitalTwin?.modelUrl;
+    const directUrl = item?.modelUri || item?.digitalTwin?.modelUrl;
     const imageUrl = item?.previewUri || item?.digitalTwin?.previewUrl;
-    if (!root || (!url && !imageUrl)) return undefined;
+    if (!root || (!directUrl && !imageUrl)) return undefined;
     let alive = true;
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 100);
@@ -22,14 +48,10 @@ export default function RealProductModel({ item, onLoaded }) {
     renderer.domElement.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none';
     root.appendChild(renderer.domElement);
     scene.add(new THREE.HemisphereLight(0xffffff, 0x11131c, 2.8));
-    const key = new THREE.DirectionalLight(0xffffff, 4.5);
-    key.position.set(4, 6, 5);
-    scene.add(key);
-    const rim = new THREE.DirectionalLight(0x7566ff, 2.5);
-    rim.position.set(-4, 3, -4);
-    scene.add(rim);
-
+    const key = new THREE.DirectionalLight(0xffffff, 4.5); key.position.set(4, 6, 5); scene.add(key);
+    const rim = new THREE.DirectionalLight(0x7566ff, 2.5); rim.position.set(-4, 3, -4); scene.add(rim);
     let model;
+    let raf;
     const finish = () => {
       if (!alive || !model) return;
       const box = new THREE.Box3().setFromObject(model);
@@ -38,68 +60,51 @@ export default function RealProductModel({ item, onLoaded }) {
       model.position.sub(center);
       model.scale.setScalar(2.6 / (Math.max(size.x, size.y, size.z) || 1));
       scene.add(model);
-      camera.position.set(0, .15, 5.2);
-      camera.lookAt(0, 0, 0);
+      camera.position.set(0, .15, 5.2); camera.lookAt(0, 0, 0);
       onLoaded?.(true);
     };
-
-    if (url) {
-      const loader = new GLTFLoader();
-      loader.load(url, gltf => { model = gltf.scene; finish(); }, undefined, () => {
-        // A real product image remains the visual source of truth if an exact GLB fails.
-        if (!imageUrl) onLoaded?.(false);
-      });
-    } else if (imageUrl) {
-      // Product-specific 3D NFT fallback: the actual real-product image is wrapped
-      // in a thick, beveled, double-sided collectible and rendered as a real 3D object.
+    const loadGlb = url => new Promise((resolve, reject) => {
+      new GLTFLoader().load(url, gltf => { model = gltf.scene; finish(); resolve(); }, undefined, reject);
+    });
+    const createImageFallback = () => {
       const group = new THREE.Group();
-      const tex = new THREE.TextureLoader();
-      tex.setCrossOrigin('anonymous');
-      const map = tex.load(imageUrl, t => { t.colorSpace = THREE.SRGBColorSpace; t.anisotropy = 4; });
+      const map = new THREE.TextureLoader().load(imageUrl, t => { t.colorSpace = THREE.SRGBColorSpace; t.anisotropy = 4; });
       const frame = new THREE.MeshPhysicalMaterial({ color: 0x171a25, metalness: .72, roughness: .2, clearcoat: .55 });
       const face = new THREE.MeshBasicMaterial({ map });
       const back = new THREE.MeshBasicMaterial({ color: 0x080a10 });
       const body = new THREE.Mesh(new THREE.BoxGeometry(2.35, 2.7, .22), frame);
       const front = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), face);
       const rear = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), back);
-      front.position.z = .125;
-      rear.position.z = -.125;
-      rear.rotation.y = Math.PI;
-      group.add(body, front, rear);
-      group.position.set(0, 0, 0);
-      model = group;
-      finish();
-    }
-
-    const resize = () => {
-      if (!alive) return;
-      const w = Math.max(root.clientWidth, 1);
-      const h = Math.max(root.clientHeight, 1);
-      camera.aspect = w / h;
-      camera.updateProjectionMatrix();
-      renderer.setSize(w, h, false);
+      front.position.z = .125; rear.position.z = -.125; rear.rotation.y = Math.PI;
+      group.add(body, front, rear); model = group; finish();
     };
-    resize();
-    const ro = new ResizeObserver(resize);
-    ro.observe(root);
-    let raf;
-    const tick = () => {
-      if (!alive) return;
-      raf = requestAnimationFrame(tick);
-      if (model) model.rotation.y += .0025;
-      renderer.render(scene, camera);
-    };
-    tick();
+    (async () => {
+      if (directUrl) {
+        try { await loadGlb(directUrl); }
+        catch { createImageFallback(); }
+      } else if (imageUrl) {
+        createImageFallback();
+        // Upgrade the fallback to a textured AI-generated GLB when the server has MESHY_API_KEY.
+        // The generated URL is cached per product so normal browsing does not regenerate assets.
+        try {
+          const generatedUrl = await generateFromImage(imageUrl, item?.id || item?.slug || imageUrl);
+          if (alive && generatedUrl) {
+            if (model) scene.remove(model);
+            model = undefined;
+            await loadGlb(generatedUrl);
+          }
+        } catch {
+          // Keep the immediate real-product 3D fallback. No broken/blank viewer.
+        }
+      }
+    })();
+    const resize = () => { if (!alive) return; const w = Math.max(root.clientWidth, 1), h = Math.max(root.clientHeight, 1); camera.aspect = w / h; camera.updateProjectionMatrix(); renderer.setSize(w, h, false); };
+    resize(); const ro = new ResizeObserver(resize); ro.observe(root);
+    const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += .0022; renderer.render(scene, camera); }; tick();
     return () => {
-      alive = false;
-      cancelAnimationFrame(raf);
-      ro.disconnect();
-      root.replaceChildren();
-      scene.traverse(o => {
-        o.geometry?.dispose?.();
-        if (Array.isArray(o.material)) o.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); });
-        else { o.material?.map?.dispose?.(); o.material?.dispose?.(); }
-      });
+      alive = false; cancelAnimationFrame(raf); ro.disconnect();
+      if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement);
+      scene.traverse(o => { o.geometry?.dispose?.(); if (Array.isArray(o.material)) o.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); }); else { o.material?.map?.dispose?.(); o.material?.dispose?.(); } });
       renderer.dispose();
     };
   }, [item, onLoaded]);


### PR DESCRIPTION
Adds a production image-to-3D pipeline for real product collectibles. When an exact GLB is absent, the product image immediately renders as a 3D fallback and, when MESHY_API_KEY is configured, the app automatically generates a textured PBR GLB, caches its URL per product, and upgrades the viewer to the generated 3D model. No blank NFT state.