### PR TITLE
Pin VoxelFlip production deployment source of truth

### DIFF
--- a/lib/voxelflip-deployment.ts
+++ b/lib/voxelflip-deployment.ts
@@ -6,6 +6,14 @@ const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 const TX_RE = /^0x[a-fA-F0-9]{64}$/;
 const APPROVED_OWNER = '0x02f93c7547309ca50EEAB446DaEBE8ce8E694cBb';
 
+/**
+ * Production VoxelFlip is deliberately pinned here.
+ *
+ * A mutable Supabase object or a stale Vercel environment variable must never
+ * be able to switch the contract used for mint verification, market actions,
+ * or Neural Core. A future production contract change therefore requires a
+ * reviewed code deployment that updates this record.
+ */
 const VERIFIED_PRODUCTION_FALLBACK: VoxelFlipDeployment = {
   address: '0xa00758b05f96ef4409d97c3ffebb6794b2eafbde',
   chainId: 8453,
@@ -32,37 +40,118 @@ export type VoxelFlipDeployment = {
   registeredAt: string;
 };
 
-let memoryCache: { value: VoxelFlipDeployment | null; expiresAt: number } | null = null;
+let memoryCache: { value: VoxelFlipDeployment; expiresAt: number } | null = null;
+let warnedAboutStoredConflict = false;
+let warnedAboutEnvConflict = false;
+
+function normalizeAddress(value: unknown) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeTx(value: unknown) {
+  return String(value || '').trim().toLowerCase();
+}
 
 function validDeployment(value: any): value is VoxelFlipDeployment {
-  return Boolean(value && ADDRESS_RE.test(String(value.address || '')) && Number(value.chainId) === 8453 && ADDRESS_RE.test(String(value.owner || '')) && ADDRESS_RE.test(String(value.mintSigner || '')) && ADDRESS_RE.test(String(value.royaltyReceiver || '')) && Number.isInteger(Number(value.royaltyBps)) && Number(value.royaltyBps) >= 0 && Number(value.royaltyBps) <= 1000 && TX_RE.test(String(value.deploymentTxHash || '')));
+  return Boolean(
+    value
+    && ADDRESS_RE.test(String(value.address || ''))
+    && Number(value.chainId) === 8453
+    && ADDRESS_RE.test(String(value.owner || ''))
+    && ADDRESS_RE.test(String(value.mintSigner || ''))
+    && ADDRESS_RE.test(String(value.royaltyReceiver || ''))
+    && Number.isInteger(Number(value.royaltyBps))
+    && Number(value.royaltyBps) >= 0
+    && Number(value.royaltyBps) <= 1000
+    && TX_RE.test(String(value.deploymentTxHash || ''))
+  );
 }
 
-function envFallback(): VoxelFlipDeployment | null {
-  const address = (process.env.NEXT_PUBLIC_VOXELFLIP_NFT_ADDRESS || process.env.VOXELFLIP_NFT_ADDRESS || '').trim();
-  if (!ADDRESS_RE.test(address)) return null;
-  const owner = (process.env.MULTISIG_OWNER || APPROVED_OWNER).trim();
-  const royaltyReceiver = (process.env.VOXELFLIP_ROYALTY_RECEIVER || owner).trim();
-  const mintSigner = (process.env.VOXELFLIP_MINT_SIGNER_ADDRESS || owner).trim();
-  if (![owner, royaltyReceiver, mintSigner].every((value) => ADDRESS_RE.test(value))) return null;
-  return { address, chainId: 8453, network: 'base', owner, mintSigner, royaltyReceiver, royaltyBps: 500, deploymentTxHash: '0x' + '0'.repeat(64), deployedAt: '', registeredAt: '' };
+function normalizeDeployment(value: VoxelFlipDeployment): VoxelFlipDeployment {
+  return {
+    ...value,
+    address: String(value.address).trim(),
+    chainId: 8453,
+    network: 'base',
+    owner: String(value.owner).trim(),
+    mintSigner: String(value.mintSigner).trim(),
+    royaltyReceiver: String(value.royaltyReceiver).trim(),
+    royaltyBps: Number(value.royaltyBps),
+    deploymentTxHash: String(value.deploymentTxHash).trim(),
+    deployedAt: String(value.deployedAt || ''),
+    registeredAt: String(value.registeredAt || ''),
+  };
 }
 
-export async function getVoxelFlipDeployment(options: { bypassCache?: boolean } = {}): Promise<VoxelFlipDeployment | null> {
+function matchesVerifiedProduction(value: VoxelFlipDeployment) {
+  const trusted = VERIFIED_PRODUCTION_FALLBACK;
+  return (
+    normalizeAddress(value.address) === normalizeAddress(trusted.address)
+    && Number(value.chainId) === trusted.chainId
+    && String(value.network || '').trim().toLowerCase() === trusted.network
+    && normalizeAddress(value.owner) === normalizeAddress(trusted.owner)
+    && normalizeAddress(value.mintSigner) === normalizeAddress(trusted.mintSigner)
+    && normalizeAddress(value.royaltyReceiver) === normalizeAddress(trusted.royaltyReceiver)
+    && Number(value.royaltyBps) === trusted.royaltyBps
+    && normalizeTx(value.deploymentTxHash) === normalizeTx(trusted.deploymentTxHash)
+  );
+}
+
+function warnAboutConflictingEnvironment() {
+  if (warnedAboutEnvConflict) return;
+  const configured = [
+    process.env.NEXT_PUBLIC_VOXELFLIP_NFT_ADDRESS,
+    process.env.VOXELFLIP_NFT_ADDRESS,
+  ].map(value => String(value || '').trim()).filter(Boolean);
+
+  const conflict = configured.find(value => ADDRESS_RE.test(value) && normalizeAddress(value) !== normalizeAddress(VERIFIED_PRODUCTION_FALLBACK.address));
+  if (!conflict) return;
+
+  warnedAboutEnvConflict = true;
+  console.warn('Ignoring stale VoxelFlip contract environment override; production is pinned to the reviewed deployment.', {
+    configuredAddress: conflict,
+    productionAddress: VERIFIED_PRODUCTION_FALLBACK.address,
+  });
+}
+
+export async function getVoxelFlipDeployment(options: { bypassCache?: boolean } = {}): Promise<VoxelFlipDeployment> {
   if (!options.bypassCache && memoryCache && memoryCache.expiresAt > Date.now()) return memoryCache.value;
+
+  warnAboutConflictingEnvironment();
+
   try {
     const supabase = getSupabaseAdmin();
     const downloaded = await supabase.storage.from(BUCKET).download(FILE);
     if (!downloaded.error && downloaded.data) {
       const parsed = JSON.parse(await downloaded.data.text());
       if (validDeployment(parsed)) {
-        const value = { ...parsed, royaltyBps: Number(parsed.royaltyBps), chainId: 8453 } as VoxelFlipDeployment;
-        memoryCache = { value, expiresAt: Date.now() + 30_000 };
-        return value;
+        const stored = normalizeDeployment(parsed);
+        if (matchesVerifiedProduction(stored)) {
+          // Stored timestamps may be newer, but security-sensitive deployment
+          // fields are accepted only when they exactly match reviewed code.
+          const value: VoxelFlipDeployment = {
+            ...VERIFIED_PRODUCTION_FALLBACK,
+            deployedAt: stored.deployedAt || VERIFIED_PRODUCTION_FALLBACK.deployedAt,
+            registeredAt: stored.registeredAt || VERIFIED_PRODUCTION_FALLBACK.registeredAt,
+          };
+          memoryCache = { value, expiresAt: Date.now() + 30_000 };
+          return value;
+        }
+
+        if (!warnedAboutStoredConflict) {
+          warnedAboutStoredConflict = true;
+          console.warn('Ignoring untrusted VoxelFlip deployment.json; it does not match the reviewed production deployment.', {
+            storedAddress: stored.address,
+            productionAddress: VERIFIED_PRODUCTION_FALLBACK.address,
+          });
+        }
       }
     }
-  } catch {}
-  const fallback = envFallback() || VERIFIED_PRODUCTION_FALLBACK;
-  memoryCache = { value: fallback, expiresAt: Date.now() + 30_000 };
-  return fallback;
+  } catch (error) {
+    console.warn('VoxelFlip deployment metadata storage is unavailable; using the reviewed production deployment.', error);
+  }
+
+  const value = { ...VERIFIED_PRODUCTION_FALLBACK };
+  memoryCache = { value, expiresAt: Date.now() + 30_000 };
+  return value;
 }

--- a/scripts/test-route-integrity.mjs
+++ b/scripts/test-route-integrity.mjs
@@ -48,6 +48,7 @@ for(const required of [
  'app/api/whatsapp/webhook/route.ts',
  'app/api/cron/neural-core/route.ts',
  'app/api/creator-pack/nft/confirm/route.ts',
+ 'lib/voxelflip-deployment.ts',
  'lib/whatsapp-cloud.ts',
  'lib/voxelflip-control-actions.ts',
  'supabase/migrations/013_voxelflip_whatsapp_control.sql',
@@ -81,6 +82,12 @@ for(const rel of criticalSources){
  if(/automaticListingActive\s*[:=]\s*true/.test(text))failures.push(`${rel} enables automatic listing directly.`);
  if(/automaticBuyingActive\s*[:=]\s*true/.test(text))failures.push(`${rel} enables automatic buying directly.`);
 }
+
+const deploymentSource=fs.readFileSync(path.join(root,'lib/voxelflip-deployment.ts'),'utf8');
+if(!deploymentSource.includes('0xa00758b05f96ef4409d97c3ffebb6794b2eafbde'))failures.push('VoxelFlip production deployment is not pinned to the reviewed Base contract.');
+if(!deploymentSource.includes('matchesVerifiedProduction'))failures.push('VoxelFlip stored deployment metadata is not gated against the reviewed production deployment.');
+if(!deploymentSource.includes('Ignoring untrusted VoxelFlip deployment.json'))failures.push('VoxelFlip deployment resolver does not fail closed on a conflicting stored deployment.');
+if(/return\s+envFallback\s*\(/.test(deploymentSource)||/envFallback\s*\(\)\s*\|\|/.test(deploymentSource))failures.push('VoxelFlip production contract may not be selected from a mutable environment fallback.');
 
 const adminApi=fs.readFileSync(path.join(root,'app/api/admin/neural-core/route.ts'),'utf8');
 if(!adminApi.includes('requireNeuralCoreAdmin'))failures.push('Neural Core admin API is missing server-side admin authentication.');
@@ -120,4 +127,4 @@ if(failures.length){
  for(const failure of failures)console.error(`- ${failure}`);
  process.exit(1);
 }
-console.log('Route integrity passed: no duplicate route handlers, critical VoxelFlip/Neural Core/WhatsApp routes exist, admin auth, ownership, webhook signatures and private database controls are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');
+console.log('Route integrity passed: no duplicate route handlers, critical VoxelFlip/Neural Core/WhatsApp routes exist, the production deployment is pinned, admin auth, ownership, webhook signatures and private database controls are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');


### PR DESCRIPTION
## What this fixes

Prevents a stale Supabase `voxelflip-config/deployment.json` object or stale Vercel contract env var from silently overriding the reviewed VoxelFlip Base deployment.

## Changes

- Pin production VoxelFlip to `0xa00758b05f96ef4409d97c3ffebb6794b2eafbde` and its reviewed deployment transaction.
- Accept Supabase deployment metadata only when all security-sensitive deployment fields exactly match the reviewed production record.
- Ignore conflicting Vercel contract-address env values instead of using them as a fallback source of truth.
- Preserve stored deployment/registration timestamps when the stored record matches production.
- Add release-audit regression checks so mutable deployment precedence cannot be reintroduced accidentally.
- Keep WhatsApp/Neural Core execution safety unchanged: automatic signing/buying/listing remain disabled.

## Why

The previous resolver preferred mutable Supabase storage over the code-reviewed fallback. A stale stored address could therefore send mint preparation/confirmation and Neural Core consumers to the wrong contract. This change makes contract rotation an explicit reviewed code deployment rather than a silent data/config mutation.