### PR TITLE
Automatic recovery for stalled collectible builds

### DIFF
--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -5,6 +5,8 @@ import { catalog3DStoreHealth, listCatalog3D } from '../../../../lib/catalog3dSt
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
+const STALE_AFTER_MS = 25 * 60 * 1000;
+
 function authorized(request) {
   const secret = process.env.CRON_SECRET;
   if (secret) return request.headers.get('authorization') === `Bearer ${secret}`;
@@ -17,6 +19,12 @@ function terminalFailure(row) {
 
 function hasFinishedModel(row) {
   return Boolean(row?.model_storage_path || row?.model_url);
+}
+
+function isStale(row) {
+  if (!row?.task_id || hasFinishedModel(row)) return false;
+  const stamp = Date.parse(row.updated_at || row.started_at || '');
+  return Number.isFinite(stamp) && Date.now() - stamp > STALE_AFTER_MS;
 }
 
 export async function GET(request) {
@@ -39,19 +47,30 @@ export async function GET(request) {
   const operations = [];
 
   for (const row of rows) {
-    if (!row.task_id || hasFinishedModel(row) || terminalFailure(row)) continue;
+    if (!row.task_id || hasFinishedModel(row) || terminalFailure(row) || isStale(row)) continue;
     operations.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, {
       cache: 'no-store',
     }).then(async response => ({ kind: 'poll', itemId: row.item_id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
 
+  const toRestart = REAL_WORLD_CATALOG.filter(item => {
+    const row = byItem.get(item.id);
+    return Boolean(row && !hasFinishedModel(row) && (terminalFailure(row) || isStale(row)));
+  });
+
   const toStart = REAL_WORLD_CATALOG.filter(item => {
     const row = byItem.get(item.id);
-    if (!row) return true;
-    if (hasFinishedModel(row)) return false;
-    if (!row.task_id) return true;
-    return terminalFailure(row);
+    return !row || (!hasFinishedModel(row) && !row.task_id);
   });
+
+  for (const item of toRestart) {
+    operations.push(fetch(`${origin}/api/image-to-3d`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ item, forceRestart: true }),
+      cache: 'no-store',
+    }).then(async response => ({ kind: 'restart', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
+  }
 
   for (const item of toStart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
@@ -79,6 +98,7 @@ export async function GET(request) {
     failed,
     queued: Math.max(0, REAL_WORLD_CATALOG.length - ready - building - failed),
     started: toStart.length,
+    restarted: toRestart.length,
     operations: settled.length,
     operationFailures: failures,
     updatedAt: new Date().toISOString(),

--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -71,8 +71,9 @@ export async function POST(request) {
     const body = await request.json();
     const item = body?.item && typeof body.item === 'object' ? body.item : {};
     const itemId = String(item?.id || body?.itemId || '').trim();
+    const forceRestart = body?.forceRestart === true;
 
-    if (itemId) {
+    if (itemId && !forceRestart) {
       const saved = await readCatalog3D(itemId);
       if (saved?.model_url || saved?.model_storage_path) {
         return NextResponse.json({ configured: true, reused: true, modelUrl: saved.model_url || null, stored: Boolean(saved.model_storage_path), taskId: saved.task_id || null, progress: 100 });
@@ -138,13 +139,17 @@ export async function POST(request) {
         task_id: taskId,
         source_image_url: imageUrls[0],
         source_image_urls: imageUrls,
+        model_url: null,
+        model_storage_path: null,
+        thumbnail_url: null,
         status: 'PENDING',
         progress: 0,
         started_at: new Date().toISOString(),
-        error: null,
+        completed_at: null,
+        error: forceRestart ? 'Previous build was stale or failed; server restarted generation automatically.' : null,
       });
     }
-    return NextResponse.json({ configured: true, sourceImageUrl: imageUrls[0], sourceImageCount: imageUrls.length, generationMode: useMultiView ? 'multi-view' : 'single-view', taskId });
+    return NextResponse.json({ configured: true, restarted: forceRestart, sourceImageUrl: imageUrls[0], sourceImageCount: imageUrls.length, generationMode: useMultiView ? 'multi-view' : 'single-view', taskId });
   } catch (error) {
     return NextResponse.json({ error: error?.message || 'Model request failed.' }, { status: 500 });
   }

--- a/app/components/Auto3DPreview.js
+++ b/app/components/Auto3DPreview.js
@@ -35,12 +35,12 @@ export default function Auto3DPreview({ item, hero = false }) {
         if(data?.modelUrl){useReadyModel(data.modelUrl);return;}
         if(data?.storageReady===false){
           setStatus('storage');
-          setError('Collectible storage is not connected in production yet. The server cannot safely keep finished models until that database migration is applied.');
+          setError('Collectible storage is not connected in production yet. Finished previews cannot be safely reused until storage is available.');
           timer=window.setTimeout(check,10000);
           return;
         }
         if(data?.taskId){
-          setStatus('building');
+          setStatus(data?.error && /restart|stale|failed/i.test(data.error) ? 'rebuilding' : 'building');
           setProgress(Math.max(0,Math.min(99,Number(data.progress||0))));
           setError(data?.error||'');
         } else {
@@ -62,8 +62,8 @@ export default function Auto3DPreview({ item, hero = false }) {
   if(modelUrl)return <div><Product3DTwin item={runtimeItem} hero={hero}/><div className="vv3-liveReview"><b>INTERACTIVE PREVIEW READY · MATCH REVIEW</b><span>This prebuilt model is reused across visits and devices. It remains preview-only until Voxel Vault confirms it closely matches the physical item.</span></div></div>;
 
   const finishing=progress>=95;
-  const message=status==='storage'?'Collectible pipeline needs storage':status==='queued'?'Prebuilding this collectible':status==='building'?(finishing?'Finishing the collectible…':`Prebuilding collectible${progress?` · ${progress}%`:''}`):status==='waiting'?'Collectible is still preparing':'Checking for a prebuilt collectible…';
-  const detail=status==='storage'?error:status==='queued'?'This product is in the server build queue. No generation happens on your iPhone.':status==='building'?(finishing?'The provider is packaging the finished model. The server checks every minute and saves it permanently when ready.':'Voxel Vault is building this once on the server so future visitors load the finished object instead of waiting for generation.'):error||'Finished assets are loaded from the server and cached on your device for fast repeat visits.';
+  const message=status==='storage'?'Collectible pipeline needs storage':status==='queued'?'Prebuilding this collectible':status==='rebuilding'?'Improving this preview automatically':status==='building'?(finishing?'Finishing the collectible…':`Prebuilding collectible${progress?` · ${progress}%`:''}`):status==='waiting'?'Collectible is still preparing':'Checking for a prebuilt collectible…';
+  const detail=status==='storage'?error:status==='queued'?'This product is in the server build queue. No generation happens on your phone.':status==='rebuilding'?'The previous build stalled or failed, so Voxel Vault automatically started a fresh reconstruction from the product reference images.':status==='building'?(finishing?'The provider is packaging the finished model. The server keeps checking and saves it permanently when ready.':'Voxel Vault is building this once on the server so future visitors load the finished object instead of waiting for generation.'):error||'Finished assets are loaded from the server and cached on your device for fast repeat visits.';
 
-  return <div className="vv3-generationState"><div className="vv3-generationOrb">◆</div><strong>{message}</strong><small>{detail}</small>{status==='building'&&<div className="vv3-progress"><i style={{width:`${Math.max(6,Math.min(99,progress||8))}%`}}/></div>}</div>;
+  return <div className="vv3-generationState"><div className="vv3-generationOrb">◆</div><strong>{message}</strong><small>{detail}</small>{(status==='building'||status==='rebuilding')&&<div className="vv3-progress"><i style={{width:`${Math.max(6,Math.min(99,progress||8))}%`}}/></div>}</div>;
 }


### PR DESCRIPTION
Reliability release for the background collectible pipeline. Adds stale-task detection, controlled server-side regeneration for jobs stuck or failed, preserves multi-angle reconstruction, clears stale model state before rebuilding, reports restart counts from cron, and updates the customer viewer to explain automatic rebuilding instead of looking frozen at 99%. Keeps previews unapproved until product-match review and keeps checkout fail-closed.