### PR TITLE
Security hardening: fail-closed mint and mainnet multisig gate

### DIFF
--- a/contracts/VoxelVaultNFT.sol
+++ b/contracts/VoxelVaultNFT.sol
@@ -11,8 +11,8 @@ contract VoxelVaultNFT is ERC721, ERC721URIStorage, ERC721Royalty, Ownable {
     uint96 public constant MAX_ROYALTY_BPS = 1500;
     mapping(address => bool) public minters;
 
-    /// @notice When false, only minters/owner may mint (recommended for mainnet).
-    bool public publicMintEnabled = true;
+    /// @notice Public mint is fail-closed. Enable deliberately via the owner for a controlled launch.
+    bool public publicMintEnabled = false;
 
     event VoxelMinted(uint256 indexed tokenId, address indexed creator, string tokenURI, uint96 royaltyBps);
     event MinterUpdated(address indexed account, bool allowed);
@@ -36,7 +36,7 @@ contract VoxelVaultNFT is ERC721, ERC721URIStorage, ERC721Royalty, Ownable {
         emit PublicMintEnabledUpdated(enabled);
     }
 
-    /// @notice Public mint path. Disable via setPublicMintEnabled(false) before mainnet if desired.
+    /// @notice Public mint path. Disabled by default; enable deliberately through owner governance.
     function mint(string calldata uri, uint96 royaltyBps) external returns (uint256 tokenId) {
         require(publicMintEnabled, "Public mint disabled");
         return _mintTo(msg.sender, msg.sender, uri, royaltyBps);

--- a/scripts/deploy-mainnet.js
+++ b/scripts/deploy-mainnet.js
@@ -4,8 +4,9 @@
  * SAFETY:
  * - Refuses to run unless CONFIRM_MAINNET=yes
  * - Refuses unless chainId === 1
- * - Public mint DISABLED by default after deploy
- * - Prefer MULTISIG_OWNER + FEE_RECIPIENT (not the deployer hot wallet)
+ * - Refuses unless MULTISIG_OWNER is explicitly supplied
+ * - Public mint is disabled in the NFT contract by default
+ * - The deployer is never accepted as the mainnet owner fallback
  *
  * NEVER paste private keys into chat, GitHub, or Vercel public env.
  * Run only from a secure local machine with a funded deployer.
@@ -30,27 +31,29 @@ async function main() {
     throw new Error(`Expected Ethereum mainnet chainId 1, got ${chainId}. Check MAINNET_RPC_URL.`);
   }
 
-  const owner = process.env.MULTISIG_OWNER || process.env.OWNER_ADDRESS || deployer.address;
-  const feeRecipient = process.env.FEE_RECIPIENT || owner;
-
-  if (!process.env.MULTISIG_OWNER && !process.env.OWNER_ADDRESS) {
-    console.warn(
-      'WARNING: MULTISIG_OWNER not set — owner will be the deployer EOA. Prefer a multisig on mainnet.'
+  const owner = process.env.MULTISIG_OWNER;
+  if (!owner) {
+    throw new Error(
+      'Refusing mainnet deploy: MULTISIG_OWNER is required. Do not deploy the production contracts with the deployer EOA as owner.'
     );
   }
+
+  const feeRecipient = process.env.FEE_RECIPIENT || owner;
+
+  if (!hre.ethers.isAddress(owner)) throw new Error('Invalid MULTISIG_OWNER address');
+  if (!hre.ethers.isAddress(feeRecipient)) throw new Error('Invalid FEE_RECIPIENT address');
 
   const balance = await hre.ethers.provider.getBalance(deployer.address);
   console.log('=== Voxel Vault MAINNET deploy ===');
   console.log('Deployer:', deployer.address);
   console.log('Balance:', hre.ethers.formatEther(balance), 'ETH');
-  console.log('Owner:', owner);
+  console.log('Owner multisig:', owner);
   console.log('Fee recipient:', feeRecipient);
 
   if (balance === 0n) {
     throw new Error('Deployer has 0 ETH on mainnet. Fund the wallet, then retry.');
   }
 
-  // ~0.05–0.2 ETH usually enough depending on gas; warn if very low
   if (balance < hre.ethers.parseEther('0.02')) {
     console.warn('WARNING: Deployer balance is under 0.02 ETH. Deploy may fail if gas spikes.');
   }
@@ -67,27 +70,12 @@ async function main() {
   const marketAddress = await market.getAddress();
   console.log('VoxelVaultMarketplace:', marketAddress);
 
-  // Configure minter + disable public mint when deployer is owner
-  if (owner.toLowerCase() === deployer.address.toLowerCase()) {
-    const minterTx = await nft.setMinter(marketAddress, true);
-    await minterTx.wait();
-    console.log('Marketplace enabled as minter');
-
-    // Mainnet default: public mint OFF (claim path should use minter or re-enable deliberately)
-    const disablePublic = process.env.DISABLE_PUBLIC_MINT !== 'false';
-    if (disablePublic) {
-      const tx = await nft.setPublicMintEnabled(false);
-      await tx.wait();
-      console.log('Public mint DISABLED (mainnet default)');
-    } else {
-      console.warn('Public mint LEFT ENABLED because DISABLE_PUBLIC_MINT=false');
-    }
-  } else {
-    console.log('Owner is not deployer.');
-    console.log('From the owner multisig you must call:');
-    console.log(`  nft.setMinter("${marketAddress}", true)`);
-    console.log('  nft.setPublicMintEnabled(false)  // recommended');
-  }
+  // The owner is a multisig, so configuration must be executed by that multisig.
+  // Do not attempt privileged configuration from the deployer EOA.
+  console.log('Initial public mint state:', await nft.publicMintEnabled());
+  console.log('Owner-controlled configuration required from the multisig:');
+  console.log(`  nft.setMinter("${marketAddress}", true)`);
+  console.log('  nft.setPublicMintEnabled(false)  // already the contract default; verify on-chain');
 
   const addresses = {
     chainId: '1',
@@ -97,7 +85,8 @@ async function main() {
     feeRecipient,
     VoxelVaultNFT: nftAddress,
     VoxelVaultMarketplace: marketAddress,
-    publicMintEnabled: process.env.DISABLE_PUBLIC_MINT === 'false',
+    publicMintEnabled: false,
+    marketplaceMinterConfigured: false,
     deployedAt: new Date().toISOString(),
     explorerNft: `https://etherscan.io/address/${nftAddress}`,
     explorerMarket: `https://etherscan.io/address/${marketAddress}`,
@@ -105,14 +94,9 @@ async function main() {
 
   fs.writeFileSync('deployed-mainnet-addresses.json', JSON.stringify(addresses, null, 2));
 
-  console.log('\n=== MAINNET DEPLOY COMPLETE ===');
-  console.log('NEXT_PUBLIC_EVM_CHAIN_ID=0x1');
-  console.log('NEXT_PUBLIC_EVM_CHAIN_NAME=Ethereum');
-  console.log('NEXT_PUBLIC_EVM_EXPLORER_URL=https://etherscan.io');
-  console.log('NEXT_PUBLIC_VOXEL_NFT_ADDRESS=' + nftAddress);
-  console.log('NEXT_PUBLIC_VOXEL_MARKET_ADDRESS=' + marketAddress);
-  console.log('\nSaved deployed-mainnet-addresses.json');
-  console.log('Verify on Etherscan, then set Vercel production env and redeploy the app.');
+  console.log('\n=== MAINNET CONTRACT DEPLOYMENT COMPLETE ===');
+  console.log('The contracts are NOT ready for public sales until the multisig configures the marketplace as minter.');
+  console.log('Verify both contracts on Etherscan, then configure the multisig and test on Sepolia before mainnet funds.');
   console.log('Reminder: contracts are not a substitute for a professional audit.');
 }
 

--- a/test/VoxelVaultMarketplace.test.js
+++ b/test/VoxelVaultMarketplace.test.js
@@ -15,6 +15,17 @@ describe('Voxel Vault Ethereum marketplace', function () {
     return { owner, creator, buyer, bidder, nft, market };
   }
 
+  it('defaults public mint to disabled', async function () {
+    const [owner, creator] = await ethers.getSigners();
+    const NFT = await ethers.getContractFactory('VoxelVaultNFT');
+    const nft = await NFT.deploy(owner.address);
+    await nft.waitForDeployment();
+
+    expect(await nft.publicMintEnabled()).to.equal(false);
+    await expect(nft.connect(creator).mint('ipfs://public-mint-should-be-disabled', 0))
+      .to.be.revertedWith('Public mint disabled');
+  });
+
   it('mints and lists through the marketplace', async function () {
     const { creator, nft, market } = await deploy();
     await market.connect(creator).mintAndList('ipfs://asset-1', 500, ethers.parseEther('1'));
@@ -29,14 +40,13 @@ describe('Voxel Vault Ethereum marketplace', function () {
     await market.connect(creator).mintAndList('ipfs://asset-2', 500, ethers.parseEther('1'));
     await market.connect(buyer).buy(1, { value: ethers.parseEther('1') });
     expect(await nft.ownerOf(1)).to.equal(buyer.address);
-    // The creator is also the ERC-2981 royalty receiver, so the creator receives
-    // both the seller proceeds (92.5%) and royalty (5%) = 97.5% total.
     expect(await market.pendingWithdrawals(creator.address)).to.equal(ethers.parseEther('0.975'));
     expect(await market.pendingWithdrawals(owner.address)).to.equal(ethers.parseEther('0.025'));
   });
 
   it('supports funded offers and refunds replaced offers', async function () {
     const { creator, buyer, bidder, nft, market } = await deploy();
+    await nft.connect(creator).setApprovalForAll(await market.getAddress(), true);
     await nft.connect(creator).mint('ipfs://asset-3', 250);
     const expiry = Math.floor(Date.now() / 1000) + 3600;
     await market.connect(buyer).makeOffer(1, expiry, { value: ethers.parseEther('0.5') });


### PR DESCRIPTION
Security-first hardening from the contract/deployment review.

Changes:
- VoxelVaultNFT public mint now defaults to disabled.
- Mainnet deployment refuses to proceed without an explicit MULTISIG_OWNER.
- Deployment no longer falls back to the deployer EOA as owner.
- Deployment records that marketplace minter configuration must be performed by the owner multisig.
- Added regression coverage proving public mint is disabled by default.

This does NOT represent an independent professional audit and does not deploy these contracts to mainnet. The intended path is CI/build verification, merge, Sepolia testing, then external audit before mainnet funds.