### PR TITLE
fix: show real products as 3D digital twins

### DIFF
--- a/app/components/RealProductModel.js
+++ b/app/components/RealProductModel.js
@@ -9,7 +9,6 @@ const CACHE_PREFIX = 'vv3-image-to-3d:';
 async function generateFromImage(imageUrl, cacheKey) {
   const cacheName = CACHE_PREFIX + cacheKey;
   const cached = window.localStorage.getItem(cacheName);
-
   if (cached) {
     try {
       const response = await fetch(cached, { method: 'HEAD', cache: 'no-store' });
@@ -17,33 +16,80 @@ async function generateFromImage(imageUrl, cacheKey) {
     } catch {}
     window.localStorage.removeItem(cacheName);
   }
-
   const start = await fetch('/api/image-to-3d', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ imageUrl }),
   });
   if (!start.ok) throw new Error('Image-to-3D generation is not configured or failed to start.');
-
   const { taskId } = await start.json();
   if (!taskId) throw new Error('Image-to-3D provider returned no task id.');
-
   for (let attempt = 0; attempt < 45; attempt += 1) {
     await new Promise(resolve => setTimeout(resolve, 4000));
     const status = await fetch(`/api/image-to-3d?taskId=${encodeURIComponent(taskId)}`, { cache: 'no-store' });
     if (!status.ok) throw new Error('Unable to read image-to-3D generation status.');
     const data = await status.json();
-
     if (data.status === 'SUCCEEDED' && data.modelUrl) {
       window.localStorage.setItem(cacheName, data.modelUrl);
       return data.modelUrl;
     }
-    if (['FAILED', 'CANCELED'].includes(data.status)) {
-      throw new Error(data.error || `Image-to-3D generation ${data.status.toLowerCase()}.`);
-    }
+    if (['FAILED', 'CANCELED'].includes(data.status)) throw new Error(data.error || 'Image-to-3D generation failed.');
   }
-
   throw new Error('Image-to-3D generation timed out.');
