### PR TITLE
Add conservative VoxelFlip Factory loop

### DIFF
--- a/app/api/voxelflip/factory/route.ts
+++ b/app/api/voxelflip/factory/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from 'next/server';
+import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const PRIVATE_KEY_RE = /^(0x)?[a-fA-F0-9]{64}$/;
+const OPENSEA = 'https://api.opensea.io/api/v2';
+const OPENSEA_TIMEOUT_MS = 8_000;
+
+function bool(value: string | undefined) {
+  return String(value || '').trim().toLowerCase() === 'true';
+}
+
+function positiveNumber(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function openSeaGet(path: string, apiKey: string) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENSEA_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${OPENSEA}${path}`, {
+      headers: { 'x-api-key': apiKey, accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const data = await response.json().catch(() => ({}));
+    return { ok: response.ok, status: response.status, data: response.ok ? data : null, error: response.ok ? null : String(data?.detail || data?.error || `OpenSea ${response.status}`) };
+  } catch (error) {
+    const message = error instanceof Error && error.name === 'AbortError' ? 'OpenSea request timed out' : error instanceof Error ? error.message : 'OpenSea request failed';
+    return { ok: false, status: 0, data: null, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function eventList(value: any) {
+  if (!value || typeof value !== 'object') return [];
+  for (const key of ['asset_events', 'assetEvents', 'events', 'results']) {
+    if (Array.isArray(value[key])) return value[key];
+  }
+  return [];
+}
+
+function address(value: any) {
+  const candidate = typeof value === 'string' ? value : value?.address || value?.account_address || value?.wallet || '';
+  return ADDRESS_RE.test(String(candidate)) ? String(candidate).toLowerCase() : '';
+}
+
+function nftContract(event: any) {
+  return address(event?.nft?.contract || event?.nft?.contract_address || event?.asset?.contract || event?.asset?.contract_address || event?.contract);
+}
+
+function saleSeller(event: any) {
+  return address(event?.seller || event?.from_account || event?.from_address || event?.maker);
+}
+
+function saleBuyer(event: any) {
+  return address(event?.buyer || event?.to_account || event?.to_address || event?.taker);
+}
+
+function paymentEthEquivalent(event: any) {
+  const payment = event?.payment || event?.payment_token || event?.price || null;
+  if (!payment || typeof payment !== 'object') return null;
+  const symbol = String(payment.symbol || payment.token_symbol || payment?.token?.symbol || '').toUpperCase();
+  if (symbol !== 'ETH' && symbol !== 'WETH') return null;
+  const raw = payment.quantity ?? payment.amount ?? payment.value;
+  const decimals = Number(payment.decimals ?? payment?.token?.decimals ?? 18);
+  if (raw == null || !Number.isFinite(decimals) || decimals < 0 || decimals > 30) return null;
+  try {
+    const quantity = BigInt(String(raw));
+    const whole = Number(quantity) / Math.pow(10, decimals);
+    return Number.isFinite(whole) && whole >= 0 ? whole : null;
+  } catch {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  }
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const wallet = (url.searchParams.get('wallet') || '').trim();
+  if (!ADDRESS_RE.test(wallet)) return NextResponse.json({ error: 'Connect the VoxelFlip wallet to inspect Factory mode.' }, { status: 400 });
+
+  const deployment = await getVoxelFlipDeployment();
+  const contract = deployment?.address || '';
+  const apiKey = process.env.OPENSEA_API_KEY?.trim() || '';
+  const rpcReady = Boolean((process.env.VOXELFLIP_RPC_URL || '').trim());
+  const traderSignerReady = PRIVATE_KEY_RE.test((process.env.VOXELFLIP_TRADER_PRIVATE_KEY || '').trim());
+  const executorReady = false;
+  const factoryRequested = bool(process.env.VOXELFLIP_FACTORY_ENABLED);
+  const killSwitch = bool(process.env.VOXELFLIP_AUTOPILOT_KILL_SWITCH) || bool(process.env.VOXELFLIP_FACTORY_KILL_SWITCH);
+
+  const reinvestPercent = Math.min(40, positiveNumber(process.env.VOXELFLIP_FACTORY_REINVEST_PERCENT, 25));
+  const reservePercent = 100 - reinvestPercent;
+  const maxReinvestPerCycleEth = positiveNumber(process.env.VOXELFLIP_FACTORY_MAX_REINVEST_ETH, 0.01);
+  const maxFactoryMintsPerDay = Math.max(1, Math.floor(positiveNumber(process.env.VOXELFLIP_FACTORY_MAX_MINTS_PER_DAY, 3)));
+  const maxFactoryInventory = Math.max(1, Math.floor(positiveNumber(process.env.VOXELFLIP_FACTORY_MAX_INVENTORY, 5)));
+  const minimumRealizedProfitEth = positiveNumber(process.env.VOXELFLIP_FACTORY_MIN_REALIZED_PROFIT_ETH, 0.003);
+
+  let saleFeed: any = null;
+  let verifiedSales = 0;
+  let recognizedProceedsEth = 0;
+  let proceedsCoverage = 0;
+  if (apiKey && ADDRESS_RE.test(contract)) {
+    const after = Math.floor(Date.now() / 1000) - 30 * 86_400;
+    saleFeed = await openSeaGet(`/events/accounts/${wallet}?event_type=sale&chain=base&after=${after}&limit=200`, apiKey);
+    if (saleFeed.ok) {
+      const walletLower = wallet.toLowerCase();
+      const contractLower = contract.toLowerCase();
+      for (const event of eventList(saleFeed.data)) {
+        const seller = saleSeller(event);
+        const buyer = saleBuyer(event);
+        if (!seller || seller !== walletLower || buyer === walletLower) continue;
+        if (nftContract(event) !== contractLower) continue;
+        verifiedSales += 1;
+        const proceeds = paymentEthEquivalent(event);
+        if (proceeds != null) {
+          recognizedProceedsEth += proceeds;
+          proceedsCoverage += 1;
+        }
+      }
+    }
+  }
+
+  const profitLedgerReady = false;
+  const generationFactoryReady = false;
+  const automaticFactoryActive = false;
+  const foundationReady = Boolean(apiKey && rpcReady && traderSignerReady && ADDRESS_RE.test(contract));
+
+  return NextResponse.json({
+    wallet,
+    contract,
+    chain: 'base',
+    checkedAt: new Date().toISOString(),
+    mode: automaticFactoryActive ? 'automatic' : 'approval-gated',
+    factoryRequested,
+    automaticFactoryActive,
+    killSwitch,
+    observed: {
+      verifiedExternalSales30d: verifiedSales,
+      recognizedSaleProceedsEth: Number(recognizedProceedsEth.toFixed(8)),
+      proceedsParsedSales: proceedsCoverage,
+      saleFeedHealthy: Boolean(saleFeed?.ok),
+    },
+    policy: {
+      reinvestPercent,
+      reservePercent,
+      maxReinvestPerCycleEth,
+      maxFactoryMintsPerDay,
+      maxFactoryInventory,
+      minimumRealizedProfitEth,
+      requireSettledExternalSale: true,
+      requireRealizedNetProfit: true,
+      selfTradesCountAsProfit: false,
+      unsoldInventoryCountsAsProfit: false,
+      principalSpendingAllowed: false,
+    },
+    readiness: {
+      openSea: Boolean(apiKey),
+      productionRpc: rpcReady,
+      separateTraderSigner: traderSignerReady,
+      collection: ADDRESS_RE.test(contract),
+      profitLedger: profitLedgerReady,
+      generationFactory: generationFactoryReady,
+      boundedExecutor: executorReady,
+      foundation: foundationReady,
+    },
+    loop: [
+      { key: 'sell', label: 'External sale settles', ready: Boolean(apiKey) },
+      { key: 'profit', label: 'Verify net profit after costs', ready: profitLedgerReady },
+      { key: 'reserve', label: `Reserve ${reservePercent}%`, ready: profitLedgerReady },
+      { key: 'reinvest', label: `Reinvest up to ${reinvestPercent}%`, ready: profitLedgerReady && !killSwitch },
+      { key: 'generate', label: 'Generate next voxel', ready: generationFactoryReady },
+      { key: 'mint', label: 'Mint with bounded approval', ready: executorReady },
+      { key: 'list', label: 'List with bounded approval', ready: executorReady },
+      { key: 'repeat', label: 'Repeat only after another settled sale', ready: false },
+    ],
+    nextStep: profitLedgerReady
+      ? 'Factory profit accounting is ready. Keep automatic execution disabled until generation and bounded mint/list approvals are installed.'
+      : 'Install a real cost/profit ledger before reinvesting. Sale proceeds alone are not profit, so Factory will not spend them automatically yet.',
+    notice: 'Factory never treats minting, self-trades, or unsold NFTs as profit. Automatic spending and signing remain OFF.',
+  }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/app/voxelflip/autopilot/page.js
+++ b/app/voxelflip/autopilot/page.js
@@ -58,6 +58,7 @@ export default function VoxelFlipAutopilotPage(){
  const openSeaHref=scanner?.openSeaUrl||'https://opensea.io';
  const listed=scanner?.tokenListed===true?'LISTED':scanner?.tokenListed===false?'NOT LISTED':'—';
  const marketReady=scanner?.marketDataConfigured===true;
+ const factoryQuery=new URLSearchParams();if(wallet)factoryQuery.set('wallet',wallet);if(tokenId)factoryQuery.set('tokenId',tokenId);if(sessionId)factoryQuery.set('session_id',sessionId);const factoryHref=`/voxelflip/factory${factoryQuery.toString()?`?${factoryQuery}`:''}`;
 
  return <main className={styles.page}>
   <nav className={styles.nav}><a href="/studio"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>VoxelPop</b></a><em>VOXELFLIP · AUTOPILOT</em></nav>
@@ -92,18 +93,19 @@ export default function VoxelFlipAutopilotPage(){
    </section>
 
    <section className={styles.panel}>
-    <div className={styles.panelHead}><div><small>WHAT YOU CAN DO NOW</small><h2>Watch it or sell manually.</h2></div><span className={styles.status}>AUTOPILOT TRADING · COMING SOON</span></div>
+    <div className={styles.panelHead}><div><small>WHAT YOU CAN DO NOW</small><h2>Watch it, sell manually, or inspect Factory.</h2></div><span className={styles.status}>AUTOPILOT TRADING · COMING SOON</span></div>
     <div className={styles.notice}>Automatic signing is OFF. Nothing on this page can spend ETH or list your NFT without you.</div>
     <div className={styles.actions}>
+     <a href={factoryHref}>Open Factory loop →</a>
      <a href={openSeaHref} target="_blank" rel="noreferrer">List manually on OpenSea ↗</a>
      <a href={openSeaHref} target="_blank" rel="noreferrer">Open {tokenId?`VoxelFlip #${tokenId}`:'VoxelFlip'} ↗</a>
      <a href="/studio#my-voxels">My Voxels</a>
      {sessionId&&<a href={`/voxelflip/mint?session_id=${encodeURIComponent(sessionId)}`}>Open minted 3D</a>}
     </div>
-    <p className={styles.riskText}>Next development phase: a separately tested bounded executor with explicit spending limits and approvals. It is not active here.</p>
+    <p className={styles.riskText}>Factory can observe settled external sales and enforce conservative reserve/reinvestment rules. Spending, minting, and listing stay approval-gated until a bounded executor is installed and tested.</p>
    </section>
   </div>
 
-  <footer className={styles.footer}><a href="/studio#my-voxels">← My Voxels</a><a href={openSeaHref} target="_blank" rel="noreferrer">OpenSea ↗</a></footer>
+  <footer className={styles.footer}><a href="/studio#my-voxels">← My Voxels</a><a href={factoryHref}>Factory →</a><a href={openSeaHref} target="_blank" rel="noreferrer">OpenSea ↗</a></footer>
  </main>;
 }

