### PR TITLE
Fix real-product 2D to 3D NFT upgrade pipeline

### DIFF
--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -4,24 +4,48 @@ export const runtime = 'nodejs';
 
 const MESHY_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 
+function configured() {
+  return Boolean(process.env.MESHY_API_KEY);
+}
+
 export async function POST(request) {
   const apiKey = process.env.MESHY_API_KEY;
   if (!apiKey) {
-    return NextResponse.json({ error: 'Image-to-3D generation is not configured. Set MESHY_API_KEY in the production environment.' }, { status: 503 });
+    return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured. Add MESHY_API_KEY to Vercel Production.' }, { status: 503 });
   }
+
   try {
     const body = await request.json();
     const imageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) return NextResponse.json({ error: 'A public product image URL is required.' }, { status: 400 });
+    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) {
+      return NextResponse.json({ error: 'A public JPG, JPEG, or PNG product image URL is required.' }, { status: 400 });
+    }
+
     const response = await fetch(MESHY_ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ image_url: imageUrl, target_formats: ['glb'], should_texture: true, enable_pbr: true, auto_size: true, origin_at: 'bottom' }),
+      body: JSON.stringify({
+        image_url: imageUrl,
+        model_type: 'standard',
+        ai_model: 'latest',
+        image_enhancement: true,
+        remove_lighting: true,
+        should_texture: true,
+        enable_pbr: true,
+        texture_resolution: '2k',
+        target_formats: ['glb'],
+        auto_size: true,
+        origin_at: 'bottom',
+      }),
       cache: 'no-store',
     });
+
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || 'Image-to-3D provider rejected the request.' }, { status: response.status });
-    return NextResponse.json({ taskId: data?.result || data?.id || null });
+    if (!response.ok) {
+      return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Image-to-3D provider rejected the request.' }, { status: response.status });
+    }
+
+    return NextResponse.json({ configured: true, taskId: data?.result || data?.id || null });
   } catch (error) {
     return NextResponse.json({ error: error?.message || 'Image-to-3D request failed.' }, { status: 500 });
   }
