### PR TITLE
Fix VoxelFlip mint verification 403 and prevent duplicate retries

### DIFF
--- a/app/api/creator-pack/nft/confirm/route.ts
+++ b/app/api/creator-pack/nft/confirm/route.ts
@@ -9,27 +9,70 @@ export const runtime = 'nodejs';
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 const TX_RE = /^0x[a-fA-F0-9]{64}$/;
 const ABI = ['function ownerOf(uint256 tokenId) view returns (address)','function tokenURI(uint256 tokenId) view returns (string)'];
+
 function rpcCandidates() {
   const configured = (process.env.VOXELFLIP_RPC_URL || process.env.NEXT_PUBLIC_VOXELFLIP_RPC_URL || '').trim();
-  return Array.from(new Set([configured, 'https://base.llamarpc.com', 'https://mainnet.base.org', 'https://base-rpc.publicnode.com'].filter(Boolean)));
+  // PublicNode's Base endpoint can reject ordinary verification calls as archive
+  // requests unless a provider token is supplied. Do not use it as a fallback.
+  return Array.from(new Set([configured, 'https://mainnet.base.org', 'https://base.llamarpc.com'].filter(Boolean)));
 }
+
+function readableRpcError(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return String(error || 'Unknown RPC error');
+}
+
 async function verifyMintOnChain(contractAddress: string, tokenId: string, txHash: string, wallet: string, metadataUrl: string) {
-  let lastError: unknown = null;
+  const transportErrors: string[] = [];
+  let receiptSeen = false;
+
   for (const rpcUrl of rpcCandidates()) {
     try {
       const provider = new JsonRpcProvider(rpcUrl, 8453, { staticNetwork: true });
       const receipt = await provider.getTransactionReceipt(txHash);
-      if (!receipt) throw new Error('The mint transaction is not visible on this RPC yet.');
-      if (receipt.status !== 1) throw new Error('The mint transaction failed.');
+      if (!receipt) {
+        transportErrors.push(`${rpcUrl}: transaction not visible yet`);
+        continue;
+      }
+      receiptSeen = true;
+
+      // These are deterministic validation failures. If an RPC successfully
+      // returned the receipt, do not hide them behind a later transport error.
+      if (receipt.status !== 1) throw new Error('The mint transaction failed on Base.');
       if (receipt.to?.toLowerCase() !== contractAddress.toLowerCase()) throw new Error('The transaction did not mint from the registered VoxelFlip contract.');
-      const contract = new Contract(contractAddress, ABI, provider);
-      const [owner, uri] = await Promise.all([contract.ownerOf(tokenId), contract.tokenURI(tokenId)]);
+
+      let owner: string;
+      let uri: string;
+      try {
+        const contract = new Contract(contractAddress, ABI, provider);
+        [owner, uri] = await Promise.all([contract.ownerOf(tokenId), contract.tokenURI(tokenId)]);
+      } catch (error) {
+        transportErrors.push(`${rpcUrl}: ${readableRpcError(error)}`);
+        continue;
+      }
+
       if (String(owner).toLowerCase() !== wallet.toLowerCase()) throw new Error('The connected wallet does not own this VoxelFlip token.');
       if (String(uri) !== metadataUrl) throw new Error('The minted token metadata does not match this VoxelPop asset.');
       return;
-    } catch (error) { lastError = error; }
+    } catch (error) {
+      const message = readableRpcError(error);
+      if (
+        message.includes('mint transaction failed on Base') ||
+        message.includes('did not mint from the registered VoxelFlip contract') ||
+        message.includes('does not own this VoxelFlip token') ||
+        message.includes('metadata does not match')
+      ) {
+        throw error;
+      }
+      transportErrors.push(`${rpcUrl}: ${message}`);
+    }
   }
