### PR TITLE
Fix VoxelPop logo rendering on mobile

### DIFF
--- a/app/studio/page.js
+++ b/app/studio/page.js
@@ -7,7 +7,7 @@ const examples=[
  ['/voxelpop/rune-portal.jpg','Rune Portal'],
  ['/voxelpop/glowcap-lantern.jpg','Glowcap Lantern']
 ];
-function Brand(){return <a href="/" className={styles.brand}><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop" className={styles.brandLogo}/></a>}
+function Brand(){return <a href="/" className={styles.brand}><img src="/voxelpop/voxelpop-logo.svg" alt="VoxelPop" className={styles.brandLogo} width="96" height="96"/></a>}
 export default function StudioPage(){
  const [idea,setIdea]=useState('Enchanted ruins');
  const [busy,setBusy]=useState(false);


### PR DESCRIPTION
The live screenshot shows the PNG logo collapsing into a thin strip on mobile. Switches the brand image to the repository's square 512x512 VoxelPop SVG and gives the image explicit intrinsic dimensions so Safari renders the full logo reliably.