### PR TITLE
Wire CJ API media directly into marketplace and 3D generation

### DIFF
--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cjProductImages, getCjProductBySku } from '../../../lib/cjApi';
 
 export const runtime = 'nodejs';
 
@@ -10,27 +11,23 @@ function buildPrompt(item = {}) {
   const source = item.sourceName ? `This is a real commercial product listed by ${item.sourceName}.` : '';
   const note = item.sourceNote || '';
   return [
-    `Create a photorealistic, production-ready 3D digital twin of the exact physical product shown in the reference image: ${name || 'the product'}.`,
+    `Create a photorealistic review model of the exact physical product shown in the reference image: ${name || 'the product'}.`,
     material, source, note,
     'Match the reference exactly: silhouette, proportions, thickness, openings, seams, controls, buttons, handles, feet, hardware, surface finish, color placement and visible construction details.',
     'Do not redesign, stylize, voxelize, cartoonize, beautify, simplify, or add fictional components. Do not invent logos, labels, controls, accessories, patterns, or geometry that is not supported by the reference.',
-    'Preserve physically plausible manufacturing details and real-world scale. Produce clean manifold geometry suitable for an interactive e-commerce digital twin and NFT asset.',
+    'Preserve physically plausible manufacturing details and real-world scale. Produce clean manifold geometry suitable for interactive e-commerce review.',
     'Use realistic physically based materials with accurate roughness, metallic response, reflections and subtle surface variation. Keep textures aligned to the actual product rather than painting a generic material over the mesh.',
   ].filter(Boolean).join(' ');
 }
 
 function isPlaceholderImage(url = '') { return /unsplash\.com/i.test(url); }
+function isHttpUrl(value = '') { try { const url = new URL(value); return url.protocol === 'http:' || url.protocol === 'https:'; } catch { return false; } }
 