-  throw lastError instanceof Error ? lastError : new Error('Unable to verify the mint on Base right now.');
+
+  if (!receiptSeen) {
+    throw new Error('Your mint transaction was submitted, but Base has not exposed the receipt to our verifier yet. Use Resume mint verification instead of minting again.');
+  }
+  console.warn('VoxelFlip RPC verification exhausted', transportErrors);
+  throw new Error('Your VoxelFlip transaction is on Base, but verification is temporarily unavailable. Use Resume mint verification instead of minting again.');
 }
 
 export async function POST(request: Request) {

--- a/app/api/creator-pack/nft/prepare/route.ts
+++ b/app/api/creator-pack/nft/prepare/route.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac } from 'crypto';
-import { getBytes, keccak256, solidityPackedKeccak256, toUtf8Bytes, Wallet } from 'ethers';
+import { Contract, getBytes, id, JsonRpcProvider, keccak256, solidityPackedKeccak256, toUtf8Bytes, Wallet, zeroPadValue } from 'ethers';
 import { NextResponse } from 'next/server';
+import { getVoxelFlipDeployment } from '../../../../../lib/voxelflip-deployment';
 import { getVoxelPopEntitlement, updateVoxelPopEntitlementMetadata } from '../../../../../lib/voxelpop-entitlement';
 import { attributionFromMetadata, recordVoxelPopEvent } from '../../../../../lib/voxelpop-analytics';
 
