### PR TITLE
Activate existing Base revenue Forge safely

### DIFF
--- a/app/api/forge/deployment-config/route.ts
+++ b/app/api/forge/deployment-config/route.ts
@@ -8,6 +8,7 @@ export const dynamic = 'force-dynamic';
 
 const LAUNCH_FEE_WEI = parseEther('0.001');
 const LAUNCH_ROYALTY_BPS = 500;
+const EXISTING_BASE_CANDIDATE = '0x34d7E9d8Cae07B61eb1f0c1dABD4876F2429cd3D';
 
 export async function GET() {
   try {
@@ -25,6 +26,7 @@ export async function GET() {
       feeEth: '0.001',
       royaltyBps: LAUNCH_ROYALTY_BPS,
       existingDeployment: existing,
+      pendingCandidateAddress: existing ? null : EXISTING_BASE_CANDIDATE,
       safety: 'Only the reviewed VoxelFlip owner wallet may deploy/register this production Forge. That wallet is also the treasury. The Forge signer is a distinct server-derived address whose private key never reaches the browser.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {

--- a/app/api/forge/register-mainnet/route.ts
+++ b/app/api/forge/register-mainnet/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { Contract, JsonRpcProvider, getAddress, isAddress, parseEther } from 'ethers';
 import { NextResponse } from 'next/server';
 import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
@@ -11,6 +12,8 @@ const BASE_CHAIN_ID = 8453;
 const LAUNCH_FEE = parseEther('0.001');
 const LAUNCH_ROYALTY_BPS = 500;
 const TX_RE = /^0x[a-fA-F0-9]{64}$/;
+const EXPECTED_RUNTIME_SHA256 = 'f35b3b6f8dec6705e612f179f39f44e1c7650ea7743b6034800e99adc066ed56';
+const EXPECTED_RUNTIME_BYTES = 11727;
 const FORGE_ABI = [
   'function owner() view returns (address)',
   'function forgeSigner() view returns (address)',
@@ -46,6 +49,13 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs = 6_000): Promise<T
   }
 }
 
+function runtimeSha256(code: string) {
+  if (!/^0x[0-9a-fA-F]+$/.test(code)) return '';
+  const bytes = Buffer.from(code.slice(2), 'hex');
+  if (bytes.length !== EXPECTED_RUNTIME_BYTES) return '';
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
 type VerifiedDeployment = {
   forgeSigner: string;
   treasury: string;
@@ -56,7 +66,7 @@ type VerifiedDeployment = {
 
 async function verifyAcrossBaseProviders(params: {
   address: string;
-  txHash: string;
+  txHash?: string;
   approvedOwner: string;
   parentCollection: string;
   expectedSigner: string;
@@ -67,29 +77,26 @@ async function verifyAcrossBaseProviders(params: {
     const provider = new JsonRpcProvider(url, BASE_CHAIN_ID, { staticNetwork: true });
     try {
       await withTimeout(provider.getBlockNumber(), 4_000);
+      const code = await withTimeout(provider.getCode(params.address), 8_000);
+      if (!code || code === '0x') throw new Error('No contract bytecode exists at the submitted Base address.');
+      if (runtimeSha256(code) !== EXPECTED_RUNTIME_SHA256) {
+        throw new Error('The Base address does not contain the reviewed VoxelForgeRevenue runtime bytecode.');
+      }
 
-      const [receipt, tx, code] = await withTimeout(Promise.all([
-        provider.getTransactionReceipt(params.txHash),
-        provider.getTransaction(params.txHash),
-        provider.getCode(params.address),
-      ]), 10_000);
-
-      if (!receipt || receipt.status !== 1 || !receipt.contractAddress) {
-        throw new Error('The Base deployment transaction is not confirmed successfully.');
-      }
-      if (getAddress(receipt.contractAddress) !== params.address) {
-        throw new Error('Deployment transaction does not match the submitted Forge address.');
-      }
-      if (!tx || getAddress(tx.from) !== params.approvedOwner) {
-        throw new Error('The Forge was not deployed by the reviewed owner wallet.');
-      }
-      if (!code || code === '0x') {
-        throw new Error('No contract bytecode exists at the submitted Base address.');
+      let deployedAt = '';
+      if (params.txHash) {
+        const [receipt, tx] = await withTimeout(Promise.all([
+          provider.getTransactionReceipt(params.txHash),
+          provider.getTransaction(params.txHash),
+        ]), 10_000);
+        if (!receipt || receipt.status !== 1 || !receipt.contractAddress) throw new Error('The Base deployment transaction is not confirmed successfully.');
+        if (getAddress(receipt.contractAddress) !== params.address) throw new Error('Deployment transaction does not match the submitted Forge address.');
+        if (!tx || getAddress(tx.from) !== params.approvedOwner) throw new Error('The Forge was not deployed by the reviewed owner wallet.');
+        const block = await withTimeout(provider.getBlock(receipt.blockNumber), 6_000).catch(() => null);
+        deployedAt = block?.timestamp ? new Date(Number(block.timestamp) * 1000).toISOString() : '';
       }
 
       const forge = new Contract(params.address, FORGE_ABI, provider);
-      // Read getters individually. Some public Base RPCs intermittently fail one
-      // eth_call while accepting others; a failed provider is retried as a whole.
       const owner = getAddress(await withTimeout(forge.owner(), 6_000));
       const forgeSigner = getAddress(await withTimeout(forge.forgeSigner(), 6_000));
       const treasury = getAddress(await withTimeout(forge.treasury(), 6_000));
@@ -106,14 +113,7 @@ async function verifyAcrossBaseProviders(params: {
       if (!parentApproved) throw new Error('The reviewed VoxelFlip Base collection is not approved as a parent collection.');
       if (paused) throw new Error('The newly deployed production Forge is unexpectedly paused.');
 
-      const block = await withTimeout(provider.getBlock(receipt.blockNumber), 6_000).catch(() => null);
-      return {
-        forgeSigner,
-        treasury,
-        feeWei,
-        royaltyBps,
-        deployedAt: block?.timestamp ? new Date(Number(block.timestamp) * 1000).toISOString() : '',
-      };
+      return { forgeSigner, treasury, feeWei, royaltyBps, deployedAt };
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error || 'Base verification failed.');
     } finally {
@@ -129,9 +129,9 @@ export async function POST(request: Request) {
     const body = await request.json();
     const walletRaw = String(body?.wallet || '').trim();
     const addressRaw = String(body?.address || '').trim();
-    const txHash = String(body?.txHash || '').trim();
-    if (!isAddress(walletRaw) || !isAddress(addressRaw) || !TX_RE.test(txHash)) {
-      return NextResponse.json({ error: 'A valid owner wallet, deployed contract address, and deployment transaction hash are required.' }, { status: 400 });
+    const txHashRaw = String(body?.txHash || '').trim();
+    if (!isAddress(walletRaw) || !isAddress(addressRaw) || (txHashRaw && !TX_RE.test(txHashRaw))) {
+      return NextResponse.json({ error: 'A valid owner wallet and deployed Base contract address are required.' }, { status: 400 });
     }
 
     const wallet = getAddress(walletRaw);
@@ -145,7 +145,7 @@ export async function POST(request: Request) {
     const expectedSigner = getAddress(revenueForgeSigningWallet().address);
     const verified = await verifyAcrossBaseProviders({
       address,
-      txHash,
+      txHash: txHashRaw || undefined,
       approvedOwner,
       parentCollection: getAddress(parent.address),
       expectedSigner,
@@ -155,7 +155,7 @@ export async function POST(request: Request) {
       chainId: 8453,
       network: 'base',
       address,
-      deploymentTxHash: txHash,
+      deploymentTxHash: txHashRaw,
       owner: approvedOwner,
       forgeSigner: verified.forgeSigner,
       treasury: verified.treasury,

--- a/app/api/forge/register-mainnet/route.ts
+++ b/app/api/forge/register-mainnet/route.ts
@@ -37,28 +37,94 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs = 6_000): Promise<T
   try {
     return await Promise.race([
       promise,
-      new Promise<T>((_resolve, reject) => { timer = setTimeout(() => reject(new Error('Base RPC timed out.')), timeoutMs); }),
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('Base RPC timed out.')), timeoutMs);
+      }),
     ]);
   } finally {
     if (timer) clearTimeout(timer);
   }
 }
 
-async function providerForBase() {
+type VerifiedDeployment = {
+  forgeSigner: string;
+  treasury: string;
+  feeWei: bigint;
+  royaltyBps: number;
+  deployedAt: string;
+};
+
+async function verifyAcrossBaseProviders(params: {
+  address: string;
+  txHash: string;
+  approvedOwner: string;
+  parentCollection: string;
+  expectedSigner: string;
+}): Promise<VerifiedDeployment> {
+  let lastError = 'No Base RPC completed the verification.';
+
   for (const url of rpcCandidates()) {
     const provider = new JsonRpcProvider(url, BASE_CHAIN_ID, { staticNetwork: true });
     try {
       await withTimeout(provider.getBlockNumber(), 4_000);
-      return provider;
-    } catch {
+
+      const [receipt, tx, code] = await withTimeout(Promise.all([
+        provider.getTransactionReceipt(params.txHash),
+        provider.getTransaction(params.txHash),
+        provider.getCode(params.address),
+      ]), 10_000);
+
+      if (!receipt || receipt.status !== 1 || !receipt.contractAddress) {
+        throw new Error('The Base deployment transaction is not confirmed successfully.');
+      }
+      if (getAddress(receipt.contractAddress) !== params.address) {
+        throw new Error('Deployment transaction does not match the submitted Forge address.');
+      }
+      if (!tx || getAddress(tx.from) !== params.approvedOwner) {
+        throw new Error('The Forge was not deployed by the reviewed owner wallet.');
+      }
+      if (!code || code === '0x') {
+        throw new Error('No contract bytecode exists at the submitted Base address.');
+      }
+
+      const forge = new Contract(params.address, FORGE_ABI, provider);
+      // Read getters individually. Some public Base RPCs intermittently fail one
+      // eth_call while accepting others; a failed provider is retried as a whole.
+      const owner = getAddress(await withTimeout(forge.owner(), 6_000));
+      const forgeSigner = getAddress(await withTimeout(forge.forgeSigner(), 6_000));
+      const treasury = getAddress(await withTimeout(forge.treasury(), 6_000));
+      const feeWei = BigInt(await withTimeout(forge.forgeFee(), 6_000));
+      const royaltyBps = Number(await withTimeout(forge.royaltyBps(), 6_000));
+      const parentApproved = Boolean(await withTimeout(forge.approvedParentCollections(params.parentCollection), 6_000));
+      const paused = Boolean(await withTimeout(forge.paused(), 6_000));
+
+      if (owner !== params.approvedOwner) throw new Error('Production Forge owner does not match the reviewed VoxelFlip owner.');
+      if (treasury !== params.approvedOwner) throw new Error('Production Forge treasury does not match the reviewed owner wallet.');
+      if (forgeSigner !== params.expectedSigner) throw new Error('Production Forge signer does not match the protected Forge signer.');
+      if (feeWei !== LAUNCH_FEE) throw new Error('Production Forge launch fee is not 0.001 ETH.');
+      if (royaltyBps !== LAUNCH_ROYALTY_BPS) throw new Error('Production Forge royalty is not the reviewed 500 bps.');
+      if (!parentApproved) throw new Error('The reviewed VoxelFlip Base collection is not approved as a parent collection.');
+      if (paused) throw new Error('The newly deployed production Forge is unexpectedly paused.');
+
+      const block = await withTimeout(provider.getBlock(receipt.blockNumber), 6_000).catch(() => null);
+      return {
+        forgeSigner,
+        treasury,
+        feeWei,
+        royaltyBps,
+        deployedAt: block?.timestamp ? new Date(Number(block.timestamp) * 1000).toISOString() : '',
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error || 'Base verification failed.');
+    } finally {
       provider.destroy();
     }
   }
-  throw new Error('No Base RPC is available to verify the deployment.');
+
+  throw new Error(`Could not verify the existing Base Forge yet. ${lastError}`);
 }
 
 export async function POST(request: Request) {
-  let provider: JsonRpcProvider | null = null;
   try {
     const body = await request.json();
     const walletRaw = String(body?.wallet || '').trim();
@@ -76,51 +142,27 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Only the reviewed VoxelFlip owner wallet can register the production revenue Forge.' }, { status: 403 });
     }
 
-    provider = await providerForBase();
-    const [receipt, tx] = await withTimeout(Promise.all([
-      provider.getTransactionReceipt(txHash),
-      provider.getTransaction(txHash),
-    ]), 8_000);
-    if (!receipt || receipt.status !== 1 || !receipt.contractAddress) throw new Error('The Base deployment transaction is not confirmed successfully.');
-    if (getAddress(receipt.contractAddress) !== address) throw new Error('Deployment transaction does not match the submitted Forge address.');
-    if (!tx || getAddress(tx.from) !== approvedOwner) throw new Error('The Forge was not deployed by the reviewed owner wallet.');
+    const expectedSigner = getAddress(revenueForgeSigningWallet().address);
+    const verified = await verifyAcrossBaseProviders({
+      address,
+      txHash,
+      approvedOwner,
+      parentCollection: getAddress(parent.address),
+      expectedSigner,
+    });
 
-    const code = await withTimeout(provider.getCode(address));
-    if (!code || code === '0x') throw new Error('No contract bytecode exists at the submitted Base address.');
-
-    const forge = new Contract(address, FORGE_ABI, provider);
-    const [owner, forgeSigner, treasury, feeWei, royaltyBps, parentApproved, paused] = await withTimeout(Promise.all([
-      forge.owner(),
-      forge.forgeSigner(),
-      forge.treasury(),
-      forge.forgeFee(),
-      forge.royaltyBps(),
-      forge.approvedParentCollections(parent.address),
-      forge.paused(),
-    ]), 8_000);
-
-    const expectedSigner = revenueForgeSigningWallet().address;
-    if (getAddress(owner) !== approvedOwner) throw new Error('Production Forge owner does not match the reviewed VoxelFlip owner.');
-    if (getAddress(treasury) !== approvedOwner) throw new Error('Production Forge treasury does not match the reviewed owner wallet.');
-    if (getAddress(forgeSigner) !== getAddress(expectedSigner)) throw new Error('Production Forge signer does not match the protected server-derived signer.');
-    if (BigInt(feeWei) !== LAUNCH_FEE) throw new Error('Production Forge launch fee is not 0.001 ETH.');
-    if (Number(royaltyBps) !== LAUNCH_ROYALTY_BPS) throw new Error('Production Forge royalty is not the reviewed 500 bps.');
-    if (!parentApproved) throw new Error('The reviewed VoxelFlip Base collection is not approved as a parent collection.');
-    if (paused) throw new Error('The newly deployed production Forge is unexpectedly paused.');
-
-    const block = await withTimeout(provider.getBlock(receipt.blockNumber)).catch(() => null);
     const record = await saveRevenueForgeDeployment({
       chainId: 8453,
       network: 'base',
       address,
       deploymentTxHash: txHash,
       owner: approvedOwner,
-      forgeSigner: getAddress(forgeSigner),
-      treasury: getAddress(treasury),
+      forgeSigner: verified.forgeSigner,
+      treasury: verified.treasury,
       parentCollection: getAddress(parent.address),
-      forgeFeeWei: BigInt(feeWei).toString(),
-      royaltyBps: Number(royaltyBps),
-      deployedAt: block?.timestamp ? new Date(Number(block.timestamp) * 1000).toISOString() : '',
+      forgeFeeWei: verified.feeWei.toString(),
+      royaltyBps: verified.royaltyBps,
+      deployedAt: verified.deployedAt,
       registeredAt: new Date().toISOString(),
     });
 
@@ -128,7 +170,5 @@ export async function POST(request: Request) {
   } catch (error) {
     console.error('Revenue Forge registration failed', error);
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Could not verify/register the Base revenue Forge.' }, { status: 400 });
-  } finally {
-    provider?.destroy();
   }
 }

--- a/app/forge/deploy/page.js
+++ b/app/forge/deploy/page.js
@@ -35,7 +35,7 @@ async function ensureBase(provider){
     await provider.request({method:'wallet_addEthereumChain',params:[{chainId:BASE_CHAIN_ID,chainName:'Base',nativeCurrency:{name:'Ether',symbol:'ETH',decimals:18},rpcUrls:[BASE_RPC],blockExplorerUrls:[BASE_EXPLORER]}]});
   }
   chainId=String(await provider.request({method:'eth_chainId'})||'').toLowerCase();
-  if(chainId!==BASE_CHAIN_ID)throw new Error('Switch MetaMask to Base before deploying.');
+  if(chainId!==BASE_CHAIN_ID)throw new Error('Switch MetaMask to Base before continuing.');
 }
 
 async function loadBytecode(){
@@ -67,8 +67,15 @@ export default function DeployRevenueForgePage(){
       setConfig(data);
       if(data.existingDeployment){
         setDeployment(data.existingDeployment);
-        setStatus('The Base revenue Forge is already deployed and registered. No second deployment is needed.');
-      }else setStatus('Ready. Connect the reviewed owner wallet to prepare the one-time Base deployment transaction.');
+        setStatus('Production Forge is verified and registered. The real-money Forge is ready.');
+      }else if(data.pendingCandidateAddress){
+        setDeployment({address:getAddress(data.pendingCandidateAddress),deploymentTxHash:'',pendingRegistration:true,recoveredCandidate:true});
+        setStatus('Your Base contract already exists. No second deployment is needed. Connect the owner wallet and finish activation.');
+      }else{
+        setDeployment(null);
+        setStatus('Ready. Connect the reviewed owner wallet to prepare the one-time Base deployment transaction.');
+      }
+      setError('');
     }catch(e){setError(errorText(e));setStatus('')}
   }
 
@@ -80,25 +87,42 @@ export default function DeployRevenueForgePage(){
       const accounts=await injected.request({method:'eth_requestAccounts'});
       if(!accounts?.[0])throw new Error('Wallet connection was cancelled.');
       const address=getAddress(accounts[0]);
-      if(config?.requiredOwner&&address!==getAddress(config.requiredOwner))throw new Error(`Connect the reviewed VoxelFlip owner wallet ${short(config.requiredOwner)}. This deployment is locked to that owner.`);
+      if(config?.requiredOwner&&address!==getAddress(config.requiredOwner))throw new Error(`Connect the reviewed VoxelFlip owner wallet ${short(config.requiredOwner)}.`);
       setProvider(injected);setWallet(address);
-      setStatus('Owner wallet verified. Next, MetaMask will show one real Base contract-deployment transaction. Only Base gas is spent during deployment.');
+      setStatus(deployment?.pendingRegistration?'Owner wallet verified. Ready to verify and activate the existing Base Forge — no new deployment transaction.':'Owner wallet verified. MetaMask will show the one real Base deployment transaction before anything is sent.');
     }catch(e){setError(errorText(e));setStatus('')}finally{setBusy(false)}
   }
 
-  async function register(address,txHash,addressWallet=wallet){
+  async function register(address,txHash='',addressWallet=wallet){
     const response=await fetch('/api/forge/register-mainnet',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({wallet:addressWallet,address,txHash})});
     const data=await response.json().catch(()=>({}));
-    if(!response.ok)throw new Error(data.error||'The contract deployed, but automatic production registration did not finish.');
+    if(!response.ok)throw new Error(data.error||'The contract exists, but production activation did not finish.');
     setDeployment(data.deployment);
-    setStatus('Production Forge verified and registered on Base. The real-money Forge page is now activated.');
+    setError('');
+    setStatus('Production Forge verified and registered on Base. The real-money Forge is activated.');
     return data.deployment;
+  }
+
+  async function activateExisting(){
+    if(!deployment?.address)throw new Error('No existing Base Forge was found to activate.');
+    if(!provider||!wallet){await connect();return}
+    setBusy(true);setError('');
+    try{
+      await ensureBase(provider);
+      const accounts=await provider.request({method:'eth_accounts'});
+      const active=getAddress(accounts?.[0]||'0x0000000000000000000000000000000000000000');
+      if(active!==getAddress(config.requiredOwner))throw new Error('Reconnect the reviewed VoxelFlip owner wallet before activation.');
+      setStatus('Verifying the existing Base contract bytecode, owner, signer, treasury, 0.001 ETH fee and parent collection across Base RPCs…');
+      await register(deployment.address,deployment.deploymentTxHash||'',wallet);
+      await refreshConfig();
+    }catch(e){setError(errorText(e));setStatus('The existing contract is safe from redeployment. Activation can be retried without spending Base gas.')}finally{setBusy(false)}
   }
 
   async function deploy(){
     if(!config)throw new Error('Deployment configuration is still loading.');
+    if(deployment?.pendingRegistration){await activateExisting();return}
     if(config.existingDeployment||deployment?.address){setStatus('The production Forge is already registered.');return}
-    if(!provider||!wallet)throw new Error('Connect the reviewed owner wallet first.');
+    if(!provider||!wallet){await connect();return}
     if(wallet!==getAddress(config.requiredOwner))throw new Error('Connected wallet is not the reviewed VoxelFlip owner.');
     setBusy(true);setError('');
     try{
@@ -114,14 +138,7 @@ export default function DeployRevenueForgePage(){
       const factory=new ContractFactory(CONSTRUCTOR_ABI,bytecode,signer);
 
       setStatus('Opening MetaMask. Review the Base gas estimate carefully, then approve only if you want to deploy the real revenue Forge.');
-      const contract=await factory.deploy(
-        wallet,
-        getAddress(config.forgeSigner),
-        wallet,
-        getAddress(config.parentCollection),
-        BigInt(config.feeWei),
-        Number(config.royaltyBps),
-      );
+      const contract=await factory.deploy(wallet,getAddress(config.forgeSigner),wallet,getAddress(config.parentCollection),BigInt(config.feeWei),Number(config.royaltyBps));
       const tx=contract.deploymentTransaction();
       if(!tx?.hash)throw new Error('MetaMask did not return a deployment transaction hash.');
       setStatus('Deployment submitted to Base. Waiting for confirmation…');
@@ -129,35 +146,39 @@ export default function DeployRevenueForgePage(){
       if(!receipt||receipt.status!==1)throw new Error('The Base deployment transaction did not succeed.');
       const address=await contract.getAddress();
       setDeployment({address,deploymentTxHash:tx.hash,owner:wallet,treasury:wallet,forgeSigner:config.forgeSigner,forgeFeeWei:config.feeWei,royaltyBps:config.royaltyBps,pendingRegistration:true});
-      setStatus('Contract confirmed on Base. Verifying owner, signer, treasury, fee and approved parent collection before activation…');
+      setStatus('Contract confirmed on Base. Verifying production settings before activation…');
       await register(address,tx.hash,wallet);
       await refreshConfig();
-    }catch(e){setError(errorText(e));if(!deployment?.address)setStatus('Deployment stopped or needs attention. No retry will happen automatically.')}finally{setBusy(false)}
+    }catch(e){setError(errorText(e));setStatus('Deployment stopped or needs attention. No retry will happen automatically.')}finally{setBusy(false)}
   }
+
+  const ready=Boolean(deployment?.address&&!deployment?.pendingRegistration);
+  const pending=Boolean(deployment?.address&&deployment?.pendingRegistration);
 
   return <main className={styles.page}>
     <nav className={styles.nav}><a href="/studio"><img src="/voxelpop/voxelpop-logo.png" alt="VoxelPop"/><b>Voxel Forge</b></a><em>BASE · PRODUCTION DEPLOY</em></nav>
     <div className={styles.shell}>
-      <header className={styles.hero}><p>ONE-TIME PRODUCTION STEP</p><h1>Deploy the<br/><em>revenue Forge.</em></h1><span>This page is locked to the reviewed VoxelFlip owner wallet. It deploys the CI-passed Forge contract on Base, with a 0.001 ETH customer Forge fee. Deployment itself only spends the Base gas MetaMask shows you.</span></header>
+      <header className={styles.hero}><p>ONE-TIME PRODUCTION STEP</p><h1>Deploy the<br/><em>revenue Forge.</em></h1><span>This page is locked to the reviewed VoxelFlip owner wallet. The live contract charges a 0.001 ETH customer Forge fee. Activation of an already-deployed contract does not spend more gas.</span></header>
 
       <section className={styles.panel}>
-        <div className={styles.safety} style={{background:'rgba(255,183,77,.08)',borderColor:'rgba(255,183,77,.26)'}}><b style={{color:'#ffcf76'}}>REAL BASE TRANSACTION</b><span>No private key is requested here. MetaMask shows the exact deployment transaction and gas before anything is sent. Cancelling in MetaMask deploys nothing.</span></div>
+        <div className={styles.safety} style={{background:'rgba(255,183,77,.08)',borderColor:'rgba(255,183,77,.26)'}}><b style={{color:'#ffcf76'}}>{pending?'EXISTING BASE CONTRACT':'REAL BASE TRANSACTION'}</b><span>{pending?'The contract is already on Base. This page will verify and register that exact reviewed runtime; it will not deploy another contract.':'No private key is requested here. MetaMask shows the exact deployment transaction and gas before anything is sent.'}</span></div>
         {config&&<div className={styles.review}>
-          <article><small>OWNER + TREASURY</small><b>{short(config.requiredOwner)}</b><span>Only this reviewed wallet can register production.</span></article>
+          <article><small>OWNER + TREASURY</small><b>{short(config.requiredOwner)}</b><span>Only this reviewed wallet can activate production.</span></article>
           <article><small>FORGE FEE</small><b>{config.feeEth} ETH</b><span>Collected from each successful customer 3→1 Forge.</span></article>
           <article><small>ROYALTY</small><b>{Number(config.royaltyBps)/100}%</b><span>Descendant ERC-2981 royalty to treasury.</span></article>
         </div>}
-        <div className={styles.row}><div><small>CONNECTED WALLET</small><b>{wallet||'Not connected'}</b></div><button onClick={connect} disabled={busy||Boolean(deployment?.address)}>{wallet?'RECONNECT':'CONNECT METAMASK'}</button></div>
+        <div className={styles.row}><div><small>CONNECTED WALLET</small><b>{wallet||'Not connected'}</b></div><button onClick={connect} disabled={busy||ready}>{wallet?'RECONNECT':'CONNECT METAMASK'}</button></div>
         {status&&<div className={styles.notice}><b>STATUS</b><span>{status}</span></div>}
         {error&&<div className={styles.error}>{error}</div>}
 
+        {pending&&<button className={styles.primary} onClick={wallet?activateExisting:connect} disabled={busy||!config}>{busy?'VERIFYING…':wallet?'FINISH ACTIVATION — NO NEW GAS':'CONNECT OWNER WALLET'}</button>}
         {!deployment?.address&&<button className={styles.primary} onClick={wallet?deploy:connect} disabled={busy||!config}>{busy?'WAITING…':wallet?'DEPLOY REVENUE FORGE ON BASE':'CONNECT OWNER WALLET'}</button>}
 
         {deployment?.address&&<div className={styles.confirmed}>
-          <b>✓ {deployment.pendingRegistration?'BASE CONTRACT DEPLOYED':'PRODUCTION FORGE READY'}</b>
-          <span>Contract: {deployment.address}<br/>{deployment.deploymentTxHash?`Transaction: ${deployment.deploymentTxHash}`:''}</span>
-          {deployment.deploymentTxHash&&<a href={`${BASE_EXPLORER}/tx/${deployment.deploymentTxHash}`} target="_blank" rel="noreferrer">VIEW DEPLOYMENT ON BASESCAN ↗</a>}
-          {!deployment.pendingRegistration&&<a href="/forge/mainnet">OPEN REAL-MONEY FORGE →</a>}
+          <b>✓ {pending?'BASE CONTRACT DEPLOYED':'PRODUCTION FORGE READY'}</b>
+          <span>Contract: {deployment.address}{deployment.deploymentTxHash?<><br/>Transaction: {deployment.deploymentTxHash}</>:null}</span>
+          {deployment.deploymentTxHash?<a href={`${BASE_EXPLORER}/tx/${deployment.deploymentTxHash}`} target="_blank" rel="noreferrer">VIEW DEPLOYMENT ON BASESCAN ↗</a>:<a href={`${BASE_EXPLORER}/address/${deployment.address}`} target="_blank" rel="noreferrer">VIEW CONTRACT ON BASESCAN ↗</a>}
+          {ready&&<a href="/forge/mainnet">OPEN REAL-MONEY FORGE →</a>}
         </div>}
       </section>
     </div>

--- a/lib/forge-revenue-deployment.ts
+++ b/lib/forge-revenue-deployment.ts
@@ -36,8 +36,6 @@ export function revenueForgeSigningWallet() {
   const mintSignerSeed = String(process.env.VOXELFLIP_MINT_SIGNER_PRIVATE_KEY || '').trim();
   if (!mintSignerSeed) throw new Error('No server signing seed is configured for the Base revenue Forge.');
 
-  // Derive a distinct Forge-only EOA from the existing protected server signing seed.
-  // The derived key is never returned to the client, stored in Supabase, or committed.
   const derivedHex = createHmac('sha256', normalizePrivateKey(mintSignerSeed))
     .update('VoxelForgeRevenue:v1')
     .digest('hex');
@@ -45,12 +43,13 @@ export function revenueForgeSigningWallet() {
 }
 
 function validDeployment(value: any): value is RevenueForgeDeployment {
+  const txHash = String(value?.deploymentTxHash || '');
   return Boolean(
     value
     && Number(value.chainId) === 8453
     && String(value.network || '').toLowerCase() === 'base'
     && ADDRESS_RE.test(String(value.address || ''))
-    && TX_RE.test(String(value.deploymentTxHash || ''))
+    && (!txHash || TX_RE.test(txHash))
     && ADDRESS_RE.test(String(value.owner || ''))
     && ADDRESS_RE.test(String(value.forgeSigner || ''))
     && ADDRESS_RE.test(String(value.treasury || ''))
@@ -67,7 +66,7 @@ function normalizeDeployment(value: RevenueForgeDeployment): RevenueForgeDeploym
     chainId: 8453,
     network: 'base',
     address: getAddress(value.address),
-    deploymentTxHash: String(value.deploymentTxHash),
+    deploymentTxHash: String(value.deploymentTxHash || ''),
     owner: getAddress(value.owner),
     forgeSigner: getAddress(value.forgeSigner),
     treasury: getAddress(value.treasury),


### PR DESCRIPTION
Hotfix for the already-deployed Base revenue Forge at 0x34d7E9d8Cae07B61eb1f0c1dABD4876F2429cd3D. Avoids any second deployment. Registration now retries across Base RPCs, verifies the exact reviewed runtime bytecode by SHA-256 and byte length, verifies owner/treasury/signer/fee/royalty/parent approval/paused state, and can activate the existing contract even if the original deployment tx hash is not available in the browser after refresh. The deploy page exposes a no-new-gas FINISH ACTIVATION flow for the existing contract.