+}
+
+function makeMaterial(texture, color, metalness, roughness) {
+  if (texture) texture.colorSpace = THREE.SRGBColorSpace;
+  return new THREE.MeshPhysicalMaterial({ color, map: texture || null, metalness, roughness, clearcoat: 0.35, clearcoatRoughness: 0.18 });
+}
+
+function box(group, size, position, material) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
+  mesh.position.set(...position);
+  group.add(mesh);
+  return mesh;
+}
+
+function createProductTwin(item, imageUrl) {
+  const group = new THREE.Group();
+  const texture = imageUrl ? new THREE.TextureLoader().load(imageUrl) : null;
+  const name = `${item?.name || ''} ${item?.type || ''}`.toLowerCase();
+  const product = makeMaterial(texture, 0xf1f3f7, 0.18, 0.3);
+  const dark = makeMaterial(null, 0x171a24, 0.72, 0.2);
+  const metal = makeMaterial(null, 0x8d93a5, 0.78, 0.22);
+  const soft = makeMaterial(null, 0xc8ccd6, 0.12, 0.62);
+
+  if (name.includes('blender')) {
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.62, 2.15, 48), product); body.position.y = 0.25; group.add(body);
+    const base = new THREE.Mesh(new THREE.CylinderGeometry(0.78, 0.78, 0.28, 48), dark); base.position.y = -0.92; group.add(base);
+    const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.58, 0.58, 0.2, 48), dark); cap.position.y = 1.42; group.add(cap);
+    const handle = new THREE.Mesh(new THREE.TorusGeometry(0.48, 0.11, 18, 48, Math.PI), dark); handle.rotation.z = Math.PI / 2; handle.position.set(0.7, 0.25, 0); group.add(handle);
+  } else if (name.includes('lamp')) {
+    box(group, [1.65, 0.24, 1.05], [0, -1.15, 0], dark);
+    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.1, 1.85, 24), metal); stem.position.set(0, -0.15, 0); stem.rotation.z = -0.12; group.add(stem);
+    const shade = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.42, 0.52, 48), product); shade.position.set(0.12, 0.82, 0); shade.rotation.z = -0.18; group.add(shade);
+    const glow = new THREE.Mesh(new THREE.CircleGeometry(0.34, 40), new THREE.MeshBasicMaterial({ color: 0xfff1c4 })); glow.position.set(0.2, 0.55, 0.27); group.add(glow);
+  } else if (name.includes('bowl') || name.includes('fountain') || name.includes('dispenser')) {
+    const reservoir = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.62, 1.0, 48), product); reservoir.position.y = -0.2; group.add(reservoir);
+    const basin = new THREE.Mesh(new THREE.CylinderGeometry(1.0, 0.82, 0.28, 48), soft); basin.position.y = -0.82; group.add(basin);
+    const rim = new THREE.Mesh(new THREE.TorusGeometry(0.88, 0.08, 18, 64), dark); rim.rotation.x = Math.PI / 2; rim.position.y = -0.64; group.add(rim);
+    const spout = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.16, 0.72, 24), metal); spout.position.y = 0.55; group.add(spout);
+  } else if (name.includes('vanity') || name.includes('desk')) {
+    box(group, [2.7, 0.22, 1.15], [0, 0.35, 0], product);
+    box(group, [0.22, 1.55, 0.9], [-1.15, -0.45, 0], dark);
+    box(group, [0.22, 1.55, 0.9], [1.15, -0.45, 0], dark);
+    box(group, [1.45, 1.25, 0.1], [0, 1.15, -0.02], metal);
+    const mirror = new THREE.Mesh(new THREE.PlaneGeometry(1.28, 1.08), new THREE.MeshPhysicalMaterial({ color: 0x8fa3c8, metalness: 0.65, roughness: 0.12 })); mirror.position.set(0, 1.15, 0.045); group.add(mirror);
+    box(group, [0.85, 0.28, 0.85], [0, -1.25, 0], soft);
+  } else if (name.includes('cup') || name.includes('bottle') || name.includes('water')) {
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.54, 1.9, 48), product); body.position.y = 0; group.add(body);
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.42, 0.45, 40), dark); neck.position.y = 1.12; group.add(neck);
+    const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.43, 0.43, 0.18, 40), dark); cap.position.y = 1.43; group.add(cap);
+  } else {
+    const body = new THREE.Mesh(new THREE.SphereGeometry(1.0, 48, 32), product); body.scale.set(1.1, 1.05, 0.72); group.add(body);
+    const base = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.8, 0.25, 48), dark); base.position.y = -0.95; group.add(base);
+  }
+  return group;
 }
 
 export default function RealProductModel({ item, onLoaded }) {
@@ -67,132 +113,62 @@ export default function RealProductModel({ item, onLoaded }) {
     root.appendChild(renderer.domElement);
 
     scene.add(new THREE.HemisphereLight(0xffffff, 0x11131c, 2.8));
-    const key = new THREE.DirectionalLight(0xffffff, 4.5);
-    key.position.set(4, 6, 5);
-    scene.add(key);
-    const rim = new THREE.DirectionalLight(0x7566ff, 2.5);
-    rim.position.set(-4, 3, -4);
-    scene.add(rim);
+    const key = new THREE.DirectionalLight(0xffffff, 4.5); key.position.set(4, 6, 5); scene.add(key);
+    const rim = new THREE.DirectionalLight(0x7566ff, 2.5); rim.position.set(-4, 3, -4); scene.add(rim);
 
     let model = null;
     let raf;
-
     const normalize = object => {
-      const box = new THREE.Box3().setFromObject(object);
-      const size = box.getSize(new THREE.Vector3());
-      const center = box.getCenter(new THREE.Vector3());
+      const box3 = new THREE.Box3().setFromObject(object);
+      const size = box3.getSize(new THREE.Vector3());
+      const center = box3.getCenter(new THREE.Vector3());
       object.position.sub(center);
-      object.scale.setScalar(2.6 / (Math.max(size.x, size.y, size.z) || 1));
+      object.scale.setScalar(2.65 / (Math.max(size.x, size.y, size.z) || 1));
       object.position.y += 0.05;
     };
-
     const showModel = object => {
       if (!alive) return false;
-      normalize(object);
-      scene.add(object);
-      model = object;
-      camera.position.set(0, 0.15, 5.2);
-      camera.lookAt(0, 0, 0);
-      onLoaded?.(true);
-      return true;
+      normalize(object); scene.add(object); model = object;
+      camera.position.set(0, 0.15, 5.2); camera.lookAt(0, 0, 0); onLoaded?.(true); return true;
     };
-
-    const loadGlb = url => new Promise((resolve, reject) => {
-      new GLTFLoader().load(
-        url,
-        gltf => resolve(gltf.scene),
-        undefined,
-        reject,
-      );
-    });
-
-    const createImageFallback = () => {
-      if (!imageUrl || !alive) return;
-      const group = new THREE.Group();
-      const map = new THREE.TextureLoader().load(imageUrl, texture => {
-        texture.colorSpace = THREE.SRGBColorSpace;
-        texture.anisotropy = 4;
-      });
-      const frame = new THREE.MeshPhysicalMaterial({ color: 0x171a25, metalness: .72, roughness: .2, clearcoat: .55 });
-      const face = new THREE.MeshBasicMaterial({ map });
-      const back = new THREE.MeshBasicMaterial({ color: 0x080a10 });
-      const body = new THREE.Mesh(new THREE.BoxGeometry(2.35, 2.7, .22), frame);
-      const front = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), face);
-      const rear = new THREE.Mesh(new THREE.PlaneGeometry(2.05, 2.4), back);
-      front.position.z = .125;
-      rear.position.z = -.125;
-      rear.rotation.y = Math.PI;
-      group.add(body, front, rear);
-      showModel(group);
-    };
+    const loadGlb = url => new Promise((resolve, reject) => new GLTFLoader().load(url, gltf => resolve(gltf.scene), undefined, reject));
+    const createProceduralTwin = () => { if (alive) showModel(createProductTwin(item, imageUrl)); };
 
     (async () => {
       if (directUrl) {
-        try {
-          const exactModel = await loadGlb(directUrl);
-          showModel(exactModel);
-          return;
-        } catch {
-          createImageFallback();
-          return;
-        }
+        try { showModel(await loadGlb(directUrl)); return; } catch { createProceduralTwin(); return; }
       }
-
       if (!imageUrl) return;
-
-      // Always show the real product immediately. AI reconstruction is an upgrade,
-      // never a dependency that can make the viewer disappear.
-      createImageFallback();
-
+      createProceduralTwin();
       try {
         const generatedUrl = await generateFromImage(imageUrl, item?.id || item?.slug || imageUrl);
         if (!alive || !generatedUrl) return;
-
         const generatedModel = await loadGlb(generatedUrl);
         if (!alive) return;
-
         if (model) scene.remove(model);
         showModel(generatedModel);
       } catch {
-        // The real-product 3D fallback stays visible when the AI provider is unavailable,
-        // the signed asset expires, credits are exhausted, or generation fails.
+        // Keep the product-specific 3D twin visible when AI reconstruction is unavailable.
       }
     })();
 
     const resize = () => {
       if (!alive) return;
-      const width = Math.max(root.clientWidth, 1);
-      const height = Math.max(root.clientHeight, 1);
-      camera.aspect = width / height;
-      camera.updateProjectionMatrix();
-      renderer.setSize(width, height, false);
+      const width = Math.max(root.clientWidth, 1), height = Math.max(root.clientHeight, 1);
+      camera.aspect = width / height; camera.updateProjectionMatrix(); renderer.setSize(width, height, false);
     };
