### PR TITLE
Simplify Autopilot to a real monitoring dashboard

### DIFF
--- a/app/api/voxelflip/trader/route.ts
+++ b/app/api/voxelflip/trader/route.ts
@@ -7,22 +7,48 @@ export const dynamic = 'force-dynamic';
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 const PRIVATE_KEY_RE = /^(0x)?[a-fA-F0-9]{64}$/;
 const OPENSEA = 'https://api.opensea.io/api/v2';
+const OPENSEA_TIMEOUT_MS = 8_000;
 
 async function openSeaGet(path: string, apiKey: string) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENSEA_TIMEOUT_MS);
   try {
-    const response = await fetch(`${OPENSEA}${path}`, { headers: { 'x-api-key': apiKey, accept: 'application/json' }, cache: 'no-store' });
+    const response = await fetch(`${OPENSEA}${path}`, {
+      headers: { 'x-api-key': apiKey, accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
     const data = await response.json().catch(() => ({}));
     return { ok: response.ok, status: response.status, data: response.ok ? data : null, error: response.ok ? null : String(data?.detail || data?.error || `OpenSea ${response.status}`) };
   } catch (error) {
-    return { ok: false, status: 0, data: null, error: error instanceof Error ? error.message : 'OpenSea request failed' };
+    const message = error instanceof Error && error.name === 'AbortError' ? 'OpenSea request timed out' : error instanceof Error ? error.message : 'OpenSea request failed';
+    return { ok: false, status: 0, data: null, error: message };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 function listCount(value: any) {
   if (Array.isArray(value)) return value.length;
   if (!value || typeof value !== 'object') return 0;
-  for (const key of ['listings','offers','orders','nfts','items','results']) if (Array.isArray(value[key])) return value[key].length;
+  for (const key of ['listings','offers','orders','nfts','items','results','asset_events','assetEvents','events']) if (Array.isArray(value[key])) return value[key].length;
   return 0;
+}
+
+function collectionSlug(value: any) {
+  if (!value || typeof value !== 'object') return '';
+  const candidate = value.collection;
+  if (typeof candidate === 'string') return candidate;
+  if (candidate && typeof candidate === 'object') return String(candidate.collection || candidate.slug || '');
+  return String(value.slug || value.collection_slug || '');
+}
+
+function metricNumber(...values: any[]) {
+  for (const value of values) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
 }
 
 function positiveNumber(value: string | undefined, fallback: number) {
@@ -68,40 +94,21 @@ export async function GET(request: Request) {
   };
 
   const gatewayPolicy = {
-    auto: {
-      enabledWhenExecutorExists: true,
-      description: 'Allowlisted, verified, non-grail trading inventory only.',
-      maxTradeEth: riskPolicy.maxTradeEth,
-      dailySpendCapEth: riskPolicy.maxDailySpendEth,
-      maxGasPercent: riskPolicy.maxGasPercent,
-      whitelistOnly: true,
-    },
-    oneTap: {
-      description: 'Medium-risk opportunities wait for a phone approval.',
-      minTradeEth: riskPolicy.maxTradeEth,
-      maxTradeEth: positiveNumber(process.env.VOXELFLIP_ONE_TAP_MAX_TRADE_ETH, 0.05),
-      timeoutSeconds: Math.max(30, Math.floor(positiveNumber(process.env.VOXELFLIP_ONE_TAP_TIMEOUT_SECONDS, 60))),
-    },
-    manual: {
-      description: 'Swaps, grails, unverified collections, or trades above the 1-tap cap require manual review.',
-      swapsAlwaysManual: true,
-      grailsAlwaysManual: true,
-      unverifiedAlwaysManual: true,
-    },
-    circuitBreaker: {
-      lossesBeforePause: riskPolicy.lossesBeforePause,
-      windowMinutes: riskPolicy.lossWindowMinutes,
-      pauseMinutes: riskPolicy.pauseMinutes,
-      killSwitch,
-    },
+    auto: { enabledWhenExecutorExists: true, description: 'Allowlisted, verified, non-grail trading inventory only.', maxTradeEth: riskPolicy.maxTradeEth, dailySpendCapEth: riskPolicy.maxDailySpendEth, maxGasPercent: riskPolicy.maxGasPercent, whitelistOnly: true },
+    oneTap: { description: 'Medium-risk opportunities wait for a phone approval.', minTradeEth: riskPolicy.maxTradeEth, maxTradeEth: positiveNumber(process.env.VOXELFLIP_ONE_TAP_MAX_TRADE_ETH, 0.05), timeoutSeconds: Math.max(30, Math.floor(positiveNumber(process.env.VOXELFLIP_ONE_TAP_TIMEOUT_SECONDS, 60))) },
+    manual: { description: 'Swaps, grails, unverified collections, or trades above the 1-tap cap require manual review.', swapsAlwaysManual: true, grailsAlwaysManual: true, unverifiedAlwaysManual: true },
+    circuitBreaker: { lossesBeforePause: riskPolicy.lossesBeforePause, windowMinutes: riskPolicy.lossWindowMinutes, pauseMinutes: riskPolicy.pauseMinutes, killSwitch },
     inventoryModel: 'Trading inventory belongs in the dedicated bot wallet/sub-account. Owner-wallet grails are watch-only unless explicitly delegated.',
   };
 
   const automaticSigningActive = false;
+  const openSeaUrl = ADDRESS_RE.test(contract) && /^\d+$/.test(tokenId) ? `https://opensea.io/assets/base/${contract}/${tokenId}` : 'https://opensea.io';
   const base = {
     wallet,
+    tokenId,
     contract,
     chain: 'base',
+    openSeaUrl,
     scanner: apiKey ? 'live' : 'configuration-needed',
     executionMode: executionFoundationReady ? 'autopilot-foundation-ready' : 'autopilot-setup-needed',
     executionFoundationReady,
@@ -114,71 +121,78 @@ export async function GET(request: Request) {
     killSwitch,
     riskPolicy,
     gatewayPolicy,
-    setup: {
-      openSea: Boolean(apiKey),
-      productionRpc: dedicatedRpcConfigured,
-      traderSigner: traderKeyConfigured,
-      collection: ADDRESS_RE.test(contract),
-      allowlist: allowlist.length > 0,
-      executor: false,
-    },
-    protections: [
-      'Dedicated trading signer only; never reuse the collection-owner or mint-signer key',
-      'Trading inventory wallet/sub-account separated from owner-wallet grails',
-      'Whitelist-only automatic buys',
-      `Per-trade cap ${riskPolicy.maxTradeEth} ETH`,
-      `Daily spend cap ${riskPolicy.maxDailySpendEth} ETH`,
-      `Daily loss circuit breaker ${riskPolicy.maxDailyLossEth} ETH`,
-      `Gas guard ${riskPolicy.maxGasPercent}% of trade value`,
-      `Inventory cap ${riskPolicy.maxInventory}`,
-      `Minimum modeled edge ${riskPolicy.minimumEdgeBps} bps`,
-      `${riskPolicy.lossesBeforePause} losses in ${riskPolicy.lossWindowMinutes} minutes pauses trading for ${riskPolicy.pauseMinutes} minutes`,
-      'Kill switch remains available before automatic execution is activated',
-    ],
-    executionNotice: executionFoundationReady
-      ? 'Scanner, RPC and dedicated signer foundation are ready. Automatic signing remains OFF until the constrained OpenSea/Base executor and spend/delegation permission are activated.'
-      : 'Autopilot is monitoring-only until OpenSea, a production Base RPC, a separate trader signer, and a bounded permission/executor are configured.',
+    setup: { openSea: Boolean(apiKey), productionRpc: dedicatedRpcConfigured, traderSigner: traderKeyConfigured, collection: ADDRESS_RE.test(contract), allowlist: allowlist.length > 0, executor: false },
+    executionNotice: 'Monitoring only. Autopilot cannot buy, sell, list, or sign transactions yet.',
   };
 
-  if (!apiKey) return NextResponse.json({ ...base, marketDataConfigured: false, listings: 0, offersReceived: 0, portfolio: null, nft: null, activity: [], nextStep: 'Configure OPENSEA_API_KEY on the production server to activate automatic market monitoring.' }, { headers: { 'Cache-Control': 'no-store' } });
+  if (!apiKey) return NextResponse.json({ ...base, marketDataConfigured: false, listings: 0, offersReceived: 0, collectionFloorEth: null, collectionListings: null, sales24h: null, tokenListed: null, activity: [], nextStep: 'Connect OpenSea market data to show live floor, listings, and sales.' }, { headers: { 'Cache-Control': 'no-store' } });
 
-  const calls: Promise<any>[] = [
+  const accountCalls: Promise<any>[] = [
     openSeaGet(`/account/${wallet}/listings?limit=50&chains=base`, apiKey),
     openSeaGet(`/account/${wallet}/offers_received?limit=50`, apiKey),
-    openSeaGet(`/account/${wallet}/portfolio`, apiKey),
   ];
-  if (ADDRESS_RE.test(contract) && /^\d+$/.test(tokenId)) {
-    calls.push(openSeaGet(`/chain/base/contract/${contract}/nfts/${tokenId}`, apiKey));
-    calls.push(openSeaGet(`/chain/base/contract/${contract}/nfts/${tokenId}/analytics`, apiKey));
+  const hasToken = ADDRESS_RE.test(contract) && /^\d+$/.test(tokenId);
+  if (hasToken) accountCalls.push(openSeaGet(`/chain/base/contract/${contract}/nfts/${tokenId}`, apiKey));
+  const [walletListings, offers, nft] = await Promise.all(accountCalls);
+
+  let slug = '';
+  let stats: any = null;
+  let collectionListings: any = null;
+  let sales: any = null;
+  let bestListing: any = null;
+  if (hasToken) {
+    const collectionLookup = await openSeaGet(`/chain/base/contract/${contract}/nfts/${tokenId}/collection`, apiKey);
+    slug = collectionLookup.ok ? collectionSlug(collectionLookup.data) : '';
+    if (slug) {
+      const after = Math.floor(Date.now() / 1000) - 86_400;
+      [stats, collectionListings, sales, bestListing] = await Promise.all([
+        openSeaGet(`/collections/${encodeURIComponent(slug)}/stats`, apiKey),
+        openSeaGet(`/listings/collection/${encodeURIComponent(slug)}/all?limit=200`, apiKey),
+        openSeaGet(`/events/collection/${encodeURIComponent(slug)}?event_type=sale&after=${after}&limit=200`, apiKey),
+        openSeaGet(`/listings/collection/${encodeURIComponent(slug)}/nfts/${tokenId}/best`, apiKey),
+      ]);
+    }
   }
-  const [listings, offers, portfolio, nft, analytics] = await Promise.all(calls);
-  const healthy = [listings, offers, portfolio].filter(Boolean).filter(result => result.ok).length;
-  const listingCount = listCount(listings?.data);
+
+  const walletListingCount = listCount(walletListings?.data);
   const offerCount = listCount(offers?.data);
+  const collectionListingCount = collectionListings?.ok ? listCount(collectionListings.data) : null;
+  const collectionListingsMore = Boolean(collectionListings?.data?.next || collectionListings?.data?.next?.value);
+  const sales24h = sales?.ok ? listCount(sales.data) : null;
+  const sales24hMore = Boolean(sales?.data?.next || sales?.data?.next?.value);
+  const totalStats = stats?.data?.total || stats?.data?.stats || stats?.data || {};
+  const collectionFloorEth = stats?.ok ? metricNumber(totalStats.floor_price, totalStats.floorPrice, stats?.data?.floor_price, stats?.data?.floorPrice) : null;
+  const tokenListed = bestListing ? Boolean(bestListing.ok && listCount(bestListing.data) > 0 || bestListing.ok && bestListing.data && Object.keys(bestListing.data).length > 0) : null;
   const checkedAt = new Date().toISOString();
   const activity = [
-    { type: 'SCAN', at: checkedAt, text: `OpenSea scan complete · ${listingCount} active listings · ${offerCount} offers received.` },
+    { type: 'SCAN', at: checkedAt, text: slug ? `OpenSea collection scan complete for ${slug}.` : 'OpenSea wallet scan complete.' },
     ...(tokenId ? [{ type: 'WATCH', at: checkedAt, text: `Watching VoxelFlip #${tokenId} on Base.` }] : []),
-    { type: automaticSigningActive ? 'AUTO' : 'SAFE', at: checkedAt, text: automaticSigningActive ? 'Bounded automatic executor is active.' : 'No automatic signature was sent. Monitoring and gateway checks only.' },
+    { type: 'SAFE', at: checkedAt, text: 'No transaction was signed. Autopilot remains monitoring-only.' },
   ];
 
   return NextResponse.json({
     ...base,
     marketDataConfigured: true,
-    scanner: healthy ? 'live' : 'degraded',
+    scanner: walletListings?.ok || offers?.ok || nft?.ok ? 'live' : 'degraded',
     checkedAt,
-    listings: listingCount,
+    collectionSlug: slug || null,
+    collectionFloorEth,
+    collectionListings: collectionListingCount,
+    collectionListingsMore,
+    sales24h,
+    sales24hMore,
+    tokenListed,
+    listings: walletListingCount,
     offersReceived: offerCount,
-    portfolio: portfolio?.data || null,
     nft: nft?.data || null,
-    analytics: analytics?.data || null,
     activity,
     sourceHealth: {
-      listings: listings?.ok ? 'ok' : listings?.error || 'unavailable',
+      walletListings: walletListings?.ok ? 'ok' : walletListings?.error || 'unavailable',
       offers: offers?.ok ? 'ok' : offers?.error || 'unavailable',
-      portfolio: portfolio?.ok ? 'ok' : portfolio?.error || 'unavailable',
       nft: nft ? (nft.ok ? 'ok' : nft.error || 'unavailable') : 'not-requested',
-      analytics: analytics ? (analytics.ok ? 'ok' : analytics.error || 'unavailable') : 'not-requested',
+      stats: stats ? (stats.ok ? 'ok' : stats.error || 'unavailable') : 'not-requested',
+      collectionListings: collectionListings ? (collectionListings.ok ? 'ok' : collectionListings.error || 'unavailable') : 'not-requested',
+      sales24h: sales ? (sales.ok ? 'ok' : sales.error || 'unavailable') : 'not-requested',
     },
   }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/app/voxelflip/autopilot/page.js
+++ b/app/voxelflip/autopilot/page.js
@@ -2,13 +2,13 @@
 
 import {useEffect,useState} from 'react';
 import {connectVoxelFlipWallet} from '../../../lib/voxelflip';
-import {getSupabaseBrowserAsync} from '../../../lib/supabase-browser';
 import styles from './autopilot.module.css';
 
 const ADDRESS_RE=/^0x[a-fA-F0-9]{40}$/;
 function short(value){return value?`${value.slice(0,6)}…${value.slice(-4)}`:'—'}
-function yes(value){return value?<span className={styles.good}>READY</span>:<span className={styles.bad}>NEEDED</span>}
-function time(value){try{return new Date(value).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit',second:'2-digit'})}catch{return ''}}
+function time(value){try{return new Date(value).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});}catch{return ''}}
+function eth(value){const n=Number(value);return Number.isFinite(n)?`${n.toLocaleString(undefined,{maximumFractionDigits:4})} ETH`:'—'}
+function count(value,more=false){return Number.isFinite(Number(value))?`${Number(value)}${more?'+':''}`:'—'}
 
 export default function VoxelFlipAutopilotPage(){
  const [wallet,setWallet]=useState('');
@@ -18,61 +18,92 @@ export default function VoxelFlipAutopilotPage(){
  const [busy,setBusy]=useState(false);
  const [autoScan,setAutoScan]=useState(true);
  const [error,setError]=useState('');
- const [googleConnected,setGoogleConnected]=useState(false);
 
  useEffect(()=>{
-  const q=new URLSearchParams(window.location.search);const w=q.get('wallet')||'';setWallet(ADDRESS_RE.test(w)?w:'');setTokenId(q.get('tokenId')||'');setSessionId(q.get('session_id')||'');
-  getSupabaseBrowserAsync().then(async client=>{const {data}=await client.auth.getSession();setGoogleConnected(Boolean(data.session?.user))}).catch(()=>setGoogleConnected(false));
+  const q=new URLSearchParams(window.location.search);
+  const w=q.get('wallet')||'';
+  setWallet(ADDRESS_RE.test(w)?w:'');
+  setTokenId(q.get('tokenId')||'');
+  setSessionId(q.get('session_id')||'');
  },[]);
- useEffect(()=>{if(!ADDRESS_RE.test(wallet)||!autoScan)return;runScan();const timer=setInterval(runScan,30000);return()=>clearInterval(timer)},[wallet,tokenId,autoScan]);
 
- async function connect(){setBusy(true);setError('');try{const result=await connectVoxelFlipWallet();setWallet(result.address)}catch(e){if(e?.code==='NO_WALLET_PROVIDER'&&e?.deepLink){location.href=e.deepLink;return}setError(e instanceof Error?e.message:'Wallet connection failed.')}finally{setBusy(false)}}
- async function runScan(){if(!ADDRESS_RE.test(wallet)||busy)return;setBusy(true);setError('');try{const q=new URLSearchParams({wallet});if(/^\d+$/.test(tokenId))q.set('tokenId',tokenId);const response=await fetch(`/api/voxelflip/trader?${q}`,{cache:'no-store'});const data=await response.json();if(!response.ok)throw new Error(data.error||'Autopilot scan failed.');setScanner(data)}catch(e){setError(e instanceof Error?e.message:'Autopilot scan failed.')}finally{setBusy(false)}}
+ useEffect(()=>{
+  if(!ADDRESS_RE.test(wallet)||!autoScan)return;
+  runScan();
+  const timer=setInterval(runScan,30000);
+  return()=>clearInterval(timer);
+ },[wallet,tokenId,autoScan]);
 
- const risk=scanner?.riskPolicy||{};const policy=scanner?.gatewayPolicy||{};const setup=scanner?.setup||{};const execution=scanner?.automaticSigningActive?'RUNNING':scanner?.executionFoundationReady?'FOUNDATION READY':'SETUP';const activity=scanner?.activity||[];
- const ecologyQuery=new URLSearchParams();if(wallet)ecologyQuery.set('wallet',wallet);if(tokenId)ecologyQuery.set('tokenId',tokenId);if(sessionId)ecologyQuery.set('session_id',sessionId);const ecologyHref=`/voxelflip/ecology${ecologyQuery.toString()?`?${ecologyQuery}`:''}`;
+ async function connect(){
+  setBusy(true);setError('');
+  try{const result=await connectVoxelFlipWallet();setWallet(result.address)}
+  catch(e){if(e?.code==='NO_WALLET_PROVIDER'&&e?.deepLink){location.href=e.deepLink;return}setError(e instanceof Error?e.message:'Wallet connection failed.')}
+  finally{setBusy(false)}
+ }
+
+ async function runScan(){
+  if(!ADDRESS_RE.test(wallet)||busy)return;
+  setBusy(true);setError('');
+  try{
+   const q=new URLSearchParams({wallet});if(/^\d+$/.test(tokenId))q.set('tokenId',tokenId);
+   const response=await fetch(`/api/voxelflip/trader?${q}`,{cache:'no-store'});
+   const data=await response.json();
+   if(!response.ok)throw new Error(data.error||'Autopilot scan failed.');
+   setScanner(data);
+  }catch(e){setError(e instanceof Error?e.message:'Autopilot scan failed.')}
+  finally{setBusy(false)}
+ }
+
+ const watching=tokenId?`VoxelFlip #${tokenId}`:'your VoxelFlip wallet';
+ const openSeaHref=scanner?.openSeaUrl||'https://opensea.io';
+ const listed=scanner?.tokenListed===true?'LISTED':scanner?.tokenListed===false?'NOT LISTED':'—';
+ const marketReady=scanner?.marketDataConfigured===true;
+
  return <main className={styles.page}>
   <nav className={styles.nav}><a href="/studio"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>VoxelPop</b></a><em>VOXELFLIP · AUTOPILOT</em></nav>
-  <header className={styles.hero}><p className={styles.eyebrow}>SCAN → SCORE → GATE → EXECUTE → MONITOR</p><h1>Your market bot.<br/><em>With speed bumps.</em></h1><span>This is the trading workspace. Minting is separate. Every opportunity is classified into automatic, one-tap, or manual review before money or inventory can move.</span></header>
+
+  <header className={styles.hero}>
+   <p className={styles.eyebrow}>MONITORING MODE · NO AUTOMATIC SIGNING</p>
+   <h1>Watching<br/><em>{watching}.</em></h1>
+   <span>Autopilot watches OpenSea and Base for you. It cannot buy, sell, list, or sign transactions yet.</span>
+  </header>
+
   <div className={styles.shell}>
    <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>LIVE SYSTEM</small><h2>Autopilot status</h2></div><button className={`${styles.status} ${autoScan?styles.statusOn:''}`} onClick={()=>setAutoScan(v=>!v)}>{autoScan?'AUTO SCAN ON':'AUTO SCAN OFF'}</button></div>
-    {!wallet?<button className={styles.connect} onClick={connect} disabled={busy}>{busy?'Connecting…':'Connect Base wallet'}</button>:<div className={styles.wallet}><div><small>CONNECTED OWNER / WATCH WALLET</small><b>{short(wallet)}</b></div><button onClick={runScan} disabled={busy}>{busy?'Scanning…':'Refresh now'}</button></div>}
+    <div className={styles.panelHead}>
+     <div><small>LIVE MARKET MONITOR</small><h2>{tokenId?`VoxelFlip #${tokenId}`:'Connect your VoxelFlip'}</h2></div>
+     <button className={`${styles.status} ${autoScan?styles.statusOn:''}`} onClick={()=>setAutoScan(v=>!v)}>{autoScan?'AUTO SCAN · ON':'AUTO SCAN · OFF'}</button>
+    </div>
+
+    {!wallet?<button className={styles.connect} onClick={connect} disabled={busy}>{busy?'Connecting…':'Connect Base wallet'}</button>:<div className={styles.wallet}><div><small>WATCH WALLET</small><b>{short(wallet)}</b></div><button onClick={runScan} disabled={busy}>{busy?'Scanning…':'Refresh now'}</button></div>}
     {error&&<div className={styles.notice}>{error}</div>}
-    <div className={styles.grid4}><article className={styles.metric}><small>SCANNER</small><b>{scanner?.scanner==='live'?'LIVE':scanner?'SETUP':'—'}</b></article><article className={styles.metric}><small>EXECUTION</small><b>{execution}</b></article><article className={styles.metric}><small>LISTINGS</small><b>{scanner?.listings??'—'}</b></article><article className={styles.metric}><small>OFFERS</small><b>{scanner?.offersReceived??'—'}</b></article></div>
-    {scanner?.executionNotice&&<div className={styles.notice}>{scanner.executionNotice}</div>}
-   </section>
 
-   <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>TRANSACTION GATEWAY</small><h2>Three approval modes</h2></div><span className={styles.status}>POLICY ENFORCED SERVER-SIDE</span></div>
-    <div className={styles.tiers}>
-     <article className={styles.tier}><div className={styles.tierTop}><span className={styles.auto}>TIER 1 · AUTO</span><span>NO TAP</span></div><h3>Small, verified trades</h3><p>{policy.auto?.description||'Allowlisted trading inventory only.'}</p><ul><li>Up to {policy.auto?.maxTradeEth??risk.maxTradeEth??'—'} ETH per trade</li><li>Daily cap {policy.auto?.dailySpendCapEth??risk.maxDailySpendEth??'—'} ETH</li><li>Gas must stay under {policy.auto?.maxGasPercent??risk.maxGasPercent??'—'}%</li><li>Whitelist only · never grails</li></ul></article>
-     <article className={styles.tier}><div className={styles.tierTop}><span className={styles.oneTap}>TIER 2 · 1-TAP</span><span>PHONE</span></div><h3>Medium-risk opportunities</h3><p>{policy.oneTap?.description||'Bot pauses for your approval.'}</p><ul><li>{policy.oneTap?.minTradeEth??risk.maxTradeEth??'—'}–{policy.oneTap?.maxTradeEth??'0.05'} ETH</li><li>{policy.oneTap?.timeoutSeconds??60}-second approval window</li><li>Approve or reject from phone</li><li>No silent execution after timeout</li></ul></article>
-     <article className={styles.tier}><div className={styles.tierTop}><span className={styles.manual}>TIER 3 · MANUAL</span><span>STOP</span></div><h3>Grails, swaps & high risk</h3><p>{policy.manual?.description||'Manual review is mandatory.'}</p><ul><li>All swaps</li><li>All grail-tagged assets</li><li>Unverified/new collections</li><li>Anything above the 1-tap cap</li></ul></article>
+    <div className={styles.grid4}>
+     <article className={styles.metric}><small>FLOOR PRICE</small><b>{eth(scanner?.collectionFloorEth)}</b></article>
+     <article className={styles.metric}><small>ACTIVE LISTINGS</small><b>{count(scanner?.collectionListings,scanner?.collectionListingsMore)}</b></article>
+     <article className={styles.metric}><small>24H SALES</small><b>{count(scanner?.sales24h,scanner?.sales24hMore)}</b></article>
+     <article className={styles.metric}><small>YOUR VOXEL</small><b>{listed}</b></article>
     </div>
+
+    {!scanner&&wallet&&<div className={styles.notice}>Waiting for the first market scan.</div>}
+    {scanner&&!marketReady&&<div className={styles.notice}>OpenSea market data is not connected yet, so live floor, listings and sales are unavailable. Your VoxelFlip is still safe and no transaction can be sent from this page.</div>}
+    {scanner&&marketReady&&!scanner.collectionSlug&&tokenId&&<div className={styles.notice}>OpenSea has not returned collection-level stats for this VoxelFlip yet. Autopilot will keep checking every 30 seconds.</div>}
+    {scanner?.checkedAt&&<p className={styles.riskText}>Last checked {time(scanner.checkedAt)} · OpenSea data can lag behind on-chain activity.</p>}
    </section>
 
    <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>SAFETY + READINESS</small><h2>Execution controls</h2></div><span className={styles.status}>{scanner?.killSwitch?'KILL SWITCH ON':'KILL SWITCH READY'}</span></div>
-    <div className={styles.split}>
-     <div className={styles.subpanel}><h3>System checklist</h3><div className={styles.checks}><div className={styles.check}><b>OpenSea market data</b>{yes(setup.openSea)}</div><div className={styles.check}><b>Production Base RPC</b>{yes(setup.productionRpc)}</div><div className={styles.check}><b>Separate trader signer</b>{yes(setup.traderSigner)}</div><div className={styles.check}><b>VoxelFlip contract</b>{yes(setup.collection)}</div><div className={styles.check}><b>Automatic-buy allowlist</b>{yes(setup.allowlist)}</div><div className={styles.check}><b>Bounded executor / delegation</b>{yes(setup.executor)}</div><div className={styles.check}><b>Google phone identity</b>{yes(googleConnected)}</div></div></div>
-     <div className={styles.subpanel}><h3>Hard limits</h3><div className={styles.riskGrid}><div className={styles.risk}><small>MAX / TRADE</small><b>{risk.maxTradeEth??'—'} ETH</b></div><div className={styles.risk}><small>DAILY SPEND</small><b>{risk.maxDailySpendEth??'—'} ETH</b></div><div className={styles.risk}><small>DAILY LOSS STOP</small><b>{risk.maxDailyLossEth??'—'} ETH</b></div><div className={styles.risk}><small>BOT WALLET MAX</small><b>{risk.maxBotWalletEth??'—'} ETH</b></div><div className={styles.risk}><small>INVENTORY CAP</small><b>{risk.maxInventory??'—'}</b></div><div className={styles.risk}><small>MIN EDGE</small><b>{risk.minimumEdgeBps??'—'} bps</b></div><div className={styles.risk}><small>GAS GUARD</small><b>{risk.maxGasPercent??'—'}%</b></div><div className={styles.risk}><small>LOSS BREAKER</small><b>{risk.lossesBeforePause??'—'} / {risk.lossWindowMinutes??'—'}m</b></div></div></div>
+    <div className={styles.panelHead}><div><small>WHAT YOU CAN DO NOW</small><h2>Watch it or sell manually.</h2></div><span className={styles.status}>AUTOPILOT TRADING · COMING SOON</span></div>
+    <div className={styles.notice}>Automatic signing is OFF. Nothing on this page can spend ETH or list your NFT without you.</div>
+    <div className={styles.actions}>
+     <a href={openSeaHref} target="_blank" rel="noreferrer">List manually on OpenSea ↗</a>
+     <a href={openSeaHref} target="_blank" rel="noreferrer">Open {tokenId?`VoxelFlip #${tokenId}`:'VoxelFlip'} ↗</a>
+     <a href="/studio#my-voxels">My Voxels</a>
+     {sessionId&&<a href={`/voxelflip/mint?session_id=${encodeURIComponent(sessionId)}`}>Open minted 3D</a>}
     </div>
-    <div className={styles.notice}>{policy.inventoryModel||'Trading inventory stays separate from owner-wallet grails.'}</div>
-   </section>
-
-   <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>MONITOR</small><h2>Bot activity stream</h2></div><span className={styles.status}>{scanner?.checkedAt?`UPDATED ${time(scanner.checkedAt)}`:'NOT STARTED'}</span></div>
-    <div className={styles.activity}>{activity.length?activity.map((event,i)=><div className={styles.event} key={`${event.at}-${i}`}><b>{event.type}</b><span>{time(event.at)} · {event.text}</span></div>):<div className={styles.event}><b>STANDBY</b><span>Connect a wallet to begin the live market scan.</span></div>}</div>
-   </section>
-
-   <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>NON-NEGOTIABLE</small><h2>Guardrails</h2></div></div>
-    <div className={styles.guardrails}>{(scanner?.protections||['Dedicated trader wallet only','Whitelist-only automatic buys','Grails stay manual','Gas guard','Daily loss circuit breaker','Kill switch']).map((item,i)=><div className={styles.guardrail} key={i}><span>✓</span><p>{item}</p></div>)}</div>
-    <div className={styles.actions}><a href={ecologyHref}>Enter Ecology →</a><a href="/studio#my-voxels">Google / My Voxels</a>{sessionId&&<a href={`/voxelflip/mint?session_id=${encodeURIComponent(sessionId)}`}>Mint page</a>}<a href="https://opensea.io" target="_blank" rel="noreferrer">OpenSea ↗</a></div>
-    <p className={styles.riskText}>Automatic NFT trading can lose money. Limits, allowlists and circuit breakers reduce risk but cannot guarantee profit or prevent every loss. Automatic signing remains off until the separate bounded executor/delegation is actually installed and verified.</p>
+    <p className={styles.riskText}>Next development phase: a separately tested bounded executor with explicit spending limits and approvals. It is not active here.</p>
    </section>
   </div>
-  <footer className={styles.footer}><a href="/studio">← VoxelPop Studio</a><a href={ecologyHref}>Ecology →</a></footer>
+
+  <footer className={styles.footer}><a href="/studio#my-voxels">← My Voxels</a><a href={openSeaHref} target="_blank" rel="noreferrer">OpenSea ↗</a></footer>
  </main>;
 }


### PR DESCRIPTION
Replaces the confusing execution-focused Autopilot UI with a monitoring-first dashboard for the selected VoxelFlip. Shows real OpenSea-derived collection floor, active listings, 24h sales and token listing state when available, plus Refresh / Auto Scan and direct OpenSea actions. Removes Ecology and infrastructure-detail clutter from the page. Automatic signing remains explicitly OFF and no executor, signer, spending or listing behavior is enabled. Also adds timeouts around OpenSea reads so market monitoring cannot hang indefinitely.