--- a/app/voxelflip/factory/README.md
+++ b/app/voxelflip/factory/README.md
@@ -1,0 +1,5 @@
+# VoxelFlip Factory
+
+Factory is a conservative sale-to-reinvestment workflow. It observes settled external sales, requires a real net-profit ledger before reinvestment, reserves most realized profit, and keeps spending/mint/list actions approval-gated until a separately tested bounded executor exists.
+
+It must never count self-trades, minting, or unsold inventory as profit. Automatic spending/signing is intentionally off.

--- a/app/voxelflip/factory/layout.js
+++ b/app/voxelflip/factory/layout.js
@@ -1,0 +1,2 @@
+export const metadata={title:'VoxelFlip Factory | VoxelPop',description:'Conservative VoxelFlip sale-to-reinvestment factory loop with bounded approvals.'};
+export default function FactoryLayout({children}){return children}

--- a/app/voxelflip/factory/page.js
+++ b/app/voxelflip/factory/page.js
@@ -1,0 +1,125 @@
+'use client';
+
+import {useEffect,useState} from 'react';
+import {connectVoxelFlipWallet} from '../../../lib/voxelflip';
+import styles from '../autopilot/autopilot.module.css';
+
+const ADDRESS_RE=/^0x[a-fA-F0-9]{40}$/;
+function short(value){return value?`${value.slice(0,6)}…${value.slice(-4)}`:'—'}
+function eth(value){const n=Number(value);return Number.isFinite(n)?`${n.toLocaleString(undefined,{maximumFractionDigits:5})} ETH`:'—'}
+function time(value){try{return new Date(value).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'});}catch{return ''}}
+
+export default function VoxelFlipFactoryPage(){
+ const [wallet,setWallet]=useState('');
+ const [tokenId,setTokenId]=useState('');
+ const [sessionId,setSessionId]=useState('');
+ const [factory,setFactory]=useState(null);
+ const [busy,setBusy]=useState(false);
+ const [error,setError]=useState('');
+
+ useEffect(()=>{
+  const q=new URLSearchParams(window.location.search);
+  const w=q.get('wallet')||'';
+  setWallet(ADDRESS_RE.test(w)?w:'');
+  setTokenId(q.get('tokenId')||'');
+  setSessionId(q.get('session_id')||'');
+ },[]);
+
+ useEffect(()=>{if(ADDRESS_RE.test(wallet))refresh()},[wallet]);
+
+ async function connect(){
+  setBusy(true);setError('');
+  try{const result=await connectVoxelFlipWallet();setWallet(result.address)}
+  catch(e){if(e?.code==='NO_WALLET_PROVIDER'&&e?.deepLink){location.href=e.deepLink;return}setError(e instanceof Error?e.message:'Wallet connection failed.')}
+  finally{setBusy(false)}
+ }
+
+ async function refresh(){
+  if(!ADDRESS_RE.test(wallet)||busy)return;
+  setBusy(true);setError('');
+  try{
+   const response=await fetch(`/api/voxelflip/factory?wallet=${encodeURIComponent(wallet)}`,{cache:'no-store'});
+   const data=await response.json();
+   if(!response.ok)throw new Error(data.error||'Factory check failed.');
+   setFactory(data);
+  }catch(e){setError(e instanceof Error?e.message:'Factory check failed.')}
+  finally{setBusy(false)}
+ }
+
+ const policy=factory?.policy||{};
+ const observed=factory?.observed||{};
+ const readiness=factory?.readiness||{};
+ const factoryQuery=new URLSearchParams();
+ if(wallet)factoryQuery.set('wallet',wallet);if(tokenId)factoryQuery.set('tokenId',tokenId);if(sessionId)factoryQuery.set('session_id',sessionId);
+ const autopilotHref=`/voxelflip/autopilot${factoryQuery.toString()?`?${factoryQuery}`:''}`;
+
+ return <main className={styles.page}>
+  <nav className={styles.nav}><a href="/studio"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>VoxelPop</b></a><em>VOXELFLIP · FACTORY</em></nav>
+
+  <header className={styles.hero}>
+   <p className={styles.eyebrow}>SELL → VERIFY PROFIT → RESERVE → REINVEST → BUILD → MINT → LIST → REPEAT</p>
+   <h1>The voxel<br/><em>factory loop.</em></h1>
+   <span>Factory is designed to compound only verified external profit. It never treats minting, self-trades, or unsold inventory as profit, and it cannot spend or sign automatically yet.</span>
+  </header>
+
+  <div className={styles.shell}>
+   <section className={styles.panel}>
+    <div className={styles.panelHead}><div><small>FACTORY MODE</small><h2>{factory?.automaticFactoryActive?'Running':'Approval-gated'}</h2></div><span className={`${styles.status} ${factory?.automaticFactoryActive?styles.statusOn:''}`}>{factory?.automaticFactoryActive?'AUTOMATIC · ON':'AUTOMATIC · OFF'}</span></div>
+    {!wallet?<button className={styles.connect} onClick={connect} disabled={busy}>{busy?'Connecting…':'Connect Factory wallet'}</button>:<div className={styles.wallet}><div><small>FACTORY / SALE WALLET</small><b>{short(wallet)}</b></div><button onClick={refresh} disabled={busy}>{busy?'Checking…':'Refresh factory'}</button></div>}
+    {error&&<div className={styles.notice}>{error}</div>}
+    <div className={styles.grid4}>
+     <article className={styles.metric}><small>EXTERNAL SALES · 30D</small><b>{factory?observed.verifiedExternalSales30d:'—'}</b></article>
+     <article className={styles.metric}><small>RECOGNIZED PROCEEDS</small><b>{factory?eth(observed.recognizedSaleProceedsEth):'—'}</b></article>
+     <article className={styles.metric}><small>RESERVE TARGET</small><b>{factory?`${policy.reservePercent}%`:'—'}</b></article>
+     <article className={styles.metric}><small>REINVEST CAP</small><b>{factory?`${policy.reinvestPercent}%`:'—'}</b></article>
+    </div>
+    {factory&&<div className={styles.notice}>{factory.nextStep}</div>}
+    {factory?.checkedAt&&<p className={styles.riskText}>Last checked {time(factory.checkedAt)} · sale events can lag while OpenSea indexes Base.</p>}
+   </section>
+
+   <section className={styles.panel}>
+    <div className={styles.panelHead}><div><small>THE LOOP</small><h2>One sale funds the next candidate.</h2></div><span className={styles.status}>PRINCIPAL SPENDING · BLOCKED</span></div>
+    <div className={styles.activity}>
+     {(factory?.loop||[
+      {label:'External sale settles',ready:false},{label:'Verify net profit after costs',ready:false},{label:'Reserve capital',ready:false},{label:'Reinvest a capped slice',ready:false},{label:'Generate next voxel',ready:false},{label:'Mint with approval',ready:false},{label:'List with approval',ready:false},{label:'Repeat after another sale',ready:false}
+     ]).map((step,i)=><div className={styles.event} key={`${step.key||i}`}><b>{String(i+1).padStart(2,'0')}</b><span>{step.ready?'✓ ':'○ '}{step.label}</span></div>)}
+    </div>
+   </section>
+
+   <section className={styles.panel}>
+    <div className={styles.panelHead}><div><small>CONSERVATIVE LIMITS</small><h2>Factory cannot snowball recklessly.</h2></div><span className={styles.status}>{factory?.killSwitch?'KILL SWITCH · ON':'KILL SWITCH · READY'}</span></div>
+    <div className={styles.grid4}>
+     <article className={styles.metric}><small>MAX / CYCLE</small><b>{factory?eth(policy.maxReinvestPerCycleEth):'—'}</b></article>
+     <article className={styles.metric}><small>MAX MINTS / DAY</small><b>{factory?policy.maxFactoryMintsPerDay:'—'}</b></article>
+     <article className={styles.metric}><small>MAX FACTORY INVENTORY</small><b>{factory?policy.maxFactoryInventory:'—'}</b></article>
+     <article className={styles.metric}><small>MIN REALIZED PROFIT</small><b>{factory?eth(policy.minimumRealizedProfitEth):'—'}</b></article>
+    </div>
+    <div className={styles.guardrails}>
+     <div className={styles.guardrail}><span>✓</span><p>Only settled external sales can enter the loop.</p></div>
+     <div className={styles.guardrail}><span>✓</span><p>Unsold NFTs and self-trades never count as profit.</p></div>
+     <div className={styles.guardrail}><span>✓</span><p>{policy.reservePercent??75}% stays reserved by default; at most {policy.reinvestPercent??25}% can be considered for reinvestment.</p></div>
+     <div className={styles.guardrail}><span>✓</span><p>Every spend, mint, and listing remains approval-gated until the bounded executor is separately installed and tested.</p></div>
+    </div>
+   </section>
+
+   <section className={styles.panel}>
+    <div className={styles.panelHead}><div><small>READINESS</small><h2>What still has to exist before self-looping.</h2></div></div>
+    <div className={styles.activity}>
+     <div className={styles.event}><b>{readiness.openSea?'READY':'WAIT'}</b><span>OpenSea sale monitoring</span></div>
+     <div className={styles.event}><b>{readiness.productionRpc?'READY':'WAIT'}</b><span>Production Base RPC</span></div>
+     <div className={styles.event}><b>{readiness.profitLedger?'READY':'WAIT'}</b><span>Real cost + realized-profit ledger</span></div>
+     <div className={styles.event}><b>{readiness.generationFactory?'READY':'WAIT'}</b><span>Internal factory generation queue</span></div>
+     <div className={styles.event}><b>{readiness.boundedExecutor?'READY':'WAIT'}</b><span>Bounded mint/list executor</span></div>
+    </div>
+    <div className={styles.actions}>
+     <a href={autopilotHref}>← Autopilot monitor</a>
+     <a href="/studio">Create next voxel</a>
+     <a href="/studio#my-voxels">My Voxels</a>
+    </div>
+    <p className={styles.riskText}>Factory is a compounding workflow, not a profit guarantee. The loop stays stopped whenever verified net profit, inventory capacity, or execution safety is missing.</p>
+   </section>
+  </div>
+
+  <footer className={styles.footer}><a href={autopilotHref}>← Autopilot</a><a href="/studio#my-voxels">My Voxels</a></footer>
+ </main>;
+}


### PR DESCRIPTION
Adds a dedicated VoxelFlip Factory dashboard and read-only factory API. The factory observes external OpenSea sale events, ignores self-sales, never treats minting or unsold inventory as profit, and exposes conservative defaults: 75% reserve / 25% reinvestment, per-cycle spend cap, daily mint cap, inventory cap, minimum realized-profit threshold, and kill-switch readiness. It explicitly requires a real cost/profit ledger before reinvestment and keeps all spending, minting, listing, and signing approval-gated because the bounded executor is not installed. Autopilot now links into Factory. No automatic financial execution is enabled.