@@ -30,13 +54,25 @@ export async function POST(request) {
 export async function GET(request) {
   const apiKey = process.env.MESHY_API_KEY;
   const taskId = new URL(request.url).searchParams.get('taskId');
-  if (!apiKey) return NextResponse.json({ error: 'Image-to-3D generation is not configured.' }, { status: 503 });
+  if (!apiKey) return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured.' }, { status: 503 });
   if (!taskId) return NextResponse.json({ error: 'taskId is required.' }, { status: 400 });
+
   try {
-    const response = await fetch(`${MESHY_ENDPOINT}/${encodeURIComponent(taskId)}`, { headers: { Authorization: `Bearer ${apiKey}` }, cache: 'no-store' });
+    const response = await fetch(`${MESHY_ENDPOINT}/${encodeURIComponent(taskId)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || 'Unable to read 3D generation status.' }, { status: response.status });
-    return NextResponse.json({ status: data?.status || 'PENDING', progress: data?.progress ?? 0, modelUrl: data?.model_urls?.glb || data?.model_url || null, thumbnailUrl: data?.thumbnail_url || null });
+    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Unable to read 3D generation status.' }, { status: response.status });
+
+    return NextResponse.json({
+      configured: true,
+      status: data?.status || 'PENDING',
+      progress: data?.progress ?? 0,
+      modelUrl: data?.model_urls?.glb || null,
+      thumbnailUrl: data?.thumbnail_url || null,
+      error: data?.task_error?.message || null,
+    });
   } catch (error) {
     return NextResponse.json({ error: error?.message || '3D generation status request failed.' }, { status: 500 });
   }

--- a/app/components/RealProductModel.js
+++ b/app/components/RealProductModel.js
@@ -7,107 +7,197 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 const CACHE_PREFIX = 'vv3-image-to-3d:';
 
 async function generateFromImage(imageUrl, cacheKey) {
-  const cached = window.localStorage.getItem(CACHE_PREFIX + cacheKey);
-  if (cached) return cached;
+  const cacheName = CACHE_PREFIX + cacheKey;
+  const cached = window.localStorage.getItem(cacheName);
+
+  if (cached) {
+    try {
+      const response = await fetch(cached, { method: 'HEAD', cache: 'no-store' });
+      if (response.ok) return cached;
+    } catch {}
+    window.localStorage.removeItem(cacheName);
+  }
+
   const start = await fetch('/api/image-to-3d', {
-    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ imageUrl }),
   });
   if (!start.ok) throw new Error('Image-to-3D generation is not configured or failed to start.');
+
   const { taskId } = await start.json();
   if (!taskId) throw new Error('Image-to-3D provider returned no task id.');
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await new Promise(r => setTimeout(r, 4000));
+
+  for (let attempt = 0; attempt < 45; attempt += 1) {
+    await new Promise(resolve => setTimeout(resolve, 4000));
     const status = await fetch(`/api/image-to-3d?taskId=${encodeURIComponent(taskId)}`, { cache: 'no-store' });
     if (!status.ok) throw new Error('Unable to read image-to-3D generation status.');
     const data = await status.json();
+
     if (data.status === 'SUCCEEDED' && data.modelUrl) {
-      window.localStorage.setItem(CACHE_PREFIX + cacheKey, data.modelUrl);
+      window.localStorage.setItem(cacheName, data.modelUrl);
       return data.modelUrl;
     }
-    if (['FAILED', 'CANCELED'].includes(data.status)) throw new Error(`Image-to-3D generation ${data.status.toLowerCase()}.`);
+    if (['FAILED', 'CANCELED'].includes(data.status)) {
+      throw new Error(data.error || `Image-to-3D generation ${data.status.toLowerCase()}.`);
+    }
   }
+
   throw new Error('Image-to-3D generation timed out.');
 }
 
 export default function RealProductModel({ item, onLoaded }) {
   const host = useRef(null);
+
   useEffect(() => {
     const root = host.current;
     const directUrl = item?.modelUri || item?.digitalTwin?.modelUrl;
     const imageUrl = item?.previewUri || item?.digitalTwin?.previewUrl;
     if (!root || (!directUrl && !imageUrl)) return undefined;
+
     let alive = true;
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 100);
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1.15;
     renderer.domElement.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none';
     root.appendChild(renderer.domElement);
+
     scene.add(new THREE.HemisphereLight(0xffffff, 0x11131c, 2.8));
-    const key = new THREE.DirectionalLight(0xffffff, 4.5); key.position.set(4, 6, 5); scene.add(key);
-    const rim = new THREE.DirectionalLight(0x7566ff, 2.5); rim.position.set(-4, 3, -4); scene.add(rim);
-    let model;
+    const key = new THREE.DirectionalLight(0xffffff, 4.5);
+    key.position.set(4, 6, 5);
+    scene.add(key);
+    const rim = new THREE.DirectionalLight(0x7566ff, 2.5);
+    rim.position.set(-4, 3, -4);
+    scene.add(rim);
+
+    let model = null;
     let raf;
-    const finish = () => {
-      if (!alive || !model) return;
-      const box = new THREE.Box3().setFromObject(model);
+
+    const normalize = object => {
+      const box = new THREE.Box3().setFromObject(object);
       const size = box.getSize(new THREE.Vector3());
       const center = box.getCenter(new THREE.Vector3());
-      model.position.sub(center);
-      model.scale.setScalar(2.6 / (Math.max(size.x, size.y, size.z) || 1));
-      scene.add(model);
-      camera.position.set(0, .15, 5.2); camera.lookAt(0, 0, 0);
-      onLoaded?.(true);
+      object.position.sub(center);
+      object.scale.setScalar(2.6 / (Math.max(size.x, size.y, size.z) || 1));
+      object.position.y += 0.05;
     };
+
+    const showModel = object => {
+      if (!alive) return false;
+      normalize(object);
+      scene.add(object);
+      model = object;
+      camera.position.set(0, 0.15, 5.2);
+      camera.lookAt(0, 0, 0);
+      onLoaded?.(true);
+      return true;
+    };
+
     const loadGlb = url => new Promise((resolve, reject) => {
-      new GLTFLoader().load(url, gltf => { model = gltf.scene; finish(); resolve(); }, undefined, reject);
+      new GLTFLoader().load(
+        url,
+        gltf => resolve(gltf.scene),
+        undefined,
+        reject,
+      );
     });
+
     const createImageFallback = () => {
+      if (!imageUrl || !alive) return;
       const group = new THREE.Group();
-      const map = new THREE.TextureLoader().load(imageUrl, t => { t.colorSpace = THREE.SRGBColorSpace; t.anisotropy = 4; });
+      const map = new THREE.TextureLoader().load(imageUrl, texture => {
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.anisotropy = 4;
+      });
       const frame = new THREE.MeshPhysicalMaterial({ color: 0x171a25, metalness: .72, roughness: .2, clearcoat: .55 });
       const face = new THREE.MeshBasicMaterial({ map });
       const back = new THREE.MeshBasicMaterial({ color: 0x080a10 });
       const body = new THREE.Mesh(new THREE.BoxGeometry(2.35, 2.7, .22), frame);
       const front = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), face);
       const rear = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), back);
-      front.position.z = .125; rear.position.z = -.125; rear.rotation.y = Math.PI;
-      group.add(body, front, rear); model = group; finish();
+      front.position.z = .125;
+      rear.position.z = -.125;
+      rear.rotation.y = Math.PI;
+      group.add(body, front, rear);
+      showModel(group);
     };
+
     (async () => {
       if (directUrl) {
-        try { await loadGlb(directUrl); }
-        catch { createImageFallback(); }
-      } else if (imageUrl) {
-        createImageFallback();
-        // Upgrade the fallback to a textured AI-generated GLB when the server has MESHY_API_KEY.
-        // The generated URL is cached per product so normal browsing does not regenerate assets.
         try {
-          const generatedUrl = await generateFromImage(imageUrl, item?.id || item?.slug || imageUrl);
-          if (alive && generatedUrl) {
-            if (model) scene.remove(model);
-            model = undefined;
-            await loadGlb(generatedUrl);
-          }
+          const exactModel = await loadGlb(directUrl);
+          showModel(exactModel);
+          return;
         } catch {
-          // Keep the immediate real-product 3D fallback. No broken/blank viewer.
+          createImageFallback();
+          return;
         }
       }
+
+      if (!imageUrl) return;
+
+      // Always show the real product immediately. AI reconstruction is an upgrade,
+      // never a dependency that can make the viewer disappear.
+      createImageFallback();
+
+      try {
+        const generatedUrl = await generateFromImage(imageUrl, item?.id || item?.slug || imageUrl);
+        if (!alive || !generatedUrl) return;
+
+        const generatedModel = await loadGlb(generatedUrl);
+        if (!alive) return;
+
+        if (model) scene.remove(model);
+        showModel(generatedModel);
+      } catch {
+        // The real-product 3D fallback stays visible when the AI provider is unavailable,
+        // the signed asset expires, credits are exhausted, or generation fails.
+      }
     })();
-    const resize = () => { if (!alive) return; const w = Math.max(root.clientWidth, 1), h = Math.max(root.clientHeight, 1); camera.aspect = w / h; camera.updateProjectionMatrix(); renderer.setSize(w, h, false); };
-    resize(); const ro = new ResizeObserver(resize); ro.observe(root);
-    const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += .0022; renderer.render(scene, camera); }; tick();
+
+    const resize = () => {
+      if (!alive) return;
+      const width = Math.max(root.clientWidth, 1);
+      const height = Math.max(root.clientHeight, 1);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height, false);
+    };
+
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(root);
+
+    const tick = () => {
+      if (!alive) return;
+      raf = requestAnimationFrame(tick);
+      if (model) model.rotation.y += 0.0022;
+      renderer.render(scene, camera);
+    };
+    tick();
+
     return () => {
-      alive = false; cancelAnimationFrame(raf); ro.disconnect();
+      alive = false;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
       if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement);
-      scene.traverse(o => { o.geometry?.dispose?.(); if (Array.isArray(o.material)) o.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); }); else { o.material?.map?.dispose?.(); o.material?.dispose?.(); } });
+      scene.traverse(object => {
+        object.geometry?.dispose?.();
+        if (Array.isArray(object.material)) {
+          object.material.forEach(material => { material.map?.dispose?.(); material.dispose?.(); });
+        } else {
+          object.material?.map?.dispose?.();
+          object.material?.dispose?.();
+        }
+      });
       renderer.dispose();
     };
   }, [item, onLoaded]);
+
   if (!item?.modelUri && !item?.digitalTwin?.modelUrl && !item?.previewUri && !item?.digitalTwin?.previewUrl) return null;
   return <div ref={host} aria-hidden="true" style={{ position: 'absolute', inset: 0, zIndex: 5, pointerEvents: 'none' }} />;
 }


### PR DESCRIPTION
Fixes the real-product 3D pipeline so a visible real-product 3D fallback is never removed before a generated GLB successfully loads. Expired Meshy signed URLs are discarded, generation can retry, and the API uses the current Meshy standard/latest image-to-3D parameters with textured GLB + PBR output. Exact GLB assets remain preferred. This preserves the storefront while making AI reconstruction an upgrade rather than a blanking dependency.