### PR TITLE
Upgrade AI real-product 3D twin generation

### DIFF
--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -4,47 +4,39 @@ export const runtime = 'nodejs';
 
 const MESHY_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 
+function buildPrompt(item = {}) {
+  const name = [item.name, item.type].filter(Boolean).join(' / ');
+  const material = item.material ? `Material family: ${item.material}.` : '';
+  const source = item.sourceName ? `This is a real commercial product listed by ${item.sourceName}.` : '';
+  const note = item.sourceNote || '';
+  return [
+    `Create a photorealistic, production-ready 3D digital twin of the exact physical product shown in the reference image: ${name || 'the product'}.`,
+    material,
+    source,
+    note,
+    'Match the reference exactly: silhouette, proportions, thickness, openings, seams, controls, buttons, handles, feet, hardware, surface finish, color placement and visible construction details.',
+    'Do not redesign, stylize, voxelize, cartoonize, beautify, simplify, or add fictional components. Do not invent logos, labels, controls, accessories, patterns, or geometry that is not supported by the reference.',
+    'Preserve physically plausible manufacturing details and real-world scale. Produce clean manifold geometry suitable for an interactive e-commerce digital twin and NFT asset.',
+    'Use realistic physically based materials with accurate roughness, metallic response, reflections and subtle surface variation. Keep textures aligned to the actual product rather than painting a generic material over the mesh.',
+  ].filter(Boolean).join(' ');
+}
+
 export async function POST(request) {
   const apiKey = process.env.MESHY_API_KEY;
-  if (!apiKey) {
-    return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured. Add MESHY_API_KEY to Vercel Production.' }, { status: 503 });
-  }
-
+  if (!apiKey) return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured. Add MESHY_API_KEY to Vercel Production.' }, { status: 503 });
   try {
     const body = await request.json();
     const imageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) {
-      return NextResponse.json({ error: 'A public JPG, JPEG, or PNG product image URL is required.' }, { status: 400 });
-    }
-
+    const item = body?.item && typeof body.item === 'object' ? body.item : {};
+    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) return NextResponse.json({ error: 'A public JPG, JPEG, or PNG product image URL is required.' }, { status: 400 });
     const response = await fetch(MESHY_ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        image_url: imageUrl,
-        model_type: 'standard',
-        ai_model: 'latest',
-        ultra_mode: true,
-        image_enhancement: true,
-        remove_lighting: true,
-        should_texture: true,
-        enable_pbr: true,
-        texture_resolution: '4k',
-        texture_image_url: imageUrl,
-        texture_prompt: 'Photorealistic commercial product reconstruction. Preserve the exact visible product proportions, silhouette, materials, colors, buttons, seams, openings, hardware, and surface details from the reference image. Do not add decorative elements or invent branding. Produce a clean physically based material suitable for an e-commerce digital twin.',
-        target_formats: ['glb'],
-        auto_size: true,
-        origin_at: 'bottom',
-        multi_view_thumbnails: true,
-      }),
+      body: JSON.stringify({ image_url: imageUrl, model_type: 'standard', ai_model: 'latest', ultra_mode: true, image_enhancement: true, remove_lighting: true, should_texture: true, enable_pbr: true, texture_resolution: '4k', texture_image_url: imageUrl, texture_prompt: buildPrompt(item), target_formats: ['glb'], auto_size: true, origin_at: 'bottom', multi_view_thumbnails: true }),
       cache: 'no-store',
     });
