### PR TITLE
Fix VoxelFlip stale mint recovery with Blockscout

### DIFF
--- a/app/api/creator-pack/nft/prepare/route.ts
+++ b/app/api/creator-pack/nft/prepare/route.ts
@@ -11,7 +11,6 @@ export const maxDuration = 120;
 const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const TASK_KEY = 'mesh_task_0';
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
-const TX_RE = /^0x[a-fA-F0-9]{64}$/;
 const PRIVATE_KEY_RE = /^[a-fA-F0-9]{64}$/;
 const VOXELFLIP_MINT_TOPIC = id('VoxelFlipMinted(uint256,address,bytes32,string)');
 const EXISTING_MINT_ABI = [
@@ -43,7 +42,12 @@ function voucherIdFor(sessionId: string, taskId: string) {
 }
 function rpcCandidates() {
   const configured = (process.env.VOXELFLIP_RPC_URL || process.env.NEXT_PUBLIC_VOXELFLIP_RPC_URL || '').trim();
-  return Array.from(new Set([configured, 'https://mainnet.base.org', 'https://base.llamarpc.com'].filter(Boolean)));
+  return Array.from(new Set([
+    configured,
+    'https://base.blockscout.com/api/eth-rpc',
+    'https://mainnet.base.org',
+    'https://base.llamarpc.com',
+  ].filter(Boolean)));
 }
 async function mintVoucher(wallet: string, metadataUrl: string, voucherId: string) {
   const rawPrivateKey = process.env.VOXELFLIP_MINT_SIGNER_PRIVATE_KEY;
@@ -55,26 +59,23 @@ async function mintVoucher(wallet: string, metadataUrl: string, voucherId: strin
   return { signature, signer: signer.address };
 }
 
-async function findVoucherMint(contractAddress: string, wallet: string, voucherId: string, deploymentTxHash: string) {
+async function findVoucherMint(contractAddress: string, wallet: string, voucherId: string): Promise<any> {
+  let voucherKnownUsed = false;
   for (const rpcUrl of rpcCandidates()) {
     try {
       const provider = new JsonRpcProvider(rpcUrl, 8453, { staticNetwork: true });
       const contract = new Contract(contractAddress, EXISTING_MINT_ABI, provider);
       const used = Boolean(await contract.usedVouchers(voucherId));
       if (!used) return { checked: true, used: false, mint: null };
+      voucherKnownUsed = true;
 
+      // The mint happened during the current VoxelFlip launch. Search recent
+      // blocks in small ranges so recovery does not require archive RPC access.
       const latest = await provider.getBlockNumber();
-      let firstBlock = Math.max(0, latest - 100_000);
-      if (TX_RE.test(deploymentTxHash || '')) {
-        try {
-          const deploymentReceipt = await provider.getTransactionReceipt(deploymentTxHash);
-          if (deploymentReceipt?.blockNumber != null) firstBlock = deploymentReceipt.blockNumber;
-        } catch {}
-      }
-
+      const firstBlock = Math.max(0, latest - 20_000);
       let toBlock = latest;
       while (toBlock >= firstBlock) {
-        const fromBlock = Math.max(firstBlock, toBlock - 4_999);
+        const fromBlock = Math.max(firstBlock, toBlock - 1_999);
         const logs = await provider.getLogs({
           address: contractAddress,
           fromBlock,
@@ -110,14 +111,12 @@ async function findVoucherMint(contractAddress: string, wallet: string, voucherI
         if (fromBlock === firstBlock) break;
         toBlock = fromBlock - 1;
       }
-
-      // The voucher is indisputably consumed. Never issue a second voucher even
-      // if a public RPC cannot return the historical event right now.
-      return { checked: true, used: true, mint: null };
     } catch (error) {
       console.warn('VoxelFlip voucher recovery RPC unavailable', rpcUrl, error);
     }
   }
+
+  if (voucherKnownUsed) return { checked: true, used: true, mint: null };
   return { checked: false, used: false, mint: null };
 }
 
@@ -165,13 +164,13 @@ export async function POST(request: Request) {
     let existingMintChecked = false;
     let voucherUsed = false;
     if (ADDRESS_RE.test(contractAddress)) {
-      const lookup = await findVoucherMint(contractAddress, wallet, voucherId, deployment?.deploymentTxHash || '');
+      const lookup = await findVoucherMint(contractAddress, wallet, voucherId);
       existingMintChecked = lookup.checked;
       voucherUsed = lookup.used;
       existingMint = lookup.mint;
       if (!lookup.checked) {
         return NextResponse.json({
-          error: 'Base verification is temporarily unavailable, so VoxelFlip stopped before sending another mint. This protects you from accidentally minting a duplicate.',
+          error: 'Base verification is temporarily unavailable, so VoxelFlip stopped before sending another mint. No transaction was sent. Use Recover existing mint again.',
         }, { status: 503 });
       }
       if (lookup.ownerMismatch) {
@@ -182,7 +181,7 @@ export async function POST(request: Request) {
       }
       if (lookup.used && !lookup.mint) {
         return NextResponse.json({
-          error: 'This voucher is already minted on Base. VoxelFlip stopped before creating a duplicate, but the public RPC could not return the original mint event yet. Use Recover existing mint again rather than minting.',
+          error: 'This voucher is already minted on Base. VoxelFlip blocked a duplicate, but no recovery provider returned the mint event yet. Use Recover existing mint again; do not approve another mint.',
           voucherUsed: true,
         }, { status: 409 });
       }

--- a/app/mint-trade/page.js
+++ b/app/mint-trade/page.js
@@ -8,7 +8,9 @@ import {connectVoxelFlipWallet,mintVoxelFlip} from '../../lib/voxelflip';
 import styles from './mint-trade.module.css';
 
 function short(value){return value?`${value.slice(0,6)}…${value.slice(-4)}`:''}
-function isVoucherUsedError(error){const text=String(error?.reason||error?.message||error||'').toLowerCase();return text.includes('voucher already used')||text.includes('voucher is already minted')||text.includes('voucher was already minted')}
+function errorText(error){return String(error?.reason||error?.message||error||'')}
+function isVoucherUsedError(error){const text=errorText(error).toLowerCase();return text.includes('voucher already used')||text.includes('voucher is already minted')||text.includes('voucher was already minted')}
+function isStaleVerificationError(error){const text=errorText(error).toLowerCase();return text.includes('did not mint from the registered voxelflip contract')||text.includes('connected wallet does not own')||text.includes('minted token metadata does not match')||text.includes('mint confirmation details are incomplete')}
 
 export default function MintTradePage(){
  const [sessionId,setSessionId]=useState('');
@@ -87,7 +89,13 @@ export default function MintTradePage(){
 
  async function resumeVerification(){
   if(!pendingMint)return;
-  try{await verifySubmitted(pendingMint)}catch(error){setStage('error');setMessage(`Your VoxelFlip was already submitted to Base. Verification is still pending: ${error instanceof Error?error.message:'RPC unavailable'}. Do not mint it again; use Resume mint verification.`)}
+  try{await verifySubmitted(pendingMint)}catch(error){
+   if(isStaleVerificationError(error)){
+    try{localStorage.removeItem(`voxelflip:pending:${sessionId}`)}catch{}
+    setPendingMint(null);setRecoverMode(true);setStage('error');setMessage('The saved browser transaction was not the VoxelFlip mint. It has been cleared safely. Click Recover existing mint to find the NFT from its one-time voucher — no new mint will be sent.');return;
+   }
+   setStage('error');setMessage(`Your VoxelFlip was already submitted to Base. Verification is still pending: ${errorText(error)||'RPC unavailable'}. Do not mint it again; use Resume mint verification.`)
+  }
  }
 
  async function mint(){
@@ -112,6 +120,7 @@ export default function MintTradePage(){
    }
 
    if(prepared.voucherUsed){setRecoverMode(true);throw new Error('This voucher is already minted. Recover the existing mint instead of creating another.');}
+   if(recoverMode){throw new Error('Recovery did not find the original mint yet. No new mint transaction was sent. Try Recover existing mint again.');}
    if(!prepared.mintConfigured||!prepared.signature)throw new Error('The secure VoxelFlip mint signer is not configured on this deployment.');
    setRecoverMode(false);setStage('minting');setMessage('Confirm the Base mint transaction in your wallet. Keep this page open; it will recover the NFT automatically after confirmation.');
    const result=await mintVoxelFlip({metadataUrl:prepared.metadataUrl,voucherId:prepared.voucherId,signature:prepared.signature});if(!result?.tokenId)throw new Error('The mint transaction completed but the token ID could not be read.');
@@ -120,9 +129,9 @@ export default function MintTradePage(){
    await verifySubmitted(submission);
   }catch(error){
    if(error?.code==='NO_WALLET_PROVIDER'&&error?.deepLink){location.href=error.deepLink;return}
-   if(submission?.tokenId){setPendingMint(submission);setStage('error');setMessage(`Your VoxelFlip #${submission.tokenId} was already submitted to Base, but verification hit an RPC problem: ${error instanceof Error?error.message:'verification unavailable'}. Do not mint again; use Resume mint verification.`);return}
+   if(submission?.tokenId){setPendingMint(submission);setStage('error');setMessage(`Your VoxelFlip #${submission.tokenId} was already submitted to Base, but verification hit an RPC problem: ${errorText(error)||'verification unavailable'}. Do not mint again; use Resume mint verification.`);return}
    if(isVoucherUsedError(error)){setRecoverMode(true);setStage('error');setMessage('That voucher is already used, which means this voxel was already minted on Base. Click Recover existing mint — VoxelFlip will find the original token instead of sending another transaction.');return}
-   setStage('error');setMessage(error instanceof Error?error.message:'VoxelFlip minting failed.');
+   setStage('error');setMessage(errorText(error)||'VoxelFlip minting failed.');
   }
  }
 


### PR DESCRIPTION
Minimal recovery-only fix for the currently consumed voucher. Adds Base Blockscout ETH-RPC as the first recovery source, restricts voucher-event scans to recent blocks in small ranges so archive access is not required, and keeps duplicate protection if the voucher is consumed. The Mint & Trade page now detects the stale locally saved transaction that produced `The transaction did not mint from the registered VoxelFlip contract`, removes only that browser record, and switches to Recover existing mint. Recovery mode is prevented from ever sending a fresh mint transaction.