### PR TITLE
Keep VoxelPop funnel tracking alive without migration secrets

### DIFF
--- a/app/api/creator-pack/analytics/summary/route.ts
+++ b/app/api/creator-pack/analytics/summary/route.ts
@@ -16,6 +16,20 @@ function authorized(request: Request) {
   return Boolean(secret && request.headers.get('authorization') === `Bearer ${secret}`);
 }
 
+function buildStages(counts: Record<string, number>) {
+  return FUNNEL.map((eventName, index) => {
+    const count = Number(counts[eventName] || 0);
+    const previousCount = index === 0 ? null : Number(counts[FUNNEL[index - 1]] || 0);
+    return {
+      event: eventName,
+      count,
+      conversionFromPrevious: previousCount && previousCount > 0
+        ? Math.round((count / previousCount) * 1000) / 10
+        : null,
+    };
+  });
+}
+
 export async function GET(request: Request) {
   if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -27,26 +41,46 @@ export async function GET(request: Request) {
   try {
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase.rpc('voxelpop_funnel_summary', { since_at: since });
-    if (error) throw error;
 
-    const counts = Object.fromEntries((data || []).map((row: { event_name: string; event_count: number | string }) => [
-      row.event_name,
-      Number(row.event_count || 0),
-    ]));
+    if (!error) {
+      const counts = Object.fromEntries((data || []).map((row: { event_name: string; event_count: number | string }) => [
+        row.event_name,
+        Number(row.event_count || 0),
+      ])) as Record<string, number>;
 
-    const stages = FUNNEL.map((eventName, index) => {
-      const count = Number(counts[eventName] || 0);
-      const previousCount = index === 0 ? null : Number(counts[FUNNEL[index - 1]] || 0);
-      return {
-        event: eventName,
-        count,
-        conversionFromPrevious: previousCount && previousCount > 0
-          ? Math.round((count / previousCount) * 1000) / 10
-          : null,
-      };
+      return NextResponse.json({
+        days,
+        since,
+        counts,
+        stages: buildStages(counts),
+        storageMode: 'rich',
+        attributionAvailable: true,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    console.warn('VoxelPop rich analytics summary unavailable; using fallback', error.message);
+    const fallbackCounts: Record<string, number> = {};
+    for (const eventName of FUNNEL) {
+      const { count, error: countError } = await supabase
+        .from('commerce_webhook_events')
+        .select('*', { count: 'exact', head: true })
+        .eq('provider', 'voxelpop')
+        .eq('event_type', eventName)
+        .gte('processed_at', since);
+      if (countError) throw countError;
+      fallbackCounts[eventName] = Number(count || 0);
+    }
+
+    return NextResponse.json({
+      days,
+      since,
+      counts: fallbackCounts,
+      stages: buildStages(fallbackCounts),
+      storageMode: 'fallback',
+      attributionAvailable: false,
+      updatedAt: new Date().toISOString(),
     });
-
-    return NextResponse.json({ days, since, counts, stages, updatedAt: new Date().toISOString() });
   } catch (error) {
     console.error('VoxelPop analytics summary failed', error);
     return NextResponse.json({ error: 'Analytics summary unavailable.' }, { status: 500 });

--- a/lib/voxelpop-analytics.ts
+++ b/lib/voxelpop-analytics.ts
@@ -70,8 +70,15 @@ export async function recordVoxelPopEvent(input: {
   if (!eventKey) return false;
   const attribution = cleanAttribution(input.attribution);
 
+  let supabase: ReturnType<typeof getSupabaseAdmin>;
   try {
-    const supabase = getSupabaseAdmin();
+    supabase = getSupabaseAdmin();
+  } catch (error) {
+    console.error('VoxelPop analytics client unavailable', input.eventName, error);
+    return false;
+  }
+
+  try {
     const { error } = await supabase.from('voxelpop_conversion_events').upsert({
       event_name: input.eventName,
       event_key: eventKey,
@@ -84,11 +91,23 @@ export async function recordVoxelPopEvent(input: {
       content: attribution.content || null,
       details: input.details || {},
     }, { onConflict: 'event_key', ignoreDuplicates: true });
+    if (!error) return true;
+    console.warn('VoxelPop rich analytics unavailable; using fallback', input.eventName, error.message);
+  } catch (error) {
+    console.warn('VoxelPop rich analytics unavailable; using fallback', input.eventName, error);
+  }
+
+  try {
+    const { error } = await supabase.from('commerce_webhook_events').upsert({
+      provider: 'voxelpop',
+      event_id: eventKey,
+      event_type: input.eventName,
+    }, { onConflict: 'provider,event_id', ignoreDuplicates: true });
     if (error) throw error;
     return true;
   } catch (error) {
     // Analytics must never break checkout, generation, meshing, or downloads.
-    console.error('VoxelPop conversion event failed', input.eventName, error);
+    console.error('VoxelPop conversion event failed on primary and fallback stores', input.eventName, error);
     return false;
   }
 }


### PR DESCRIPTION
## Why
PR #215 added the richer `voxelpop_conversion_events` schema, but the post-merge Supabase workflow skipped CLI/link/push because production migration credentials are not configured in GitHub Actions.

## Fix
- keep the rich analytics table as the preferred event store
- automatically fall back to the existing `commerce_webhook_events` server-side table when the rich table is unavailable
- preserve event-key idempotency in the fallback store
- make the protected funnel summary endpoint fall back to exact per-stage counts from the existing event store
- clearly report `storageMode: "fallback"` and `attributionAvailable: false` until the rich migration is actually applied

## Safety
Both analytics stores remain best-effort: failures never block Stripe checkout, generation, meshing, or GLB downloads. No prompt text, email, or IP data is written by the fallback.