-
     resize();
-    const ro = new ResizeObserver(resize);
-    ro.observe(root);
-
-    const tick = () => {
-      if (!alive) return;
-      raf = requestAnimationFrame(tick);
-      if (model) model.rotation.y += 0.0022;
-      renderer.render(scene, camera);
-    };
+    const ro = new ResizeObserver(resize); ro.observe(root);
+    const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += 0.0024; renderer.render(scene, camera); };
     tick();
 
     return () => {
-      alive = false;
-      cancelAnimationFrame(raf);
-      ro.disconnect();
+      alive = false; cancelAnimationFrame(raf); ro.disconnect();
       if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement);
       scene.traverse(object => {
         object.geometry?.dispose?.();
-        if (Array.isArray(object.material)) {
-          object.material.forEach(material => { material.map?.dispose?.(); material.dispose?.(); });
-        } else {
-          object.material?.map?.dispose?.();
-          object.material?.dispose?.();
-        }
+        if (Array.isArray(object.material)) object.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); });
+        else { object.material?.map?.dispose?.(); object.material?.dispose?.(); }
       });
       renderer.dispose();
     };


### PR DESCRIPTION
Fixes the real-product 3D experience without changing the existing visual layout.

- Renders a product-specific 3D procedural twin immediately from the real product imagery/specification instead of a flat framed image.
- Keeps exact GLB/GLTF models as the highest-priority source.
- Keeps the Meshy image-to-3D pipeline as an accuracy upgrade when MESHY_API_KEY is configured.
- Never leaves a real-product card blank when the AI provider is unavailable.
- Blender, lamps, bowls/fountains/dispensers, desks/vanities, cups/bottles/water products, and generic products get distinct 3D forms.

Important: a single 2D image cannot guarantee an exact reconstruction of hidden surfaces. The procedural twin is an immediate product-specific 3D presentation; the AI GLB becomes the higher-fidelity twin when configured.