### PR TITLE
Recover already-used VoxelFlip vouchers deterministically

### DIFF
--- a/app/api/creator-pack/nft/prepare/route.ts
+++ b/app/api/creator-pack/nft/prepare/route.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac } from 'crypto';
-import { Contract, getBytes, id, JsonRpcProvider, keccak256, solidityPackedKeccak256, toUtf8Bytes, Wallet, zeroPadValue } from 'ethers';
+import { Contract, getBytes, id, JsonRpcProvider, keccak256, solidityPackedKeccak256, toUtf8Bytes, Wallet } from 'ethers';
 import { NextResponse } from 'next/server';
 import { getVoxelFlipDeployment } from '../../../../../lib/voxelflip-deployment';
 import { getVoxelPopEntitlement, updateVoxelPopEntitlementMetadata } from '../../../../../lib/voxelpop-entitlement';
@@ -11,9 +11,11 @@ export const maxDuration = 120;
 const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const TASK_KEY = 'mesh_task_0';
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const TX_RE = /^0x[a-fA-F0-9]{64}$/;
 const PRIVATE_KEY_RE = /^[a-fA-F0-9]{64}$/;
-const TRANSFER_TOPIC = id('Transfer(address,address,uint256)');
+const VOXELFLIP_MINT_TOPIC = id('VoxelFlipMinted(uint256,address,bytes32,string)');
 const EXISTING_MINT_ABI = [
+  'function usedVouchers(bytes32 voucherId) view returns (bool)',
   'function ownerOf(uint256 tokenId) view returns (address)',
   'function tokenURI(uint256 tokenId) view returns (string)',
 ];
@@ -53,41 +55,70 @@ async function mintVoucher(wallet: string, metadataUrl: string, voucherId: strin
   return { signature, signer: signer.address };
 }
 
