### PR TITLE
Prebuild every collectible + repair model persistence

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,38 @@
+name: Supabase migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - '.github/workflows/supabase-migrations.yml'
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check migration credentials
+        id: credentials
+        shell: bash
+        run: |
+          if [ -n "$SUPABASE_ACCESS_TOKEN" ] && [ -n "$SUPABASE_PROJECT_REF" ] && [ -n "$SUPABASE_DB_PASSWORD" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Supabase migration secrets are not configured in GitHub; skipping automatic database migration."
+          fi
+      - name: Install Supabase CLI
+        if: steps.credentials.outputs.ready == 'true'
+        run: npm install --global supabase
+      - name: Link production project
+        if: steps.credentials.outputs.ready == 'true'
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
+      - name: Apply pending migrations
+        if: steps.credentials.outputs.ready == 'true'
+        run: supabase db push --password "$SUPABASE_DB_PASSWORD"

--- a/app/api/catalog-3d/route.js
+++ b/app/api/catalog-3d/route.js
@@ -1,15 +1,28 @@
 import { NextResponse } from 'next/server';
-import { readCatalog3D } from '../../../lib/catalog3dStore';
+import { catalog3DStoreReady, readCatalog3D } from '../../../lib/catalog3dStore';
 
 export const runtime = 'nodejs';
 
 export async function GET(request) {
   const itemId = new URL(request.url).searchParams.get('itemId');
   if (!itemId) return NextResponse.json({ error: 'itemId is required' }, { status: 400 });
+
+  const storageReady = await catalog3DStoreReady();
+  if (!storageReady) {
+    return NextResponse.json({
+      found: false,
+      storageReady: false,
+      status: 'storage_unavailable',
+      error: 'Persistent collectible storage is not ready.',
+    }, { status: 503 });
+  }
+
   const row = await readCatalog3D(itemId);
-  if (!row) return NextResponse.json({ found: false });
+  if (!row) return NextResponse.json({ found: false, storageReady: true, status: 'queued' });
+
   return NextResponse.json({
     found: true,
+    storageReady: true,
     itemId: row.item_id,
     taskId: row.task_id || null,
     status: row.status || 'pending',

--- a/app/api/catalog-3d/status/route.js
+++ b/app/api/catalog-3d/status/route.js
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { REAL_WORLD_CATALOG } from '../../../../lib/realWorldCatalog';
+import { catalog3DStoreReady, listCatalog3D } from '../../../../lib/catalog3dStore';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const storageReady = await catalog3DStoreReady();
+  if (!storageReady) {
+    return NextResponse.json({
+      ok: false,
+      storageReady: false,
+      catalogTotal: REAL_WORLD_CATALOG.length,
+      ready: 0,
+      building: 0,
+      failed: 0,
+      queued: REAL_WORLD_CATALOG.length,
+      reason: 'Persistent collectible storage is not ready.',
+    }, { status: 503 });
+  }
+
+  const rows = await listCatalog3D();
+  const byItem = new Map(rows.map(row => [row.item_id, row]));
+  let ready = 0;
+  let building = 0;
+  let failed = 0;
+  let queued = 0;
+
+  for (const item of REAL_WORLD_CATALOG) {
+    const row = byItem.get(item.id);
+    const status = String(row?.status || '').toUpperCase();
+    if (row?.model_url) ready += 1;
+    else if (['FAILED', 'CANCELED'].includes(status)) failed += 1;
+    else if (row?.task_id) building += 1;
+    else queued += 1;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    storageReady: true,
+    catalogTotal: REAL_WORLD_CATALOG.length,
+    ready,
+    building,
+    failed,
+    queued,
+    updatedAt: new Date().toISOString(),
+  });
+}

--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -11,36 +11,70 @@ function authorized(request) {
   return /vercel-cron/i.test(request.headers.get('user-agent') || '');
 }
 
+function terminalFailure(row) {
+  return ['FAILED', 'CANCELED'].includes(String(row?.status || '').toUpperCase());
+}
+
 export async function GET(request) {
   if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  if (!(await catalog3DStoreReady())) {
-    return NextResponse.json({ ok: false, skipped: true, reason: 'catalog_3d_media persistence is not ready; generation skipped to prevent duplicate provider jobs.' }, { status: 503 });
+
+  const storeReady = await catalog3DStoreReady();
+  if (!storeReady) {
+    return NextResponse.json({
+      ok: false,
+      skipped: true,
+      storageReady: false,
+      reason: 'catalog_3d_media is unavailable. Apply supabase/migrations/007_catalog_3d_media.sql to production Supabase before background generation can persist safely.',
+    }, { status: 503 });
   }
 
   const origin = new URL(request.url).origin;
   const rows = await listCatalog3D();
   const byItem = new Map(rows.map(row => [row.item_id, row]));
-  const work = [];
+  const operations = [];
 
+  // Advance every active provider task on every worker run.
   for (const row of rows) {
-    if (!row.task_id || row.model_url || ['FAILED','CANCELED'].includes(String(row.status || '').toUpperCase())) continue;
-    work.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, { cache: 'no-store' }).then(r => r.json()).catch(() => null));
+    if (!row.task_id || row.model_url || terminalFailure(row)) continue;
+    operations.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, {
+      cache: 'no-store',
+    }).then(async response => ({ kind: 'poll', itemId: row.item_id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
 
-  const missing = REAL_WORLD_CATALOG.filter(item => {
+  // Prebuild every catalog item. Failed/canceled tasks are retried automatically.
+  const toStart = REAL_WORLD_CATALOG.filter(item => {
     const row = byItem.get(item.id);
-    return !row?.model_url && !row?.task_id;
+    if (!row) return true;
+    if (row.model_url) return false;
+    if (!row.task_id) return true;
+    return terminalFailure(row);
   });
 
-  for (const item of missing) {
-    work.push(fetch(`${origin}/api/image-to-3d`, {
+  for (const item of toStart) {
+    operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ item }),
       cache: 'no-store',
-    }).then(r => r.json()).catch(() => null));
+    }).then(async response => ({ kind: 'start', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
 
-  const results = await Promise.allSettled(work);
-  return NextResponse.json({ ok: true, checked: rows.length, started: missing.length, operations: results.length });
+  const settled = await Promise.allSettled(operations);
+  const failures = settled.filter(result => result.status === 'rejected' || (result.status === 'fulfilled' && !result.value?.ok)).length;
+  const after = await listCatalog3D();
+  const ready = after.filter(row => Boolean(row.model_url)).length;
+  const building = after.filter(row => row.task_id && !row.model_url && !terminalFailure(row)).length;
+  const failed = after.filter(terminalFailure).length;
+
+  return NextResponse.json({
+    ok: failures === 0,
+    storageReady: true,
+    catalogTotal: REAL_WORLD_CATALOG.length,
+    ready,
+    building,
+    failed,
+    started: toStart.length,
+    operations: settled.length,
+    operationFailures: failures,
+  });
 }

--- a/app/components/Auto3DPreview.js
+++ b/app/components/Auto3DPreview.js
@@ -29,12 +29,25 @@ export default function Auto3DPreview({ item, hero = false }) {
       if(!alive)return;
       try{
         const response=await fetch(`/api/catalog-3d?itemId=${encodeURIComponent(item.id)}`,{cache:'no-store'});
-        const data=response.ok?await response.json():null;
+        const data=await response.json().catch(()=>null);
         if(!alive)return;
+
         if(data?.modelUrl){useReadyModel(data.modelUrl);return;}
-        if(data?.taskId){setStatus('building');setProgress(Math.max(0,Math.min(99,Number(data.progress||0))));}
-        else setStatus('queued');
-        timer=window.setTimeout(check,5000);
+        if(data?.storageReady===false){
+          setStatus('storage');
+          setError('Collectible storage is not connected in production yet. The server cannot safely keep finished models until that database migration is applied.');
+          timer=window.setTimeout(check,10000);
+          return;
+        }
+        if(data?.taskId){
+          setStatus('building');
+          setProgress(Math.max(0,Math.min(99,Number(data.progress||0))));
+          setError(data?.error||'');
+        } else {
+          setStatus('queued');
+          setError('');
+        }
+        timer=window.setTimeout(check,4000);
       }catch(e){
         if(!alive)return;
         setStatus('waiting');setError(e?.message||'Preview status temporarily unavailable.');
@@ -49,6 +62,8 @@ export default function Auto3DPreview({ item, hero = false }) {
   if(modelUrl)return <div><Product3DTwin item={runtimeItem} hero={hero}/><div className="vv3-liveReview"><b>INTERACTIVE PREVIEW READY · MATCH REVIEW</b><span>This prebuilt model is reused across visits and devices. It remains preview-only until Voxel Vault confirms it closely matches the physical item.</span></div></div>;
 
   const finishing=progress>=95;
-  const message=status==='queued'?'Preview is queued in the background':status==='building'?(finishing?'Finishing your interactive preview…':`Preparing interactive preview${progress?` · ${progress}%`:''}`):status==='waiting'?'Preview is still preparing':'Checking for a prebuilt preview…';
-  return <div className="vv3-generationState"><div className="vv3-generationOrb">◆</div><strong>{message}</strong><small>{error||'Generation runs on Voxel Vault servers, not on your phone. You can leave the site and come back later; finished assets are saved and load instantly when available.'}</small>{status==='building'&&<div className="vv3-progress"><i style={{width:`${Math.max(6,Math.min(99,progress||8))}%`}}/></div>}</div>;
+  const message=status==='storage'?'Collectible pipeline needs storage':status==='queued'?'Prebuilding this collectible':status==='building'?(finishing?'Finishing the collectible…':`Prebuilding collectible${progress?` · ${progress}%`:''}`):status==='waiting'?'Collectible is still preparing':'Checking for a prebuilt collectible…';
+  const detail=status==='storage'?error:status==='queued'?'This product is in the server build queue. No generation happens on your iPhone.':status==='building'?(finishing?'The provider is packaging the finished model. The server checks every minute and saves it permanently when ready.':'Voxel Vault is building this once on the server so future visitors load the finished object instead of waiting for generation.'):error||'Finished assets are loaded from the server and cached on your device for fast repeat visits.';
+
+  return <div className="vv3-generationState"><div className="vv3-generationOrb">◆</div><strong>{message}</strong><small>{detail}</small>{status==='building'&&<div className="vv3-progress"><i style={{width:`${Math.max(6,Math.min(99,progress||8))}%`}}/></div>}</div>;
 }

--- a/supabase/migrations/008_catalog_3d_media_hardening.sql
+++ b/supabase/migrations/008_catalog_3d_media_hardening.sql
@@ -1,0 +1,45 @@
+-- Idempotent hardening for the server-prebuilt collectible pipeline.
+-- Safe to run whether or not 007_catalog_3d_media.sql has already been applied.
+
+create table if not exists public.catalog_3d_media (
+  item_id text primary key,
+  supplier_sku text,
+  task_id text unique,
+  source_image_url text,
+  model_url text,
+  thumbnail_url text,
+  provider text not null default 'meshy',
+  status text not null default 'pending',
+  progress integer not null default 0,
+  exact_model_approved boolean not null default false,
+  error text,
+  started_at timestamptz,
+  completed_at timestamptz,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.catalog_3d_media add column if not exists supplier_sku text;
+alter table public.catalog_3d_media add column if not exists task_id text;
+alter table public.catalog_3d_media add column if not exists source_image_url text;
+alter table public.catalog_3d_media add column if not exists model_url text;
+alter table public.catalog_3d_media add column if not exists thumbnail_url text;
+alter table public.catalog_3d_media add column if not exists provider text not null default 'meshy';
+alter table public.catalog_3d_media add column if not exists status text not null default 'pending';
+alter table public.catalog_3d_media add column if not exists progress integer not null default 0;
+alter table public.catalog_3d_media add column if not exists exact_model_approved boolean not null default false;
+alter table public.catalog_3d_media add column if not exists error text;
+alter table public.catalog_3d_media add column if not exists started_at timestamptz;
+alter table public.catalog_3d_media add column if not exists completed_at timestamptz;
+alter table public.catalog_3d_media add column if not exists updated_at timestamptz not null default now();
+
+create unique index if not exists catalog_3d_media_task_unique_idx on public.catalog_3d_media(task_id) where task_id is not null;
+create index if not exists catalog_3d_media_status_idx on public.catalog_3d_media(status, updated_at);
+
+alter table public.catalog_3d_media enable row level security;
+drop policy if exists "catalog 3d media is publicly readable" on public.catalog_3d_media;
+create policy "catalog 3d media is publicly readable"
+on public.catalog_3d_media for select
+using (true);
+
+-- Writes remain service-role only. exact_model_approved stays false until
+-- internal product-match review confirms the model represents the physical item.

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "framework": "nextjs",
   "regions": ["iad1"],
   "crons": [
-    { "path": "/api/cron/catalog-3d", "schedule": "*/5 * * * *" }
+    { "path": "/api/cron/catalog-3d", "schedule": "* * * * *" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Full prebuild reliability pass. Runs the server collectible worker every minute, starts every missing catalog model, automatically retries failed/canceled provider jobs, continuously polls active jobs, exposes pipeline health/status, makes iPhone/browser status explicit without starting generation on-device, adds an idempotent hardening migration for catalog_3d_media, and adds a GitHub migration workflow that applies Supabase migrations automatically when the required production secrets are configured. The goal is that models are generated once in the background, persisted, then simply loaded by customers.