### PR TITLE
Keep marketplace focused on the real-world product

### DIFF
--- a/app/marketplace/page.js
+++ b/app/marketplace/page.js
@@ -1,7 +1,7 @@
 'use client';
 
-import VaultUniverse from '../components/VaultUniverse';
+import RealWorldCommerceHome from '../components/RealWorldCommerceHome';
 
 export default function MarketplacePage() {
-  return <VaultUniverse />;
+  return <RealWorldCommerceHome />;
 }


### PR DESCRIPTION
Removes the public jump back into the legacy VaultUniverse marketplace. The /marketplace route now uses the same focused real-world commerce experience as the homepage, keeping the customer path centered on the physical lamp + included digital twin and avoiding the old crypto-heavy marketplace UI.