### PR TITLE
Clean capture metadata branding

### DIFF
--- a/app/capture/page.tsx
+++ b/app/capture/page.tsx
@@ -1,5 +1,5 @@
 import CaptureStudio from '../components/CaptureStudio';
 import './capture.css';
 
-export const metadata = { title: 'Create an Elemental Twin | Vault', description: 'Scan or capture a real object to create a private 3D collectible draft.' };
+export const metadata = { title: 'Create a 3D Collectible | Voxel Vault', description: 'Scan or capture a real object to create a private 3D collectible draft.' };
 export default function CapturePage() { return <CaptureStudio />; }


### PR DESCRIPTION
Fourth cleanup batch from the full repository/file review. Removes the remaining Elemental Twin title from the capture route and aligns it with the 3D collectible naming used across the storefront.