-function isHttpUrl(value = '') {
-  try { const url = new URL(value); return url.protocol === 'http:' || url.protocol === 'https:'; } catch { return false; }
-}
-
-async function resolveProductImage(imageUrl, sourceUrl) {
-  if (imageUrl && !isPlaceholderImage(imageUrl)) return imageUrl;
-  if (!isHttpUrl(sourceUrl)) return imageUrl || '';
+async function scrapeProductImage(sourceUrl) {
+  if (!isHttpUrl(sourceUrl)) return '';
   try {
     const response = await fetch(sourceUrl, { headers: { 'User-Agent': 'Mozilla/5.0 (compatible; VoxelVaultProductResolver/1.0)' }, cache: 'no-store' });
-    if (!response.ok) return imageUrl || '';
+    if (!response.ok) return '';
     const html = await response.text();
     const patterns = [
       /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i,
@@ -38,12 +35,21 @@ async function resolveProductImage(imageUrl, sourceUrl) {
       /<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)["']/i,
       /<meta[^>]+content=["']([^"']+)["'][^>]+name=["']twitter:image["']/i,
     ];
-    for (const pattern of patterns) {
-      const match = html.match(pattern);
-      if (match?.[1]) { try { return new URL(match[1], sourceUrl).toString(); } catch {} }
-    }
+    for (const pattern of patterns) { const match = html.match(pattern); if (match?.[1]) { try { return new URL(match[1], sourceUrl).toString(); } catch {} } }
   } catch {}
-  return imageUrl || '';
+  return '';
+}
+
+async function resolveProductImage(imageUrl, item) {
+  if (imageUrl && !isPlaceholderImage(imageUrl)) return imageUrl;
+  if (item?.supplierSku) {
+    try {
+      const product = await getCjProductBySku(item.supplierSku);
+      const images = cjProductImages(product);
+      if (images[0]) return images[0];
+    } catch {}
+  }
+  return scrapeProductImage(item?.sourceUrl || '');
 }
 
 export async function POST(request) {
@@ -53,8 +59,8 @@ export async function POST(request) {
     const body = await request.json();
     const item = body?.item && typeof body.item === 'object' ? body.item : {};
     const requestedImageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    const imageUrl = await resolveProductImage(requestedImageUrl, typeof item.sourceUrl === 'string' ? item.sourceUrl : '');
-    if (!isHttpUrl(imageUrl)) return NextResponse.json({ error: 'A public product image URL could not be resolved from the supplier listing.' }, { status: 400 });
+    const imageUrl = await resolveProductImage(requestedImageUrl, item);
+    if (!isHttpUrl(imageUrl)) return NextResponse.json({ error: 'A public CJ product image could not be resolved. Confirm CJ_API_KEY and the supplier SKU.' }, { status: 400 });
     const response = await fetch(MESHY_ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },

--- a/app/api/product-image/route.js
+++ b/app/api/product-image/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cjProductImages, getCjProductBySku } from '../../../lib/cjApi';
 
 export const runtime = 'nodejs';
 
@@ -18,19 +19,33 @@ function extractImage(html, sourceUrl) {
   return null;
 }
 
+async function scrapeFallback(sourceUrl) {
+  if (!/^https?:\/\//i.test(sourceUrl)) return null;
+  const response = await fetch(sourceUrl, { headers: { 'User-Agent': 'Mozilla/5.0 (compatible; VoxelVaultProductResolver/1.0)' }, cache: 'no-store' });
+  if (!response.ok) return null;
+  return extractImage(await response.text(), sourceUrl);
+}
+
 export async function GET(request) {
-  const sourceUrl = new URL(request.url).searchParams.get('url') || '';
-  if (!/^https?:\/\//i.test(sourceUrl)) return NextResponse.json({ error: 'A valid supplier URL is required.' }, { status: 400 });
+  const params = new URL(request.url).searchParams;
+  const sourceUrl = params.get('url') || '';
+  const sku = params.get('sku') || '';
+
+  if (sku) {
+    try {
+      const product = await getCjProductBySku(sku);
+      const images = cjProductImages(product);
+      if (images[0]) return NextResponse.json({ imageUrl: images[0], images, sourceUrl, sku, source: 'cj-api' });
+    } catch (error) {
+      if (!sourceUrl) return NextResponse.json({ error: error?.message || 'CJ product media unavailable.' }, { status: 502 });
+    }
+  }
+
+  if (!/^https?:\/\//i.test(sourceUrl)) return NextResponse.json({ error: 'A valid supplier URL or CJ SKU is required.' }, { status: 400 });
   try {
-    const response = await fetch(sourceUrl, {
-      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; VoxelVaultProductResolver/1.0)' },
-      cache: 'no-store',
-    });
-    if (!response.ok) return NextResponse.json({ error: 'Supplier listing could not be fetched.' }, { status: 502 });
-    const html = await response.text();
-    const imageUrl = extractImage(html, sourceUrl);
-    if (!imageUrl) return NextResponse.json({ error: 'No public product image was advertised by the supplier listing.' }, { status: 404 });
-    return NextResponse.json({ imageUrl, sourceUrl });
+    const imageUrl = await scrapeFallback(sourceUrl);
+    if (!imageUrl) return NextResponse.json({ error: 'No product image could be resolved from CJ.' }, { status: 404 });
+    return NextResponse.json({ imageUrl, images: [imageUrl], sourceUrl, sku, source: 'page-fallback' });
   } catch (error) {
     return NextResponse.json({ error: error?.message || 'Supplier image resolution failed.' }, { status: 500 });
   }

--- a/app/components/RealWorld3DNFT.js
+++ b/app/components/RealWorld3DNFT.js
@@ -18,7 +18,7 @@ function PendingMedia() {
   return <div className="vv3-accuracyEmpty">
     <div aria-hidden="true" style={{width:72,height:72,border:'1px solid rgba(255,255,255,.18)',borderRadius:20,display:'grid',placeItems:'center',marginBottom:16,background:'linear-gradient(145deg,rgba(143,112,255,.16),rgba(255,255,255,.03))'}}><span style={{fontSize:28,color:'#a894ff'}}>◇</span></div>
     <strong>Exact product media is being verified</strong>
-    <small>We removed generic or stock imagery. The supplier product photo and interactive 3D collectible will appear here only after they are confirmed to match the product you can actually buy.</small>
+    <small>Voxel Vault is syncing the supplier image and 3D review asset for this exact CJ product. Checkout stays locked until the product-specific model is approved.</small>
     <span style={{marginTop:12,fontSize:8,letterSpacing:'.14em',fontWeight:900,color:'#a894ff'}}>PREVIEW ONLY · CHECKOUT LOCKED</span>
   </div>;
 }
@@ -30,9 +30,12 @@ function VerifiedProductPhoto({ item }) {
 
   useEffect(() => {
     let active = true;
-    if (!item?.sourceUrl) return undefined;
+    if (!item?.sourceUrl && !item?.supplierSku) return undefined;
+    const params = new URLSearchParams();
+    if (item?.sourceUrl) params.set('url', item.sourceUrl);
+    if (item?.supplierSku) params.set('sku', item.supplierSku);
 
-    fetch(`/api/product-image?url=${encodeURIComponent(item.sourceUrl)}`, { cache: 'no-store' })
+    fetch(`/api/product-image?${params.toString()}`, { cache: 'no-store' })
       .then((response) => (response.ok ? response.json() : Promise.reject(new Error('Product image unavailable'))))
       .then((data) => {
         if (active && data?.imageUrl && !isPlaceholder(data.imageUrl)) {
@@ -48,11 +51,11 @@ function VerifiedProductPhoto({ item }) {
       });
 
     return () => { active = false; };
-  }, [item?.sourceUrl, fallback]);
+  }, [item?.sourceUrl, item?.supplierSku, fallback]);
 
   if (!src || failed) return <PendingMedia />;
 
-  return <div className="vv3-verifiedPhoto"><img src={src} alt={`${item?.name || 'Product'} from the linked supplier`} /><span>VERIFIED SUPPLIER PRODUCT IMAGE</span></div>;
+  return <div className="vv3-verifiedPhoto"><img src={src} alt={`${item?.name || 'Product'} from CJdropshipping`} /><span>LIVE CJ PRODUCT IMAGE · 3D REVIEW PENDING</span></div>;
 }
 
 export default function RealWorld3DNFT({ item, hero = false }) {
@@ -67,16 +70,11 @@ export default function RealWorld3DNFT({ item, hero = false }) {
         <span className={`vv3-twinPill ${exactModelVerified ? 'is-verified' : 'is-pending'}`}><span aria-hidden="true">◆</span> {exactModelVerified ? 'VERIFIED 3D COLLECTIBLE' : 'EXACT 3D PENDING'}</span>
         <span className="vv3-twinSource">PRODUCT-SPECIFIC ACCURACY REQUIRED</span>
       </div>
-
-      <div className="vv3-accuracyStage">
-        {exactModelVerified ? <Product3DTwin item={item} hero={hero} /> : <VerifiedProductPhoto item={item} />}
-      </div>
-
+      <div className="vv3-accuracyStage">{exactModelVerified ? <Product3DTwin item={item} hero={hero} /> : <VerifiedProductPhoto item={item} />}</div>
       <div className={`vv3-accuracyStatus ${exactModelVerified ? 'is-verified' : 'is-pending'}`}>
         <strong>{exactModelVerified ? 'Exact 3D collectible verified' : 'Exact 3D collectible not yet verified'}</strong>
-        <small>{exactModelVerified ? 'This interactive 3D collectible has been checked against the physical product.' : 'Preview only. We will not show a generic shape or open checkout as though it were this product.'}</small>
+        <small>{exactModelVerified ? 'This interactive 3D collectible has been checked against the physical product.' : 'The real CJ product image can display now. Interactive 3D appears after the generated model is reviewed and approved.'}</small>
       </div>
-
       <figcaption className="vv3-twinFooter" id={titleId}>
         <div className="vv3-twinName"><small>{item?.creator || 'Voxel Vault'}</small><strong>{item?.name || 'Collectible object'}</strong></div>
         <div className="vv3-twinPrice"><small>PHYSICAL + 3D COLLECTIBLE</small>{price && <strong>{price}</strong>}</div>

--- a/lib/cjApi.js
+++ b/lib/cjApi.js
@@ -1,0 +1,37 @@
+const CJ_BASE='https://developers.cjdropshipping.com/api2.0/v1';
+let cachedToken=null;
+let cachedUntil=0;
+
+function apiKey(){return process.env.CJ_API_KEY||process.env.CJDROPSHIPPING_API_KEY||''}
+
+export async function getCjAccessToken(){
+  if(cachedToken&&Date.now()<cachedUntil)return cachedToken;
+  const key=apiKey();
+  if(!key)throw new Error('CJ API key is not configured');
+  const response=await fetch(`${CJ_BASE}/authentication/getAccessToken`,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({apiKey:key}),cache:'no-store'});
+  const data=await response.json().catch(()=>({}));
+  const token=data?.data?.accessToken;
+  if(!response.ok||!token)throw new Error(data?.message||'CJ authentication failed');
+  cachedToken=token;
+  cachedUntil=Date.now()+12*60*60*1000;
+  return token;
+}
+
+export async function getCjProductBySku(productSku){
+  if(!productSku)throw new Error('CJ product SKU is required');
+  const token=await getCjAccessToken();
+  const url=new URL(`${CJ_BASE}/product/query`);
+  url.searchParams.set('productSku',productSku);
+  url.searchParams.set('features','enable_video');
+  const response=await fetch(url,{headers:{'CJ-Access-Token':token},cache:'no-store'});
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok||payload?.result===false||!payload?.data)throw new Error(payload?.message||'CJ product query failed');
+  return payload.data;
+}
+
+export function cjProductImages(product){
+  const images=[];
+  if(product?.bigImage)images.push(product.bigImage);
+  if(Array.isArray(product?.productImageSet))images.push(...product.productImageSet);
+  return [...new Set(images.filter(value=>typeof value==='string'&&/^https?:\/\//i.test(value)))];
+}


### PR DESCRIPTION
Fixes the core media-sync gap. Adds an official CJ API client using CJ_API_KEY/CJDROPSHIPPING_API_KEY, loads product images by supplier SKU instead of scraping CJ pages, and feeds those exact CJ images into Meshy image-to-3D generation. The marketplace can now show the real CJ product image while exact 3D remains pending review.