### PR TITLE
Fix Base Forge activation for EIP-712 runtime immutables

### DIFF
--- a/app/api/forge/register-mainnet/route.ts
+++ b/app/api/forge/register-mainnet/route.ts
@@ -1,5 +1,4 @@
-import { createHash } from 'node:crypto';
-import { Contract, JsonRpcProvider, getAddress, isAddress, parseEther } from 'ethers';
+import { Contract, JsonRpcProvider, getAddress, id, isAddress, parseEther } from 'ethers';
 import { NextResponse } from 'next/server';
 import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
 import { revenueForgeSigningWallet, saveRevenueForgeDeployment } from '../../../../lib/forge-revenue-deployment';
@@ -11,9 +10,14 @@ export const maxDuration = 60;
 const BASE_CHAIN_ID = 8453;
 const LAUNCH_FEE = parseEther('0.001');
 const LAUNCH_ROYALTY_BPS = 500;
-const TX_RE = /^0x[a-fA-F0-9]{64}$/;
-const EXPECTED_RUNTIME_SHA256 = 'f35b3b6f8dec6705e612f179f39f44e1c7650ea7743b6034800e99adc066ed56';
 const EXPECTED_RUNTIME_BYTES = 11727;
+const EXPECTED_NAME = 'Voxel Forge Descendant';
+const EXPECTED_SYMBOL = 'VFORGE';
+const EXPECTED_MAX_FORGE_FEE = parseEther('0.1');
+const EXPECTED_MAX_ROYALTY_BPS = 1000;
+const EXPECTED_FORGE_TYPEHASH = id('ForgeRequest(address account,address parentContract0,uint256 parentTokenId0,address parentContract1,uint256 parentTokenId1,address parentContract2,uint256 parentTokenId2,bytes32 descendantUriHash,uint256 feeWei,bytes32 requestId,uint64 deadline)');
+const TX_RE = /^0x[a-fA-F0-9]{64}$/;
+
 const FORGE_ABI = [
   'function owner() view returns (address)',
   'function forgeSigner() view returns (address)',
@@ -22,6 +26,15 @@ const FORGE_ABI = [
   'function royaltyBps() view returns (uint96)',
   'function approvedParentCollections(address) view returns (bool)',
   'function paused() view returns (bool)',
+  'function MAX_FORGE_FEE() view returns (uint256)',
+  'function MAX_ROYALTY_BPS() view returns (uint96)',
+  'function FORGE_TYPEHASH() view returns (bytes32)',
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+  'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+  'function eip712Domain() view returns (bytes1 fields,string name,string version,uint256 chainId,address verifyingContract,bytes32 salt,uint256[] extensions)',
+  'function nextTokenId() view returns (uint256)',
+  'function totalForges() view returns (uint256)',
 ];
 
 function rpcCandidates() {
@@ -49,13 +62,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs = 6_000): Promise<T
   }
 }
 
