### PR TITLE
Fix Forge cross-browser voxel recovery and legacy NFT detection

### DIFF
--- a/app/api/creator-pack/checkout/route.ts
+++ b/app/api/creator-pack/checkout/route.ts
@@ -1,6 +1,26 @@
 import { NextResponse } from 'next/server';
 import { stripe } from '../../../../lib/stripe-server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { cleanAttribution, normalizeFlowId, recordVoxelPopEvent } from '../../../../lib/voxelpop-analytics';
+
+function bearerToken(request: Request) {
+  const header = request.headers.get('authorization') || '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || '';
+}
+
+async function verifiedAccount(request: Request) {
+  const token = bearerToken(request);
+  if (!token) return null;
+  try {
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return data.user;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: Request) {
   try {
@@ -15,13 +35,16 @@ export async function POST(request: Request) {
       attribution = cleanAttribution(body?.attribution);
     } catch {}
 
+    const account = await verifiedAccount(request);
     const metadata: Record<string, string> = { product: 'voxelpop-3d-asset', style, generations: '0' };
     if (flowId) metadata.flow_id = flowId;
+    if (account?.id) metadata.voxelpop_user_id = account.id;
     if (attribution.source) metadata.utm_source = attribution.source;
     if (attribution.medium) metadata.utm_medium = attribution.medium;
     if (attribution.campaign) metadata.utm_campaign = attribution.campaign;
     if (attribution.content) metadata.utm_content = attribution.content;
 
+    const accountEmail = typeof account?.email === 'string' && account.email.includes('@') ? account.email : undefined;
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       line_items: [{
@@ -36,6 +59,8 @@ export async function POST(request: Request) {
         },
       }],
       metadata,
+      ...(account?.id ? { client_reference_id: account.id } : {}),
+      ...(accountEmail ? { customer_email: accountEmail } : {}),
       success_url: `${origin}/pack/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${origin}/studio?checkout=cancelled`,
     });
@@ -46,10 +71,10 @@ export async function POST(request: Request) {
       flowId,
       stripeSessionId: session.id,
       attribution,
-      details: { amount_cents: 199, currency: 'usd' },
+      details: { amount_cents: 199, currency: 'usd', account_linked: Boolean(account?.id) },
     });
 