-
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Image-to-3D provider rejected the request.' }, { status: response.status });
-    }
-
+    if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Image-to-3D provider rejected the request.' }, { status: response.status });
     return NextResponse.json({ configured: true, taskId: data?.result || data?.id || null });
   } catch (error) {
     return NextResponse.json({ error: error?.message || 'Image-to-3D request failed.' }, { status: 500 });
@@ -56,24 +48,11 @@ export async function GET(request) {
   const taskId = new URL(request.url).searchParams.get('taskId');
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured.' }, { status: 503 });
   if (!taskId) return NextResponse.json({ error: 'taskId is required.' }, { status: 400 });
-
   try {
-    const response = await fetch(`${MESHY_ENDPOINT}/${encodeURIComponent(taskId)}`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      cache: 'no-store',
-    });
+    const response = await fetch(`${MESHY_ENDPOINT}/${encodeURIComponent(taskId)}`, { headers: { Authorization: `Bearer ${apiKey}` }, cache: 'no-store' });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Unable to read 3D generation status.' }, { status: response.status });
-
-    return NextResponse.json({
-      configured: true,
-      status: data?.status || 'PENDING',
-      progress: data?.progress ?? 0,
-      modelUrl: data?.model_urls?.glb || null,
-      thumbnailUrl: data?.thumbnail_url || null,
-      thumbnailUrls: data?.thumbnail_urls || null,
-      error: data?.task_error?.message || null,
-    });
+    return NextResponse.json({ configured: true, status: data?.status || 'PENDING', progress: data?.progress ?? 0, modelUrl: data?.model_urls?.glb || null, thumbnailUrl: data?.thumbnail_url || null, thumbnailUrls: data?.thumbnail_urls || null, error: data?.task_error?.message || null });
   } catch (error) {
     return NextResponse.json({ error: error?.message || '3D generation status request failed.' }, { status: 500 });
   }

--- a/app/components/RealProductModel.js
+++ b/app/components/RealProductModel.js
@@ -6,7 +6,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 const CACHE_PREFIX = 'vv3-image-to-3d:';
 
-async function generateFromImage(imageUrl, cacheKey) {
+async function generateFromImage(imageUrl, item, cacheKey) {
   const cacheName = CACHE_PREFIX + cacheKey;
   const cached = window.localStorage.getItem(cacheName);
   if (cached) {
@@ -19,7 +19,7 @@ async function generateFromImage(imageUrl, cacheKey) {
   const start = await fetch('/api/image-to-3d', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ imageUrl }),
+    body: JSON.stringify({ imageUrl, item: { name: item?.name, type: item?.type, material: item?.material, sourceName: item?.sourceName, sourceNote: item?.sourceNote } }),
   });
   if (!start.ok) throw new Error('Image-to-3D generation is not configured or failed to start.');
   const { taskId } = await start.json();
@@ -42,23 +42,12 @@ function makeMaterial(texture, color, metalness, roughness) {
   if (texture) texture.colorSpace = THREE.SRGBColorSpace;
   return new THREE.MeshPhysicalMaterial({ color, map: texture || null, metalness, roughness, clearcoat: 0.35, clearcoatRoughness: 0.18 });
 }
-
-function box(group, size, position, material) {
-  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
-  mesh.position.set(...position);
-  group.add(mesh);
-  return mesh;
-}
-
+function box(group, size, position, material) { const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material); mesh.position.set(...position); group.add(mesh); return mesh; }
 function createProductTwin(item, imageUrl) {
   const group = new THREE.Group();
   const texture = imageUrl ? new THREE.TextureLoader().load(imageUrl) : null;
   const name = `${item?.name || ''} ${item?.type || ''}`.toLowerCase();
-  const product = makeMaterial(texture, 0xf1f3f7, 0.18, 0.3);
-  const dark = makeMaterial(null, 0x171a24, 0.72, 0.2);
-  const metal = makeMaterial(null, 0x8d93a5, 0.78, 0.22);
-  const soft = makeMaterial(null, 0xc8ccd6, 0.12, 0.62);
-
+  const product = makeMaterial(texture, 0xf1f3f7, 0.18, 0.3), dark = makeMaterial(null, 0x171a24, 0.72, 0.2), metal = makeMaterial(null, 0x8d93a5, 0.78, 0.22), soft = makeMaterial(null, 0xc8ccd6, 0.12, 0.62);
   if (name.includes('blender')) {
     const body = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.62, 2.15, 48), product); body.position.y = 0.25; group.add(body);
     const base = new THREE.Mesh(new THREE.CylinderGeometry(0.78, 0.78, 0.28, 48), dark); base.position.y = -0.92; group.add(base);
@@ -75,105 +64,45 @@ function createProductTwin(item, imageUrl) {
     const rim = new THREE.Mesh(new THREE.TorusGeometry(0.88, 0.08, 18, 64), dark); rim.rotation.x = Math.PI / 2; rim.position.y = -0.64; group.add(rim);
     const spout = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.16, 0.72, 24), metal); spout.position.y = 0.55; group.add(spout);
   } else if (name.includes('vanity') || name.includes('desk')) {
-    box(group, [2.7, 0.22, 1.15], [0, 0.35, 0], product);
-    box(group, [0.22, 1.55, 0.9], [-1.15, -0.45, 0], dark);
-    box(group, [0.22, 1.55, 0.9], [1.15, -0.45, 0], dark);
-    box(group, [1.45, 1.25, 0.1], [0, 1.15, -0.02], metal);
-    const mirror = new THREE.Mesh(new THREE.PlaneGeometry(1.28, 1.08), new THREE.MeshPhysicalMaterial({ color: 0x8fa3c8, metalness: 0.65, roughness: 0.12 })); mirror.position.set(0, 1.15, 0.045); group.add(mirror);
-    box(group, [0.85, 0.28, 0.85], [0, -1.25, 0], soft);
+    box(group, [2.7, 0.22, 1.15], [0, 0.35, 0], product); box(group, [0.22, 1.55, 0.9], [-1.15, -0.45, 0], dark); box(group, [0.22, 1.55, 0.9], [1.15, -0.45, 0], dark); box(group, [1.45, 1.25, 0.1], [0, 1.15, -0.02], metal);
+    const mirror = new THREE.Mesh(new THREE.PlaneGeometry(1.28, 1.08), new THREE.MeshPhysicalMaterial({ color: 0x8fa3c8, metalness: 0.65, roughness: 0.12 })); mirror.position.set(0, 1.15, 0.045); group.add(mirror); box(group, [0.85, 0.28, 0.85], [0, -1.25, 0], soft);
   } else if (name.includes('cup') || name.includes('bottle') || name.includes('water')) {
-    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.54, 1.9, 48), product); body.position.y = 0; group.add(body);
-    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.42, 0.45, 40), dark); neck.position.y = 1.12; group.add(neck);
-    const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.43, 0.43, 0.18, 40), dark); cap.position.y = 1.43; group.add(cap);
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.62, 0.54, 1.9, 48), product); body.position.y = 0; group.add(body); const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.42, 0.45, 40), dark); neck.position.y = 1.12; group.add(neck); const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.43, 0.43, 0.18, 40), dark); cap.position.y = 1.43; group.add(cap);
   } else {
-    const body = new THREE.Mesh(new THREE.SphereGeometry(1.0, 48, 32), product); body.scale.set(1.1, 1.05, 0.72); group.add(body);
-    const base = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.8, 0.25, 48), dark); base.position.y = -0.95; group.add(base);
+    const body = new THREE.Mesh(new THREE.SphereGeometry(1.0, 48, 32), product); body.scale.set(1.1, 1.05, 0.72); group.add(body); const base = new THREE.Mesh(new THREE.CylinderGeometry(0.72, 0.8, 0.25, 48), dark); base.position.y = -0.95; group.add(base);
   }
   return group;
 }
 
 export default function RealProductModel({ item, onLoaded }) {
   const host = useRef(null);
-
   useEffect(() => {
     const root = host.current;
     const directUrl = item?.modelUri || item?.digitalTwin?.modelUrl;
     const imageUrl = item?.previewUri || item?.digitalTwin?.previewUrl;
     if (!root || (!directUrl && !imageUrl)) return undefined;
-
     let alive = true;
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(30, 1, 0.01, 100);
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
-    renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 1.15;
-    renderer.domElement.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none';
-    root.appendChild(renderer.domElement);
-
-    scene.add(new THREE.HemisphereLight(0xffffff, 0x11131c, 2.8));
-    const key = new THREE.DirectionalLight(0xffffff, 4.5); key.position.set(4, 6, 5); scene.add(key);
-    const rim = new THREE.DirectionalLight(0x7566ff, 2.5); rim.position.set(-4, 3, -4); scene.add(rim);
-
-    let model = null;
-    let raf;
-    const normalize = object => {
-      const box3 = new THREE.Box3().setFromObject(object);
-      const size = box3.getSize(new THREE.Vector3());
-      const center = box3.getCenter(new THREE.Vector3());
-      object.position.sub(center);
-      object.scale.setScalar(2.65 / (Math.max(size.x, size.y, size.z) || 1));
-      object.position.y += 0.05;
-    };
-    const showModel = object => {
-      if (!alive) return false;
-      normalize(object); scene.add(object); model = object;
-      camera.position.set(0, 0.15, 5.2); camera.lookAt(0, 0, 0); onLoaded?.(true); return true;
-    };
+    const scene = new THREE.Scene(), camera = new THREE.PerspectiveCamera(30, 1, 0.01, 100), renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2)); renderer.outputColorSpace = THREE.SRGBColorSpace; renderer.toneMapping = THREE.ACESFilmicToneMapping; renderer.toneMappingExposure = 1.15; renderer.domElement.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none'; root.appendChild(renderer.domElement);
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x11131c, 2.8)); const key = new THREE.DirectionalLight(0xffffff, 4.5); key.position.set(4, 6, 5); scene.add(key); const rim = new THREE.DirectionalLight(0x7566ff, 2.5); rim.position.set(-4, 3, -4); scene.add(rim);
+    let model = null, raf;
+    const normalize = object => { const box3 = new THREE.Box3().setFromObject(object), size = box3.getSize(new THREE.Vector3()), center = box3.getCenter(new THREE.Vector3()); object.position.sub(center); object.scale.setScalar(2.65 / (Math.max(size.x, size.y, size.z) || 1)); object.position.y += 0.05; };
+    const showModel = object => { if (!alive) return false; normalize(object); scene.add(object); model = object; camera.position.set(0, 0.15, 5.2); camera.lookAt(0, 0, 0); onLoaded?.(true); return true; };
     const loadGlb = url => new Promise((resolve, reject) => new GLTFLoader().load(url, gltf => resolve(gltf.scene), undefined, reject));
     const createProceduralTwin = () => { if (alive) showModel(createProductTwin(item, imageUrl)); };
