### PR TITLE
Return 401 before checkout dependency initialization

### DIFF
--- a/app/api/physical-nft-checkout/route.ts
+++ b/app/api/physical-nft-checkout/route.ts
@@ -22,10 +22,10 @@ function customerPriceCents(basePrice) {
 
 export async function POST(request: Request) {
   try {
-    const supabaseAdmin = getSupabaseAdmin();
     const auth = request.headers.get('authorization');
     const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
     if (!token) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    const supabaseAdmin = getSupabaseAdmin();
     const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
     if (authError || !user) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
 


### PR DESCRIPTION
Production verification found that an unauthenticated physical-checkout request initialized Supabase before checking the bearer token. The route still failed closed, but returned 500. This moves the token presence check ahead of dependency initialization so unauthorized requests consistently return 401 without touching Stripe, Supabase, or fulfillment.