### PR TITLE
Harden the full VoxelPop → Forge flow

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -28,6 +28,7 @@ jobs:
       - run: npm run test:universal
       - run: npm run test:media
       - run: npm run test:mobile
+      - run: npm run test:voxel-flow
       - run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: '1'

--- a/app/forge/real/page.js
+++ b/app/forge/real/page.js
@@ -196,7 +196,7 @@ function descendantMetadata(selected,clone){
 async function ensureBaseSepolia(provider){
   let chainId=String(await provider.request({method:'eth_chainId'})||'').toLowerCase();
   if(chainId===BASE_SEPOLIA_CHAIN_ID)return chainId;
-  try{await provider.request({method:'wallet_switchEthereumChain',params:[{chainId:BASE_SEPOLIA_CHAIN_ID}]});
+  try{await provider.request({method:'wallet_switchEthereumChain',params:[{chainId:BASE_SEPOLIA_CHAIN_ID}]});}
   catch(error){
     if(error?.code===4001)throw new Error('Base Sepolia network switch was cancelled in MetaMask.');
     if(error?.code!==4902)throw new Error(error?.message||'Please switch MetaMask to Base Sepolia.');

--- a/app/forge/real/page.js
+++ b/app/forge/real/page.js
@@ -196,7 +196,7 @@ function descendantMetadata(selected,clone){
 async function ensureBaseSepolia(provider){
   let chainId=String(await provider.request({method:'eth_chainId'})||'').toLowerCase();
   if(chainId===BASE_SEPOLIA_CHAIN_ID)return chainId;
-  try{await provider.request({method:'wallet_switchEthereumChain',params:[{chainId:BASE_SEPOLIA_CHAIN_ID}]});}
+  try{await provider.request({method:'wallet_switchEthereumChain',params:[{chainId:BASE_SEPOLIA_CHAIN_ID}]});
   catch(error){
     if(error?.code===4001)throw new Error('Base Sepolia network switch was cancelled in MetaMask.');
     if(error?.code!==4902)throw new Error(error?.message||'Please switch MetaMask to Base Sepolia.');
@@ -224,9 +224,21 @@ export default function RealVoxelForgePage(){
   const [error,setError]=useState('');
 
   useEffect(()=>{
+    let active=true;
     const q=new URLSearchParams(window.location.search);
     const clone=q.get('clone')||'';
     if(ADDRESS_RE.test(clone))setCloneAddress(getAddress(clone));
+    loadMyVoxels().then(library=>{
+      if(!active)return;
+      const localDisplay=mergeLibraryAndChain(library,[]);
+      setAssets(localDisplay);
+      setScanInfo({libraryLoaded:true,libraryCount:library.length,eligibleCount:0,totalShown:localDisplay.length,sourceWarning:null});
+      if(library.length){
+        const ready=library.filter(asset=>asset.library3d).length;
+        setStatus(`Loaded ${library.length} saved My Voxel${library.length===1?'':'s'} including ${ready} 3D-ready. Connect MetaMask only when you want to add verified Base NFTs.`);
+      }
+    }).catch(()=>{});
+    return()=>{active=false};
   },[]);
 
   const selected=useMemo(()=>selectedIds.map(id=>assets.find(asset=>asset.key===id)).filter(Boolean),[selectedIds,assets]);
@@ -258,14 +270,18 @@ export default function RealVoxelForgePage(){
   }
 
   async function scanAssets(){
-    setBusy(true);setError('');setAssets([]);setSelectedIds([]);setImported([]);setRare(null);setCloneVerified(false);setScanInfo(null);
+    setBusy(true);setError('');setSelectedIds([]);setImported([]);setRare(null);setCloneVerified(false);
     try{
-      if(!wallet)throw new Error('Connect MetaMask first.');
       setStatus('Loading your saved My Voxels first…');
       const library=await loadMyVoxels();
       const localDisplay=mergeLibraryAndChain(library,[]);
       setAssets(localDisplay);
       setScanInfo({libraryLoaded:true,libraryCount:library.length,eligibleCount:0,totalShown:localDisplay.length,sourceWarning:null});
+      if(!wallet){
+        const ready=library.filter(asset=>asset.library3d).length;
+        setStatus(`Loaded ${library.length} saved My Voxel${library.length===1?'':'s'} including ${ready} 3D-ready. Connect MetaMask to add wallet-owned Base NFTs.`);
+        return;
+      }
       setStatus(`Loaded ${library.length} saved My Voxel${library.length===1?'':'s'}. Now reading the connected wallet on Base.`);
 
       try{
@@ -400,13 +416,13 @@ export default function RealVoxelForgePage(){
       <section className={styles.panel}>
         <div className={styles.row}><div><small>CONNECTED WALLET</small><b>{wallet?wallet:'Not connected'}</b>{balanceEth&&<span>{Number(balanceEth).toFixed(5)} Base Sepolia ETH</span>}</div><button onClick={connect} disabled={busy}>{wallet?'RECONNECT':'CONNECT METAMASK'}</button></div>
         <div className={styles.safety}><b>Your Base mainnet NFTs are read-only here.</b><span>The scan does not approve, transfer, burn, list, or sign any Base NFT. The only write contract used later is your Base Sepolia test Forge clone.</span></div>
-        <div className={styles.sectionHead}><small>STEP 1 · LOAD SAVED + WALLET ASSETS</small><h2>Read the wallet, not just one collection.</h2><p>We show every saved My Voxel first, then discover likely VoxelPop/VoxelFlip ERC-721s from the connected Base wallet and independently verify current ownership across multiple Base RPCs.</p></div>
-        <button className={styles.primary} onClick={wallet?scanAssets:connect} disabled={busy}>{busy?'LOADING…':wallet?'LOAD ALL MY VOXELS':'CONNECT METAMASK'}</button>
+        <div className={styles.sectionHead}><small>STEP 1 · LOAD SAVED + WALLET ASSETS</small><h2>Read the library first, then the wallet.</h2><p>Saved My Voxels—including non-minted 3D-ready assets—load before wallet connection. Connecting MetaMask only adds independently verified wallet-owned Base voxel NFTs.</p></div>
+        <button className={styles.primary} onClick={wallet?scanAssets:connect} disabled={busy}>{busy?'LOADING…':wallet?'LOAD ALL MY VOXELS':'CONNECT METAMASK TO ADD MINTED NFTS'}</button>
         {scanInfo?.sourceWarning&&<div className={styles.notice}><b>SCAN NOTE</b><span>{scanInfo.sourceWarning}</span></div>}
         {scanInfo&&<div className={styles.notice}><b>LIBRARY + WALLET · READ ONLY</b><span>{savedCount} saved My Voxel{savedCount===1?'':'s'} · {readyCount} 3D ready · {selectableCount} verified Base voxel NFT{selectableCount===1?'':'s'} · {legacyCount} legacy-contract match{legacyCount===1?'':'es'}.</span></div>}
         {counts&&<div className={styles.notice}><b>WALLET SCAN DETAILS</b><span>Blockscout wallet NFTs: {counts.blockscoutWalletItems??'—'} · OpenSea wallet NFTs: {counts.openSeaWalletItems??'—'} · Voxel candidates: {counts.discoveredVoxelCandidates??'—'} · Verified: {counts.verified??'—'} · Current collection: {counts.currentProduction??'—'} · Legacy voxel contracts: {counts.legacyVoxel??'—'} · RPCs used: {counts.rpcProviders??'—'}.</span></div>}
-        {assets.length>0&&<><div className={styles.sectionHead}><small>STEP 2 · REVIEW / CHOOSE 3</small><h2>Each contract + token stays separate.</h2><p>A card becomes selectable only after Base confirms that the connected wallet owns it and its tokenURI can be read. Saved non-minted 3D voxels remain visible but are not selected automatically.</p></div><div className={styles.assetGrid}>{assets.map(asset=>{const chosen=selectedIds.includes(asset.key);const label=asset.selectable?(asset.legacyVoxelFlip?`VERIFIED LEGACY VOXEL NFT · #${asset.tokenId}`:`REAL BASE NFT · #${asset.tokenId}`):asset.library3d?'3D READY · MINT / RECOVER FIRST':'3D NOT READY';const detail=asset.selectable?`Owned by connected wallet · ${short(asset.contract)}`:asset.library3d?'This finished 3D voxel is saved. Open it from its paid voxel page to carry it into this same browser, or mint/recover it before Forge selection.':`Saved in My Voxels · mesh status ${asset.meshStatus||'idle'}.`;return <button key={asset.key} type="button" className={`${styles.asset} ${chosen?styles.selected:''} ${!asset.selectable?styles.unavailable:''}`} onClick={()=>toggle(asset.key)} disabled={imported.length>0||!asset.selectable}><span className={styles.check}>{chosen?'✓':asset.selectable?'+':'!'}</span>{asset.imageUrl?<img src={asset.imageUrl} alt={asset.name}/>:<div className={styles.placeholder}>{asset.selectable?`NFT #${asset.tokenId}`:'MY VOXEL'}</div>}<div className={styles.assetBody}><small>{label}</small><b>{asset.name}</b><span>{detail}</span></div></button>})}</div><div className={styles.selectionBar}><div><b>{selected.length} / 3 selected</b><span>{selected.length===3?'Ready to verify your test Forge.':selectableCount>=3?'Choose any three verified Base voxel NFT cards.':'Forge needs 3 verified Base voxel NFTs. The scan details above show exactly where discovery or verification stopped.'}</span></div>{selected.length>0&&imported.length===0&&<button className={styles.secondary} onClick={()=>setSelectedIds([])}>CLEAR SELECTION</button>}</div></>}
-        {scanInfo&&selectableCount<3&&<div className={styles.notice}><b>FORGE NEEDS 3 VERIFIED NFTS</b><span>If you know more are in this wallet, the WALLET SCAN DETAILS above now exposes whether discovery or owner verification is missing them. No automatic mint is performed here.</span></div>}
+        {assets.length>0&&<><div className={styles.sectionHead}><small>STEP 2 · REVIEW / CHOOSE 3</small><h2>Every saved voxel stays visible.</h2><p>Non-minted 3D voxels stay visible but disabled for forging. A card becomes selectable only after Base confirms that the connected wallet owns its NFT and its tokenURI can be read.</p></div><div className={styles.assetGrid}>{assets.map(asset=>{const chosen=selectedIds.includes(asset.key);const label=asset.selectable?(asset.legacyVoxelFlip?`VERIFIED LEGACY VOXEL NFT · #${asset.tokenId}`:`REAL BASE NFT · #${asset.tokenId}`):asset.library3d?'3D READY · NOT MINTED':'3D NOT READY';const detail=asset.selectable?`Owned by connected wallet · ${short(asset.contract)}`:asset.library3d?'Finished 3D voxel saved in My Voxels. It is visible here without minting; mint/recover only if you want to use it as a Forge parent.':`Saved in My Voxels · mesh status ${asset.meshStatus||'idle'}.`;return <button key={asset.key} type="button" className={`${styles.asset} ${chosen?styles.selected:''} ${!asset.selectable?styles.unavailable:''}`} onClick={()=>toggle(asset.key)} disabled={imported.length>0||!asset.selectable}><span className={styles.check}>{chosen?'✓':asset.selectable?'+':'!'}</span>{asset.imageUrl?<img src={asset.imageUrl} alt={asset.name}/>:<div className={styles.placeholder}>{asset.selectable?`NFT #${asset.tokenId}`:'MY VOXEL'}</div>}<div className={styles.assetBody}><small>{label}</small><b>{asset.name}</b><span>{detail}</span></div></button>})}</div><div className={styles.selectionBar}><div><b>{selected.length} / 3 selected</b><span>{selected.length===3?'Ready to verify your test Forge.':selectableCount>=3?'Choose any three verified Base voxel NFT cards.':'Forge needs 3 verified Base voxel NFTs. Your non-minted 3D voxels remain visible above but are not used as parents.'}</span></div>{selected.length>0&&imported.length===0&&<button className={styles.secondary} onClick={()=>setSelectedIds([])}>CLEAR SELECTION</button>}</div></>}
+        {scanInfo&&wallet&&selectableCount<3&&<div className={styles.notice}><b>FORGE NEEDS 3 VERIFIED NFTS</b><span>If you know more are in this wallet, the WALLET SCAN DETAILS above shows whether discovery or owner verification is missing them. No automatic mint is performed here.</span></div>}
         {selected.length===3&&<><div className={styles.sectionHead}><small>STEP 3 · VERIFY TEST FORGE</small><h2>Review the destination before anything is written.</h2><p>This is your already-deployed Base Sepolia creator Forge. MetaMask may switch networks here, but verifying it does not spend ETH.</p></div><div className={styles.inputRow}><input value={cloneAddress} onChange={e=>{setCloneAddress(e.target.value);setCloneVerified(false)}} placeholder="Base Sepolia Forge clone 0x…" autoCapitalize="off" autoCorrect="off" spellCheck="false"/><button className={styles.secondary} onClick={verifyClone} disabled={busy}>{cloneVerified?'✓ VERIFIED':'VERIFY FORGE'}</button></div><div className={styles.review}>{selected.map((asset,index)=><article key={asset.key}><small>PARENT {index+1}</small><b>{asset.name}</b><span>{asset.legacyVoxelFlip?'Legacy Voxel NFT':'VoxelFlip'} #{asset.tokenId}<br/>{asset.contract}</span></article>)}</div>{cloneVerified&&<button className={styles.primary} onClick={importSelected} disabled={busy||imported.length===3}>{imported.length===3?'3 TEST COPIES IMPORTED':busy?'WAITING FOR METAMASK…':'IMPORT 3 METADATA COPIES TO SEPOLIA'}</button>}<p className={styles.fine}>Import means minting three separate Common NFTs inside the test Forge with the same tokenURI metadata. It does not move the original Base NFTs.</p></>}
         {status&&<div className={styles.notice}><b>STATUS</b><span>{status}</span></div>}{error&&<div className={styles.error}>{error}</div>}
       </section>

--- a/app/studio/page.js
+++ b/app/studio/page.js
@@ -114,7 +114,9 @@ export default function StudioPage(){
   setBusy(true);setError('');
   try{
    sessionStorage.setItem('voxelPackBrief',JSON.stringify({idea:idea.trim(),style:'polished'}));
-   const r=await fetch('/api/creator-pack/checkout',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({idea:idea.trim().slice(0,180),style:'polished',flowId:id,attribution})});
+   const headers={'Content-Type':'application/json'};
+   if(session?.access_token)headers.Authorization=`Bearer ${session.access_token}`;
+   const r=await fetch('/api/creator-pack/checkout',{method:'POST',headers,body:JSON.stringify({idea:idea.trim().slice(0,180),style:'polished',flowId:id,attribution})});
    const d=await r.json(); if(!r.ok||!d.url) throw new Error(d.error||'Checkout unavailable'); location.href=d.url;
   }catch(e){setError(e instanceof Error?e.message:'Checkout unavailable');setBusy(false)}
  }
@@ -149,13 +151,14 @@ export default function StudioPage(){
    {myVoxels.length>0?<div style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(210px,1fr))',gap:14}}>
     {myVoxels.map(voxel=>{
      const ready=voxel.meshStatus==='ready';const minted=voxel.mint?.tokenId?voxel.mint:null;
-     const assetHref=`/pack/success?session_id=${encodeURIComponent(voxel.sessionId)}`;const mintHref=`/voxelflip/mint?session_id=${encodeURIComponent(voxel.sessionId)}`;const href=minted?mintHref:assetHref;
+     const assetHref=`/pack/success?session_id=${encodeURIComponent(voxel.sessionId)}`;const mintHref=`/voxelflip/mint?session_id=${encodeURIComponent(voxel.sessionId)}`;const forgeHref=`/forge/real?focus_session=${encodeURIComponent(voxel.sessionId)}`;const href=minted?mintHref:assetHref;
      return <article key={voxel.sessionId} style={{overflow:'hidden',borderRadius:18,border:'1px solid #e5e7eb',background:'#f8fafc'}}>
       <img src={voxel.image} alt={voxel.name.replaceAll('-',' ')} style={{width:'100%',height:190,display:'block',objectFit:'cover',background:'#f3f4f6'}}/>
       <div style={{padding:14}}>
        <small style={{fontWeight:900,letterSpacing:'.08em',color:minted?'#4d7c0f':'#6b7280'}}>{minted?`VOXELFLIP #${minted.tokenId} · MINTED`:ready?'3D READY':'PAID VOXEL'}</small>
        <h3 style={{margin:'5px 0 12px',fontSize:18,textTransform:'capitalize',color:'#111827'}}>{voxel.name.replaceAll('-',' ')}</h3>
        <a href={href} style={{display:'block',textAlign:'center',textDecoration:'none',padding:'11px 12px',borderRadius:12,fontWeight:900,background:minted?'#365314':'#111827',color:'#fff'}}>{minted?`Open minted 3D · #${minted.tokenId}`:ready?'Open 3D voxel':'Continue voxel'}</a>
+       {!minted&&ready&&<a href={forgeHref} style={{display:'block',textAlign:'center',textDecoration:'none',padding:'10px 10px 0',fontSize:13,fontWeight:900,color:'#365314'}}>Add this 3D voxel to Forge →</a>}
        {minted?.openSeaUrl&&<a href={minted.openSeaUrl} target="_blank" rel="noreferrer" style={{display:'block',textAlign:'center',textDecoration:'none',padding:'9px 10px 0',fontSize:13,fontWeight:800,color:'#475569'}}>Open on OpenSea ↗</a>}
       </div>
      </article>;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:collection": "node scripts/test-collection-experience.mjs",
     "test:commerce": "node scripts/test-commerce-hardening.mjs",
     "test:routes": "node scripts/test-route-integrity.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:commerce && npm run test:routes && npm run build",
+    "test:voxel-flow": "node scripts/test-voxel-flow-integrity.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:commerce && npm run test:routes && npm run test:voxel-flow && npm run build",
     "chain:compile": "hardhat compile",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet"

--- a/scripts/test-voxel-flow-integrity.mjs
+++ b/scripts/test-voxel-flow-integrity.mjs
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=process.cwd();
+const failures=[];
+const read=rel=>fs.readFileSync(path.join(root,rel),'utf8');
+const requireText=(rel,text,message)=>{const source=read(rel);if(!source.includes(text))failures.push(`${rel}: ${message}`)};
+const forbid=(rel,pattern,message)=>{const source=read(rel);if(pattern.test(source))failures.push(`${rel}: ${message}`)};
+
+requireText('app/studio/page.js','session?.access_token','signed-in checkout must use the current Supabase access token.');
+requireText('app/studio/page.js','Authorization=`Bearer ${session.access_token}`','signed-in checkout must send a Bearer token to the server.');
+requireText('app/studio/page.js','/forge/real?focus_session=','3D-ready non-minted My Voxels must have an exact-session Forge handoff.');
+
+requireText('app/api/creator-pack/checkout/route.ts','verifiedAccount(request)','checkout must verify a supplied account token server-side.');
+requireText('app/api/creator-pack/checkout/route.ts','metadata.voxelpop_user_id = account.id','verified purchases must be permanently linked to the VoxelPop account ID.');
+requireText('app/api/creator-pack/checkout/route.ts','client_reference_id: account.id','Stripe checkout must retain the verified account reference.');
+
+requireText('app/pack/success/PackBuilder.tsx','focus_session=${encodeURIComponent(sessionId)}','finished paid 3D pages must preserve the exact paid session when opening Forge.');
+
+requireText('app/forge/real/layout.js','/api/forge/session-asset?','Forge must recover an exact paid session across browser handoff.');
+requireText('app/forge/real/layout.js','/api/forge/account-assets','Forge must support authenticated historical paid-asset recovery.');
+requireText('app/forge/real/layout.js','REFRESH PAID 3D VOXELS','Forge must expose an explicit paid 3D recovery retry.');
+
+requireText('app/api/forge/session-asset/route.ts','getVoxelPopEntitlement(sessionId)','focused-session recovery must verify the paid entitlement.');
+requireText('app/api/forge/session-asset/route.ts','mesh_task_0','focused-session recovery must use the saved Meshy task.');
+requireText('app/api/forge/account-assets/route.ts','mesh_completed','historical recovery must use completed-mesh analytics.');
+requireText('app/api/forge/account-assets/route.ts','nonMintedReady','historical recovery must explicitly report finished non-minted 3D assets.');
+requireText('app/api/forge/account-assets/route.ts','voxelpop_user_id','historical paid sessions must support stable account-ID linkage.');
+
+requireText('app/forge/real/page.js','loadMyVoxels().then','saved My Voxels must load before wallet connection.');
+requireText('app/forge/real/page.js','3D READY · NOT MINTED','non-minted 3D assets must remain visibly distinct from wallet NFTs.');
+requireText('app/forge/real/page.js','Connect MetaMask only when you want to add verified Base NFTs.','wallet connection must not be required merely to see saved My Voxels.');
+requireText('app/forge/real/page.js',"const BASE_SEPOLIA_CHAIN_ID='0x14a34'",'Forge write flow must remain locked to Base Sepolia.');
+requireText('app/forge/real/page.js','network.chainId!==84532n','Forge transaction provider must reject non-Sepolia networks.');
+forbid('app/forge/real/page.js',/wallet_switchEthereumChain[^\n]+0x2105/i,'Forge must not switch the write flow to Base mainnet.');
+
+requireText('app/api/forge/owned-assets/route.ts','verifyOwnedAcrossProviders','wallet NFT discovery must independently verify current ownership.');
+requireText('app/api/forge/owned-assets/route.ts','blockscoutOwned','wallet NFT discovery must have an indexer fallback independent of OpenSea.');
+requireText('app/api/forge/owned-assets/route.ts','legacyVoxelFlip','older Voxel-like contracts must stay distinguishable after verification.');
+
+if(failures.length){
+ console.error('\nVoxel flow integrity failures:');
+ for(const failure of failures)console.error(`- ${failure}`);
+ process.exit(1);
+}
+
+console.log('Voxel flow integrity passed: signed-in purchases are account-linked, non-minted 3D assets recover by paid session/history and remain visible without a wallet, minted NFTs are ownership-verified, and Forge writes stay locked to Base Sepolia.');


### PR DESCRIPTION
Full integration audit for the live VoxelPop/VoxelFlip/Forge path.

Fixes two wiring issues the generic build could not detect:
- Signed-in Studio checkouts now send the verified Supabase Bearer token, allowing the existing server checkout route to permanently link purchases to the VoxelPop account ID.
- Forge now loads saved My Voxels, including non-minted 3D-ready assets, before wallet connection instead of making MetaMask a prerequisite for seeing the library.

Also:
- Adds a direct `Add this 3D voxel to Forge` link on each 3D-ready non-minted My Voxels card using its exact paid session ID.
- Keeps non-minted assets visible but non-selectable until a Base NFT is actually verified.
- Adds `test:voxel-flow` regression coverage for account-linked checkout, exact-session recovery, historical paid 3D recovery, wallet ownership verification, and Base-Sepolia-only Forge writes.
- Adds the new integration test to the release test suite and Quality Gate.

No Base mainnet mint, transfer, approval, burn, listing, signing, or automatic wallet action is added.