### PR TITLE
Enable VoxelPop checkout recovery plumbing

### DIFF
--- a/app/api/creator-pack/checkout/route.ts
+++ b/app/api/creator-pack/checkout/route.ts
@@ -36,6 +36,8 @@ export async function POST(request: Request) {
         },
       }],
       metadata,
+      consent_collection: { promotions: 'auto' },
+      after_expiration: { recovery: { enabled: true } },
       success_url: `${origin}/pack/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${origin}/studio?checkout=cancelled`,
     });
@@ -46,7 +48,7 @@ export async function POST(request: Request) {
       flowId,
       stripeSessionId: session.id,
       attribution,
-      details: { amount_cents: 199, currency: 'usd' },
+      details: { amount_cents: 199, currency: 'usd', recovery_enabled: true },
     });
 
     return NextResponse.json({ url: session.url });

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
       if (session.payment_status !== 'paid') return NextResponse.json({ received: true });
 
       if (session.metadata?.product === 'voxelpop-3d-asset' && session.recovered_from) {
-        const recoveredFrom = typeof session.recovered_from === 'string' ? session.recovered_from : session.recovered_from.id;
+        const recoveredFrom = session.recovered_from;
         await recordVoxelPopEvent({
           eventName: 'checkout_recovered',
           eventKey: `checkout_recovered:${session.id}`,

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -6,6 +6,7 @@ import { getCatalogItem } from '../../../../lib/catalog';
 import { submitPhysicalFulfillment } from '../../../../lib/fulfillment';
 import { buildVerifiedRewardRecord } from '../../../../lib/rewards/stripeWebhook.js';
 import { persistRewardEvent } from '../../../../lib/rewards/persistence.js';
+import { attributionFromMetadata, recordVoxelPopEvent } from '../../../../lib/voxelpop-analytics';
 
 const WALLET_RE = /^0x[a-f0-9]{40}$/;
 type ShippingDetails = {
@@ -39,9 +40,41 @@ export async function POST(request: Request) {
     if (eventError) throw eventError;
     eventRecorded = true;
     await supabaseAdmin.from('stripe_events').upsert({ id: event.id, type: event.type, livemode: Boolean(event.livemode) }, { onConflict: 'id', ignoreDuplicates: true });
+
+    if (event.type === 'checkout.session.expired') {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (session.metadata?.product === 'voxelpop-3d-asset') {
+        await recordVoxelPopEvent({
+          eventName: 'checkout_expired',
+          eventKey: `checkout_expired:${session.id}`,
+          flowId: session.metadata?.flow_id || null,
+          stripeSessionId: session.id,
+          stripeEventId: event.id,
+          attribution: attributionFromMetadata(session.metadata),
+          details: {
+            recovery_enabled: Boolean(session.after_expiration?.recovery?.enabled),
+            promotions_opt_in: session.consent?.promotions === 'opt_in',
+          },
+        });
+      }
+    }
+
     if (event.type === 'checkout.session.completed' || event.type === 'checkout.session.async_payment_succeeded') {
       const session = event.data.object as CheckoutSessionWithShipping;
       if (session.payment_status !== 'paid') return NextResponse.json({ received: true });
+
+      if (session.metadata?.product === 'voxelpop-3d-asset' && session.recovered_from) {
+        const recoveredFrom = typeof session.recovered_from === 'string' ? session.recovered_from : session.recovered_from.id;
+        await recordVoxelPopEvent({
+          eventName: 'checkout_recovered',
+          eventKey: `checkout_recovered:${session.id}`,
+          flowId: session.metadata?.flow_id || null,
+          stripeSessionId: session.id,
+          stripeEventId: event.id,
+          attribution: attributionFromMetadata(session.metadata),
+          details: { recovered_from: recoveredFrom },
+        });
+      }
 
       if (session.metadata?.mint_mode === 'physical_nft') {
         const wallet = session.metadata?.wallet?.toLowerCase();

--- a/lib/voxelpop-analytics.ts
+++ b/lib/voxelpop-analytics.ts
@@ -6,6 +6,8 @@ export const VOXELPOP_EVENT_NAMES = [
   'checkout_clicked',
   'checkout_started',
   'checkout_cancelled',
+  'checkout_expired',
+  'checkout_recovered',
   'exit_intent_shown',
   'exit_intent_cta',
   'purchase_completed',


### PR DESCRIPTION
Adds the abandoned-checkout infrastructure from the approved growth sprint without changing the frozen website FINAL snapshot or poster FINAL.

Changes:
- enables Stripe Checkout recovery URLs after session expiration
- enables Stripe promotional-email consent collection so recovery outreach can be permission-aware
- records VoxelPop `checkout_expired` and `checkout_recovered` analytics events
- does not send recovery emails yet because no transactional email sender is connected
- does not add discounts or promotion codes

The frozen rollback branch remains `final/voxelpop-website-2026-08-25`.