@@ -11,6 +12,11 @@ const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const TASK_KEY = 'mesh_task_0';
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 const PRIVATE_KEY_RE = /^[a-fA-F0-9]{64}$/;
+const TRANSFER_TOPIC = id('Transfer(address,address,uint256)');
+const EXISTING_MINT_ABI = [
+  'function ownerOf(uint256 tokenId) view returns (address)',
+  'function tokenURI(uint256 tokenId) view returns (string)',
+];
 
 function safeName(value: unknown) {
   const cleaned = String(value || 'your-voxel').trim().slice(0, 72).replace(/[^a-z0-9 _-]+/gi, '').replace(/\s+/g, ' ');
@@ -33,6 +39,10 @@ function hmacHex(value: string) {
 function voucherIdFor(sessionId: string, taskId: string) {
   return `0x${createHash('sha256').update(`voxelflip:${sessionId}:${taskId}`).digest('hex')}`;
 }
+function rpcCandidates() {
+  const configured = (process.env.VOXELFLIP_RPC_URL || process.env.NEXT_PUBLIC_VOXELFLIP_RPC_URL || '').trim();
+  return Array.from(new Set([configured, 'https://mainnet.base.org', 'https://base.llamarpc.com'].filter(Boolean)));
+}
 async function mintVoucher(wallet: string, metadataUrl: string, voucherId: string) {
   const rawPrivateKey = process.env.VOXELFLIP_MINT_SIGNER_PRIVATE_KEY;
   if (!rawPrivateKey) return null;
@@ -41,6 +51,39 @@ async function mintVoucher(wallet: string, metadataUrl: string, voucherId: strin
   const digest = solidityPackedKeccak256(['address', 'bytes32', 'bytes32'], [wallet, uriHash, voucherId]);
   const signature = await signer.signMessage(getBytes(digest));
   return { signature, signer: signer.address };
+}
+
+async function findExistingMint(contractAddress: string, wallet: string, metadataUrl: string) {
+  const walletTopic = zeroPadValue(wallet, 32);
+  for (const rpcUrl of rpcCandidates()) {
+    try {
+      const provider = new JsonRpcProvider(rpcUrl, 8453, { staticNetwork: true });
+      const latest = await provider.getBlockNumber();
+      const fromBlock = Math.max(0, latest - 20_000);
+      const logs = await provider.getLogs({
+        address: contractAddress,
+        fromBlock,
+        toBlock: latest,
+        topics: [TRANSFER_TOPIC, null, walletTopic],
+      });
+      if (!logs.length) continue;
+      const contract = new Contract(contractAddress, EXISTING_MINT_ABI, provider);
+      for (const log of logs.slice(-50).reverse()) {
+        const tokenTopic = log.topics?.[3];
+        if (!tokenTopic) continue;
+        const tokenId = BigInt(tokenTopic).toString();
+        try {
+          const [owner, uri] = await Promise.all([contract.ownerOf(tokenId), contract.tokenURI(tokenId)]);
+          if (String(owner).toLowerCase() === wallet.toLowerCase() && String(uri) === metadataUrl) {
+            return { tokenId, txHash: log.transactionHash, owner: wallet };
+          }
+        } catch {}
+      }
+    } catch (error) {
+      console.warn('VoxelFlip existing-mint lookup RPC unavailable', rpcUrl, error);
+    }
+  }
+  return null;
 }
 
 export async function POST(request: Request) {
@@ -80,7 +123,10 @@ export async function POST(request: Request) {
     const modelUrl = `${origin}/api/creator-pack/nft/media?${new URLSearchParams({ taskId, kind: 'model', sig: mediaSig }).toString()}`;
     const metadataUrl = `${origin}/api/creator-pack/nft/metadata?${new URLSearchParams({ taskId, name, idea, sig: metadataSig }).toString()}`;
     const voucherId = voucherIdFor(sessionId, taskId);
-    const voucher = await mintVoucher(wallet, metadataUrl, voucherId);
+    const deployment = await getVoxelFlipDeployment();
+    const contractAddress = deployment?.address || '';
+    const existingMint = ADDRESS_RE.test(contractAddress) ? await findExistingMint(contractAddress, wallet, metadataUrl) : null;
+    const voucher = existingMint ? null : await mintVoucher(wallet, metadataUrl, voucherId);
 
     try {
       await updateVoxelPopEntitlementMetadata(entitlement, {
@@ -96,7 +142,7 @@ export async function POST(request: Request) {
     await recordVoxelPopEvent({
       eventName: 'nft_prepared', eventKey: `nft_prepared:${sessionId}:${taskId}`, flowId: entitlement.metadata?.flow_id || null,
       stripeSessionId: entitlement.id, attribution,
-      details: { assetId, format: 'glb', wallet: wallet.toLowerCase(), voucherReady: Boolean(voucher), payment_method: 'stripe' },
+      details: { assetId, format: 'glb', wallet: wallet.toLowerCase(), voucherReady: Boolean(voucher), existingMint: Boolean(existingMint), payment_method: 'stripe' },
     });
 
     return NextResponse.json({
@@ -109,9 +155,10 @@ export async function POST(request: Request) {
       name: `${name} · VoxelFlip`,
       wallet,
       voucherId,
-      mintConfigured: Boolean(voucher),
+      mintConfigured: Boolean(voucher) || Boolean(existingMint),
       signature: voucher?.signature || null,
       signer: voucher?.signer || null,
+      existingMint,
     });
   } catch (error) {
     console.error('VoxelFlip NFT preparation failed', error);

--- a/app/mint-trade/page.js
+++ b/app/mint-trade/page.js
@@ -17,6 +17,7 @@ export default function MintTradePage(){
  const [stage,setStage]=useState('loading');
  const [message,setMessage]=useState('Loading your paid voxel…');
  const [minted,setMinted]=useState(null);
+ const [pendingMint,setPendingMint]=useState(null);
  const [scannerOn,setScannerOn]=useState(true);
  const [scanner,setScanner]=useState(null);
  const [scannerBusy,setScannerBusy]=useState(false);
@@ -39,7 +40,11 @@ export default function MintTradePage(){
     }catch{}
    });
   }
-  try{const saved=JSON.parse(localStorage.getItem(`voxelflip:mint:${sid}`)||'null');if(saved?.tokenId){setMinted(saved);setWallet(saved.owner||'');setStage('done');setMessage(`VoxelFlip #${saved.tokenId} is already minted.`)}}catch{}
+  let confirmed=null;
+  try{confirmed=JSON.parse(localStorage.getItem(`voxelflip:mint:${sid}`)||'null');if(confirmed?.tokenId){setMinted(confirmed);setWallet(confirmed.owner||'');setStage('done');setMessage(`VoxelFlip #${confirmed.tokenId} is already minted.`)}}catch{}
+  if(!confirmed?.tokenId){
+   try{const pending=JSON.parse(localStorage.getItem(`voxelflip:pending:${sid}`)||'null');if(pending?.tokenId&&pending?.hash&&pending?.metadataUrl){setPendingMint(pending);setWallet(pending.owner||'');setStage('ready');setMessage(`VoxelFlip #${pending.tokenId} was already submitted to Base. Resume verification — do not mint it again.`)}}catch{}
+  }
  },[]);
 
  useEffect(()=>{if(!sessionId||!voxel?.asset?.dataUrl||voxel.mesh?.status!=='ready'||voxel.mesh?.taskId||recovering.current)return;recoverTask(voxel)},[sessionId,voxel?.asset?.dataUrl,voxel?.mesh?.status,voxel?.mesh?.taskId]);
@@ -67,22 +72,52 @@ export default function MintTradePage(){
   catch(error){if(error?.code==='NO_WALLET_PROVIDER'&&error?.deepLink){location.href=error.deepLink;return ''}setStage('error');setMessage(error instanceof Error?error.message:'Wallet connection failed.');return ''}
  }
 
+ async function verifySubmitted(submission){
+  setStage('verifying');setMessage(`Verifying VoxelFlip #${submission.tokenId} on Base…`);
+  const txHash=submission.hash||submission.txHash||'';
+  const confirm=await fetch('/api/creator-pack/nft/confirm',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId,taskId:submission.taskId,tokenId:submission.tokenId,txHash,wallet:submission.owner,metadataUrl:submission.metadataUrl})});
+  const verified=await confirm.json();if(!confirm.ok)throw new Error(verified.error||'The mint was submitted but could not be verified yet.');
+  const finalResult={...submission,hash:txHash,openSeaUrl:verified.openSeaUrl||submission.openSeaUrl||'',explorerUrl:verified.explorerUrl||submission.explorerUrl||''};
+  setMinted(finalResult);setPendingMint(null);setWallet(finalResult.owner||wallet);setStage('done');setMessage(`VoxelFlip #${finalResult.tokenId} is minted and owned by ${short(finalResult.owner)}.`);
+  try{localStorage.setItem(`voxelflip:mint:${sessionId}`,JSON.stringify(finalResult));localStorage.removeItem(`voxelflip:pending:${sessionId}`)}catch{}
+  return finalResult;
+ }
+
+ async function resumeVerification(){
+  if(!pendingMint)return;
+  try{await verifySubmitted(pendingMint)}catch(error){setStage('error');setMessage(`Your VoxelFlip was already submitted to Base. Verification is still pending: ${error instanceof Error?error.message:'RPC unavailable'}. Do not mint it again; use Resume mint verification.`)}
+ }
+
  async function mint(){
+  if(pendingMint){await resumeVerification();return;}
   if(!voxel?.asset?.dataUrl||voxel.mesh?.status!=='ready'){setStage('error');setMessage('Finish the 3D mesh before minting.');return;}
   let taskId=voxel.mesh?.taskId||'';if(!taskId)taskId=await recoverTask(voxel);if(!taskId)return;
+  let submission=null;
   try{
    setStage('connecting');setMessage('Connect the wallet that should own this VoxelFlip.');
    const connected=await connectVoxelFlipWallet();setWallet(connected.address);
    setStage('preparing');setMessage('Packaging your exact image + GLB into VoxelFlip metadata…');
    const prep=await fetch('/api/creator-pack/nft/prepare',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId,taskId,image:voxel.asset.dataUrl,name:voxel.asset.name||'your-voxel',idea:voxel.idea||voxel.asset.name||'VoxelPop creation',wallet:connected.address})});
-   const prepared=await prep.json();if(!prep.ok)throw new Error(prepared.error||'Could not prepare this VoxelFlip.');if(!prepared.mintConfigured||!prepared.signature)throw new Error('The secure VoxelFlip mint signer is not configured on this deployment.');
+   const prepared=await prep.json();if(!prep.ok)throw new Error(prepared.error||'Could not prepare this VoxelFlip.');
+
+   if(prepared.existingMint?.tokenId&&prepared.existingMint?.txHash){
+    submission={tokenId:String(prepared.existingMint.tokenId),owner:prepared.existingMint.owner||connected.address,hash:prepared.existingMint.txHash,status:'confirmed',metadataUrl:prepared.metadataUrl,taskId,openSeaUrl:'',explorerUrl:''};
+    setPendingMint(submission);try{localStorage.setItem(`voxelflip:pending:${sessionId}`,JSON.stringify(submission))}catch{}
+    setMessage(`Found your earlier VoxelFlip #${submission.tokenId} on Base. Verifying it instead of minting a duplicate…`);
+    await verifySubmitted(submission);return;
+   }
+
+   if(!prepared.mintConfigured||!prepared.signature)throw new Error('The secure VoxelFlip mint signer is not configured on this deployment.');
    setStage('minting');setMessage('Confirm the Base mint transaction in your wallet.');
    const result=await mintVoxelFlip({metadataUrl:prepared.metadataUrl,voucherId:prepared.voucherId,signature:prepared.signature});if(!result?.tokenId)throw new Error('The mint transaction completed but the token ID could not be read.');
-   setStage('verifying');setMessage('Verifying your new VoxelFlip on Base…');
-   const confirm=await fetch('/api/creator-pack/nft/confirm',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId,taskId,tokenId:result.tokenId,txHash:result.hash,wallet:result.owner,metadataUrl:prepared.metadataUrl})});
-   const verified=await confirm.json();if(!confirm.ok)throw new Error(verified.error||'The mint was submitted but could not be verified yet.');
-   const finalResult={...result,openSeaUrl:verified.openSeaUrl||result.openSeaUrl,explorerUrl:verified.explorerUrl||result.explorerUrl};setMinted(finalResult);setStage('done');setMessage(`VoxelFlip #${finalResult.tokenId} is minted and owned by ${short(finalResult.owner)}.`);try{localStorage.setItem(`voxelflip:mint:${sessionId}`,JSON.stringify(finalResult))}catch{}
-  }catch(error){if(error?.code==='NO_WALLET_PROVIDER'&&error?.deepLink){location.href=error.deepLink;return}setStage('error');setMessage(error instanceof Error?error.message:'VoxelFlip minting failed.')}
+   submission={...result,metadataUrl:prepared.metadataUrl,taskId};
+   setPendingMint(submission);try{localStorage.setItem(`voxelflip:pending:${sessionId}`,JSON.stringify(submission))}catch{}
+   await verifySubmitted(submission);
+  }catch(error){
+   if(error?.code==='NO_WALLET_PROVIDER'&&error?.deepLink){location.href=error.deepLink;return}
+   if(submission?.tokenId){setPendingMint(submission);setStage('error');setMessage(`Your VoxelFlip #${submission.tokenId} was already submitted to Base, but verification hit an RPC problem: ${error instanceof Error?error.message:'verification unavailable'}. Do not mint again; use Resume mint verification.`);return}
+   setStage('error');setMessage(error instanceof Error?error.message:'VoxelFlip minting failed.');
+  }
  }
 
  async function runScanner(){
@@ -92,14 +127,14 @@ export default function MintTradePage(){
 
  const asset=voxel?.asset;const mesh=voxel?.mesh;const taskId=mesh?.taskId||'';const previewUrl=sessionId&&taskId?`/api/creator-pack/mesh?${new URLSearchParams({sessionId,taskId,preview:'1'}).toString()}`:'';
  const busy=['connecting','preparing','minting','verifying'].includes(stage);
- const mintLabel=stage==='connecting'?'Connecting wallet…':stage==='preparing'?'Preparing NFT…':stage==='minting'?'Confirm mint in wallet…':stage==='verifying'?'Verifying on Base…':'Mint this voxel on Base';
+ const mintLabel=pendingMint?(stage==='verifying'?'Verifying existing mint…':'Resume mint verification'):stage==='connecting'?'Connecting wallet…':stage==='preparing'?'Preparing NFT…':stage==='minting'?'Confirm mint in wallet…':stage==='verifying'?'Verifying on Base…':'Mint this voxel on Base';
 
  return <main className={styles.page}>
   <nav className={styles.nav}><a href="/"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>VoxelPop</b></a><em>MINT & TRADE</em></nav>
   <header className={styles.hero}><p>VOXELPOP → VOXELFLIP → MARKET</p><h1>Mint it.<br/><em>Then watch the market.</em></h1><span>Your 3D voxel stays yours. Minting creates the Base NFT; the market bot watches listings, offers and portfolio changes automatically.</span></header>
   <section className={styles.assetCard}>
    <div className={styles.preview}>{previewUrl&&mesh?.status==='ready'?<GeneratedMeshViewer url={previewUrl} label={asset?.name||'Your voxel'}/>:asset?.dataUrl?<img src={asset.dataUrl} alt={asset.name||'Your voxel'}/>:<div className={styles.missing}>Open this page from a paid voxel in My Voxels.</div>}</div>
-   <div className={styles.assetInfo}><small>YOUR PAID VOXEL</small><h2>{(asset?.name||'Your voxel').replaceAll('-',' ')}</h2><div className={styles.statusRow}><span>{mesh?.status==='ready'?'✓ 3D READY':'3D NOT READY'}</span><span>Base mainnet</span></div><p>{message}</p>{!minted&&<button disabled={busy||!asset?.dataUrl||mesh?.status!=='ready'} onClick={mint}>{mintLabel}</button>}{minted&&<div className={styles.minted}><b>✓ VoxelFlip #{minted.tokenId}</b><a href={minted.openSeaUrl} target="_blank" rel="noreferrer">Open / list on OpenSea ↗</a><a href={minted.explorerUrl} target="_blank" rel="noreferrer">Verify transaction ↗</a></div>}</div>
+   <div className={styles.assetInfo}><small>YOUR PAID VOXEL</small><h2>{(asset?.name||'Your voxel').replaceAll('-',' ')}</h2><div className={styles.statusRow}><span>{mesh?.status==='ready'?'✓ 3D READY':'3D NOT READY'}</span><span>Base mainnet</span></div><p>{message}</p>{!minted&&<button disabled={busy||(!pendingMint&&(!asset?.dataUrl||mesh?.status!=='ready'))} onClick={pendingMint?resumeVerification:mint}>{mintLabel}</button>}{minted&&<div className={styles.minted}><b>✓ VoxelFlip #{minted.tokenId}</b><a href={minted.openSeaUrl} target="_blank" rel="noreferrer">Open / list on OpenSea ↗</a><a href={minted.explorerUrl} target="_blank" rel="noreferrer">Verify transaction ↗</a></div>}</div>
   </section>
   <section className={styles.bot}>
    <div className={styles.botHead}><div><small>VOXELFLIP MARKET BOT</small><h2>Automatic market monitor</h2></div><button onClick={()=>setScannerOn(value=>!value)} className={scannerOn?styles.on:styles.off}>{scannerOn?'AUTO SCAN ON':'AUTO SCAN OFF'}</button></div>


### PR DESCRIPTION
Fixes the Base mint error reported from base-rpc.publicnode.com. Removes that token-gated PublicNode fallback from VoxelFlip verification, preserves deterministic on-chain validation errors instead of masking them with a later RPC failure, adds resumable pending-mint state immediately after a wallet transaction is confirmed, and scans recent VoxelFlip transfers for an already-minted copy of the exact paid voxel before any retry can send a second transaction. If the user's previous 403 happened after the NFT minted, the next attempt verifies that existing token rather than minting a duplicate.