### PR TITLE
Add WhatsApp-controlled VoxelFlip approvals

### DIFF
--- a/app/admin/neural-core/whatsapp/page.js
+++ b/app/admin/neural-core/whatsapp/page.js
@@ -1,0 +1,195 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
+import styles from '../list/listing.module.css';
+
+const MIGRATION_SQL = `create extension if not exists pgcrypto;
+
+create table if not exists public.voxelflip_control_actions (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  wallet text check (wallet is null or wallet ~* '^0x[0-9a-f]{40}$'),
+  action_type text not null check (action_type in ('revenue_notice','reinvest','list','buy','mint','test')),
+  status text not null default 'pending' check (status in ('pending','approved','skipped','expired','notified','executed','failed')),
+  payload jsonb not null default '{}'::jsonb,
+  whatsapp_message_id text,
+  responder_hash text,
+  approved_via text,
+  expires_at timestamptz,
+  responded_at timestamptz,
+  executed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists voxelflip_control_actions_status_time_idx on public.voxelflip_control_actions (status, created_at desc);
+create index if not exists voxelflip_control_actions_wallet_time_idx on public.voxelflip_control_actions (lower(wallet), created_at desc);
+alter table public.voxelflip_control_actions enable row level security;
+revoke all on table public.voxelflip_control_actions from anon, authenticated;
+grant select, insert, update on table public.voxelflip_control_actions to service_role;
+`;
+
+function state(value) { return value ? 'READY' : 'WAITING'; }
+
+export default function WhatsAppControlPage() {
+  const [authState, setAuthState] = useState('loading');
+  const [token, setToken] = useState('');
+  const [status, setStatus] = useState(null);
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async accessToken => {
+    if (!accessToken) return;
+    setBusy('load');
+    setError('');
+    try {
+      const response = await fetch('/api/admin/neural-core/whatsapp', {
+        cache: 'no-store',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || 'WhatsApp control status could not be checked.');
+      setStatus(data);
+      setAuthState('ready');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'WhatsApp control status could not be checked.');
+    } finally {
+      setBusy('');
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let subscription;
+    (async () => {
+      try {
+        const client = await getSupabaseBrowserAsync();
+        const { data } = await client.auth.getSession();
+        if (cancelled) return;
+        const accessToken = data?.session?.access_token || '';
+        if (!accessToken) {
+          setAuthState('signed-out');
+          return;
+        }
+        setToken(accessToken);
+        setAuthState('authenticated');
+        await load(accessToken);
+        const result = client.auth.onAuthStateChange((_event, session) => {
+          const next = session?.access_token || '';
+          setToken(next);
+          setAuthState(next ? 'ready' : 'signed-out');
+        });
+        subscription = result?.data?.subscription;
+      } catch (err) {
+        if (!cancelled) {
+          setAuthState('signed-out');
+          setError(err instanceof Error ? err.message : 'Google session could not be loaded.');
+        }
+      }
+    })();
+    return () => { cancelled = true; subscription?.unsubscribe?.(); };
+  }, [load]);
+
+  async function runTest(action) {
+    if (!token) return;
+    setBusy(action);
+    setError('');
+    setMessage('');
+    try {
+      const response = await fetch('/api/admin/neural-core/whatsapp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ action }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || 'WhatsApp test failed.');
+      setMessage(data.notice || 'WhatsApp test sent.');
+      await load(token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'WhatsApp test failed.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function copySql() {
+    try {
+      await navigator.clipboard.writeText(MIGRATION_SQL);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      setError('Clipboard access was blocked. Select the SQL and copy it manually.');
+    }
+  }
+
+  if (authState === 'loading') return <main className={styles.page}><section className={styles.locked}><h1>Loading WhatsApp control…</h1></section></main>;
+  if (authState === 'signed-out') return <main className={styles.page}>
+    <nav className={styles.nav}><Link href="/studio">VoxelPop</Link><em>WHATSAPP CONTROL · PRIVATE</em></nav>
+    <section className={styles.locked}><small>GOOGLE SESSION REQUIRED</small><h1>Sign in first.</h1><p>This control page uses the private Neural Core admin allowlist.</p><Link href="/studio#my-voxels">Open Studio and sign in →</Link></section>
+  </main>;
+
+  const tableReady = Boolean(status?.database?.controlActions?.ready);
+  const meta = status?.meta || {};
+
+  return <main className={styles.page}>
+    <nav className={styles.nav}><Link href="/admin/neural-core">← Neural Core</Link><em>WHATSAPP CONTROL</em></nav>
+    <header className={styles.hero}>
+      <small>DETECT → TEXT → APPROVE / SKIP → QUEUE</small>
+      <h1>Autonomous alerts.<br/><em>You stay in control.</em></h1>
+      <p>Neural Core can notify you and collect a one-time approval in WhatsApp. A WhatsApp tap is never a blockchain signature. Spending, listing, buying and minting remain locked until the bounded executor is separately verified.</p>
+    </header>
+
+    <div className={styles.shell}>
+      <section className={styles.panel}>
+        <div className={styles.panelHead}><div><small>READINESS</small><h2>{status?.ready ? 'WhatsApp control is connected.' : 'Connect the remaining pieces.'}</h2></div><span className={styles.badge}>{status?.ready ? 'READY' : 'SETUP'}</span></div>
+        <div className={styles.grid}>
+          <article className={styles.metric}><small>CONTROL STORAGE · 013</small><b>{state(tableReady)}</b></article>
+          <article className={styles.metric}><small>META OUTBOUND</small><b>{state(Boolean(meta.outboundReady))}</b></article>
+          <article className={styles.metric}><small>SIGNED WEBHOOK</small><b>{state(Boolean(meta.webhookReady))}</b></article>
+          <article className={styles.metric}><small>REVENUE TEMPLATE</small><b>{state(Boolean(meta.revenueTemplate))}</b></article>
+          <article className={styles.metric}><small>APPROVAL TEMPLATE</small><b>{state(Boolean(meta.approvalTemplate))}</b></article>
+          <article className={styles.metric}><small>AUTO-SIGNING</small><b>OFF</b></article>
+        </div>
+        {message && <div className={styles.success} style={{marginTop:14}}>{message}</div>}
+        {error && <div className={styles.error} style={{marginTop:14}}>{error}</div>}
+      </section>
+
+      {!tableReady && <section className={styles.panel}>
+        <div className={styles.panelHead}><div><small>ONE-TIME DATABASE STEP</small><h2>Install control storage.</h2></div><span className={styles.badge}>PRIVATE</span></div>
+        <p style={{color:'#aaaab6',lineHeight:1.65}}>Copy this SQL into the Voxel Vault Supabase SQL Editor and run it once. Browser roles get no direct access to this table.</p>
+        <div className={styles.actions}><button className={styles.primary} onClick={copySql}>{copied ? 'Copied ✓' : 'Copy migration 013 SQL'}</button><a className={styles.secondary} href="https://supabase.com/dashboard/projects" target="_blank" rel="noreferrer">Open Supabase ↗</a></div>
+        <textarea readOnly value={MIGRATION_SQL} style={{width:'100%',minHeight:240,boxSizing:'border-box',marginTop:16,background:'#0b0b10',color:'#b9bbc5',border:'1px solid #31313c',borderRadius:14,padding:14,fontFamily:'ui-monospace,SFMono-Regular,Menlo,monospace',fontSize:11,lineHeight:1.5}} />
+      </section>}
+
+      <section className={styles.panel}>
+        <div className={styles.panelHead}><div><small>META CLOUD API</small><h2>Direct WhatsApp. No Twilio.</h2></div><span className={styles.badge}>SERVER ONLY</span></div>
+        <p style={{color:'#aaaab6',lineHeight:1.65}}>Create a Meta Business app, add the WhatsApp product, and use a WhatsApp Business sender number. Your approver number is stored only as a Vercel environment variable; it is never committed to GitHub. Your connected Instagram account does not by itself configure WhatsApp Cloud API.</p>
+        <div className={styles.field}><label>Webhook callback URL</label><input readOnly value={status?.webhookUrl || ''}/></div>
+        <div className={styles.field}><label>Required Vercel environment variables</label><textarea readOnly value={(status?.requiredEnv || []).join('\n')} style={{width:'100%',minHeight:190,boxSizing:'border-box',background:'#0b0b10',color:'#b9bbc5',border:'1px solid #31313c',borderRadius:14,padding:14,fontFamily:'ui-monospace,SFMono-Regular,Menlo,monospace',fontSize:12,lineHeight:1.5}} /></div>
+        <p style={{color:'#aaaab6',lineHeight:1.65}}>Use digits-only E.164 format for <code>WHATSAPP_APPROVER_NUMBER</code>. Keep the access token, app secret and webhook verification token private. Optional: <code>WHATSAPP_GRAPH_API_VERSION=v26.0</code> and <code>WHATSAPP_TEMPLATE_LANGUAGE=en_US</code>.</p>
+        <div className={styles.actions}><a className={styles.secondary} href="https://developers.facebook.com/apps/" target="_blank" rel="noreferrer">Open Meta Developer Apps ↗</a></div>
+      </section>
+
+      <section className={styles.panel}>
+        <div className={styles.panelHead}><div><small>MESSAGE TEMPLATES</small><h2>Create these two approved templates.</h2></div></div>
+        <div className={styles.field}><label>Revenue template · one body variable</label><textarea readOnly value={status?.templates?.revenue?.body || ''} /></div>
+        <div className={styles.field}><label>Approval template · three body variables + 2 quick replies</label><textarea readOnly value={`${status?.templates?.approval?.body || ''}\n\nButtons: APPROVE · SKIP`} /></div>
+        <p style={{color:'#aaaab6',lineHeight:1.65}}>Put the approved template names into <code>WHATSAPP_REVENUE_TEMPLATE_NAME</code> and <code>WHATSAPP_APPROVAL_TEMPLATE_NAME</code>. Proactive bot alerts use templates so the system does not depend on an open customer-service chat window.</p>
+      </section>
+
+      <section className={styles.panel}>
+        <div className={styles.panelHead}><div><small>LIVE TEST</small><h2>Prove the control loop before money.</h2></div><span className={styles.badge}>NO EXECUTION</span></div>
+        <p style={{color:'#aaaab6',lineHeight:1.65}}>The approval test creates a 15-minute TEST action. Tap APPROVE or SKIP in WhatsApp; the webhook stores the decision but cannot execute any blockchain action.</p>
+        <div className={styles.actions}>
+          <button className={styles.primary} disabled={Boolean(busy) || !status?.ready} onClick={() => runTest('test-approval')}>{busy === 'test-approval' ? 'Sending…' : 'Send APPROVE / SKIP test'}</button>
+          <button className={styles.secondary} disabled={Boolean(busy) || !status?.ready} onClick={() => runTest('test-revenue')}>{busy === 'test-revenue' ? 'Sending…' : 'Send revenue alert test'}</button>
+          <button className={styles.secondary} disabled={Boolean(busy)} onClick={() => load(token)}>{busy === 'load' ? 'Checking…' : 'Check again'}</button>
+        </div>
+      </section>
+    </div>
+  </main>;
+}

--- a/app/api/admin/neural-core/whatsapp/route.ts
+++ b/app/api/admin/neural-core/whatsapp/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { requireNeuralCoreAdmin } from '../../../../../lib/neural-core-auth';
+import {
+  controlActionsReady,
+  createOrLoadControlAction,
+  updateControlActionDelivery,
+} from '../../../../../lib/voxelflip-control-actions';
+import {
+  sendApprovalWhatsApp,
+  sendRevenueStartedWhatsApp,
+  whatsappCloudReadiness,
+} from '../../../../../lib/whatsapp-cloud';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function json(data: any, status = 200) {
+  return NextResponse.json(data, { status, headers: { 'Cache-Control': 'no-store, private' } });
+}
+
+function setupPayload(request: Request, table: any) {
+  const readiness = whatsappCloudReadiness();
+  return {
+    ready: Boolean(table.ready && readiness.outboundReady && readiness.webhookReady && readiness.revenueTemplate && readiness.approvalTemplate),
+    database: { controlActions: table },
+    meta: readiness,
+    webhookUrl: new URL('/api/whatsapp/webhook', request.url).toString(),
+    secretsAreServerOnly: true,
+    automaticSigningActive: false,
+    executorActive: false,
+    templates: {
+      revenue: {
+        env: 'WHATSAPP_REVENUE_TEMPLATE_NAME',
+        body: 'VoxelFlip verified realized profit has started: {{1}} ETH. Open Neural Core for details.',
+        buttons: [],
+      },
+      approval: {
+        env: 'WHATSAPP_APPROVAL_TEMPLATE_NAME',
+        body: 'VoxelFlip proposal: {{1}}\nMaximum amount: {{2}} ETH\nRisk: {{3}}\nApprove or skip?',
+        buttons: ['APPROVE', 'SKIP'],
+      },
+    },
+    requiredEnv: [
+      'WHATSAPP_PHONE_NUMBER_ID',
+      'WHATSAPP_ACCESS_TOKEN',
+      'WHATSAPP_APP_SECRET',
+      'WHATSAPP_WEBHOOK_VERIFY_TOKEN',
+      'WHATSAPP_APPROVER_NUMBER',
+      'WHATSAPP_REVENUE_TEMPLATE_NAME',
+      'WHATSAPP_APPROVAL_TEMPLATE_NAME',
+    ],
+  };
+}
+
+export async function GET(request: Request) {
+  const auth = await requireNeuralCoreAdmin(request);
+  if ('error' in auth) return json({ error: auth.error, setupRequired: Boolean(auth.setupRequired) }, auth.status);
+  const table = await controlActionsReady(auth.admin);
+  return json(setupPayload(request, table));
+}
+
+export async function POST(request: Request) {
+  const auth = await requireNeuralCoreAdmin(request);
+  if ('error' in auth) return json({ error: auth.error, setupRequired: Boolean(auth.setupRequired) }, auth.status);
+  const table = await controlActionsReady(auth.admin);
+  if (!table.ready) return json({ error: 'WhatsApp control storage is not active. Apply migration 013 first.', ...setupPayload(request, table) }, 503);
+
+  const body = await request.json().catch(() => ({}));
+  const action = String(body?.action || '').trim();
+
+  if (action === 'test-revenue') {
+    try {
+      const sent = await sendRevenueStartedWhatsApp(0.001);
+      return json({ ok: true, messageId: sent.messageId, notice: 'Test revenue template sent. No financial action was created.' });
+    } catch (error) {
+      return json({ error: error instanceof Error ? error.message : 'WhatsApp test alert failed.' }, 503);
+    }
+  }
+
+  if (action === 'test-approval') {
+    try {
+      const created = await createOrLoadControlAction({
+        idempotencyKey: `whatsapp-test:${auth.user.id}:${Date.now()}`,
+        actionType: 'test',
+        payload: { test: true, executionLocked: true },
+        expiresInMinutes: 15,
+      }, auth.admin);
+      const sent = await sendApprovalWhatsApp({
+        actionId: created.action.id,
+        actionLabel: 'TEST CONTROL — no trade',
+        limitEth: 0,
+        riskLabel: 'TEST ONLY',
+      });
+      const stored = await updateControlActionDelivery({ id: created.action.id, status: 'pending', messageId: sent.messageId }, auth.admin);
+      return json({
+        ok: true,
+        actionId: stored.id,
+        status: stored.status,
+        messageId: sent.messageId,
+        notice: 'Tap APPROVE or SKIP in WhatsApp. The test can never execute a blockchain action.',
+      });
+    } catch (error) {
+      return json({ error: error instanceof Error ? error.message : 'WhatsApp approval test failed.' }, 503);
+    }
+  }
+
+  return json({ error: 'Unsupported WhatsApp setup action.' }, 400);
+}

--- a/app/api/admin/neural-core/whatsapp/route.ts
+++ b/app/api/admin/neural-core/whatsapp/route.ts
@@ -31,7 +31,7 @@ function setupPayload(request: Request, table: any) {
     templates: {
       revenue: {
         env: 'WHATSAPP_REVENUE_TEMPLATE_NAME',
-        body: 'VoxelFlip verified realized profit has started: {{1}} ETH. Open Neural Core for details.',
+        body: 'VoxelFlip verified revenue has started: {{1}} ETH. Open Neural Core for cost and profit details.',
         buttons: [],
       },
       approval: {

--- a/app/api/cron/neural-core/route.ts
+++ b/app/api/cron/neural-core/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { readNeuralCoreWallet, refreshNeuralCore } from '../../../../lib/voxelflip-neural-core';
+import {
+  controlActionsReady,
+  createOrLoadControlAction,
+  updateControlActionDelivery,
+} from '../../../../lib/voxelflip-control-actions';
+import {
+  sendApprovalWhatsApp,
+  sendRevenueStartedWhatsApp,
+  whatsappCloudReadiness,
+} from '../../../../lib/whatsapp-cloud';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -12,6 +22,84 @@ function authorized(request: Request) {
   return request.headers.get('authorization') === `Bearer ${secret}`;
 }
 
+function positive(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function maybeSendWhatsAppControl(admin: any, wallet: string, core: any) {
+  const table = await controlActionsReady(admin);
+  const meta = whatsappCloudReadiness();
+  const profit = Number(core?.ledger?.realizedProfitEth);
+  if (!table.ready || !meta.outboundReady || !Number.isFinite(profit) || profit <= 0) {
+    return { ready: false, sent: false, reason: !table.ready ? 'control-storage' : !meta.outboundReady ? 'whatsapp-config' : 'no-realized-profit' };
+  }
+
+  const minimumProfit = positive(process.env.VOXELFLIP_FACTORY_MIN_REALIZED_PROFIT_ETH, 0.003);
+  const reinvestPercent = Math.min(40, positive(process.env.VOXELFLIP_FACTORY_REINVEST_PERCENT, 25));
+  const maxReinvest = positive(process.env.VOXELFLIP_FACTORY_MAX_REINVEST_ETH, 0.01);
+  const costCoverageComplete = Boolean(core?.ledger?.costCoverageComplete);
+
+  if (costCoverageComplete && profit >= minimumProfit && meta.approvalTemplate) {
+    const proposed = Math.min(maxReinvest, profit * reinvestPercent / 100);
+    const profitBucket = Math.floor(profit * 1_000_000);
+    const created = await createOrLoadControlAction({
+      idempotencyKey: `reinvest:${wallet.toLowerCase()}:${profitBucket}`,
+      wallet,
+      actionType: 'reinvest',
+      payload: {
+        realizedProfitEth: profit,
+        proposedReinvestEth: proposed,
+        reinvestPercent,
+        reservePercent: 100 - reinvestPercent,
+        costCoverageComplete: true,
+        executionLocked: true,
+        source: 'neural-core-cron',
+      },
+      expiresInMinutes: 60,
+    }, admin);
+
+    const current = created.action;
+    if (['approved', 'skipped', 'expired', 'executed', 'notified'].includes(current.status)) {
+      return { ready: true, sent: false, kind: 'approval', status: current.status, actionId: current.id };
+    }
+    if (current.status === 'pending' && current.whatsapp_message_id) {
+      return { ready: true, sent: false, kind: 'approval', status: 'pending', actionId: current.id };
+    }
+    try {
+      const sent = await sendApprovalWhatsApp({
+        actionId: current.id,
+        actionLabel: `Reinvest verified VoxelFlip profit (${reinvestPercent}% max)`,
+        limitEth: proposed,
+        riskLabel: 'BOUNDED · EXECUTOR STILL LOCKED',
+      });
+      await updateControlActionDelivery({ id: current.id, status: 'pending', messageId: sent.messageId }, admin);
+      return { ready: true, sent: true, kind: 'approval', status: 'pending', actionId: current.id };
+    } catch (error) {
+      await updateControlActionDelivery({ id: current.id, status: 'failed', error: error instanceof Error ? error.message : 'WhatsApp delivery failed' }, admin).catch(() => null);
+      return { ready: true, sent: false, kind: 'approval', status: 'failed', error: error instanceof Error ? error.message : 'WhatsApp delivery failed' };
+    }
+  }
+
+  if (!meta.revenueTemplate) return { ready: false, sent: false, reason: 'revenue-template' };
+  const created = await createOrLoadControlAction({
+    idempotencyKey: `revenue-started:${wallet.toLowerCase()}`,
+    wallet,
+    actionType: 'revenue_notice',
+    payload: { realizedProfitEth: profit, costCoverageComplete, source: 'neural-core-cron' },
+    expiresInMinutes: null,
+  }, admin);
+  if (created.action.status === 'notified') return { ready: true, sent: false, kind: 'revenue', status: 'notified' };
+  try {
+    const sent = await sendRevenueStartedWhatsApp(profit);
+    await updateControlActionDelivery({ id: created.action.id, status: 'notified', messageId: sent.messageId }, admin);
+    return { ready: true, sent: true, kind: 'revenue', status: 'notified' };
+  } catch (error) {
+    await updateControlActionDelivery({ id: created.action.id, status: 'failed', error: error instanceof Error ? error.message : 'WhatsApp delivery failed' }, admin).catch(() => null);
+    return { ready: true, sent: false, kind: 'revenue', status: 'failed', error: error instanceof Error ? error.message : 'WhatsApp delivery failed' };
+  }
+}
+
 export async function GET(request: Request) {
   if (!authorized(request)) return NextResponse.json({ error: 'Neural Core cron is not authorized.' }, { status: 401 });
   try {
@@ -19,6 +107,9 @@ export async function GET(request: Request) {
     const wallet = await readNeuralCoreWallet(admin);
     if (!wallet) return NextResponse.json({ ok: true, skipped: true, reason: 'No Neural Core wallet has been configured yet.' }, { headers: { 'Cache-Control': 'no-store' } });
     const core = await refreshNeuralCore({ wallet, persist: true });
+    let whatsapp: any = { ready: false, sent: false, reason: 'not-checked' };
+    try { whatsapp = await maybeSendWhatsAppControl(admin, wallet, core); }
+    catch (error) { whatsapp = { ready: false, sent: false, reason: 'safe-failure', error: error instanceof Error ? error.message : 'WhatsApp control failed' }; }
     return NextResponse.json({
       ok: true,
       checkedAt: core.checkedAt,
@@ -27,7 +118,9 @@ export async function GET(request: Request) {
       snapshotStored: core.memory.snapshotStored,
       recommendationStored: core.memory.recommendationStored,
       recommendation: core.recommendation,
+      whatsapp,
       automaticSigningActive: false,
+      executorActive: false,
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Neural Core cron failed', error);

--- a/app/api/cron/neural-core/route.ts
+++ b/app/api/cron/neural-core/route.ts
@@ -30,9 +30,10 @@ function positive(value: string | undefined, fallback: number) {
 async function maybeSendWhatsAppControl(admin: any, wallet: string, core: any) {
   const table = await controlActionsReady(admin);
   const meta = whatsappCloudReadiness();
+  const verifiedRevenue = Number(core?.ledger?.verifiedIncomeEth);
   const profit = Number(core?.ledger?.realizedProfitEth);
-  if (!table.ready || !meta.outboundReady || !Number.isFinite(profit) || profit <= 0) {
-    return { ready: false, sent: false, reason: !table.ready ? 'control-storage' : !meta.outboundReady ? 'whatsapp-config' : 'no-realized-profit' };
+  if (!table.ready || !meta.outboundReady || !Number.isFinite(verifiedRevenue) || verifiedRevenue <= 0) {
+    return { ready: false, sent: false, reason: !table.ready ? 'control-storage' : !meta.outboundReady ? 'whatsapp-config' : 'no-verified-revenue' };
   }
 
   const minimumProfit = positive(process.env.VOXELFLIP_FACTORY_MIN_REALIZED_PROFIT_ETH, 0.003);
@@ -40,7 +41,7 @@ async function maybeSendWhatsAppControl(admin: any, wallet: string, core: any) {
   const maxReinvest = positive(process.env.VOXELFLIP_FACTORY_MAX_REINVEST_ETH, 0.01);
   const costCoverageComplete = Boolean(core?.ledger?.costCoverageComplete);
 
-  if (costCoverageComplete && profit >= minimumProfit && meta.approvalTemplate) {
+  if (costCoverageComplete && Number.isFinite(profit) && profit >= minimumProfit && meta.approvalTemplate) {
     const proposed = Math.min(maxReinvest, profit * reinvestPercent / 100);
     const profitBucket = Math.floor(profit * 1_000_000);
     const created = await createOrLoadControlAction({
@@ -48,6 +49,7 @@ async function maybeSendWhatsAppControl(admin: any, wallet: string, core: any) {
       wallet,
       actionType: 'reinvest',
       payload: {
+        verifiedRevenueEth: verifiedRevenue,
         realizedProfitEth: profit,
         proposedReinvestEth: proposed,
         reinvestPercent,
@@ -86,12 +88,12 @@ async function maybeSendWhatsAppControl(admin: any, wallet: string, core: any) {
     idempotencyKey: `revenue-started:${wallet.toLowerCase()}`,
     wallet,
     actionType: 'revenue_notice',
-    payload: { realizedProfitEth: profit, costCoverageComplete, source: 'neural-core-cron' },
+    payload: { verifiedRevenueEth: verifiedRevenue, realizedProfitEth: Number.isFinite(profit) ? profit : null, costCoverageComplete, source: 'neural-core-cron' },
     expiresInMinutes: null,
   }, admin);
   if (created.action.status === 'notified') return { ready: true, sent: false, kind: 'revenue', status: 'notified' };
   try {
-    const sent = await sendRevenueStartedWhatsApp(profit);
+    const sent = await sendRevenueStartedWhatsApp(verifiedRevenue);
     await updateControlActionDelivery({ id: created.action.id, status: 'notified', messageId: sent.messageId }, admin);
     return { ready: true, sent: true, kind: 'revenue', status: 'notified' };
   } catch (error) {

--- a/app/api/whatsapp/webhook/route.ts
+++ b/app/api/whatsapp/webhook/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { decideControlAction } from '../../../../lib/voxelflip-control-actions';
+import {
+  sendWhatsAppText,
+  whatsappCloudConfig,
+  whatsappSenderAuthorized,
+  whatsappWebhookSignatureValid,
+} from '../../../../lib/whatsapp-cloud';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CONTROL_RE = /^(approve|skip):([0-9a-fA-F-]{36})$/;
+
+function ok(data: any = { ok: true }) {
+  return NextResponse.json(data, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const mode = url.searchParams.get('hub.mode') || '';
+  const token = url.searchParams.get('hub.verify_token') || '';
+  const challenge = url.searchParams.get('hub.challenge') || '';
+  const configured = whatsappCloudConfig().verifyToken;
+  if (mode === 'subscribe' && configured && token === configured && challenge) {
+    return new Response(challenge, { status: 200, headers: { 'content-type': 'text/plain', 'Cache-Control': 'no-store' } });
+  }
+  return new Response('Forbidden', { status: 403 });
+}
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  if (!whatsappWebhookSignatureValid(rawBody, request.headers.get('x-hub-signature-256'))) {
+    return new Response('Invalid signature', { status: 401 });
+  }
+
+  let body: any = null;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return new Response('Bad request', { status: 400 });
+  }
+
+  const message = body?.entry?.[0]?.changes?.[0]?.value?.messages?.[0];
+  if (!message) return ok({ ok: true, ignored: 'no-user-message' });
+
+  const sender = String(message?.from || '');
+  if (!whatsappSenderAuthorized(sender)) {
+    console.warn('Ignored WhatsApp control from an unauthorized sender.');
+    return ok({ ok: true, ignored: 'unauthorized-sender' });
+  }
+
+  const payload = String(
+    message?.interactive?.button_reply?.id ||
+    message?.button?.payload ||
+    ''
+  ).trim();
+  const match = payload.match(CONTROL_RE);
+  if (!match) return ok({ ok: true, ignored: 'not-a-control-reply' });
+
+  const decision = match[1] as 'approve' | 'skip';
+  const id = match[2];
+  try {
+    const result = await decideControlAction({ id, decision, responderPhone: sender });
+    let reply = '';
+    if (result.accepted && decision === 'approve') {
+      reply = '✅ APPROVED\nThe proposal is queued as approved. This WhatsApp tap is not a blockchain signature and cannot spend ETH by itself. The bounded executor is still required before execution.';
+    } else if (result.accepted) {
+      reply = '⏭️ SKIPPED\nThe proposal was rejected and will not be executed.';
+    } else if (result.reason === 'expired') {
+      reply = '⌛ EXPIRED\nThat proposal expired. Neural Core will create a fresh proposal if the conditions are still valid.';
+    } else {
+      reply = `ℹ️ NO CHANGE\nThat proposal is ${String(result.action?.status || result.reason || 'not available')}.`;
+    }
+    try { await sendWhatsAppText(sender, reply); } catch (error) { console.error('WhatsApp control acknowledgement failed', error); }
+    return ok({ ok: true, accepted: result.accepted, decision, status: result.action?.status || null });
+  } catch (error) {
+    console.error('WhatsApp control decision failed', error);
+    try { await sendWhatsAppText(sender, '⚠️ CONTROL ERROR\nYour tap was received, but the approval could not be stored safely. Nothing was executed.'); } catch {}
+    return ok({ ok: false, safeFailure: true });
+  }
+}

--- a/lib/voxelflip-control-actions.ts
+++ b/lib/voxelflip-control-actions.ts
@@ -1,0 +1,144 @@
+import { createHash } from 'node:crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseAdmin } from './supabase-admin';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const ACTIONS = new Set(['revenue_notice', 'reinvest', 'list', 'buy', 'mint', 'test']);
+
+export type VoxelFlipControlAction = {
+  id: string;
+  idempotency_key: string;
+  wallet?: string | null;
+  action_type: string;
+  status: string;
+  payload: Record<string, any>;
+  whatsapp_message_id?: string | null;
+  expires_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export function normalizeControlPhone(value: string | undefined | null) {
+  return String(value || '').replace(/\D/g, '');
+}
+
+export function controlPhoneHash(value: string) {
+  return createHash('sha256').update(normalizeControlPhone(value)).digest('hex');
+}
+
+export async function controlActionsReady(admin: SupabaseClient = getSupabaseAdmin()) {
+  try {
+    const { error } = await admin.from('voxelflip_control_actions').select('id', { head: true, count: 'exact' });
+    return { ready: !error, error: error?.message || '' };
+  } catch (error) {
+    return { ready: false, error: error instanceof Error ? error.message : 'control table unavailable' };
+  }
+}
+
+export async function getControlAction(id: string, admin: SupabaseClient = getSupabaseAdmin()) {
+  const { data, error } = await admin
+    .from('voxelflip_control_actions')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw new Error(`VoxelFlip control action could not be loaded: ${error.message}`);
+  return data as VoxelFlipControlAction | null;
+}
+
+export async function createOrLoadControlAction(input: {
+  idempotencyKey: string;
+  wallet?: string | null;
+  actionType: string;
+  payload?: Record<string, any>;
+  expiresInMinutes?: number | null;
+}, admin: SupabaseClient = getSupabaseAdmin()) {
+  if (!input.idempotencyKey.trim()) throw new Error('Control action idempotency key is required.');
+  if (!ACTIONS.has(input.actionType)) throw new Error('Unsupported VoxelFlip control action.');
+  const wallet = String(input.wallet || '').trim().toLowerCase();
+  if (wallet && !ADDRESS_RE.test(wallet)) throw new Error('Control action wallet is invalid.');
+  const expiresInMinutes = input.expiresInMinutes == null ? null : Math.max(1, Math.min(24 * 60, Math.floor(input.expiresInMinutes)));
+  const expiresAt = expiresInMinutes ? new Date(Date.now() + expiresInMinutes * 60_000).toISOString() : null;
+  const row = {
+    idempotency_key: input.idempotencyKey.trim(),
+    wallet: wallet || null,
+    action_type: input.actionType,
+    status: 'pending',
+    payload: input.payload || {},
+    expires_at: expiresAt,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await admin.from('voxelflip_control_actions').insert(row).select('*').single();
+  if (!error && data) return { created: true, action: data as VoxelFlipControlAction };
+  if ((error as any)?.code !== '23505') throw new Error(`VoxelFlip control action could not be created: ${error?.message || 'unknown database error'}`);
+  const { data: existing, error: existingError } = await admin
+    .from('voxelflip_control_actions')
+    .select('*')
+    .eq('idempotency_key', input.idempotencyKey.trim())
+    .maybeSingle();
+  if (existingError || !existing) throw new Error(`VoxelFlip control action could not be recovered: ${existingError?.message || 'missing action'}`);
+  return { created: false, action: existing as VoxelFlipControlAction };
+}
+
+export async function updateControlActionDelivery(input: {
+  id: string;
+  status: 'pending' | 'notified' | 'failed';
+  messageId?: string | null;
+  error?: string;
+}, admin: SupabaseClient = getSupabaseAdmin()) {
+  const current = await getControlAction(input.id, admin);
+  if (!current) throw new Error('VoxelFlip control action no longer exists.');
+  const payload = { ...(current.payload || {}) };
+  if (input.error) payload.lastDeliveryError = input.error.slice(0, 500);
+  else delete payload.lastDeliveryError;
+  const { data, error } = await admin
+    .from('voxelflip_control_actions')
+    .update({
+      status: input.status,
+      payload,
+      whatsapp_message_id: input.messageId || current.whatsapp_message_id || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', input.id)
+    .select('*')
+    .single();
+  if (error) throw new Error(`VoxelFlip control delivery could not be updated: ${error.message}`);
+  return data as VoxelFlipControlAction;
+}
+
+export async function decideControlAction(input: {
+  id: string;
+  decision: 'approve' | 'skip';
+  responderPhone: string;
+}, admin: SupabaseClient = getSupabaseAdmin()) {
+  const current = await getControlAction(input.id, admin);
+  if (!current) return { accepted: false, reason: 'unknown', action: null };
+  if (current.status !== 'pending') return { accepted: false, reason: `already-${current.status}`, action: current };
+  if (current.expires_at && Date.parse(current.expires_at) <= Date.now()) {
+    const { data } = await admin
+      .from('voxelflip_control_actions')
+      .update({ status: 'expired', updated_at: new Date().toISOString() })
+      .eq('id', current.id)
+      .eq('status', 'pending')
+      .select('*')
+      .maybeSingle();
+    return { accepted: false, reason: 'expired', action: (data || current) as VoxelFlipControlAction };
+  }
+  const status = input.decision === 'approve' ? 'approved' : 'skipped';
+  const now = new Date().toISOString();
+  const { data, error } = await admin
+    .from('voxelflip_control_actions')
+    .update({
+      status,
+      responder_hash: controlPhoneHash(input.responderPhone),
+      approved_via: 'whatsapp',
+      responded_at: now,
+      updated_at: now,
+    })
+    .eq('id', current.id)
+    .eq('status', 'pending')
+    .select('*')
+    .maybeSingle();
+  if (error) throw new Error(`VoxelFlip control decision could not be saved: ${error.message}`);
+  if (!data) return { accepted: false, reason: 'race-lost', action: await getControlAction(current.id, admin) };
+  return { accepted: true, reason: status, action: data as VoxelFlipControlAction };
+}

--- a/lib/whatsapp-cloud.ts
+++ b/lib/whatsapp-cloud.ts
@@ -1,0 +1,155 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { normalizeControlPhone } from './voxelflip-control-actions';
+
+const HTTP_TIMEOUT_MS = 10_000;
+
+export function whatsappCloudConfig() {
+  return {
+    graphVersion: String(process.env.WHATSAPP_GRAPH_API_VERSION || 'v26.0').trim(),
+    phoneNumberId: String(process.env.WHATSAPP_PHONE_NUMBER_ID || '').trim(),
+    accessToken: String(process.env.WHATSAPP_ACCESS_TOKEN || '').trim(),
+    appSecret: String(process.env.WHATSAPP_APP_SECRET || '').trim(),
+    verifyToken: String(process.env.WHATSAPP_WEBHOOK_VERIFY_TOKEN || '').trim(),
+    approverNumber: normalizeControlPhone(process.env.WHATSAPP_APPROVER_NUMBER),
+    revenueTemplate: String(process.env.WHATSAPP_REVENUE_TEMPLATE_NAME || '').trim(),
+    approvalTemplate: String(process.env.WHATSAPP_APPROVAL_TEMPLATE_NAME || '').trim(),
+    language: String(process.env.WHATSAPP_TEMPLATE_LANGUAGE || 'en_US').trim() || 'en_US',
+  };
+}
+
+export function whatsappCloudReadiness() {
+  const config = whatsappCloudConfig();
+  return {
+    graphVersion: config.graphVersion,
+    phoneNumberId: Boolean(config.phoneNumberId),
+    accessToken: Boolean(config.accessToken),
+    appSecret: Boolean(config.appSecret),
+    verifyToken: Boolean(config.verifyToken),
+    approverNumber: Boolean(config.approverNumber),
+    revenueTemplate: Boolean(config.revenueTemplate),
+    approvalTemplate: Boolean(config.approvalTemplate),
+    outboundReady: Boolean(config.phoneNumberId && config.accessToken && config.approverNumber),
+    webhookReady: Boolean(config.appSecret && config.verifyToken && config.approverNumber),
+  };
+}
+
+export function whatsappWebhookSignatureValid(rawBody: string, header: string | null) {
+  const { appSecret } = whatsappCloudConfig();
+  if (!appSecret || !header?.startsWith('sha256=')) return false;
+  const expected = createHmac('sha256', appSecret).update(rawBody).digest('hex');
+  const provided = header.slice('sha256='.length).trim().toLowerCase();
+  if (!/^[a-f0-9]{64}$/.test(provided)) return false;
+  const a = Buffer.from(expected, 'hex');
+  const b = Buffer.from(provided, 'hex');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export function whatsappSenderAuthorized(sender: string) {
+  const configured = whatsappCloudConfig().approverNumber;
+  const actual = normalizeControlPhone(sender);
+  return Boolean(configured && actual && configured === actual);
+}
+
+async function postMessage(body: any) {
+  const config = whatsappCloudConfig();
+  if (!config.phoneNumberId || !config.accessToken) throw new Error('WhatsApp Cloud API sender credentials are not configured.');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+  try {
+    const response = await fetch(`https://graph.facebook.com/${config.graphVersion}/${config.phoneNumberId}/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${config.accessToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(String(payload?.error?.message || payload?.error || `WhatsApp Cloud API ${response.status}`));
+    return {
+      messageId: String(payload?.messages?.[0]?.id || ''),
+      payload,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') throw new Error('WhatsApp Cloud API request timed out.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function sendWhatsAppTemplate(input: {
+  to?: string;
+  name: string;
+  bodyParameters?: string[];
+  quickReplyPayloads?: string[];
+}) {
+  const config = whatsappCloudConfig();
+  const to = normalizeControlPhone(input.to || config.approverNumber);
+  if (!to) throw new Error('WhatsApp approver number is not configured.');
+  if (!input.name.trim()) throw new Error('WhatsApp template name is not configured.');
+  const components: any[] = [];
+  if (input.bodyParameters?.length) {
+    components.push({
+      type: 'body',
+      parameters: input.bodyParameters.map(text => ({ type: 'text', text: String(text).slice(0, 1000) })),
+    });
+  }
+  for (const [index, payload] of (input.quickReplyPayloads || []).entries()) {
+    components.push({
+      type: 'button',
+      sub_type: 'quick_reply',
+      index: String(index),
+      parameters: [{ type: 'payload', payload: String(payload).slice(0, 256) }],
+    });
+  }
+  return postMessage({
+    messaging_product: 'whatsapp',
+    recipient_type: 'individual',
+    to,
+    type: 'template',
+    template: {
+      name: input.name.trim(),
+      language: { code: config.language },
+      ...(components.length ? { components } : {}),
+    },
+  });
+}
+
+export async function sendWhatsAppText(to: string, text: string) {
+  const recipient = normalizeControlPhone(to);
+  if (!recipient) throw new Error('WhatsApp recipient is invalid.');
+  return postMessage({
+    messaging_product: 'whatsapp',
+    recipient_type: 'individual',
+    to: recipient,
+    type: 'text',
+    text: { body: String(text).slice(0, 4000), preview_url: false },
+  });
+}
+
+export async function sendRevenueStartedWhatsApp(realizedProfitEth: number) {
+  const config = whatsappCloudConfig();
+  if (!config.revenueTemplate) throw new Error('WHATSAPP_REVENUE_TEMPLATE_NAME is not configured.');
+  return sendWhatsAppTemplate({
+    name: config.revenueTemplate,
+    bodyParameters: [Number(realizedProfitEth).toFixed(6)],
+  });
+}
+
+export async function sendApprovalWhatsApp(input: {
+  actionId: string;
+  actionLabel: string;
+  limitEth: number;
+  riskLabel?: string;
+}) {
+  const config = whatsappCloudConfig();
+  if (!config.approvalTemplate) throw new Error('WHATSAPP_APPROVAL_TEMPLATE_NAME is not configured.');
+  return sendWhatsAppTemplate({
+    name: config.approvalTemplate,
+    bodyParameters: [input.actionLabel.slice(0, 100), Number(input.limitEth).toFixed(6), String(input.riskLabel || 'CONTROLLED').slice(0, 100)],
+    quickReplyPayloads: [`approve:${input.actionId}`, `skip:${input.actionId}`],
+  });
+}

--- a/scripts/test-route-integrity.mjs
+++ b/scripts/test-route-integrity.mjs
@@ -38,13 +38,19 @@ for(const required of [
  'app/admin/neural-core/page.js',
  'app/admin/neural-core/list/page.js',
  'app/admin/neural-core/setup/page.js',
+ 'app/admin/neural-core/whatsapp/page.js',
  'app/api/voxelflip/trader/route.ts',
  'app/api/voxelflip/factory/route.ts',
  'app/api/admin/neural-core/route.ts',
  'app/api/admin/neural-core/listing-actions/route.ts',
  'app/api/admin/neural-core/setup/route.ts',
+ 'app/api/admin/neural-core/whatsapp/route.ts',
+ 'app/api/whatsapp/webhook/route.ts',
  'app/api/cron/neural-core/route.ts',
  'app/api/creator-pack/nft/confirm/route.ts',
+ 'lib/whatsapp-cloud.ts',
+ 'lib/voxelflip-control-actions.ts',
+ 'supabase/migrations/013_voxelflip_whatsapp_control.sql',
 ]){
  if(!fs.existsSync(path.join(root,required)))failures.push(`Missing critical VoxelPop/VoxelFlip route: ${required}`);
 }
@@ -57,10 +63,16 @@ const criticalSources=[
  'app/admin/neural-core/page.js',
  'app/admin/neural-core/list/page.js',
  'app/admin/neural-core/setup/page.js',
+ 'app/admin/neural-core/whatsapp/page.js',
  'app/api/admin/neural-core/route.ts',
  'app/api/admin/neural-core/listing-actions/route.ts',
  'app/api/admin/neural-core/setup/route.ts',
+ 'app/api/admin/neural-core/whatsapp/route.ts',
+ 'app/api/whatsapp/webhook/route.ts',
+ 'app/api/cron/neural-core/route.ts',
  'lib/voxelflip-neural-core.ts',
+ 'lib/whatsapp-cloud.ts',
+ 'lib/voxelflip-control-actions.ts',
 ];
 for(const rel of criticalSources){
  const text=fs.readFileSync(path.join(root,rel),'utf8');
@@ -78,6 +90,18 @@ if(!listingApi.includes('6352211e'))failures.push('Listing Assistant must verify
 const setupApi=fs.readFileSync(path.join(root,'app/api/admin/neural-core/setup/route.ts'),'utf8');
 if(!setupApi.includes('requireNeuralCoreAdmin'))failures.push('Neural Core setup status is missing server-side admin authentication.');
 if(!setupApi.includes('voxelflip_profit_ledger')||!setupApi.includes('voxelflip_neural_memory'))failures.push('Neural Core setup must verify both private database tables.');
+const whatsappAdminApi=fs.readFileSync(path.join(root,'app/api/admin/neural-core/whatsapp/route.ts'),'utf8');
+if(!whatsappAdminApi.includes('requireNeuralCoreAdmin'))failures.push('WhatsApp control setup API is missing server-side admin authentication.');
+const whatsappWebhook=fs.readFileSync(path.join(root,'app/api/whatsapp/webhook/route.ts'),'utf8');
+if(!whatsappWebhook.includes('whatsappWebhookSignatureValid'))failures.push('WhatsApp webhook must verify Meta x-hub-signature-256 before processing controls.');
+if(!whatsappWebhook.includes('whatsappSenderAuthorized'))failures.push('WhatsApp webhook must restrict controls to the configured approver phone.');
+if(!whatsappWebhook.includes('decideControlAction'))failures.push('WhatsApp webhook must use single-use stored control decisions.');
+if(/eth_sendTransaction|eth_signTypedData|personal_sign|signTypedData\s*\(/.test(whatsappWebhook))failures.push('WhatsApp webhook may not sign or broadcast blockchain actions.');
+const whatsappLib=fs.readFileSync(path.join(root,'lib/whatsapp-cloud.ts'),'utf8');
+if(!whatsappLib.includes('WHATSAPP_APPROVER_NUMBER'))failures.push('WhatsApp approver number must come from server environment configuration.');
+if(/7163593694/.test(whatsappLib)||/7163593694/.test(whatsappWebhook))failures.push('A personal phone number was hardcoded into the public repository.');
+const controlMigration=fs.readFileSync(path.join(root,'supabase/migrations/013_voxelflip_whatsapp_control.sql'),'utf8');
+if(!controlMigration.includes('revoke all on table public.voxelflip_control_actions from anon, authenticated'))failures.push('WhatsApp control actions must remain server-only.');
 const listingPage=fs.readFileSync(path.join(root,'app/admin/neural-core/list/page.js'),'utf8');
 if(/eth_sendTransaction|eth_signTypedData|personal_sign|signTypedData\s*\(/.test(listingPage))failures.push('Listing Assistant may not sign or broadcast wallet actions until the live OpenSea action parser is separately verified.');
 const adminAuth=fs.readFileSync(path.join(root,'lib/neural-core-auth.ts'),'utf8');
@@ -96,4 +120,4 @@ if(failures.length){
  for(const failure of failures)console.error(`- ${failure}`);
  process.exit(1);
 }
-console.log('Route integrity passed: no duplicate route handlers, critical VoxelFlip/Neural Core routes exist, admin auth, ownership and database readiness checks are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');
+console.log('Route integrity passed: no duplicate route handlers, critical VoxelFlip/Neural Core/WhatsApp routes exist, admin auth, ownership, webhook signatures and private database controls are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');

--- a/supabase/migrations/013_voxelflip_whatsapp_control.sql
+++ b/supabase/migrations/013_voxelflip_whatsapp_control.sql
@@ -1,0 +1,30 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.voxelflip_control_actions (
+  id uuid primary key default gen_random_uuid(),
+  idempotency_key text not null unique,
+  wallet text check (wallet is null or wallet ~* '^0x[0-9a-f]{40}$'),
+  action_type text not null check (action_type in ('revenue_notice','reinvest','list','buy','mint','test')),
+  status text not null default 'pending' check (status in ('pending','approved','skipped','expired','notified','executed','failed')),
+  payload jsonb not null default '{}'::jsonb,
+  whatsapp_message_id text,
+  responder_hash text,
+  approved_via text,
+  expires_at timestamptz,
+  responded_at timestamptz,
+  executed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists voxelflip_control_actions_status_time_idx
+  on public.voxelflip_control_actions (status, created_at desc);
+create index if not exists voxelflip_control_actions_wallet_time_idx
+  on public.voxelflip_control_actions (lower(wallet), created_at desc);
+
+alter table public.voxelflip_control_actions enable row level security;
+revoke all on table public.voxelflip_control_actions from anon, authenticated;
+grant select, insert, update on table public.voxelflip_control_actions to service_role;
+
+comment on table public.voxelflip_control_actions is
+  'Server-only, single-use control approvals for VoxelFlip. WhatsApp approval records intent only; it is never a blockchain signature and cannot bypass bounded executor rules.';


### PR DESCRIPTION
Adds a direct Meta WhatsApp Cloud API control surface for Neural Core with no Twilio dependency.

- Private `/admin/neural-core/whatsapp` setup/status/test page.
- Meta webhook verification (`hub.challenge`) plus `x-hub-signature-256` HMAC validation for POSTs.
- Only the configured `WHATSAPP_APPROVER_NUMBER` can approve or skip proposals.
- Migration 013 adds server-only, single-use, expiring control actions; browser roles have no access.
- Neural Core cron sends a first verified-revenue notification and, only after complete cost coverage + the Factory profit threshold, a bounded reinvestment proposal.
- Approved WhatsApp actions are queued intent only: no blockchain signature, buy, list, mint, spend, or transfer is executed.
- Adds direct Meta template support for proactive alerts and APPROVE/SKIP quick replies.
- Route integrity fails builds if webhook signature/sender controls disappear, a personal phone is hardcoded, or WhatsApp routes gain blockchain signing calls.

Activation still requires Meta Cloud API server environment variables, approved WhatsApp templates, and one-time migration 013. Secrets and the user's phone number are intentionally not committed to GitHub.