### PR TITLE
Make real-product AI 3D inputs use supplier imagery

### DIFF
--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -21,14 +21,45 @@ function buildPrompt(item = {}) {
   ].filter(Boolean).join(' ');
 }
 
+function isPlaceholderImage(url = '') {
+  return /images\\.unsplash\\.com|unsplash\\.com/i.test(url);
+}
+
+async function resolveProductImage(imageUrl, sourceUrl) {
+  if (imageUrl && !isPlaceholderImage(imageUrl)) return imageUrl;
+  if (!sourceUrl || !/^https?:\\/\\//i.test(sourceUrl)) return imageUrl || '';
+  try {
+    const response = await fetch(sourceUrl, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; VoxelVaultProductResolver/1.0)' },
+      cache: 'no-store',
+    });
+    if (!response.ok) return imageUrl || '';
+    const html = await response.text();
+    const patterns = [
+      /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
+      /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i,
+      /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i,
+      /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']twitter:image["']/i,
+    ];
+    for (const pattern of patterns) {
+      const match = html.match(pattern);
+      if (match?.[1]) {
+        try { return new URL(match[1], sourceUrl).toString(); } catch {}
+      }
+    }
+  } catch {}
+  return imageUrl || '';
+}
+
 export async function POST(request) {
   const apiKey = process.env.MESHY_API_KEY;
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Image-to-3D generation is not configured. Add MESHY_API_KEY to Vercel Production.' }, { status: 503 });
   try {
     const body = await request.json();
-    const imageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
     const item = body?.item && typeof body.item === 'object' ? body.item : {};
-    if (!imageUrl || !/^https?:\/\//i.test(imageUrl)) return NextResponse.json({ error: 'A public JPG, JPEG, or PNG product image URL is required.' }, { status: 400 });
+    const requestedImageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
+    const imageUrl = await resolveProductImage(requestedImageUrl, typeof item.sourceUrl === 'string' ? item.sourceUrl : '');
+    if (!imageUrl || !/^https?:\\/\\//i.test(imageUrl)) return NextResponse.json({ error: 'A public product image URL could not be resolved from the supplier listing.' }, { status: 400 });
     const response = await fetch(MESHY_ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -37,7 +68,7 @@ export async function POST(request) {
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) return NextResponse.json({ error: data?.message || data?.error || data?.task_error?.message || 'Image-to-3D provider rejected the request.' }, { status: response.status });
-    return NextResponse.json({ configured: true, taskId: data?.result || data?.id || null });
+    return NextResponse.json({ configured: true, sourceImageUrl: imageUrl, taskId: data?.result || data?.id || null });
   } catch (error) {
     return NextResponse.json({ error: error?.message || 'Image-to-3D request failed.' }, { status: 500 });
   }

--- a/app/api/product-image/route.js
+++ b/app/api/product-image/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+function extractImage(html, sourceUrl) {
+  const patterns = [
+    /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
+    /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i,
+    /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i,
+    /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']twitter:image["']/i,
+  ];
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) {
+      try { return new URL(match[1], sourceUrl).toString(); } catch {}
+    }
+  }
+  return null;
+}
+
+export async function GET(request) {
+  const sourceUrl = new URL(request.url).searchParams.get('url') || '';
+  if (!/^https?:\/\//i.test(sourceUrl)) return NextResponse.json({ error: 'A valid supplier URL is required.' }, { status: 400 });
+  try {
+    const response = await fetch(sourceUrl, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; VoxelVaultProductResolver/1.0)' },
+      cache: 'no-store',
+    });
+    if (!response.ok) return NextResponse.json({ error: 'Supplier listing could not be fetched.' }, { status: 502 });
+    const html = await response.text();
+    const imageUrl = extractImage(html, sourceUrl);
+    if (!imageUrl) return NextResponse.json({ error: 'No public product image was advertised by the supplier listing.' }, { status: 404 });
+    return NextResponse.json({ imageUrl, sourceUrl });
+  } catch (error) {
+    return NextResponse.json({ error: error?.message || 'Supplier image resolution failed.' }, { status: 500 });
+  }
+}

--- a/app/components/RealProductModel.js
+++ b/app/components/RealProductModel.js
@@ -6,6 +6,23 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 const CACHE_PREFIX = 'vv3-image-to-3d:';
 
+function isPlaceholderImage(url = '') {
+  return /images\\.unsplash\\.com|unsplash\\.com/i.test(url);
+}
+
+async function resolveProductImage(imageUrl, sourceUrl) {
+  if (imageUrl && !isPlaceholderImage(imageUrl)) return imageUrl;
+  if (!sourceUrl) return imageUrl || '';
+  try {
+    const response = await fetch(`/api/product-image?url=${encodeURIComponent(sourceUrl)}`, { cache: 'no-store' });
+    if (response.ok) {
+      const data = await response.json();
+      if (data?.imageUrl) return data.imageUrl;
+    }
+  } catch {}
+  return imageUrl || '';
+}
+
 async function generateFromImage(imageUrl, item, cacheKey) {
   const cacheName = CACHE_PREFIX + cacheKey;
   const cached = window.localStorage.getItem(cacheName);
@@ -19,7 +36,7 @@ async function generateFromImage(imageUrl, item, cacheKey) {
   const start = await fetch('/api/image-to-3d', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ imageUrl, item: { name: item?.name, type: item?.type, material: item?.material, sourceName: item?.sourceName, sourceNote: item?.sourceNote } }),
+    body: JSON.stringify({ imageUrl, item: { name: item?.name, type: item?.type, material: item?.material, sourceName: item?.sourceName, sourceNote: item?.sourceNote, sourceUrl: item?.sourceUrl } }),
   });
   if (!start.ok) throw new Error('Image-to-3D generation is not configured or failed to start.');
   const { taskId } = await start.json();
