### PR TITLE
Recover complete Forge asset library

### DIFF
--- a/app/api/forge/account-assets/route.ts
+++ b/app/api/forge/account-assets/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
+import { stripe } from '../../../../lib/stripe-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
+const MAX_STRIPE_PAGES = 5;
+const MAX_MATCHES = 30;
+const PROVIDER_TIMEOUT_MS = 7_000;
+
+function bearerToken(request: Request) {
+  const header = request.headers.get('authorization') || '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || '';
+}
+
+function normalizeEmail(value: unknown) {
+  return String(value || '').trim().toLowerCase();
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('Timed out while recovering 3D asset status.')), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function sessionEmail(session: any) {
+  const inline = normalizeEmail(session?.customer_details?.email || session?.customer_email || '');
+  if (inline) return inline;
+  try {
+    const full = await stripe.checkout.sessions.retrieve(String(session.id));
+    return normalizeEmail(full.customer_details?.email || full.customer_email || '');
+  } catch {
+    return '';
+  }
+}
+
+async function matchingPaidSessions(email: string) {
+  const matches: any[] = [];
+  let startingAfter = '';
+
+  for (let page = 0; page < MAX_STRIPE_PAGES && matches.length < MAX_MATCHES; page += 1) {
+    const listed = await stripe.checkout.sessions.list({
+      limit: 100,
+      status: 'complete',
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+
+    const candidates = listed.data.filter(session => (
+      session.payment_status === 'paid'
+      && session.metadata?.product === 'voxelpop-3d-asset'
+      && Boolean(session.metadata?.mesh_task_0)
+    ));
+
+    for (const session of candidates) {
+      if (matches.length >= MAX_MATCHES) break;
+      const paidEmail = await sessionEmail(session);
+      if (paidEmail && paidEmail === email) matches.push(session);
+    }
+
+    if (!listed.has_more || !listed.data.length) break;
+    startingAfter = String(listed.data[listed.data.length - 1]?.id || '');
+    if (!startingAfter) break;
+  }
+
+  return matches;
+}
+
+async function meshRecord(session: any, apiKey: string) {
+  const taskId = String(session.metadata?.mesh_task_0 || '').trim();
+  if (!taskId) return null;
+
+  let data: any = null;
+  let status = 'unknown';
+  let modelUrl = '';
+  let thumbnailUrl = '';
+  let progress = 0;
+  let error = '';
+
+  if (apiKey) {
+    try {
+      const response = await withTimeout(fetch(`${MESH_ENDPOINT}/${encodeURIComponent(taskId)}`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        cache: 'no-store',
+      }), PROVIDER_TIMEOUT_MS);
+      data = await response.json().catch(() => ({}));
+      if (response.ok) {
+        const providerStatus = String(data?.status || '').toUpperCase();
+        modelUrl = typeof data?.model_urls?.glb === 'string' ? data.model_urls.glb : '';
+        thumbnailUrl = typeof data?.alpha_thumbnail_url === 'string'
+          ? data.alpha_thumbnail_url
+          : (typeof data?.thumbnail_url === 'string' ? data.thumbnail_url : '');
+        progress = modelUrl ? 100 : Number(data?.progress || 0);
+        status = providerStatus === 'SUCCEEDED' && modelUrl
+          ? 'ready'
+          : providerStatus.toLowerCase() || 'unknown';
+        error = String(data?.task_error?.message || '');
+      } else {
+        error = String(data?.message || data?.error || `Mesh provider HTTP ${response.status}`);
+      }
+    } catch (providerError) {
+      error = providerError instanceof Error ? providerError.message : 'Could not refresh mesh status.';
+    }
+  }
+
+  const sessionId = String(session.id);
+  const name = String(session.metadata?.mesh_name_0 || 'Your voxel').slice(0, 80);
+  const idea = String(session.metadata?.mesh_idea_0 || '').slice(0, 120);
+  const tokenId = String(session.metadata?.voxelflip_token_id || '').trim();
+  const owner = String(session.metadata?.voxelflip_wallet || '').trim();
+  const txHash = String(session.metadata?.voxelflip_tx_hash || '').trim();
+  const metadataUrl = String(session.metadata?.voxelflip_metadata_url || '').trim();
+
+  // Use the same authenticated paid-session mesh proxy for the GLB so a recovered
+  // library record does not depend on a temporary third-party model URL.
+  const stableModelUrl = status === 'ready'
+    ? `/api/creator-pack/mesh?${new URLSearchParams({ sessionId, taskId, preview: '1' }).toString()}`
+    : '';
+
+  return {
+    sessionId,
+    updatedAt: new Date(Number(session.created || 0) * 1000 || Date.now()).toISOString(),
+    payload: {
+      asset: {
+        name,
+        dataUrl: thumbnailUrl || '/voxelpop/voxelpop-logo.png',
+      },
+      mesh: {
+        status,
+        progress,
+        taskId,
+        modelUrl: stableModelUrl,
+        error,
+      },
+      ...(tokenId ? {
+        mint: {
+          tokenId,
+          owner,
+          hash: txHash,
+          txHash,
+          metadataUrl,
+        },
+      } : {}),
+      generationsLeft: 0,
+      idea,
+      updatedAt: new Date(Number(session.created || 0) * 1000 || Date.now()).toISOString(),
+    },
+  };
+}
+
+export async function GET(request: Request) {
+  const token = bearerToken(request);
+  if (!token) return NextResponse.json({ error: 'Google sign-in is required to recover paid VoxelPop assets.' }, { status: 401 });
+
+  let admin: ReturnType<typeof getSupabaseAdmin>;
+  try {
+    admin = getSupabaseAdmin();
+  } catch {
+    return NextResponse.json({ error: 'Account recovery is not configured on this deployment.' }, { status: 503 });
+  }
+
+  const { data, error: authError } = await admin.auth.getUser(token);
+  const user = data?.user;
+  const email = normalizeEmail(user?.email);
+  if (authError || !user || !email) {
+    return NextResponse.json({ error: 'Your Google session could not be verified. Sign in again.' }, { status: 401 });
+  }
+
+  try {
+    const sessions = await matchingPaidSessions(email);
+    const apiKey = String(process.env.MESHY_API_KEY || '').trim();
+    const records = (await Promise.all(sessions.map(session => meshRecord(session, apiKey)))).filter(Boolean);
+    return NextResponse.json({
+      recovered: records.length,
+      records,
+      signedIn: true,
+      meshStatusRefreshed: Boolean(apiKey),
+      safety: 'Read-only account recovery. This does not mint, transfer, approve, list, burn, or sign any NFT transaction.',
+    }, { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    console.error('Forge account asset recovery failed', error);
+    return NextResponse.json({ error: 'Could not recover your paid VoxelPop library right now.' }, { status: 500, headers: { 'Cache-Control': 'private, no-store' } });
+  }
+}

--- a/app/api/forge/owned-assets/route.ts
+++ b/app/api/forge/owned-assets/route.ts
@@ -8,6 +8,7 @@ export const maxDuration = 60;
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 const OPENSEA = 'https://api.opensea.io/api/v2';
+const BLOCKSCOUT = 'https://base.blockscout.com/api/v2';
 const TIMEOUT_MS = 8_000;
 const LOG_CHUNK = 8_000;
 const MAX_TOKENS = 100;
@@ -25,24 +26,63 @@ function normalizeAddress(value: unknown) {
 }
 
 function tokenIdOf(value: any) {
-  const raw = value?.identifier ?? value?.token_id ?? value?.tokenId ?? '';
+  const raw = value?.identifier ?? value?.token_id ?? value?.tokenId ?? value?.id ?? '';
   const tokenId = String(raw || '').trim();
   return /^\d+$/.test(tokenId) ? tokenId : '';
 }
 
 function contractAddressOf(value: any) {
-  return normalizeAddress(value?.contract || value?.contract_address || value?.contractAddress || value?.nft_contract || '');
+  return normalizeAddress(
+    value?.contract
+    || value?.contract_address
+    || value?.contractAddress
+    || value?.nft_contract
+    || value?.token?.address_hash
+    || value?.token?.address
+    || value?.token_contract_address_hash
+    || ''
+  );
 }
 
 function metadataFields(value: any) {
+  const metadata = value?.metadata && typeof value.metadata === 'object' ? value.metadata : {};
   return {
-    name: String(value?.name || value?.title || '').trim(),
-    description: String(value?.description || '').trim(),
-    imageUrl: String(value?.display_image_url || value?.image_url || value?.image || '').trim(),
-    animationUrl: String(value?.display_animation_url || value?.animation_url || value?.animation || '').trim(),
-    metadataUrl: String(value?.metadata_url || value?.metadataUrl || '').trim(),
+    name: String(value?.name || value?.title || metadata?.name || '').trim(),
+    description: String(value?.description || metadata?.description || '').trim(),
+    imageUrl: String(value?.display_image_url || value?.image_url || value?.image || metadata?.image_url || metadata?.image || '').trim(),
+    animationUrl: String(value?.display_animation_url || value?.animation_url || value?.animation || metadata?.animation_url || '').trim(),
+    metadataUrl: String(value?.metadata_url || value?.metadataUrl || metadata?.external_url || '').trim(),
     openSeaUrl: String(value?.opensea_url || value?.openseaUrl || '').trim(),
   };
+}
+
+function rpcCandidates() {
+  const configured = String(process.env.VOXELFLIP_RPC_URL || process.env.NEXT_PUBLIC_VOXELFLIP_RPC_URL || '').trim();
+  return Array.from(new Set([
+    configured,
+    'https://base.blockscout.com/api/eth-rpc',
+    'https://mainnet.base.org',
+    'https://base.llamarpc.com',
+    'https://base-rpc.publicnode.com',
+  ].filter(Boolean)));
+}
+
+async function workingProvider() {
+  let lastError: unknown = null;
+  for (const rpc of rpcCandidates()) {
+    const provider = new JsonRpcProvider(rpc, 8453, { staticNetwork: true });
+    try {
+      await Promise.race([
+        provider.getBlockNumber(),
+        new Promise((_resolve, reject) => setTimeout(() => reject(new Error('RPC health check timed out')), 5_000)),
+      ]);
+      return provider;
+    } catch (error) {
+      lastError = error;
+      provider.destroy();
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('No Base RPC is available.');
 }
 
 async function timedJson(url: string, init: RequestInit = {}) {
@@ -80,6 +120,30 @@ async function openSeaOwned(wallet: string, contractAddress: string, apiKey: str
     }
     cursor = String(response.data?.next || '').trim();
     if (!cursor) break;
+  }
+  return { available: true, items, error: '' };
+}
+
+async function blockscoutOwned(wallet: string, contractAddress: string) {
+  const items: any[] = [];
+  let query = new URLSearchParams({ type: 'ERC-721' });
+  for (let page = 0; page < 8 && items.length < MAX_TOKENS; page += 1) {
+    const response = await timedJson(`${BLOCKSCOUT}/addresses/${wallet}/nft?${query.toString()}`, { headers: { accept: 'application/json' } });
+    if (!response.ok) return { available: false, items: [] as any[], error: response.error || 'Blockscout wallet lookup failed.' };
+    const pageItems = Array.isArray(response.data?.items) ? response.data.items : [];
+    for (const item of pageItems) {
+      if (contractAddressOf(item).toLowerCase() !== contractAddress.toLowerCase()) continue;
+      const tokenId = tokenIdOf(item);
+      if (!tokenId) continue;
+      items.push({ tokenId, ...metadataFields(item) });
+      if (items.length >= MAX_TOKENS) break;
+    }
+    const next = response.data?.next_page_params;
+    if (!next || typeof next !== 'object' || !Object.keys(next).length) break;
+    query = new URLSearchParams({ type: 'ERC-721' });
+    for (const [key, value] of Object.entries(next)) {
+      if (value !== null && value !== undefined) query.set(key, String(value));
+    }
   }
   return { available: true, items, error: '' };
 }
@@ -132,28 +196,36 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'The reviewed production VoxelFlip deployment is unavailable.' }, { status: 503 });
   }
 
-  const rpc = String(process.env.VOXELFLIP_RPC_URL || process.env.NEXT_PUBLIC_VOXELFLIP_RPC_URL || 'https://mainnet.base.org').trim();
-  const provider = new JsonRpcProvider(rpc, 8453, { staticNetwork: true });
-  const nft = new Contract(contractAddress, ERC721_ABI, provider);
   const apiKey = String(process.env.OPENSEA_API_KEY || '').trim();
-
+  let provider: JsonRpcProvider | null = null;
   try {
-    const [openSea, onchainIds] = await Promise.all([
+    provider = await workingProvider();
+    const nft = new Contract(contractAddress, ERC721_ABI, provider);
+
+    const [openSea, blockscout, eventResult] = await Promise.all([
       openSeaOwned(wallet, contractAddress, apiKey),
-      onchainCandidateTokenIds(provider, wallet, contractAddress, String(deployment?.deploymentTxHash || '')),
+      blockscoutOwned(wallet, contractAddress),
+      onchainCandidateTokenIds(provider, wallet, contractAddress, String(deployment?.deploymentTxHash || ''))
+        .then(items => ({ items, error: '' }))
+        .catch(error => ({ items: [] as string[], error: error instanceof Error ? error.message : 'Base event scan failed.' })),
     ]);
 
     const tokenIds = new Set<string>();
     for (const item of openSea.items) tokenIds.add(item.tokenId);
-    for (const tokenId of onchainIds) tokenIds.add(tokenId);
+    for (const item of blockscout.items) tokenIds.add(item.tokenId);
+    for (const tokenId of eventResult.items) tokenIds.add(tokenId);
 
-    const openSeaById = new Map(openSea.items.map(item => [item.tokenId, item]));
+    const metadataById = new Map<string, any>();
+    for (const item of [...blockscout.items, ...openSea.items]) {
+      metadataById.set(item.tokenId, { ...(metadataById.get(item.tokenId) || {}), ...item });
+    }
+
     const verified: any[] = [];
     for (const tokenId of Array.from(tokenIds).slice(0, MAX_TOKENS)) {
       try {
         const [owner, tokenURI] = await Promise.all([nft.ownerOf(tokenId), nft.tokenURI(tokenId)]);
         if (getAddress(owner) !== wallet) continue;
-        const market = openSeaById.get(tokenId) || {};
+        const market = metadataById.get(tokenId) || {};
         verified.push({
           tokenId,
           contract: contractAddress,
@@ -169,15 +241,35 @@ export async function GET(request: Request) {
       } catch {}
     }
 
-    verified.sort((a, b) => Number(a.tokenId) - Number(b.tokenId));
-    const sourceWarning = openSea.available ? '' : `${openSea.error} Direct Base event scanning was also used.`;
+    verified.sort((a, b) => {
+      try { return BigInt(a.tokenId) < BigInt(b.tokenId) ? -1 : BigInt(a.tokenId) > BigInt(b.tokenId) ? 1 : 0; } catch { return 0; }
+    });
+
+    const warnings = [
+      openSea.available ? '' : openSea.error,
+      blockscout.available ? '' : blockscout.error,
+      eventResult.error,
+    ].filter(Boolean);
+    const sources = [
+      openSea.available ? 'opensea' : '',
+      blockscout.available ? 'blockscout' : '',
+      eventResult.items.length ? 'base-events' : '',
+      'ownerOf',
+    ].filter(Boolean);
+
     return NextResponse.json({
       wallet,
       chainId: 8453,
       chain: 'base',
       contract: contractAddress,
-      source: openSea.available ? 'opensea+base-events+ownerOf' : 'base-events+ownerOf',
-      sourceWarning: sourceWarning || null,
+      source: sources.join('+'),
+      sourceWarning: warnings.length ? warnings.join(' ') : null,
+      sourceCounts: {
+        openSea: openSea.items.length,
+        blockscout: blockscout.items.length,
+        eventCandidates: eventResult.items.length,
+        verified: verified.length,
+      },
       count: verified.length,
       nfts: verified,
       safety: 'Read-only production scan. No approval, transfer, burn, listing, or signature is requested.',
@@ -185,6 +277,6 @@ export async function GET(request: Request) {
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Could not read owned VoxelFlips.' }, { status: 502, headers: { 'Cache-Control': 'no-store' } });
   } finally {
-    provider.destroy();
+    provider?.destroy();
   }
 }

--- a/app/forge/real/layout.js
+++ b/app/forge/real/layout.js
@@ -2,39 +2,87 @@
 
 import {useEffect,useState} from 'react';
 import {loadAlternateHostVoxels} from '../../../lib/voxelpop-cross-host';
-import {mergeVoxelRecords,readLocalVoxelRecords} from '../../../lib/voxelpop-account';
+import {getSupabaseBrowserAsync} from '../../../lib/supabase-browser';
+import {mergeVoxelRecords,readLocalVoxelRecords,syncLocalVoxelsToAccount} from '../../../lib/voxelpop-account';
+
+function writeRecords(records){
+  for(const record of records){
+    try{localStorage.setItem(`voxelpop:${record.sessionId}`,JSON.stringify(record.payload))}catch{}
+  }
+}
 
 export default function RealForgeLayout({children}){
   const [ready,setReady]=useState(false);
+  const [signedIn,setSignedIn]=useState(null);
+  const [accountBusy,setAccountBusy]=useState(false);
+  const [accountMessage,setAccountMessage]=useState('');
 
   useEffect(()=>{
     let active=true;
     async function sync(){
+      let current=readLocalVoxelRecords();
       try{
         const alternate=await loadAlternateHostVoxels();
-        if(alternate.length){
-          const current=readLocalVoxelRecords();
-          const merged=mergeVoxelRecords(current,alternate);
-          for(const record of merged){
-            try{localStorage.setItem(`voxelpop:${record.sessionId}`,JSON.stringify(record.payload))}catch{}
+        if(alternate.length)current=mergeVoxelRecords(current,alternate);
+      }catch{}
+
+      try{
+        const supabase=await getSupabaseBrowserAsync();
+        const {data}=await supabase.auth.getSession();
+        const session=data.session;
+        if(active)setSignedIn(Boolean(session?.user));
+        if(session?.user&&session.access_token){
+          const response=await fetch('/api/forge/account-assets',{cache:'no-store',headers:{Authorization:`Bearer ${session.access_token}`}});
+          const recovered=await response.json().catch(()=>({}));
+          if(response.ok&&Array.isArray(recovered.records)){
+            current=mergeVoxelRecords(current,recovered.records);
+            writeRecords(current);
+            try{await syncLocalVoxelsToAccount(supabase,session.user)}catch{}
+            if(active&&recovered.records.length)setAccountMessage(`Recovered ${recovered.records.length} paid VoxelPop creation${recovered.records.length===1?'':'s'} from your account.`);
+          }else if(active&&response.status!==401){
+            setAccountMessage(String(recovered.error||''));
           }
         }
-      }catch{}
+      }catch{
+        if(active)setSignedIn(false);
+      }
+
+      writeRecords(current);
       if(active)setReady(true);
     }
     sync();
     return()=>{active=false};
   },[]);
 
+  async function recoverWithGoogle(){
+    setAccountBusy(true);setAccountMessage('Opening Google sign-in…');
+    try{
+      const supabase=await getSupabaseBrowserAsync();
+      const redirectTo=new URL('/forge/real',window.location.origin).toString();
+      const {error}=await supabase.auth.signInWithOAuth({provider:'google',options:{redirectTo}});
+      if(error)throw error;
+    }catch(error){
+      setAccountMessage(error instanceof Error?error.message:'Could not start Google recovery.');
+      setAccountBusy(false);
+    }
+  }
+
   if(!ready){
     return <main style={{minHeight:'100vh',background:'#070809',color:'#f7f7f3',display:'grid',placeItems:'center',fontFamily:'Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',padding:24}}>
-      <div style={{textAlign:'center',maxWidth:420}}>
+      <div style={{textAlign:'center',maxWidth:460}}>
         <div style={{color:'#c8ff54',fontSize:11,fontWeight:900,letterSpacing:'.14em'}}>MY VOXELS</div>
-        <h1 style={{fontSize:34,margin:'12px 0 8px'}}>Loading your full library…</h1>
-        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking both voxelvault.io hostnames so older browser-saved 3D voxels do not disappear.</p>
+        <h1 style={{fontSize:34,margin:'12px 0 8px'}}>Recovering your full library…</h1>
+        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking browser storage, your other VoxelVault hostname, and—when Google is connected—your paid VoxelPop server records.</p>
       </div>
     </main>;
   }
 
-  return children;
+  return <>
+    {signedIn===false&&<div style={{position:'relative',zIndex:30,background:'#111318',borderBottom:'1px solid rgba(255,255,255,.10)',color:'#f7f7f3',padding:'12px 18px',display:'flex',alignItems:'center',justifyContent:'center',gap:14,flexWrap:'wrap',fontFamily:'Inter,ui-sans-serif,system-ui,sans-serif'}}>
+      <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Missing a paid 3D voxel?</b> Recover creations saved in a different browser with the Google account used for VoxelPop.</span>
+      <button type="button" onClick={recoverWithGoogle} disabled={accountBusy} style={{border:0,borderRadius:999,padding:'9px 14px',background:'#c8ff54',color:'#0a0b0d',fontWeight:900,cursor:accountBusy?'wait':'pointer'}}>{accountBusy?'OPENING…':'RECOVER WITH GOOGLE'}</button>
+    </div>}
+    {accountMessage&&<div style={{position:'relative',zIndex:29,background:'#0d0f12',color:'#aeb4bd',textAlign:'center',padding:'8px 16px',font: '700 12px/1.4 Inter,ui-sans-serif,system-ui,sans-serif',borderBottom:'1px solid rgba(255,255,255,.06)'}}>{accountMessage}</div>}
+    {children}
+  </>;
 }


### PR DESCRIPTION
Fixes the remaining Forge asset visibility failures without changing any mint/transfer/listing behavior.

- Makes production VoxelFlip ownership discovery source-independent so one Base RPC log failure cannot erase the whole minted list.
- Adds Base Blockscout current NFT inventory as a read-only ownership source alongside OpenSea and on-chain event candidates, with ownerOf/tokenURI verification before use.
- Adds authenticated Google-account recovery for paid VoxelPop sessions. Matching paid Stripe sessions are recovered server-side and their saved Meshy task IDs are refreshed so finished non-minted 3D assets can be rebuilt even when they were created in a different browser context.
- Forge layout merges browser, cross-host, Google-backed, and recovered paid-session records before the selector loads.
- If Google is not connected, the page offers an explicit RECOVER WITH GOOGLE control.
- No NFT mint, approval, transfer, burn, listing, wallet signature, or mainnet Forge write is added.