-
     (async () => {
-      if (directUrl) {
-        try { showModel(await loadGlb(directUrl)); return; } catch { createProceduralTwin(); return; }
-      }
+      if (directUrl) { try { showModel(await loadGlb(directUrl)); return; } catch { createProceduralTwin(); return; } }
       if (!imageUrl) return;
-      createProceduralTwin();
       try {
-        const generatedUrl = await generateFromImage(imageUrl, item?.id || item?.slug || imageUrl);
-        if (!alive || !generatedUrl) return;
-        const generatedModel = await loadGlb(generatedUrl);
-        if (!alive) return;
-        if (model) scene.remove(model);
-        showModel(generatedModel);
-      } catch {
-        // Keep the product-specific 3D twin visible when AI reconstruction is unavailable.
-      }
+        const generatedUrl = await generateFromImage(imageUrl, item, item?.id || item?.slug || imageUrl);
+        if (!alive || !generatedUrl) throw new Error('No generated model URL.');
+        const generatedModel = await loadGlb(generatedUrl); if (!alive) return; showModel(generatedModel);
+      } catch { createProceduralTwin(); }
     })();
-
-    const resize = () => {
-      if (!alive) return;
-      const width = Math.max(root.clientWidth, 1), height = Math.max(root.clientHeight, 1);
-      camera.aspect = width / height; camera.updateProjectionMatrix(); renderer.setSize(width, height, false);
-    };
-    resize();
-    const ro = new ResizeObserver(resize); ro.observe(root);
-    const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += 0.0024; renderer.render(scene, camera); };
-    tick();
-
-    return () => {
-      alive = false; cancelAnimationFrame(raf); ro.disconnect();
-      if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement);
-      scene.traverse(object => {
-        object.geometry?.dispose?.();
-        if (Array.isArray(object.material)) object.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); });
-        else { object.material?.map?.dispose?.(); object.material?.dispose?.(); }
-      });
-      renderer.dispose();
-    };
+    const resize = () => { if (!alive) return; const width = Math.max(root.clientWidth, 1), height = Math.max(root.clientHeight, 1); camera.aspect = width / height; camera.updateProjectionMatrix(); renderer.setSize(width, height, false); };
+    resize(); const ro = new ResizeObserver(resize); ro.observe(root); const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += 0.0024; renderer.render(scene, camera); }; tick();
+    return () => { alive = false; cancelAnimationFrame(raf); ro.disconnect(); if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement); scene.traverse(object => { object.geometry?.dispose?.(); if (Array.isArray(object.material)) object.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); }); else { object.material?.map?.dispose?.(); object.material?.dispose?.(); } }); renderer.dispose(); };
   }, [item, onLoaded]);
-
   if (!item?.modelUri && !item?.digitalTwin?.modelUrl && !item?.previewUri && !item?.digitalTwin?.previewUrl) return null;
   return <div ref={host} aria-hidden="true" style={{ position: 'absolute', inset: 0, zIndex: 5, pointerEvents: 'none' }} />;
 }


### PR DESCRIPTION
Improve the deployed image-to-3D pipeline so every product sends its real catalog context into the AI reconstruction prompt. The renderer now waits for the AI reconstruction first and only uses the product-specific procedural twin as fallback. This keeps the visual layout intact while prioritizing realistic product-specific geometry.