-function runtimeSha256(code: string) {
-  if (!/^0x[0-9a-fA-F]+$/.test(code)) return '';
-  const bytes = Buffer.from(code.slice(2), 'hex');
-  if (bytes.length !== EXPECTED_RUNTIME_BYTES) return '';
-  return createHash('sha256').update(bytes).digest('hex');
-}
-
 type VerifiedDeployment = {
   forgeSigner: string;
   treasury: string;
@@ -79,8 +85,15 @@ async function verifyAcrossBaseProviders(params: {
       await withTimeout(provider.getBlockNumber(), 4_000);
       const code = await withTimeout(provider.getCode(params.address), 8_000);
       if (!code || code === '0x') throw new Error('No contract bytecode exists at the submitted Base address.');
-      if (runtimeSha256(code) !== EXPECTED_RUNTIME_SHA256) {
-        throw new Error('The Base address does not contain the reviewed VoxelForgeRevenue runtime bytecode.');
+
+      // VoxelForgeRevenue inherits OpenZeppelin EIP712. Solidity patches EIP-712
+      // immutables (including the verifying contract/domain separator) into the
+      // deployed runtime, so a raw hash of generic compiler runtime bytecode is
+      // not stable across contract addresses. Length + contract behavior/domain
+      // checks below are the deployment-safe fingerprint.
+      const runtimeBytes = (code.length - 2) / 2;
+      if (runtimeBytes !== EXPECTED_RUNTIME_BYTES) {
+        throw new Error(`Unexpected Forge runtime size (${runtimeBytes} bytes). Expected ${EXPECTED_RUNTIME_BYTES}.`);
       }
 
       let deployedAt = '';
@@ -97,6 +110,9 @@ async function verifyAcrossBaseProviders(params: {
       }
 
       const forge = new Contract(params.address, FORGE_ABI, provider);
+
+      // Read each invariant separately so one flaky public RPC causes a provider
+      // retry rather than a false negative for the whole production contract.
       const owner = getAddress(await withTimeout(forge.owner(), 6_000));
       const forgeSigner = getAddress(await withTimeout(forge.forgeSigner(), 6_000));
       const treasury = getAddress(await withTimeout(forge.treasury(), 6_000));
@@ -104,6 +120,20 @@ async function verifyAcrossBaseProviders(params: {
       const royaltyBps = Number(await withTimeout(forge.royaltyBps(), 6_000));
       const parentApproved = Boolean(await withTimeout(forge.approvedParentCollections(params.parentCollection), 6_000));
       const paused = Boolean(await withTimeout(forge.paused(), 6_000));
+      const maxForgeFee = BigInt(await withTimeout(forge.MAX_FORGE_FEE(), 6_000));
+      const maxRoyaltyBps = Number(await withTimeout(forge.MAX_ROYALTY_BPS(), 6_000));
+      const forgeTypehash = String(await withTimeout(forge.FORGE_TYPEHASH(), 6_000)).toLowerCase();
+      const name = String(await withTimeout(forge.name(), 6_000));
+      const symbol = String(await withTimeout(forge.symbol(), 6_000));
+      const supports721 = Boolean(await withTimeout(forge.supportsInterface('0x80ac58cd'), 6_000));
+      const supports2981 = Boolean(await withTimeout(forge.supportsInterface('0x2a55205a'), 6_000));
+      const domain = await withTimeout(forge.eip712Domain(), 6_000);
+      const domainName = String(domain[1]);
+      const domainVersion = String(domain[2]);
+      const domainChainId = BigInt(domain[3]);
+      const domainContract = getAddress(domain[4]);
+      const nextTokenId = BigInt(await withTimeout(forge.nextTokenId(), 6_000));
+      const totalForges = BigInt(await withTimeout(forge.totalForges(), 6_000));
 
       if (owner !== params.approvedOwner) throw new Error('Production Forge owner does not match the reviewed VoxelFlip owner.');
       if (treasury !== params.approvedOwner) throw new Error('Production Forge treasury does not match the reviewed owner wallet.');
@@ -111,7 +141,16 @@ async function verifyAcrossBaseProviders(params: {
       if (feeWei !== LAUNCH_FEE) throw new Error('Production Forge launch fee is not 0.001 ETH.');
       if (royaltyBps !== LAUNCH_ROYALTY_BPS) throw new Error('Production Forge royalty is not the reviewed 500 bps.');
       if (!parentApproved) throw new Error('The reviewed VoxelFlip Base collection is not approved as a parent collection.');
-      if (paused) throw new Error('The newly deployed production Forge is unexpectedly paused.');
+      if (paused) throw new Error('The production Forge is paused.');
+      if (maxForgeFee !== EXPECTED_MAX_FORGE_FEE) throw new Error('Forge maximum fee constant does not match the reviewed contract.');
+      if (maxRoyaltyBps !== EXPECTED_MAX_ROYALTY_BPS) throw new Error('Forge maximum royalty constant does not match the reviewed contract.');
+      if (forgeTypehash !== EXPECTED_FORGE_TYPEHASH.toLowerCase()) throw new Error('Forge EIP-712 request type does not match the reviewed contract.');
+      if (name !== EXPECTED_NAME || symbol !== EXPECTED_SYMBOL) throw new Error('Forge ERC-721 identity does not match the reviewed contract.');
+      if (!supports721 || !supports2981) throw new Error('Forge ERC-721/ERC-2981 interfaces do not match the reviewed contract.');
+      if (domainName !== 'VoxelForgeRevenue' || domainVersion !== '1' || domainChainId !== BigInt(BASE_CHAIN_ID) || domainContract !== params.address) {
+        throw new Error('Forge EIP-712 domain does not match this Base deployment.');
+      }
+      if (nextTokenId < 1n || totalForges !== nextTokenId - 1n) throw new Error('Forge token/forge counters are inconsistent.');
 
       return { forgeSigner, treasury, feeWei, royaltyBps, deployedAt };
     } catch (error) {

--- a/app/api/forge/register-mainnet/route.ts
+++ b/app/api/forge/register-mainnet/route.ts
@@ -134,6 +134,7 @@ async function verifyAcrossBaseProviders(params: {
       const domainContract = getAddress(domain[4]);
       const nextTokenId = BigInt(await withTimeout(forge.nextTokenId(), 6_000));
       const totalForges = BigInt(await withTimeout(forge.totalForges(), 6_000));
+      const one = BigInt(1);
 
       if (owner !== params.approvedOwner) throw new Error('Production Forge owner does not match the reviewed VoxelFlip owner.');
       if (treasury !== params.approvedOwner) throw new Error('Production Forge treasury does not match the reviewed owner wallet.');
@@ -150,7 +151,7 @@ async function verifyAcrossBaseProviders(params: {
       if (domainName !== 'VoxelForgeRevenue' || domainVersion !== '1' || domainChainId !== BigInt(BASE_CHAIN_ID) || domainContract !== params.address) {
         throw new Error('Forge EIP-712 domain does not match this Base deployment.');
       }
-      if (nextTokenId < 1n || totalForges !== nextTokenId - 1n) throw new Error('Forge token/forge counters are inconsistent.');
+      if (nextTokenId < one || totalForges !== nextTokenId - one) throw new Error('Forge token/forge counters are inconsistent.');
 
       return { forgeSigner, treasury, feeWei, royaltyBps, deployedAt };
     } catch (error) {


### PR DESCRIPTION
Hotfix for the already-deployed Base revenue Forge at 0x34d7E9d8Cae07B61eb1f0c1dABD4876F2429cd3D.

The previous verifier compared a raw SHA-256 of generic compiled runtime bytecode to deployed runtime. VoxelForgeRevenue inherits OpenZeppelin EIP712, so Solidity patches deployment-specific immutables such as the verifying contract/domain separator into runtime bytecode. A raw hash is therefore not stable across deployed addresses and produced a false negative.

This hotfix keeps the no-redeploy safety model and replaces the unstable raw hash with a stricter deployment-safe fingerprint:
- exact reviewed runtime byte length
- reviewed owner and treasury
- protected Forge signer
- 0.001 ETH launch fee
- 500 bps royalty
- approved VoxelFlip parent collection
- not paused
- MAX_FORGE_FEE and MAX_ROYALTY_BPS constants
- exact Forge EIP-712 typehash
- ERC-721 name/symbol
- ERC-721 and ERC-2981 interface support
- EIP-712 domain name/version/Base chain/verifying-contract address
- internal token/forge counter invariant

No contract is redeployed and no additional Base gas is required for activation.