-async function findExistingMint(contractAddress: string, wallet: string, metadataUrl: string) {
-  const walletTopic = zeroPadValue(wallet, 32);
+async function findVoucherMint(contractAddress: string, wallet: string, voucherId: string, deploymentTxHash: string) {
   for (const rpcUrl of rpcCandidates()) {
     try {
       const provider = new JsonRpcProvider(rpcUrl, 8453, { staticNetwork: true });
-      const latest = await provider.getBlockNumber();
-      const fromBlock = Math.max(0, latest - 20_000);
-      const logs = await provider.getLogs({
-        address: contractAddress,
-        fromBlock,
-        toBlock: latest,
-        topics: [TRANSFER_TOPIC, null, walletTopic],
-      });
-      if (!logs.length) return { checked: true, mint: null };
-
       const contract = new Contract(contractAddress, EXISTING_MINT_ABI, provider);
-      let tokenReadSucceeded = false;
-      for (const log of logs.slice(-50).reverse()) {
-        const tokenTopic = log.topics?.[3];
-        if (!tokenTopic) continue;
-        const tokenId = BigInt(tokenTopic).toString();
+      const used = Boolean(await contract.usedVouchers(voucherId));
+      if (!used) return { checked: true, used: false, mint: null };
+
+      const latest = await provider.getBlockNumber();
+      let firstBlock = Math.max(0, latest - 100_000);
+      if (TX_RE.test(deploymentTxHash || '')) {
         try {
-          const [owner, uri] = await Promise.all([contract.ownerOf(tokenId), contract.tokenURI(tokenId)]);
-          tokenReadSucceeded = true;
-          if (String(owner).toLowerCase() === wallet.toLowerCase() && String(uri) === metadataUrl) {
-            return { checked: true, mint: { tokenId, txHash: log.transactionHash, owner: wallet } };
-          }
+          const deploymentReceipt = await provider.getTransactionReceipt(deploymentTxHash);
+          if (deploymentReceipt?.blockNumber != null) firstBlock = deploymentReceipt.blockNumber;
         } catch {}
       }
-      if (tokenReadSucceeded) return { checked: true, mint: null };
+
+      let toBlock = latest;
+      while (toBlock >= firstBlock) {
+        const fromBlock = Math.max(firstBlock, toBlock - 4_999);
+        const logs = await provider.getLogs({
+          address: contractAddress,
+          fromBlock,
+          toBlock,
+          topics: [VOXELFLIP_MINT_TOPIC, null, null, voucherId],
+        });
+        if (logs.length) {
+          const log = logs[logs.length - 1];
+          const tokenTopic = log.topics?.[1];
+          const ownerTopic = log.topics?.[2];
+          if (!tokenTopic || !ownerTopic) throw new Error('VoxelFlip mint event was incomplete.');
+          const tokenId = BigInt(tokenTopic).toString();
+          const mintedOwner = `0x${ownerTopic.slice(-40)}`;
+          if (mintedOwner.toLowerCase() !== wallet.toLowerCase()) {
+            return { checked: true, used: true, mint: null, ownerMismatch: mintedOwner };
+          }
+          const [currentOwner, tokenUri] = await Promise.all([
+            contract.ownerOf(tokenId),
+            contract.tokenURI(tokenId),
+          ]);
+          return {
+            checked: true,
+            used: true,
+            mint: {
+              tokenId,
+              txHash: log.transactionHash,
+              owner: String(currentOwner),
+              mintedOwner,
+              metadataUrl: String(tokenUri),
+            },
+          };
+        }
+        if (fromBlock === firstBlock) break;
+        toBlock = fromBlock - 1;
+      }
+
+      // The voucher is indisputably consumed. Never issue a second voucher even
+      // if a public RPC cannot return the historical event right now.
+      return { checked: true, used: true, mint: null };
     } catch (error) {
-      console.warn('VoxelFlip existing-mint lookup RPC unavailable', rpcUrl, error);
+      console.warn('VoxelFlip voucher recovery RPC unavailable', rpcUrl, error);
     }
   }
-  return { checked: false, mint: null };
+  return { checked: false, used: false, mint: null };
 }
 
 export async function POST(request: Request) {
@@ -132,24 +163,41 @@ export async function POST(request: Request) {
 
     let existingMint = null;
     let existingMintChecked = false;
+    let voucherUsed = false;
     if (ADDRESS_RE.test(contractAddress)) {
-      const lookup = await findExistingMint(contractAddress, wallet, metadataUrl);
+      const lookup = await findVoucherMint(contractAddress, wallet, voucherId, deployment?.deploymentTxHash || '');
       existingMintChecked = lookup.checked;
+      voucherUsed = lookup.used;
       existingMint = lookup.mint;
       if (!lookup.checked) {
         return NextResponse.json({
-          error: 'Base verification is temporarily unavailable, so VoxelFlip stopped before sending another mint. This protects you from accidentally minting a duplicate. Try Resume mint verification again once Base RPC is reachable.',
+          error: 'Base verification is temporarily unavailable, so VoxelFlip stopped before sending another mint. This protects you from accidentally minting a duplicate.',
         }, { status: 503 });
+      }
+      if (lookup.ownerMismatch) {
+        return NextResponse.json({
+          error: `This voucher was already minted to ${lookup.ownerMismatch}. VoxelFlip will not issue a duplicate.`,
+          voucherUsed: true,
+        }, { status: 409 });
+      }
+      if (lookup.used && !lookup.mint) {
+        return NextResponse.json({
+          error: 'This voucher is already minted on Base. VoxelFlip stopped before creating a duplicate, but the public RPC could not return the original mint event yet. Use Recover existing mint again rather than minting.',
+          voucherUsed: true,
+        }, { status: 409 });
       }
     }
 
-    const voucher = existingMint ? null : await mintVoucher(wallet, metadataUrl, voucherId);
+    const canonicalMetadataUrl = existingMint?.metadataUrl || metadataUrl;
+    const voucher = voucherUsed ? null : await mintVoucher(wallet, canonicalMetadataUrl, voucherId);
 
     try {
       await updateVoxelPopEntitlementMetadata(entitlement, {
         voxelflip_asset_id: assetId,
         voxelflip_wallet: wallet.toLowerCase(),
-        voxelflip_metadata_url: metadataUrl.slice(0, 500),
+        voxelflip_metadata_url: canonicalMetadataUrl.slice(0, 500),
+        ...(existingMint?.tokenId ? { voxelflip_token_id: String(existingMint.tokenId).slice(0, 80) } : {}),
+        ...(existingMint?.txHash ? { voxelflip_tx_hash: String(existingMint.txHash) } : {}),
       });
     } catch (error) {
       console.warn('VoxelFlip entitlement metadata persistence is unavailable; mint can continue.', error);
@@ -159,19 +207,20 @@ export async function POST(request: Request) {
     await recordVoxelPopEvent({
       eventName: 'nft_prepared', eventKey: `nft_prepared:${sessionId}:${taskId}`, flowId: entitlement.metadata?.flow_id || null,
       stripeSessionId: entitlement.id, attribution,
-      details: { assetId, format: 'glb', wallet: wallet.toLowerCase(), voucherReady: Boolean(voucher), existingMint: Boolean(existingMint), existingMintChecked, payment_method: 'stripe' },
+      details: { assetId, format: 'glb', wallet: wallet.toLowerCase(), voucherReady: Boolean(voucher), voucherUsed, existingMint: Boolean(existingMint), existingMintChecked, payment_method: 'stripe' },
     });
 
     return NextResponse.json({
       ready: true,
       assetId,
-      metadataUrl,
+      metadataUrl: canonicalMetadataUrl,
       imageUrl,
       modelUrl,
       sourcePreviewUrl: remoteImageUrl || null,
       name: `${name} · VoxelFlip`,
       wallet,
       voucherId,
+      voucherUsed,
       mintConfigured: Boolean(voucher) || Boolean(existingMint),
       signature: voucher?.signature || null,
       signer: voucher?.signer || null,
@@ -180,6 +229,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error('VoxelFlip NFT preparation failed', error);
-    return NextResponse.json({ error: 'Unable to prepare this 3D voxel for NFT minting right now.' }, { status: 500 });
+    return NextResponse.json({ error: 'Unable to prepare or recover this 3D voxel for NFT minting right now.' }, { status: 500 });
   }
 }

--- a/app/mint-trade/page.js
+++ b/app/mint-trade/page.js
@@ -8,6 +8,7 @@ import {connectVoxelFlipWallet,mintVoxelFlip} from '../../lib/voxelflip';
 import styles from './mint-trade.module.css';
 
 function short(value){return value?`${value.slice(0,6)}…${value.slice(-4)}`:''}
+function isVoucherUsedError(error){const text=String(error?.reason||error?.message||error||'').toLowerCase();return text.includes('voucher already used')||text.includes('voucher is already minted')||text.includes('voucher was already minted')}
 
 export default function MintTradePage(){
  const [sessionId,setSessionId]=useState('');
@@ -18,6 +19,7 @@ export default function MintTradePage(){
  const [message,setMessage]=useState('Loading your paid voxel…');
  const [minted,setMinted]=useState(null);
  const [pendingMint,setPendingMint]=useState(null);
+ const [recoverMode,setRecoverMode]=useState(false);
  const [scannerOn,setScannerOn]=useState(true);
  const [scanner,setScanner]=useState(null);
  const [scannerBusy,setScannerBusy]=useState(false);
@@ -78,7 +80,7 @@ export default function MintTradePage(){
   const confirm=await fetch('/api/creator-pack/nft/confirm',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId,taskId:submission.taskId,tokenId:submission.tokenId,txHash,wallet:submission.owner,metadataUrl:submission.metadataUrl})});
   const verified=await confirm.json();if(!confirm.ok)throw new Error(verified.error||'The mint was submitted but could not be verified yet.');
   const finalResult={...submission,hash:txHash,openSeaUrl:verified.openSeaUrl||submission.openSeaUrl||'',explorerUrl:verified.explorerUrl||submission.explorerUrl||''};
-  setMinted(finalResult);setPendingMint(null);setWallet(finalResult.owner||wallet);setStage('done');setMessage(`VoxelFlip #${finalResult.tokenId} is minted and owned by ${short(finalResult.owner)}.`);
+  setMinted(finalResult);setPendingMint(null);setRecoverMode(false);setWallet(finalResult.owner||wallet);setStage('done');setMessage(`VoxelFlip #${finalResult.tokenId} is minted and owned by ${short(finalResult.owner)}.`);
   try{localStorage.setItem(`voxelflip:mint:${sessionId}`,JSON.stringify(finalResult));localStorage.removeItem(`voxelflip:pending:${sessionId}`)}catch{}
   return finalResult;
  }
@@ -94,21 +96,24 @@ export default function MintTradePage(){
   let taskId=voxel.mesh?.taskId||'';if(!taskId)taskId=await recoverTask(voxel);if(!taskId)return;
   let submission=null;
   try{
-   setStage('connecting');setMessage('Connect the wallet that should own this VoxelFlip.');
+   setStage('connecting');setMessage(recoverMode?'Connecting your wallet to recover the existing VoxelFlip…':'Connect the wallet that should own this VoxelFlip.');
    const connected=await connectVoxelFlipWallet();setWallet(connected.address);
-   setStage('preparing');setMessage('Packaging your exact image + GLB into VoxelFlip metadata…');
+   setStage('preparing');setMessage(recoverMode?'Finding the already-minted voucher on Base…':'Checking Base first, then packaging your exact image + GLB…');
    const prep=await fetch('/api/creator-pack/nft/prepare',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({sessionId,taskId,image:voxel.asset.dataUrl,name:voxel.asset.name||'your-voxel',idea:voxel.idea||voxel.asset.name||'VoxelPop creation',wallet:connected.address})});
-   const prepared=await prep.json();if(!prep.ok)throw new Error(prepared.error||'Could not prepare this VoxelFlip.');
+   const prepared=await prep.json();
+   if(!prep.ok){if(prepared?.voucherUsed)setRecoverMode(true);throw new Error(prepared.error||'Could not prepare or recover this VoxelFlip.');}
 
    if(prepared.existingMint?.tokenId&&prepared.existingMint?.txHash){
-    submission={tokenId:String(prepared.existingMint.tokenId),owner:prepared.existingMint.owner||connected.address,hash:prepared.existingMint.txHash,status:'confirmed',metadataUrl:prepared.metadataUrl,taskId,openSeaUrl:'',explorerUrl:''};
-    setPendingMint(submission);try{localStorage.setItem(`voxelflip:pending:${sessionId}`,JSON.stringify(submission))}catch{}
-    setMessage(`Found your earlier VoxelFlip #${submission.tokenId} on Base. Verifying it instead of minting a duplicate…`);
+    const chainMetadataUrl=prepared.existingMint.metadataUrl||prepared.metadataUrl;
+    submission={tokenId:String(prepared.existingMint.tokenId),owner:prepared.existingMint.owner||connected.address,hash:prepared.existingMint.txHash,status:'confirmed',metadataUrl:chainMetadataUrl,taskId,openSeaUrl:'',explorerUrl:''};
+    setPendingMint(submission);setRecoverMode(true);try{localStorage.setItem(`voxelflip:pending:${sessionId}`,JSON.stringify(submission))}catch{}
+    setMessage(`Recovered your earlier VoxelFlip #${submission.tokenId} from its voucher on Base. Verifying it now…`);
     await verifySubmitted(submission);return;
    }
 
+   if(prepared.voucherUsed){setRecoverMode(true);throw new Error('This voucher is already minted. Recover the existing mint instead of creating another.');}
    if(!prepared.mintConfigured||!prepared.signature)throw new Error('The secure VoxelFlip mint signer is not configured on this deployment.');
-   setStage('minting');setMessage('Confirm the Base mint transaction in your wallet.');
+   setRecoverMode(false);setStage('minting');setMessage('Confirm the Base mint transaction in your wallet. Keep this page open; it will recover the NFT automatically after confirmation.');
    const result=await mintVoxelFlip({metadataUrl:prepared.metadataUrl,voucherId:prepared.voucherId,signature:prepared.signature});if(!result?.tokenId)throw new Error('The mint transaction completed but the token ID could not be read.');
    submission={...result,metadataUrl:prepared.metadataUrl,taskId};
    setPendingMint(submission);try{localStorage.setItem(`voxelflip:pending:${sessionId}`,JSON.stringify(submission))}catch{}
@@ -116,6 +121,7 @@ export default function MintTradePage(){
   }catch(error){
    if(error?.code==='NO_WALLET_PROVIDER'&&error?.deepLink){location.href=error.deepLink;return}
    if(submission?.tokenId){setPendingMint(submission);setStage('error');setMessage(`Your VoxelFlip #${submission.tokenId} was already submitted to Base, but verification hit an RPC problem: ${error instanceof Error?error.message:'verification unavailable'}. Do not mint again; use Resume mint verification.`);return}
+   if(isVoucherUsedError(error)){setRecoverMode(true);setStage('error');setMessage('That voucher is already used, which means this voxel was already minted on Base. Click Recover existing mint — VoxelFlip will find the original token instead of sending another transaction.');return}
    setStage('error');setMessage(error instanceof Error?error.message:'VoxelFlip minting failed.');
   }
  }
@@ -127,7 +133,7 @@ export default function MintTradePage(){
 
  const asset=voxel?.asset;const mesh=voxel?.mesh;const taskId=mesh?.taskId||'';const previewUrl=sessionId&&taskId?`/api/creator-pack/mesh?${new URLSearchParams({sessionId,taskId,preview:'1'}).toString()}`:'';
  const busy=['connecting','preparing','minting','verifying'].includes(stage);
- const mintLabel=pendingMint?(stage==='verifying'?'Verifying existing mint…':'Resume mint verification'):stage==='connecting'?'Connecting wallet…':stage==='preparing'?'Preparing NFT…':stage==='minting'?'Confirm mint in wallet…':stage==='verifying'?'Verifying on Base…':'Mint this voxel on Base';
+ const mintLabel=pendingMint?(stage==='verifying'?'Verifying existing mint…':'Resume mint verification'):recoverMode?(stage==='preparing'?'Recovering existing mint…':'Recover existing mint'):stage==='connecting'?'Connecting wallet…':stage==='preparing'?'Preparing NFT…':stage==='minting'?'Confirm mint in wallet…':stage==='verifying'?'Verifying on Base…':'Mint this voxel on Base';
 
  return <main className={styles.page}>
   <nav className={styles.nav}><a href="/"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>VoxelPop</b></a><em>MINT & TRADE</em></nav>


### PR DESCRIPTION
Fixes the blank/retry loop after a successful VoxelFlip mint that later surfaces `Voucher already used`. Recovery now reads `usedVouchers(voucherId)` and filters the indexed `VoxelFlipMinted` event by the exact voucher ID, then restores the original token ID, tx hash, current owner, and on-chain token URI. Once a voucher is consumed, the server will never issue another mint voucher. The Mint & Trade UI switches to `Recover existing mint` and verifies the recovered NFT instead of attempting another transaction.