### PR TITLE
Rebrand social cards around real products and 3D collectibles

### DIFF
--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -11,22 +11,22 @@ export async function GET(request) {
   const title = item?.name || 'Voxel Vault';
   const subtitle = item
     ? `${item.rarity} · ${item.realityBasis} · ${item.material}`
-    : 'A 3D-first digital object marketplace';
-  const price = item?.priceUsd ? `$${item.priceUsd}` : '3D NFT';
+    : 'Real products with verified 3D collectibles included';
+  const price = item?.priceUsd ? `$${item.priceUsd}` : 'USD FIRST';
 
   return new ImageResponse(
     (
       <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', padding: '70px', background: '#05060b', color: '#f7f8ff', fontFamily: 'sans-serif', position: 'relative' }}>
         <div style={{ position: 'absolute', width: 520, height: 520, borderRadius: 260, background: 'rgba(114,73,255,.22)', filter: 'blur(80px)', right: -100, top: -100 }} />
         <div style={{ display: 'flex', flexDirection: 'column', gap: 18, position: 'relative' }}>
-          <div style={{ display: 'flex', fontSize: 22, letterSpacing: 8, color: '#9b84ff', fontWeight: 800 }}>VOXELVAULT</div>
+          <div style={{ display: 'flex', fontSize: 22, letterSpacing: 8, color: '#9b84ff', fontWeight: 800 }}>VOXEL VAULT</div>
           <div style={{ display: 'flex', fontSize: 72, lineHeight: 1, fontWeight: 900, letterSpacing: -4, maxWidth: 980 }}>{title}</div>
           <div style={{ display: 'flex', fontSize: 28, color: '#aeb2c2', maxWidth: 980 }}>{subtitle}</div>
         </div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', position: 'relative' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <div style={{ fontSize: 18, color: '#73798b' }}>ORIGINAL 3D DIGITAL TWIN · REAL-WORLD REFERENCE</div>
-            <div style={{ fontSize: 24, color: '#fff' }}>Inspect the object in real 3D before collecting.</div>
+            <div style={{ fontSize: 18, color: '#73798b' }}>PHYSICAL PRODUCT · VERIFIED 3D COLLECTIBLE · QR IDENTITY</div>
+            <div style={{ fontSize: 24, color: '#fff' }}>Buy normally. Receive the real object. Keep the verified 3D collectible.</div>
           </div>
           <div style={{ display: 'flex', fontSize: 30, fontWeight: 800 }}>{price}</div>
         </div>


### PR DESCRIPTION
Second cleanup batch from the full file review. Removes stale digital-twin/NFT-first copy from the Open Graph card and makes shared links reflect the real product + verified 3D collectible + QR identity story.