### PR TITLE
Match “Love essentials.” to “The collection”

### DIFF
--- a/app/components/VoxelStorefront.css
+++ b/app/components/VoxelStorefront.css
@@ -6,8 +6,9 @@
 .vs-topbar nav a,.vs-shop{color:#9a9893;text-decoration:none;font-size:14px;padding:8px 12px;border-radius:999px}
 .vs-shop{background:#f3efe8;color:#161512}
 .vs-intro{text-align:center;padding:28px 20px 8px}
-.vs-intro p{margin:0;font-size:15px;color:#9a9893}
-.vs-intro small{display:block;margin-top:8px;color:#6d6b67;font-size:13px}
+.vs-introHeading{margin:0;color:#f4f2ee;font:500 clamp(28px,8vw,48px)/1.02 ui-sans-serif,system-ui,-apple-system,sans-serif;letter-spacing:-.04em}
+.vs-introHeading+.vs-introHeading{margin-top:4px}
+.vs-intro small{display:block;margin-top:12px;color:#6d6b67;font-size:13px}
 .vs-rail{display:flex;gap:16px;overflow-x:auto;scroll-snap-type:x mandatory;padding:12px 20px 24px;scrollbar-width:none}
 .vs-rail::-webkit-scrollbar{display:none}
 .vs-capsule{flex:0 0 82vw;max-width:380px;scroll-snap-align:center;border-radius:32px;overflow:hidden;background:#141418;box-shadow:0 24px 50px rgba(0,0,0,.35)}

--- a/app/components/VoxelStorefront.js
+++ b/app/components/VoxelStorefront.js
@@ -67,9 +67,10 @@ export default function VoxelStorefront() {
         <Link href="/marketplace" className="vs-shop">Bag</Link>
       </header>
 
-      <section className="vs-intro">
-        <p>Real objects. Digital twins.</p>
-        <small>Drag to turn. Swipe for the next.</small>
+      <section className="vs-intro" aria-labelledby="vs-collection-heading">
+        <p className="vs-introHeading">The collection</p>
+        <h1 id="vs-collection-heading" className="vs-introHeading">Love essentials.</h1>
+        <small>Real objects. Digital twins. Drag to turn. Swipe for the next.</small>
       </section>
 
       <section className="vs-rail" aria-label="3D NFT collection">


### PR DESCRIPTION
Aligns the GitHub storefront with the referenced Grok preview.

- Adds “The collection” and “Love essentials.” to the collection intro
- Gives both labels the exact same responsive font size, weight, line height, and tracking through one shared class
- Keeps the existing product rail, 3D behavior, checkout logic, and mobile navigation unchanged

Scope: 2 storefront files, 12 changed lines total.