@@ -53,6 +70,10 @@ function createProductTwin(item, imageUrl) {
     const base = new THREE.Mesh(new THREE.CylinderGeometry(0.78, 0.78, 0.28, 48), dark); base.position.y = -0.92; group.add(base);
     const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.58, 0.58, 0.2, 48), dark); cap.position.y = 1.42; group.add(cap);
     const handle = new THREE.Mesh(new THREE.TorusGeometry(0.48, 0.11, 18, 48, Math.PI), dark); handle.rotation.z = Math.PI / 2; handle.position.set(0.7, 0.25, 0); group.add(handle);
+  } else if (name.includes('spiral')) {
+    box(group, [1.55, 0.18, 1.0], [0, -1.15, 0], dark);
+    const coil = new THREE.Mesh(new THREE.TorusGeometry(0.62, 0.09, 16, 72, Math.PI * 1.75), metal); coil.rotation.z = Math.PI / 2; coil.position.y = 0.15; group.add(coil);
+    const diffuser = new THREE.Mesh(new THREE.CapsuleGeometry(0.12, 1.35, 8, 20), product); diffuser.position.set(0, 0.25, 0.05); diffuser.rotation.z = -0.18; group.add(diffuser);
   } else if (name.includes('lamp')) {
     box(group, [1.65, 0.24, 1.05], [0, -1.15, 0], dark);
     const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.1, 1.85, 24), metal); stem.position.set(0, -0.15, 0); stem.rotation.z = -0.12; group.add(stem);
@@ -79,8 +100,8 @@ export default function RealProductModel({ item, onLoaded }) {
   useEffect(() => {
     const root = host.current;
     const directUrl = item?.modelUri || item?.digitalTwin?.modelUrl;
-    const imageUrl = item?.previewUri || item?.digitalTwin?.previewUrl;
-    if (!root || (!directUrl && !imageUrl)) return undefined;
+    let imageUrl = item?.previewUri || item?.digitalTwin?.previewUrl;
+    if (!root || (!directUrl && !imageUrl && !item?.sourceUrl)) return undefined;
     let alive = true;
     const scene = new THREE.Scene(), camera = new THREE.PerspectiveCamera(30, 1, 0.01, 100), renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2)); renderer.outputColorSpace = THREE.SRGBColorSpace; renderer.toneMapping = THREE.ACESFilmicToneMapping; renderer.toneMappingExposure = 1.15; renderer.domElement.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;display:block;pointer-events:none'; root.appendChild(renderer.domElement);
@@ -91,6 +112,7 @@ export default function RealProductModel({ item, onLoaded }) {
     const loadGlb = url => new Promise((resolve, reject) => new GLTFLoader().load(url, gltf => resolve(gltf.scene), undefined, reject));
     const createProceduralTwin = () => { if (alive) showModel(createProductTwin(item, imageUrl)); };
     (async () => {
+      imageUrl = await resolveProductImage(imageUrl, item?.sourceUrl);
       if (directUrl) { try { showModel(await loadGlb(directUrl)); return; } catch { createProceduralTwin(); return; } }
       if (!imageUrl) return;
       try {
@@ -103,6 +125,6 @@ export default function RealProductModel({ item, onLoaded }) {
     resize(); const ro = new ResizeObserver(resize); ro.observe(root); const tick = () => { if (!alive) return; raf = requestAnimationFrame(tick); if (model) model.rotation.y += 0.0024; renderer.render(scene, camera); }; tick();
     return () => { alive = false; cancelAnimationFrame(raf); ro.disconnect(); if (renderer.domElement.parentNode === root) root.removeChild(renderer.domElement); scene.traverse(object => { object.geometry?.dispose?.(); if (Array.isArray(object.material)) object.material.forEach(m => { m.map?.dispose?.(); m.dispose?.(); }); else { object.material?.map?.dispose?.(); object.material?.dispose?.(); } }); renderer.dispose(); };
   }, [item, onLoaded]);
-  if (!item?.modelUri && !item?.digitalTwin?.modelUrl && !item?.previewUri && !item?.digitalTwin?.previewUrl) return null;
+  if (!item?.modelUri && !item?.digitalTwin?.modelUrl && !item?.previewUri && !item?.digitalTwin?.previewUrl && !item?.sourceUrl) return null;
   return <div ref={host} aria-hidden="true" style={{ position: 'absolute', inset: 0, zIndex: 5, pointerEvents: 'none' }} />;
 }


### PR DESCRIPTION
Improves the production 3D twin pipeline by resolving the actual supplier listing's Open Graph/Twitter product image when the catalog still contains a placeholder image. Passes supplier URL context into the AI reconstruction request and adds a small server-side product-image resolver. The existing AI generation remains optional and falls back safely when the provider is not configured.