-    return NextResponse.json({ url: session.url });
+    return NextResponse.json({ url: session.url, accountLinked: Boolean(account?.id) });
   } catch (error) {
     console.error('creator pack checkout failed', error);
     return NextResponse.json({ error: 'Secure checkout is temporarily unavailable.' }, { status: 500 });

--- a/app/api/forge/account-assets/route.ts
+++ b/app/api/forge/account-assets/route.ts
@@ -7,9 +7,11 @@ export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
 const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
-const MAX_STRIPE_PAGES = 5;
-const MAX_MATCHES = 30;
+const MAX_STRIPE_PAGES = 50;
+const MAX_MATCHES = 100;
 const PROVIDER_TIMEOUT_MS = 7_000;
+const RECOVERY_BUDGET_MS = 42_000;
+const MESH_CONCURRENCY = 6;
 
 function bearerToken(request: Request) {
   const header = request.headers.get('authorization') || '';
@@ -19,6 +21,11 @@ function bearerToken(request: Request) {
 
 function normalizeEmail(value: unknown) {
   return String(value || '').trim().toLowerCase();
+}
+
+function addEmail(set: Set<string>, value: unknown) {
+  const email = normalizeEmail(value);
+  if (email && email.includes('@')) set.add(email);
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -35,53 +42,112 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
   }
 }
 
-async function sessionEmail(session: any) {
-  const inline = normalizeEmail(session?.customer_details?.email || session?.customer_email || '');
-  if (inline) return inline;
-  try {
-    const full = await stripe.checkout.sessions.retrieve(String(session.id));
-    return normalizeEmail(full.customer_details?.email || full.customer_email || '');
-  } catch {
-    return '';
-  }
+function inlineSessionEmails(session: any) {
+  const emails = new Set<string>();
+  addEmail(emails, session?.customer_details?.email);
+  addEmail(emails, session?.customer_email);
+  addEmail(emails, session?.customer?.email);
+  addEmail(emails, session?.payment_intent?.receipt_email);
+  addEmail(emails, session?.payment_intent?.latest_charge?.billing_details?.email);
+  return emails;
 }
 
-async function matchingPaidSessions(email: string) {
+async function expandedSessionEmails(sessionId: string) {
+  const emails = new Set<string>();
+  try {
+    const full: any = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['customer', 'payment_intent.latest_charge'],
+    });
+    for (const email of inlineSessionEmails(full)) emails.add(email);
+  } catch {}
+  return emails;
+}
+
+async function sessionIdentityMatch(session: any, userId: string, email: string) {
+  const linkedUserId = String(session?.metadata?.voxelpop_user_id || '').trim();
+  if (linkedUserId && linkedUserId === userId) return { matched: true, source: 'verified-user-id' };
+
+  const inline = inlineSessionEmails(session);
+  if (inline.has(email)) return { matched: true, source: 'checkout-email' };
+
+  const expanded = await expandedSessionEmails(String(session.id || ''));
+  if (expanded.has(email)) return { matched: true, source: 'payment-email' };
+
+  return { matched: false, source: '' };
+}
+
+type RecoveryDiagnostics = {
+  pagesScanned: number;
+  checkoutSessionsScanned: number;
+  paidVoxelSessionsScanned: number;
+  identityCandidatesChecked: number;
+  matchedByUserId: number;
+  matchedByEmail: number;
+  stoppedByTimeBudget: boolean;
+};
+
+async function matchingPaidSessions(userId: string, email: string) {
   const matches: any[] = [];
   let startingAfter = '';
+  const startedAt = Date.now();
+  const diagnostics: RecoveryDiagnostics = {
+    pagesScanned: 0,
+    checkoutSessionsScanned: 0,
+    paidVoxelSessionsScanned: 0,
+    identityCandidatesChecked: 0,
+    matchedByUserId: 0,
+    matchedByEmail: 0,
+    stoppedByTimeBudget: false,
+  };
 
   for (let page = 0; page < MAX_STRIPE_PAGES && matches.length < MAX_MATCHES; page += 1) {
+    if (Date.now() - startedAt > RECOVERY_BUDGET_MS) {
+      diagnostics.stoppedByTimeBudget = true;
+      break;
+    }
+
     const listed = await stripe.checkout.sessions.list({
       limit: 100,
       status: 'complete',
       ...(startingAfter ? { starting_after: startingAfter } : {}),
     });
 
+    diagnostics.pagesScanned += 1;
+    diagnostics.checkoutSessionsScanned += listed.data.length;
+
     const candidates = listed.data.filter(session => (
       session.payment_status === 'paid'
       && session.metadata?.product === 'voxelpop-3d-asset'
       && Boolean(session.metadata?.mesh_task_0)
     ));
+    diagnostics.paidVoxelSessionsScanned += candidates.length;
 
     for (const session of candidates) {
       if (matches.length >= MAX_MATCHES) break;
-      const paidEmail = await sessionEmail(session);
-      if (paidEmail && paidEmail === email) matches.push(session);
+      if (Date.now() - startedAt > RECOVERY_BUDGET_MS) {
+        diagnostics.stoppedByTimeBudget = true;
+        break;
+      }
+      diagnostics.identityCandidatesChecked += 1;
+      const identity = await sessionIdentityMatch(session, userId, email);
+      if (!identity.matched) continue;
+      matches.push(session);
+      if (identity.source === 'verified-user-id') diagnostics.matchedByUserId += 1;
+      else diagnostics.matchedByEmail += 1;
     }
 
-    if (!listed.has_more || !listed.data.length) break;
+    if (diagnostics.stoppedByTimeBudget || !listed.has_more || !listed.data.length) break;
     startingAfter = String(listed.data[listed.data.length - 1]?.id || '');
     if (!startingAfter) break;
   }
 
-  return matches;
+  return { matches, diagnostics };
 }
 
 async function meshRecord(session: any, apiKey: string) {
   const taskId = String(session.metadata?.mesh_task_0 || '').trim();
   if (!taskId) return null;
 
-  let data: any = null;
   let status = 'unknown';
   let modelUrl = '';
   let thumbnailUrl = '';
@@ -94,7 +160,7 @@ async function meshRecord(session: any, apiKey: string) {
         headers: { Authorization: `Bearer ${apiKey}` },
         cache: 'no-store',
       }), PROVIDER_TIMEOUT_MS);
-      data = await response.json().catch(() => ({}));
+      const data: any = await response.json().catch(() => ({}));
       if (response.ok) {
         const providerStatus = String(data?.status || '').toUpperCase();
         modelUrl = typeof data?.model_urls?.glb === 'string' ? data.model_urls.glb : '';
@@ -121,16 +187,16 @@ async function meshRecord(session: any, apiKey: string) {
   const owner = String(session.metadata?.voxelflip_wallet || '').trim();
   const txHash = String(session.metadata?.voxelflip_tx_hash || '').trim();
   const metadataUrl = String(session.metadata?.voxelflip_metadata_url || '').trim();
+  const contract = String(session.metadata?.voxelflip_contract || '').trim();
 
-  // Use the same authenticated paid-session mesh proxy for the GLB so a recovered
-  // library record does not depend on a temporary third-party model URL.
   const stableModelUrl = status === 'ready'
     ? `/api/creator-pack/mesh?${new URLSearchParams({ sessionId, taskId, preview: '1' }).toString()}`
     : '';
+  const updatedAt = new Date(Number(session.created || 0) * 1000 || Date.now()).toISOString();
 
   return {
     sessionId,
-    updatedAt: new Date(Number(session.created || 0) * 1000 || Date.now()).toISOString(),
+    updatedAt,
     payload: {
       asset: {
         name,
@@ -150,13 +216,29 @@ async function meshRecord(session: any, apiKey: string) {
           hash: txHash,
           txHash,
           metadataUrl,
+          ...(contract ? { contract, contractAddress: contract } : {}),
         },
       } : {}),
       generationsLeft: 0,
       idea,
-      updatedAt: new Date(Number(session.created || 0) * 1000 || Date.now()).toISOString(),
+      updatedAt,
     },
   };
+}
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>) {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  async function run() {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length || 1) }, () => run()));
+  return results;
 }
 
 export async function GET(request: Request) {
@@ -178,14 +260,20 @@ export async function GET(request: Request) {
   }
 
   try {
-    const sessions = await matchingPaidSessions(email);
+    const { matches: sessions, diagnostics } = await matchingPaidSessions(user.id, email);
     const apiKey = String(process.env.MESHY_API_KEY || '').trim();
-    const records = (await Promise.all(sessions.map(session => meshRecord(session, apiKey)))).filter(Boolean);
+    const records = (await mapWithConcurrency(sessions, MESH_CONCURRENCY, session => meshRecord(session, apiKey))).filter(Boolean);
+    const nonMintedReady = records.filter((record: any) => record?.payload?.mesh?.status === 'ready' && !record?.payload?.mint?.tokenId).length;
+    const minted = records.filter((record: any) => Boolean(record?.payload?.mint?.tokenId)).length;
+
     return NextResponse.json({
       recovered: records.length,
+      nonMintedReady,
+      minted,
       records,
       signedIn: true,
       meshStatusRefreshed: Boolean(apiKey),
+      diagnostics,
       safety: 'Read-only account recovery. This does not mint, transfer, approve, list, burn, or sign any NFT transaction.',
     }, { headers: { 'Cache-Control': 'private, no-store' } });
   } catch (error) {

--- a/app/api/forge/account-assets/route.ts
+++ b/app/api/forge/account-assets/route.ts
@@ -9,9 +9,12 @@ export const maxDuration = 60;
 const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_STRIPE_PAGES = 50;
 const MAX_MATCHES = 100;
+const MAX_ANALYTICS_EVENTS = 2_000;
+const MAX_ANALYTICS_SESSIONS = 500;
 const PROVIDER_TIMEOUT_MS = 7_000;
-const RECOVERY_BUDGET_MS = 42_000;
+const RECOVERY_BUDGET_MS = 44_000;
 const MESH_CONCURRENCY = 6;
+const STRIPE_CONCURRENCY = 8;
 
 function bearerToken(request: Request) {
   const header = request.headers.get('authorization') || '';
@@ -42,6 +45,21 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
   }
 }
 
+async function mapWithConcurrency<T, R>(items: T[], limit: number, worker: (item: T, index: number) => Promise<R>) {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  async function run() {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length || 1) }, () => run()));
+  return results;
+}
+
 function inlineSessionEmails(session: any) {
   const emails = new Set<string>();
   addEmail(emails, session?.customer_details?.email);
@@ -52,31 +70,46 @@ function inlineSessionEmails(session: any) {
   return emails;
 }
 
-async function expandedSessionEmails(sessionId: string) {
-  const emails = new Set<string>();
+async function retrieveExpandedSession(sessionId: string) {
   try {
-    const full: any = await stripe.checkout.sessions.retrieve(sessionId, {
+    return await stripe.checkout.sessions.retrieve(sessionId, {
       expand: ['customer', 'payment_intent.latest_charge'],
-    });
-    for (const email of inlineSessionEmails(full)) emails.add(email);
-  } catch {}
-  return emails;
+    }) as any;
+  } catch {
+    return null;
+  }
 }
 
 async function sessionIdentityMatch(session: any, userId: string, email: string) {
   const linkedUserId = String(session?.metadata?.voxelpop_user_id || '').trim();
-  if (linkedUserId && linkedUserId === userId) return { matched: true, source: 'verified-user-id' };
+  if (linkedUserId && linkedUserId === userId) return { matched: true, source: 'verified-user-id', session };
 
   const inline = inlineSessionEmails(session);
-  if (inline.has(email)) return { matched: true, source: 'checkout-email' };
+  if (inline.has(email)) return { matched: true, source: 'checkout-email', session };
 
-  const expanded = await expandedSessionEmails(String(session.id || ''));
-  if (expanded.has(email)) return { matched: true, source: 'payment-email' };
+  const expanded = await retrieveExpandedSession(String(session?.id || ''));
+  if (!expanded) return { matched: false, source: '', session };
+  const expandedLinkedUserId = String(expanded?.metadata?.voxelpop_user_id || '').trim();
+  if (expandedLinkedUserId && expandedLinkedUserId === userId) return { matched: true, source: 'verified-user-id', session: expanded };
+  if (inlineSessionEmails(expanded).has(email)) return { matched: true, source: 'payment-email', session: expanded };
 
-  return { matched: false, source: '' };
+  return { matched: false, source: '', session: expanded };
+}
+
+async function backfillUserLink(session: any, userId: string) {
+  if (!session?.id || String(session?.metadata?.voxelpop_user_id || '').trim() === userId) return;
+  try {
+    await stripe.checkout.sessions.update(String(session.id), {
+      metadata: { ...(session.metadata || {}), voxelpop_user_id: userId },
+    });
+  } catch {}
 }
 
 type RecoveryDiagnostics = {
+  analyticsEventsRead: number;
+  analyticsSessionIds: number;
+  analyticsSessionsRetrieved: number;
+  analyticsMatches: number;
   pagesScanned: number;
   checkoutSessionsScanned: number;
   paidVoxelSessionsScanned: number;
@@ -86,21 +119,77 @@ type RecoveryDiagnostics = {
   stoppedByTimeBudget: boolean;
 };
 
-async function matchingPaidSessions(userId: string, email: string) {
+async function analyticsCompletedSessionIds(admin: ReturnType<typeof getSupabaseAdmin>) {
+  try {
+    const { data, error } = await admin
+      .from('voxelpop_conversion_events')
+      .select('stripe_session_id,created_at')
+      .in('event_name', ['mesh_completed', 'glb_downloaded'])
+      .not('stripe_session_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(MAX_ANALYTICS_EVENTS);
+    if (error || !Array.isArray(data)) return { ids: [] as string[], eventsRead: 0 };
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    for (const row of data) {
+      const id = String((row as any)?.stripe_session_id || '').trim();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+      if (ids.length >= MAX_ANALYTICS_SESSIONS) break;
+    }
+    return { ids, eventsRead: data.length };
+  } catch {
+    return { ids: [] as string[], eventsRead: 0 };
+  }
+}
+
+async function matchesFromAnalytics(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  userId: string,
+  email: string,
+  startedAt: number,
+  diagnostics: RecoveryDiagnostics,
+) {
+  const analytics = await analyticsCompletedSessionIds(admin);
+  diagnostics.analyticsEventsRead = analytics.eventsRead;
+  diagnostics.analyticsSessionIds = analytics.ids.length;
+
+  const sessions = await mapWithConcurrency(analytics.ids, STRIPE_CONCURRENCY, async sessionId => {
+    if (Date.now() - startedAt > RECOVERY_BUDGET_MS) return null;
+    return retrieveExpandedSession(sessionId);
+  });
+
+  const matches: any[] = [];
+  for (const raw of sessions) {
+    if (!raw || matches.length >= MAX_MATCHES) continue;
+    diagnostics.analyticsSessionsRetrieved += 1;
+    if (raw.payment_status !== 'paid' || raw.metadata?.product !== 'voxelpop-3d-asset' || !raw.metadata?.mesh_task_0) continue;
+    diagnostics.identityCandidatesChecked += 1;
+    const identity = await sessionIdentityMatch(raw, userId, email);
+    if (!identity.matched) continue;
+    const matchedSession = identity.session || raw;
+    matches.push(matchedSession);
+    diagnostics.analyticsMatches += 1;
+    if (identity.source === 'verified-user-id') diagnostics.matchedByUserId += 1;
+    else diagnostics.matchedByEmail += 1;
+    if (identity.source !== 'verified-user-id') await backfillUserLink(matchedSession, userId);
+  }
+
+  return matches;
+}
+
+async function matchesFromStripeHistory(
+  userId: string,
+  email: string,
+  startedAt: number,
+  diagnostics: RecoveryDiagnostics,
+  alreadyMatched: Set<string>,
+) {
   const matches: any[] = [];
   let startingAfter = '';
-  const startedAt = Date.now();
-  const diagnostics: RecoveryDiagnostics = {
-    pagesScanned: 0,
-    checkoutSessionsScanned: 0,
-    paidVoxelSessionsScanned: 0,
-    identityCandidatesChecked: 0,
-    matchedByUserId: 0,
-    matchedByEmail: 0,
-    stoppedByTimeBudget: false,
-  };
 
-  for (let page = 0; page < MAX_STRIPE_PAGES && matches.length < MAX_MATCHES; page += 1) {
+  for (let page = 0; page < MAX_STRIPE_PAGES && matches.length + alreadyMatched.size < MAX_MATCHES; page += 1) {
     if (Date.now() - startedAt > RECOVERY_BUDGET_MS) {
       diagnostics.stoppedByTimeBudget = true;
       break;
@@ -119,11 +208,12 @@ async function matchingPaidSessions(userId: string, email: string) {
       session.payment_status === 'paid'
       && session.metadata?.product === 'voxelpop-3d-asset'
       && Boolean(session.metadata?.mesh_task_0)
+      && !alreadyMatched.has(String(session.id))
     ));
     diagnostics.paidVoxelSessionsScanned += candidates.length;
 
     for (const session of candidates) {
-      if (matches.length >= MAX_MATCHES) break;
+      if (matches.length + alreadyMatched.size >= MAX_MATCHES) break;
       if (Date.now() - startedAt > RECOVERY_BUDGET_MS) {
         diagnostics.stoppedByTimeBudget = true;
         break;
@@ -131,9 +221,12 @@ async function matchingPaidSessions(userId: string, email: string) {
       diagnostics.identityCandidatesChecked += 1;
       const identity = await sessionIdentityMatch(session, userId, email);
       if (!identity.matched) continue;
-      matches.push(session);
+      const matchedSession = identity.session || session;
+      matches.push(matchedSession);
+      alreadyMatched.add(String(matchedSession.id));
       if (identity.source === 'verified-user-id') diagnostics.matchedByUserId += 1;
       else diagnostics.matchedByEmail += 1;
+      if (identity.source !== 'verified-user-id') await backfillUserLink(matchedSession, userId);
     }
 
     if (diagnostics.stoppedByTimeBudget || !listed.has_more || !listed.data.length) break;
@@ -141,7 +234,38 @@ async function matchingPaidSessions(userId: string, email: string) {
     if (!startingAfter) break;
   }
 
-  return { matches, diagnostics };
+  return matches;
+}
+
+async function matchingPaidSessions(admin: ReturnType<typeof getSupabaseAdmin>, userId: string, email: string) {
+  const startedAt = Date.now();
+  const diagnostics: RecoveryDiagnostics = {
+    analyticsEventsRead: 0,
+    analyticsSessionIds: 0,
+    analyticsSessionsRetrieved: 0,
+    analyticsMatches: 0,
+    pagesScanned: 0,
+    checkoutSessionsScanned: 0,
+    paidVoxelSessionsScanned: 0,
+    identityCandidatesChecked: 0,
+    matchedByUserId: 0,
+    matchedByEmail: 0,
+    stoppedByTimeBudget: false,
+  };
+
+  const analyticsMatches = await matchesFromAnalytics(admin, userId, email, startedAt, diagnostics);
+  const ids = new Set(analyticsMatches.map(session => String(session.id)));
+
+  let historyMatches: any[] = [];
+  if (ids.size < MAX_MATCHES && Date.now() - startedAt <= RECOVERY_BUDGET_MS) {
+    historyMatches = await matchesFromStripeHistory(userId, email, startedAt, diagnostics, ids);
+  } else if (Date.now() - startedAt > RECOVERY_BUDGET_MS) {
+    diagnostics.stoppedByTimeBudget = true;
+  }
+
+  const merged = new Map<string, any>();
+  for (const session of [...analyticsMatches, ...historyMatches]) merged.set(String(session.id), session);
+  return { matches: Array.from(merged.values()), diagnostics };
 }
 
 async function meshRecord(session: any, apiKey: string) {
@@ -226,21 +350,6 @@ async function meshRecord(session: any, apiKey: string) {
   };
 }
 
-async function mapWithConcurrency<T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>) {
-  const results = new Array<R>(items.length);
-  let nextIndex = 0;
-  async function run() {
-    while (true) {
-      const index = nextIndex;
-      nextIndex += 1;
-      if (index >= items.length) return;
-      results[index] = await worker(items[index]);
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length || 1) }, () => run()));
-  return results;
-}
-
 export async function GET(request: Request) {
   const token = bearerToken(request);
   if (!token) return NextResponse.json({ error: 'Google sign-in is required to recover paid VoxelPop assets.' }, { status: 401 });
@@ -260,7 +369,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const { matches: sessions, diagnostics } = await matchingPaidSessions(user.id, email);
+    const { matches: sessions, diagnostics } = await matchingPaidSessions(admin, user.id, email);
     const apiKey = String(process.env.MESHY_API_KEY || '').trim();
     const records = (await mapWithConcurrency(sessions, MESH_CONCURRENCY, session => meshRecord(session, apiKey))).filter(Boolean);
     const nonMintedReady = records.filter((record: any) => record?.payload?.mesh?.status === 'ready' && !record?.payload?.mint?.tokenId).length;

--- a/app/api/forge/owned-assets/route.ts
+++ b/app/api/forge/owned-assets/route.ts
@@ -13,7 +13,7 @@ const TIMEOUT_MS = 8_000;
 const RPC_CALL_TIMEOUT_MS = 5_000;
 const LOG_CHUNK = 8_000;
 const MAX_WALLET_NFTS = 250;
-const MAX_CANDIDATES = 100;
+const MAX_CANDIDATES = 180;
 const FALLBACK_SCAN_BLOCKS = 500_000;
 const TRANSFER_TOPIC = id('Transfer(address,address,uint256)');
 const VOXELFLIP_MINT_TOPIC = id('VoxelFlipMinted(uint256,address,bytes32,string)');
@@ -21,6 +21,8 @@ const VOXELFLIP_MINT_TOPIC = id('VoxelFlipMinted(uint256,address,bytes32,string)
 const ERC721_ABI = [
   'function ownerOf(uint256 tokenId) view returns (address)',
   'function tokenURI(uint256 tokenId) view returns (string)',
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
 ];
 
 function normalizeAddress(value: unknown) {
@@ -57,9 +59,18 @@ function metadataFields(value: any) {
     metadataUrl: String(value?.metadata_url || value?.metadataUrl || metadata?.external_url || '').trim(),
     externalUrl: String(value?.external_app_url || metadata?.external_url || metadata?.home_url || '').trim(),
     openSeaUrl: String(value?.opensea_url || value?.openseaUrl || '').trim(),
-    collectionName: String(value?.token?.name || collection?.name || value?.collection || '').trim(),
+    collectionName: String(value?.token?.name || collection?.name || (typeof value?.collection === 'string' ? value.collection : '') || '').trim(),
     collectionSymbol: String(value?.token?.symbol || collection?.symbol || '').trim(),
   };
+}
+
+function voxelText(...values: unknown[]) {
+  const haystack = values.map(value => String(value || '')).join(' ').toLowerCase();
+  return haystack.includes('voxelflip')
+    || haystack.includes('voxelpop')
+    || haystack.includes('voxel vault')
+    || haystack.includes('voxelvault.io')
+    || haystack.includes('voxel-vault');
 }
 
 function rpcCandidates() {
@@ -117,30 +128,12 @@ async function timedJson(url: string, init: RequestInit = {}) {
   }
 }
 
-function looksLikeVoxel(item: any, productionContract: string) {
-  const contract = contractAddressOf(item);
-  if (contract && contract.toLowerCase() === productionContract.toLowerCase()) return true;
-  const fields = metadataFields(item);
-  const haystack = [
-    fields.name,
-    fields.description,
-    fields.collectionName,
-    fields.collectionSymbol,
-    fields.externalUrl,
-    fields.metadataUrl,
-  ].join(' ').toLowerCase();
-  return haystack.includes('voxelflip')
-    || haystack.includes('voxelpop')
-    || haystack.includes('voxel vault')
-    || haystack.includes('voxelvault.io');
-}
-
-async function openSeaOwned(wallet: string, productionContract: string, apiKey: string) {
+async function openSeaOwned(wallet: string, apiKey: string) {
   if (!apiKey) return { available: false, items: [] as any[], walletItems: 0, error: 'OpenSea API key not configured.' };
   const items: any[] = [];
   let walletItems = 0;
   let cursor = '';
-  for (let page = 0; page < 8 && walletItems < MAX_WALLET_NFTS; page += 1) {
+  for (let page = 0; page < 8 && walletItems < MAX_WALLET_NFTS && items.length < MAX_CANDIDATES; page += 1) {
     const query = new URLSearchParams({ limit: '50' });
     if (cursor) query.set('next', cursor);
     const response = await timedJson(`${OPENSEA}/chain/base/account/${wallet}/nfts?${query.toString()}`, {
@@ -152,22 +145,21 @@ async function openSeaOwned(wallet: string, productionContract: string, apiKey: 
     for (const raw of pageItems) {
       const contract = contractAddressOf(raw);
       const tokenId = tokenIdOf(raw);
-      if (!contract || !tokenId || !looksLikeVoxel(raw, productionContract)) continue;
+      if (!contract || !tokenId) continue;
       items.push({ contract, tokenId, ...metadataFields(raw), discovery: 'opensea' });
       if (items.length >= MAX_CANDIDATES) break;
     }
-    if (items.length >= MAX_CANDIDATES) break;
     cursor = String(response.data?.next || '').trim();
     if (!cursor) break;
   }
   return { available: true, items, walletItems, error: '' };
 }
 
-async function blockscoutOwned(wallet: string, productionContract: string) {
+async function blockscoutOwned(wallet: string) {
   const items: any[] = [];
   let walletItems = 0;
   let query = new URLSearchParams({ type: 'ERC-721' });
-  for (let page = 0; page < 12 && walletItems < MAX_WALLET_NFTS; page += 1) {
+  for (let page = 0; page < 12 && walletItems < MAX_WALLET_NFTS && items.length < MAX_CANDIDATES; page += 1) {
     const response = await timedJson(`${BLOCKSCOUT}/addresses/${wallet}/nft?${query.toString()}`, { headers: { accept: 'application/json' } });
     if (!response.ok) return { available: false, items: [] as any[], walletItems, error: response.error || 'Blockscout wallet lookup failed.' };
     const pageItems = Array.isArray(response.data?.items) ? response.data.items : [];
@@ -175,11 +167,10 @@ async function blockscoutOwned(wallet: string, productionContract: string) {
     for (const raw of pageItems) {
       const contract = contractAddressOf(raw);
       const tokenId = tokenIdOf(raw);
-      if (!contract || !tokenId || !looksLikeVoxel(raw, productionContract)) continue;
+      if (!contract || !tokenId) continue;
       items.push({ contract, tokenId, ...metadataFields(raw), discovery: 'blockscout' });
       if (items.length >= MAX_CANDIDATES) break;
     }
-    if (items.length >= MAX_CANDIDATES) break;
     const next = response.data?.next_page_params;
     if (!next || typeof next !== 'object' || !Object.keys(next).length) break;
     query = new URLSearchParams({ type: 'ERC-721' });
@@ -241,6 +232,20 @@ async function verifyOwnedAcrossProviders(providers: JsonRpcProvider[], wallet: 
   return { owned: false, tokenURI: '', error: lastError || 'No Base RPC could verify this NFT.' };
 }
 
+async function contractIdentityAcrossProviders(providers: JsonRpcProvider[], contractAddress: string) {
+  for (const provider of providers) {
+    try {
+      const nft = new Contract(contractAddress, ERC721_ABI, provider);
+      const [name, symbol] = await Promise.all([
+        withTimeout(nft.name()).catch(() => ''),
+        withTimeout(nft.symbol()).catch(() => ''),
+      ]);
+      if (name || symbol) return { name: String(name || ''), symbol: String(symbol || '') };
+    } catch {}
+  }
+  return { name: '', symbol: '' };
+}
+
 function candidateKey(contract: string, tokenId: string) {
   return `${contract.toLowerCase()}:${tokenId}`;
 }
@@ -262,8 +267,8 @@ export async function GET(request: Request) {
   try {
     providers = await healthyProviders();
     const [openSea, blockscout, eventResult] = await Promise.all([
-      openSeaOwned(wallet, productionContract, apiKey),
-      blockscoutOwned(wallet, productionContract),
+      openSeaOwned(wallet, apiKey),
+      blockscoutOwned(wallet),
       onchainCandidateTokenIds(providers[0], wallet, productionContract, String(deployment?.deploymentTxHash || ''))
         .then(items => ({ items, error: '' }))
         .catch(error => ({ items: [] as string[], error: error instanceof Error ? error.message : 'Base event scan failed.' })),
@@ -287,16 +292,45 @@ export async function GET(request: Request) {
 
     const verified: any[] = [];
     const verificationErrors: string[] = [];
+    const identityCache = new Map<string, { name: string; symbol: string }>();
+    let ownedCandidates = 0;
+    let rejectedNonVoxel = 0;
+
     for (const candidate of Array.from(candidates.values()).slice(0, MAX_CANDIDATES)) {
       const contract = normalizeAddress(candidate.contract);
       const tokenId = String(candidate.tokenId || '');
       if (!contract || !/^\d+$/.test(tokenId)) continue;
+
       const check = await verifyOwnedAcrossProviders(providers, wallet, contract, tokenId);
       if (!check.owned) {
         if (check.error) verificationErrors.push(`${contract}:${tokenId} ${check.error}`);
         continue;
       }
+      ownedCandidates += 1;
+
       const currentProduction = contract.toLowerCase() === productionContract.toLowerCase();
+      let identity = identityCache.get(contract.toLowerCase());
+      if (!identity) {
+        identity = await contractIdentityAcrossProviders(providers, contract);
+        identityCache.set(contract.toLowerCase(), identity);
+      }
+
+      const metadataHint = voxelText(
+        candidate.name,
+        candidate.description,
+        candidate.collectionName,
+        candidate.collectionSymbol,
+        candidate.externalUrl,
+        candidate.metadataUrl,
+        check.tokenURI,
+        identity.name,
+        identity.symbol,
+      );
+      if (!currentProduction && !metadataHint) {
+        rejectedNonVoxel += 1;
+        continue;
+      }
+
       verified.push({
         tokenId,
         contract,
@@ -305,13 +339,13 @@ export async function GET(request: Request) {
         selectable: Boolean(check.tokenURI),
         currentProduction,
         legacyVoxelFlip: !currentProduction,
-        name: candidate.name || `${currentProduction ? 'VoxelFlip' : 'Voxel NFT'} #${tokenId}`,
+        name: candidate.name || identity.name || `${currentProduction ? 'VoxelFlip' : 'Voxel NFT'} #${tokenId}`,
         description: candidate.description || '',
         imageUrl: candidate.imageUrl || '',
         animationUrl: candidate.animationUrl || '',
         metadataUrl: candidate.metadataUrl || '',
-        collectionName: candidate.collectionName || '',
-        collectionSymbol: candidate.collectionSymbol || '',
+        collectionName: candidate.collectionName || identity.name || '',
+        collectionSymbol: candidate.collectionSymbol || identity.symbol || '',
         discovery: candidate.discovery || 'wallet',
         openSeaUrl: candidate.openSeaUrl || `https://opensea.io/assets/base/${contract}/${tokenId}`,
       });
@@ -334,6 +368,7 @@ export async function GET(request: Request) {
       blockscout.available ? 'blockscout-wallet' : '',
       eventResult.items.length ? 'production-events' : '',
       `ownerOf-across-${providers.length}-rpcs`,
+      'contract-name-symbol',
     ].filter(Boolean);
 
     return NextResponse.json({
@@ -346,11 +381,12 @@ export async function GET(request: Request) {
       sourceWarning: warnings.length ? warnings.join(' ') : null,
       sourceCounts: {
         openSeaWalletItems: openSea.walletItems,
-        openSeaVoxelCandidates: openSea.items.length,
         blockscoutWalletItems: blockscout.walletItems,
-        blockscoutVoxelCandidates: blockscout.items.length,
         productionEventCandidates: eventResult.items.length,
-        discoveredVoxelCandidates: candidates.size,
+        discoveredWalletErc721: candidates.size,
+        discoveredVoxelCandidates: verified.length,
+        ownedCandidates,
+        rejectedNonVoxel,
         verified: verified.length,
         currentProduction: verified.filter(item => item.currentProduction).length,
         legacyVoxel: verified.filter(item => item.legacyVoxelFlip).length,
@@ -358,7 +394,7 @@ export async function GET(request: Request) {
       },
       count: verified.length,
       nfts: verified,
-      safety: 'Read-only Base wallet scan. No approval, transfer, burn, listing, or signature is requested. Legacy candidates are shown only after current ownerOf verification.',
+      safety: 'Read-only Base wallet scan. No approval, transfer, burn, listing, or signature is requested. Older Voxel-like contracts are classified only after current ownerOf verification and contract metadata reads.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Could not read owned Voxel NFTs.' }, { status: 502, headers: { 'Cache-Control': 'no-store' } });

--- a/app/api/forge/session-asset/route.ts
+++ b/app/api/forge/session-asset/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import { getVoxelPopEntitlement } from '../../../../lib/voxelpop-entitlement';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const MESH_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
+const PROVIDER_TIMEOUT_MS = 8_000;
+
+function clean(value: unknown, max = 500) {
+  return String(value || '').trim().slice(0, max);
+}
+
+async function timedFetch(url: string, init: RequestInit = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, cache: 'no-store', signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const sessionId = clean(url.searchParams.get('sessionId'), 300);
+    if (!sessionId) return NextResponse.json({ error: 'Missing paid VoxelPop session.' }, { status: 400 });
+
+    const entitlement = await getVoxelPopEntitlement(sessionId);
+    if (!entitlement) return NextResponse.json({ error: 'This paid VoxelPop session could not be verified.' }, { status: 403 });
+
+    const taskId = clean(entitlement.metadata?.mesh_task_0, 200);
+    if (!taskId) return NextResponse.json({ error: 'This paid voxel does not have a saved 3D task yet.' }, { status: 404 });
+
+    const apiKey = clean(process.env.MESHY_API_KEY, 1000);
+    if (!apiKey) return NextResponse.json({ error: '3D recovery is not configured on this deployment.' }, { status: 503 });
+
+    const response = await timedFetch(`${MESH_ENDPOINT}/${encodeURIComponent(taskId)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const data: any = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return NextResponse.json({ error: clean(data?.message || data?.error || 'Could not refresh this 3D voxel.') }, { status: 502 });
+    }
+
+    const providerStatus = clean(data?.status, 40).toUpperCase();
+    const providerModelUrl = typeof data?.model_urls?.glb === 'string' ? data.model_urls.glb : '';
+    const ready = providerStatus === 'SUCCEEDED' && Boolean(providerModelUrl);
+    const thumbnailUrl = clean(data?.alpha_thumbnail_url || data?.thumbnail_url || '/voxelpop/voxelpop-logo.png', 2000);
+    const name = clean(entitlement.metadata?.mesh_name_0 || 'Your voxel', 80);
+    const idea = clean(entitlement.metadata?.mesh_idea_0 || '', 160);
+
+    const tokenId = clean(entitlement.metadata?.voxelflip_token_id, 80);
+    const owner = clean(entitlement.metadata?.voxelflip_wallet, 80);
+    const txHash = clean(entitlement.metadata?.voxelflip_tx_hash, 100);
+    const metadataUrl = clean(entitlement.metadata?.voxelflip_metadata_url, 1000);
+    const contract = clean(entitlement.metadata?.voxelflip_contract, 80);
+
+    const stableModelUrl = ready
+      ? `/api/creator-pack/mesh?${new URLSearchParams({ sessionId, taskId, preview: '1' }).toString()}`
+      : '';
+    const updatedAt = new Date().toISOString();
+
+    const record = {
+      sessionId,
+      updatedAt,
+      payload: {
+        asset: { name, dataUrl: thumbnailUrl },
+        mesh: {
+          status: ready ? 'ready' : providerStatus.toLowerCase() || 'unknown',
+          progress: ready ? 100 : Number(data?.progress || 0),
+          taskId,
+          modelUrl: stableModelUrl,
+          error: clean(data?.task_error?.message || '', 500),
+        },
+        ...(tokenId ? {
+          mint: {
+            tokenId,
+            owner,
+            hash: txHash,
+            txHash,
+            metadataUrl,
+            ...(contract ? { contract, contractAddress: contract } : {}),
+          },
+        } : {}),
+        generationsLeft: 0,
+        idea,
+        updatedAt,
+      },
+    };
+
+    return NextResponse.json({
+      recovered: true,
+      ready,
+      record,
+      safety: 'Read-only paid-session recovery. No mint, approval, transfer, listing, burn, or wallet signature is requested.',
+    }, { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    console.error('Focused Forge session recovery failed', error);
+    return NextResponse.json({ error: 'Could not recover this paid 3D voxel right now.' }, { status: 500, headers: { 'Cache-Control': 'private, no-store' } });
+  }
+}

--- a/app/forge/real/layout.js
+++ b/app/forge/real/layout.js
@@ -20,6 +20,38 @@ export default function RealForgeLayout({children}){
   const [signedIn,setSignedIn]=useState(null);
   const [accountBusy,setAccountBusy]=useState(false);
   const [accountMessage,setAccountMessage]=useState('');
+  const [lastRecovery,setLastRecovery]=useState(null);
+
+  async function recoverAccountAssets({quiet=false}={}){
+    const supabase=await getSupabaseBrowserAsync();
+    const {data}=await supabase.auth.getSession();
+    const session=data.session;
+    setSignedIn(Boolean(session?.user));
+    if(!session?.user||!session.access_token)return {records:[],signedIn:false};
+
+    if(!quiet){setAccountBusy(true);setAccountMessage('Scanning your paid VoxelPop 3D history…')}
+    try{
+      const response=await fetch('/api/forge/account-assets',{cache:'no-store',headers:{Authorization:`Bearer ${session.access_token}`}});
+      const recovered=await response.json().catch(()=>({}));
+      if(!response.ok)throw new Error(recovered.error||'Could not recover paid VoxelPop assets.');
+      const records=Array.isArray(recovered.records)?recovered.records:[];
+      let current=mergeVoxelRecords(readLocalVoxelRecords(),records);
+      writeRecords(current);
+      try{await syncLocalVoxelsToAccount(supabase,session.user)}catch{}
+      setLastRecovery(recovered);
+      const nonMinted=Number(recovered.nonMintedReady||0);
+      const minted=Number(recovered.minted||0);
+      const total=Number(recovered.recovered||records.length||0);
+      const stopped=recovered?.diagnostics?.stoppedByTimeBudget===true;
+      setAccountMessage(`Recovered ${total} paid creation${total===1?'':'s'} · ${nonMinted} finished non-minted 3D · ${minted} minted${stopped?' · history scan reached its time limit; tap Refresh again to retry':''}.`);
+      return {records,signedIn:true,recovered};
+    }catch(error){
+      setAccountMessage(error instanceof Error?error.message:'Could not recover paid VoxelPop assets.');
+      return {records:[],signedIn:true,error};
+    }finally{
+      if(!quiet)setAccountBusy(false);
+    }
+  }
 
   useEffect(()=>{
     let active=true;
@@ -53,29 +85,25 @@ export default function RealForgeLayout({children}){
         const alternate=await loadAlternateHostVoxels();
         if(alternate.length)current=mergeVoxelRecords(current,alternate);
       }catch{}
+      writeRecords(current);
 
       try{
-        const supabase=await getSupabaseBrowserAsync();
-        const {data}=await supabase.auth.getSession();
-        const session=data.session;
-        if(active)setSignedIn(Boolean(session?.user));
-        if(session?.user&&session.access_token){
-          const response=await fetch('/api/forge/account-assets',{cache:'no-store',headers:{Authorization:`Bearer ${session.access_token}`}});
-          const recovered=await response.json().catch(()=>({}));
-          if(response.ok&&Array.isArray(recovered.records)){
-            current=mergeVoxelRecords(current,recovered.records);
-            writeRecords(current);
-            try{await syncLocalVoxelsToAccount(supabase,session.user)}catch{}
-            if(active&&recovered.records.length&&!focusSession)setAccountMessage(`Recovered ${recovered.records.length} paid VoxelPop creation${recovered.records.length===1?'':'s'} from your account.`);
-          }else if(active&&response.status!==401&&!focusSession){
-            setAccountMessage(String(recovered.error||''));
+        const result=await recoverAccountAssets({quiet:true});
+        if(active&&result?.records?.length){
+          current=mergeVoxelRecords(current,result.records);
+          writeRecords(current);
+          if(!focusSession){
+            const recovered=result.recovered||{};
+            const total=Number(recovered.recovered||result.records.length||0);
+            const nonMinted=Number(recovered.nonMintedReady||0);
+            const minted=Number(recovered.minted||0);
+            setAccountMessage(`Recovered ${total} paid creation${total===1?'':'s'} · ${nonMinted} finished non-minted 3D · ${minted} minted.`);
           }
         }
       }catch{
         if(active)setSignedIn(false);
       }
 
-      writeRecords(current);
       if(active)setReady(true);
     }
     sync();
@@ -96,22 +124,34 @@ export default function RealForgeLayout({children}){
     }
   }
 
+  async function refreshPaid(){
+    await recoverAccountAssets({quiet:false});
+    // The child Forge page reads the merged local library when LOAD ALL MY VOXELS is tapped.
+    // Do not force a reload here because that would unnecessarily reconnect the wallet.
+  }
+
   if(!ready){
     return <main style={{minHeight:'100vh',background:'#070809',color:'#f7f7f3',display:'grid',placeItems:'center',fontFamily:'Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif',padding:24}}>
       <div style={{textAlign:'center',maxWidth:460}}>
         <div style={{color:'#c8ff54',fontSize:11,fontWeight:900,letterSpacing:'.14em'}}>MY VOXELS</div>
         <h1 style={{fontSize:34,margin:'12px 0 8px'}}>Recovering your full library…</h1>
-        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking the focused paid voxel, browser storage, the other VoxelVault hostname, and your Google-backed library.</p>
+        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking the focused paid voxel, browser storage, the other VoxelVault hostname, and your complete Google-matched paid 3D history.</p>
       </div>
     </main>;
   }
 
   return <>
-    {signedIn===false&&<div style={{position:'relative',zIndex:30,background:'#111318',borderBottom:'1px solid rgba(255,255,255,.10)',color:'#f7f7f3',padding:'12px 18px',display:'flex',alignItems:'center',justifyContent:'center',gap:14,flexWrap:'wrap',fontFamily:'Inter,ui-sans-serif,system-ui,sans-serif'}}>
-      <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Missing another paid 3D voxel?</b> Recover older creations with the Google account used for VoxelPop.</span>
-      <button type="button" onClick={recoverWithGoogle} disabled={accountBusy} style={{border:0,borderRadius:999,padding:'9px 14px',background:'#c8ff54',color:'#0a0b0d',fontWeight:900,cursor:accountBusy?'wait':'pointer'}}>{accountBusy?'OPENING…':'RECOVER WITH GOOGLE'}</button>
-    </div>}
+    <div style={{position:'relative',zIndex:30,background:'#111318',borderBottom:'1px solid rgba(255,255,255,.10)',color:'#f7f7f3',padding:'12px 18px',display:'flex',alignItems:'center',justifyContent:'center',gap:14,flexWrap:'wrap',fontFamily:'Inter,ui-sans-serif,system-ui,sans-serif'}}>
+      {signedIn===false?<>
+        <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Missing a paid 3D voxel?</b> Recover older creations with the Google account used for VoxelPop.</span>
+        <button type="button" onClick={recoverWithGoogle} disabled={accountBusy} style={{border:0,borderRadius:999,padding:'9px 14px',background:'#c8ff54',color:'#0a0b0d',fontWeight:900,cursor:accountBusy?'wait':'pointer'}}>{accountBusy?'OPENING…':'RECOVER WITH GOOGLE'}</button>
+      </>:<>
+        <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Google connected.</b> Re-scan Stripe + Meshy for finished non-minted 3D voxels at any time.</span>
+        <button type="button" onClick={refreshPaid} disabled={accountBusy} style={{border:0,borderRadius:999,padding:'9px 14px',background:'#c8ff54',color:'#0a0b0d',fontWeight:900,cursor:accountBusy?'wait':'pointer'}}>{accountBusy?'SCANNING…':'REFRESH PAID 3D VOXELS'}</button>
+      </>}
+    </div>
     {accountMessage&&<div style={{position:'relative',zIndex:29,background:'#0d0f12',color:'#aeb4bd',textAlign:'center',padding:'8px 16px',font:'700 12px/1.4 Inter,ui-sans-serif,system-ui,sans-serif',borderBottom:'1px solid rgba(255,255,255,.06)'}}>{accountMessage}</div>}
+    {lastRecovery?.diagnostics&&<div style={{position:'relative',zIndex:28,background:'#0b0c0f',color:'#747b86',textAlign:'center',padding:'6px 14px',font:'600 11px/1.4 Inter,ui-sans-serif,system-ui,sans-serif',borderBottom:'1px solid rgba(255,255,255,.04)'}}>History scan: {lastRecovery.diagnostics.checkoutSessionsScanned||0} checkout sessions · {lastRecovery.diagnostics.paidVoxelSessionsScanned||0} paid 3D candidates · {lastRecovery.diagnostics.identityCandidatesChecked||0} identity checks.</div>}
     {children}
   </>;
 }

--- a/app/forge/real/layout.js
+++ b/app/forge/real/layout.js
@@ -15,6 +15,47 @@ function focusedSessionId(){
   try{return String(new URLSearchParams(window.location.search).get('focus_session')||'').trim()}catch{return ''}
 }
 
+function meshReady(payload){
+  const mesh=payload?.mesh||{};
+  const status=String(mesh.status||'').toLowerCase();
+  return ['ready','succeeded','completed'].includes(status)||Boolean(String(mesh.modelUrl||'').trim())||Number(mesh.progress||0)>=100;
+}
+
+function usefulAsset(asset){
+  const image=String(asset?.dataUrl||'');
+  return Boolean(image&&!image.endsWith('/voxelpop/voxelpop-logo.png'));
+}
+
+function mergePaidRecovery(current,recovered){
+  const map=new Map(current.map(record=>[record.sessionId,record]));
+  for(const server of recovered||[]){
+    if(!server?.sessionId||!server?.payload)continue;
+    const existing=map.get(server.sessionId);
+    if(!existing){map.set(server.sessionId,server);continue}
+
+    const serverReady=meshReady(server.payload);
+    const existingReady=meshReady(existing.payload);
+    const asset=usefulAsset(existing.payload?.asset)?existing.payload.asset:server.payload.asset;
+    const mesh=serverReady||!existingReady?server.payload.mesh:existing.payload.mesh;
+    const mint=server.payload?.mint?.tokenId?server.payload.mint:existing.payload?.mint;
+    const updatedAt=new Date().toISOString();
+    map.set(server.sessionId,{
+      sessionId:server.sessionId,
+      updatedAt,
+      payload:{
+        ...existing.payload,
+        ...server.payload,
+        asset,
+        mesh,
+        ...(mint?{mint}:{}),
+        idea:existing.payload?.idea||server.payload?.idea||'',
+        updatedAt,
+      },
+    });
+  }
+  return Array.from(map.values());
+}
+
 export default function RealForgeLayout({children}){
   const [ready,setReady]=useState(false);
   const [signedIn,setSignedIn]=useState(null);
@@ -35,7 +76,7 @@ export default function RealForgeLayout({children}){
       const recovered=await response.json().catch(()=>({}));
       if(!response.ok)throw new Error(recovered.error||'Could not recover paid VoxelPop assets.');
       const records=Array.isArray(recovered.records)?recovered.records:[];
-      let current=mergeVoxelRecords(readLocalVoxelRecords(),records);
+      const current=mergePaidRecovery(readLocalVoxelRecords(),records);
       writeRecords(current);
       try{await syncLocalVoxelsToAccount(supabase,session.user)}catch{}
       setLastRecovery(recovered);
@@ -44,7 +85,7 @@ export default function RealForgeLayout({children}){
       const total=Number(recovered.recovered||records.length||0);
       const stopped=recovered?.diagnostics?.stoppedByTimeBudget===true;
       setAccountMessage(`Recovered ${total} paid creation${total===1?'':'s'} · ${nonMinted} finished non-minted 3D · ${minted} minted${stopped?' · history scan reached its time limit; tap Refresh again to retry':''}.`);
-      return {records,signedIn:true,recovered};
+      return {records:current,signedIn:true,recovered};
     }catch(error){
       setAccountMessage(error instanceof Error?error.message:'Could not recover paid VoxelPop assets.');
       return {records:[],signedIn:true,error};
@@ -59,16 +100,15 @@ export default function RealForgeLayout({children}){
       let current=readLocalVoxelRecords();
       const focusSession=focusedSessionId();
 
-      // Critical cross-browser handoff: when MetaMask opens its own browser,
-      // Safari/ChatGPT localStorage does not come with it. The focus_session URL
-      // identifies the already-paid creation, so restore that one from Stripe +
-      // Meshy before loading the rest of My Voxels. This is read-only.
+      // Cross-browser handoff: the paid session URL survives Safari/ChatGPT ->
+      // MetaMask even when localStorage does not. Restore this exact paid asset
+      // from Stripe + Meshy and make a finished server mesh authoritative.
       if(focusSession){
         try{
           const response=await fetch(`/api/forge/session-asset?${new URLSearchParams({sessionId:focusSession})}`,{cache:'no-store'});
           const recovered=await response.json().catch(()=>({}));
           if(response.ok&&recovered?.record?.sessionId){
-            current=mergeVoxelRecords(current,[recovered.record]);
+            current=mergePaidRecovery(current,[recovered.record]);
             writeRecords(current);
             if(active)setAccountMessage(recovered.ready
               ?'Recovered the exact paid 3D voxel you sent to Forge.'
@@ -90,7 +130,7 @@ export default function RealForgeLayout({children}){
       try{
         const result=await recoverAccountAssets({quiet:true});
         if(active&&result?.records?.length){
-          current=mergeVoxelRecords(current,result.records);
+          current=mergePaidRecovery(current,result.records);
           writeRecords(current);
           if(!focusSession){
             const recovered=result.recovered||{};
@@ -126,8 +166,6 @@ export default function RealForgeLayout({children}){
 
   async function refreshPaid(){
     await recoverAccountAssets({quiet:false});
-    // The child Forge page reads the merged local library when LOAD ALL MY VOXELS is tapped.
-    // Do not force a reload here because that would unnecessarily reconnect the wallet.
   }
 
   if(!ready){

--- a/app/forge/real/layout.js
+++ b/app/forge/real/layout.js
@@ -11,6 +11,10 @@ function writeRecords(records){
   }
 }
 
+function focusedSessionId(){
+  try{return String(new URLSearchParams(window.location.search).get('focus_session')||'').trim()}catch{return ''}
+}
+
 export default function RealForgeLayout({children}){
   const [ready,setReady]=useState(false);
   const [signedIn,setSignedIn]=useState(null);
@@ -21,6 +25,30 @@ export default function RealForgeLayout({children}){
     let active=true;
     async function sync(){
       let current=readLocalVoxelRecords();
+      const focusSession=focusedSessionId();
+
+      // Critical cross-browser handoff: when MetaMask opens its own browser,
+      // Safari/ChatGPT localStorage does not come with it. The focus_session URL
+      // identifies the already-paid creation, so restore that one from Stripe +
+      // Meshy before loading the rest of My Voxels. This is read-only.
+      if(focusSession){
+        try{
+          const response=await fetch(`/api/forge/session-asset?${new URLSearchParams({sessionId:focusSession})}`,{cache:'no-store'});
+          const recovered=await response.json().catch(()=>({}));
+          if(response.ok&&recovered?.record?.sessionId){
+            current=mergeVoxelRecords(current,[recovered.record]);
+            writeRecords(current);
+            if(active)setAccountMessage(recovered.ready
+              ?'Recovered the exact paid 3D voxel you sent to Forge.'
+              :'Recovered the paid voxel, but its 3D mesh is not finished yet.');
+          }else if(active){
+            setAccountMessage(String(recovered.error||'Could not restore the focused paid voxel.'));
+          }
+        }catch(error){
+          if(active)setAccountMessage(error instanceof Error?error.message:'Could not restore the focused paid voxel.');
+        }
+      }
+
       try{
         const alternate=await loadAlternateHostVoxels();
         if(alternate.length)current=mergeVoxelRecords(current,alternate);
@@ -38,8 +66,8 @@ export default function RealForgeLayout({children}){
             current=mergeVoxelRecords(current,recovered.records);
             writeRecords(current);
             try{await syncLocalVoxelsToAccount(supabase,session.user)}catch{}
-            if(active&&recovered.records.length)setAccountMessage(`Recovered ${recovered.records.length} paid VoxelPop creation${recovered.records.length===1?'':'s'} from your account.`);
-          }else if(active&&response.status!==401){
+            if(active&&recovered.records.length&&!focusSession)setAccountMessage(`Recovered ${recovered.records.length} paid VoxelPop creation${recovered.records.length===1?'':'s'} from your account.`);
+          }else if(active&&response.status!==401&&!focusSession){
             setAccountMessage(String(recovered.error||''));
           }
         }
@@ -58,8 +86,9 @@ export default function RealForgeLayout({children}){
     setAccountBusy(true);setAccountMessage('Opening Google sign-in…');
     try{
       const supabase=await getSupabaseBrowserAsync();
-      const redirectTo=new URL('/forge/real',window.location.origin).toString();
-      const {error}=await supabase.auth.signInWithOAuth({provider:'google',options:{redirectTo}});
+      const redirectTo=new URL(window.location.href);
+      redirectTo.hash='';
+      const {error}=await supabase.auth.signInWithOAuth({provider:'google',options:{redirectTo:redirectTo.toString()}});
       if(error)throw error;
     }catch(error){
       setAccountMessage(error instanceof Error?error.message:'Could not start Google recovery.');
@@ -72,17 +101,17 @@ export default function RealForgeLayout({children}){
       <div style={{textAlign:'center',maxWidth:460}}>
         <div style={{color:'#c8ff54',fontSize:11,fontWeight:900,letterSpacing:'.14em'}}>MY VOXELS</div>
         <h1 style={{fontSize:34,margin:'12px 0 8px'}}>Recovering your full library…</h1>
-        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking browser storage, your other VoxelVault hostname, and—when Google is connected—your paid VoxelPop server records.</p>
+        <p style={{color:'#8d8f98',fontSize:13,lineHeight:1.6,margin:0}}>Checking the focused paid voxel, browser storage, the other VoxelVault hostname, and your Google-backed library.</p>
       </div>
     </main>;
   }
 
   return <>
     {signedIn===false&&<div style={{position:'relative',zIndex:30,background:'#111318',borderBottom:'1px solid rgba(255,255,255,.10)',color:'#f7f7f3',padding:'12px 18px',display:'flex',alignItems:'center',justifyContent:'center',gap:14,flexWrap:'wrap',fontFamily:'Inter,ui-sans-serif,system-ui,sans-serif'}}>
-      <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Missing a paid 3D voxel?</b> Recover creations saved in a different browser with the Google account used for VoxelPop.</span>
+      <span style={{fontSize:13,lineHeight:1.45}}><b style={{color:'#c8ff54'}}>Missing another paid 3D voxel?</b> Recover older creations with the Google account used for VoxelPop.</span>
       <button type="button" onClick={recoverWithGoogle} disabled={accountBusy} style={{border:0,borderRadius:999,padding:'9px 14px',background:'#c8ff54',color:'#0a0b0d',fontWeight:900,cursor:accountBusy?'wait':'pointer'}}>{accountBusy?'OPENING…':'RECOVER WITH GOOGLE'}</button>
     </div>}
-    {accountMessage&&<div style={{position:'relative',zIndex:29,background:'#0d0f12',color:'#aeb4bd',textAlign:'center',padding:'8px 16px',font: '700 12px/1.4 Inter,ui-sans-serif,system-ui,sans-serif',borderBottom:'1px solid rgba(255,255,255,.06)'}}>{accountMessage}</div>}
+    {accountMessage&&<div style={{position:'relative',zIndex:29,background:'#0d0f12',color:'#aeb4bd',textAlign:'center',padding:'8px 16px',font:'700 12px/1.4 Inter,ui-sans-serif,system-ui,sans-serif',borderBottom:'1px solid rgba(255,255,255,.06)'}}>{accountMessage}</div>}
     {children}
   </>;
 }


### PR DESCRIPTION
Troubleshoots the remaining Forge asset-loading failures without changing any Base mainnet NFT state.

- Restores `focus_session` paid voxels server-side after Safari/ChatGPT → MetaMask browser handoff, so localStorage is no longer required for that exact finished 3D asset.
- Adds a read-only paid-session recovery endpoint using Stripe entitlement + Meshy task status.
- Recovers historical completed 3D purchases from Voxel Vault's own `mesh_completed` / `glb_downloaded` analytics session IDs first, instead of depending on only the most recent Stripe pages.
- Expands historical Stripe fallback from 5 pages to up to 50 pages within a bounded recovery budget.
- Verifies historical purchase identity using stored VoxelPop user ID, Checkout email, Customer email, PaymentIntent receipt email, and Charge billing email; matched historical sessions are backfilled with the verified VoxelPop user ID so future recovery is stable.
- Reports recovered total, non-minted 3D-ready count, minted count, and recovery diagnostics.
- Links future signed-in VoxelPop checkouts to the verified account ID and prefills the verified account email when available.
- Discovers wallet ERC-721s first, verifies current ownership across multiple Base RPCs, then classifies older Voxel-like contracts using contract name/symbol/tokenURI + marketplace metadata instead of filtering them out too early.
- Keeps production VoxelFlip discovery and Base Sepolia Forge safety boundaries intact.
- No Base mainnet mint, approval, transfer, burn, listing, or signature behavior is added.