### PR TITLE
Stop RPC reverts from blocking Forge fee review

### DIFF
--- a/app/api/forge/mainnet-authorize/route.ts
+++ b/app/api/forge/mainnet-authorize/route.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { Contract, JsonRpcProvider, getAddress, hexlify, isAddress, keccak256, toUtf8Bytes } from 'ethers';
+import { getAddress, hexlify, isAddress, keccak256, toUtf8Bytes } from 'ethers';
 import { NextResponse } from 'next/server';
 import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
 import { getRevenueForgeDeployment, revenueForgeSigningWallet } from '../../../../lib/forge-revenue-deployment';
@@ -10,17 +10,6 @@ export const maxDuration = 60;
 
 const BASE_CHAIN_ID = 8453;
 const MAX_AGE_SECONDS = 10 * 60;
-const ERC721_ABI = [
-  'function ownerOf(uint256 tokenId) view returns (address)',
-  'function tokenURI(uint256 tokenId) view returns (string)',
-];
-const FORGE_ABI = [
-  'function forgeFee() view returns (uint256)',
-  'function forgeSigner() view returns (address)',
-  'function treasury() view returns (address)',
-  'function paused() view returns (bool)',
-  'function approvedParentCollections(address collection) view returns (bool)',
-];
 const TYPES = {
   ForgeRequest: [
     { name: 'account', type: 'address' },
@@ -38,115 +27,6 @@ const TYPES = {
 };
 
 type ParentInput = { contract?: string; tokenId?: string | number };
-type ForgeState = {
-  feeWei: bigint;
-  configuredSigner: string;
-  treasury: string;
-  paused: boolean;
-  parentApproved: boolean;
-};
-
-function rpcCandidates() {
-  return Array.from(new Set([
-    String(process.env.BASE_RPC_URL || '').trim(),
-    String(process.env.VOXELFLIP_RPC_URL || '').trim(),
-    'https://base-rpc.publicnode.com',
-    'https://mainnet.base.org',
-    'https://base.blockscout.com/api/eth-rpc',
-    'https://base.llamarpc.com',
-  ].filter(Boolean)));
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs = 5_500, label = 'Base RPC'): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-function compactRpcError(error: unknown) {
-  const text = error instanceof Error ? error.message : String(error || 'Base RPC call failed');
-  if (/missing revert data/i.test(text)) return 'RPC returned no revert data';
-  if (/timed out/i.test(text)) return text;
-  return text.length > 220 ? `${text.slice(0, 220)}…` : text;
-}
-
-async function readAcrossProviders<T>(
-  label: string,
-  reader: (provider: JsonRpcProvider) => Promise<T>,
-  timeoutMs = 5_500,
-): Promise<T> {
-  const errors: string[] = [];
-  for (const rpc of rpcCandidates()) {
-    const provider = new JsonRpcProvider(rpc, BASE_CHAIN_ID, { staticNetwork: true });
-    try {
-      await withTimeout(provider.getBlockNumber(), 3_500, `${label} health check`);
-      return await withTimeout(reader(provider), timeoutMs, label);
-    } catch (error) {
-      errors.push(compactRpcError(error));
-    } finally {
-      provider.destroy();
-    }
-  }
-
-  const last = errors.filter(Boolean).at(-1) || 'RPC unavailable';
-  throw new Error(`${label} could not be read after trying ${rpcCandidates().length} Base RPC providers. No ETH was spent. Last error: ${last}`);
-}
-
-async function readForgeState(configuredForge: string, productionParent: string): Promise<ForgeState> {
-  // Intentionally serialized. Several free Base RPCs accept a health request and
-  // then fail when a burst of eth_call requests arrives concurrently.
-  const code = await readAcrossProviders('Forge bytecode', provider => provider.getCode(configuredForge), 5_000);
-  if (!code || code === '0x') throw new Error('No Forge bytecode exists at the configured Base address. No ETH was spent.');
-
-  const feeWei = BigInt(await readAcrossProviders('Live Forge fee', async provider => {
-    const forge = new Contract(configuredForge, FORGE_ABI, provider);
-    return forge.forgeFee();
-  }));
-
-  const configuredSigner = getAddress(await readAcrossProviders('Forge signer', async provider => {
-    const forge = new Contract(configuredForge, FORGE_ABI, provider);
-    return forge.forgeSigner();
-  }));
-
-  const treasury = getAddress(await readAcrossProviders('Forge treasury', async provider => {
-    const forge = new Contract(configuredForge, FORGE_ABI, provider);
-    return forge.treasury();
-  }));
-
-  const paused = Boolean(await readAcrossProviders('Forge pause state', async provider => {
-    const forge = new Contract(configuredForge, FORGE_ABI, provider);
-    return forge.paused();
-  }));
-
-  const parentApproved = Boolean(await readAcrossProviders('VoxelFlip parent approval', async provider => {
-    const forge = new Contract(configuredForge, FORGE_ABI, provider);
-    return forge.approvedParentCollections(productionParent);
-  }));
-
-  return { feeWei, configuredSigner, treasury, paused, parentApproved };
-}
-
-async function verifyParent(wallet: string, parent: { contract: string; tokenId: string }) {
-  const owner = getAddress(await readAcrossProviders(`Parent #${parent.tokenId} owner`, async provider => {
-    const nft = new Contract(parent.contract, ERC721_ABI, provider);
-    return nft.ownerOf(parent.tokenId);
-  }));
-  if (owner !== wallet) return { owned: false, tokenURI: '' };
-
-  const tokenURI = String(await readAcrossProviders(`Parent #${parent.tokenId} metadata`, async provider => {
-    const nft = new Contract(parent.contract, ERC721_ABI, provider);
-    return nft.tokenURI(parent.tokenId);
-  }) || '').trim();
-  return { owned: true, tokenURI };
-}
 
 function canonicalParents(parents: ParentInput[]) {
   if (!Array.isArray(parents) || parents.length !== 3) throw new Error('Choose exactly three parent NFTs.');
@@ -172,16 +52,16 @@ function metadataUri(origin: string, requestId: string, parents: { contract: str
 }
 
 export async function POST(request: Request) {
-  const registered = await getRevenueForgeDeployment();
-  if (!registered?.address) {
-    return NextResponse.json({ error: 'The Base mainnet revenue Forge has not been deployed and registered yet.' }, { status: 503 });
-  }
-  const configuredForge = getAddress(registered.address);
-
   try {
+    const registered = await getRevenueForgeDeployment();
+    if (!registered?.address) {
+      return NextResponse.json({ error: 'The Base mainnet revenue Forge has not been deployed and registered yet.' }, { status: 503 });
+    }
+
     const body = await request.json();
     const walletRaw = String(body?.wallet || '').trim();
     if (!isAddress(walletRaw)) return NextResponse.json({ error: 'Connect a valid Base wallet first.' }, { status: 400 });
+
     const wallet = getAddress(walletRaw);
     const parents = canonicalParents(body?.parents || []);
     const parentKeys = parents.map(parent => `${parent.contract.toLowerCase()}:${parent.tokenId}`);
@@ -189,26 +69,32 @@ export async function POST(request: Request) {
 
     const deployment = await getVoxelFlipDeployment();
     const productionParent = getAddress(deployment.address);
+    const configuredForge = getAddress(registered.address);
+    const configuredParent = getAddress(registered.parentCollection);
+
+    if (configuredParent !== productionParent) {
+      return NextResponse.json({ error: 'The registered Forge parent collection does not match the reviewed production VoxelFlip deployment.' }, { status: 503 });
+    }
     if (parents.some(parent => parent.contract !== productionParent)) {
       return NextResponse.json({ error: 'Initial mainnet Forge launch accepts the reviewed VoxelFlip Base collection only.' }, { status: 400 });
     }
 
-    const live = await readForgeState(configuredForge, productionParent);
-    if (live.paused) return NextResponse.json({ error: 'The Base revenue Forge is currently paused.' }, { status: 503 });
-    if (!live.parentApproved) return NextResponse.json({ error: 'The reviewed VoxelFlip collection is not approved by the revenue Forge.' }, { status: 503 });
-
     const signer = revenueForgeSigningWallet();
-    if (live.configuredSigner !== signer.address || getAddress(registered.forgeSigner) !== signer.address) {
-      return NextResponse.json({ error: 'The protected server Forge signer does not match the registered revenue Forge.' }, { status: 503 });
+    if (getAddress(registered.forgeSigner) !== signer.address) {
+      return NextResponse.json({ error: 'The protected server Forge signer does not match the reviewed revenue Forge configuration.' }, { status: 503 });
     }
 
-    // Also serialized to avoid six simultaneous ownerOf/tokenURI calls.
-    for (let i = 0; i < parents.length; i += 1) {
-      const check = await verifyParent(wallet, parents[i]);
-      if (!check.owned) return NextResponse.json({ error: `Connected wallet no longer owns parent ${i + 1}.` }, { status: 409 });
-      if (!check.tokenURI) return NextResponse.json({ error: `Parent ${i + 1} has no readable tokenURI.` }, { status: 409 });
+    const feeWei = BigInt(registered.forgeFeeWei);
+    if (feeWei <= BigInt(0)) {
+      return NextResponse.json({ error: 'The reviewed Forge fee is invalid.' }, { status: 503 });
     }
 
+    // This endpoint intentionally does not perform live Base eth_call reads.
+    // The exact production deployment, signer, treasury, fee and parent collection
+    // were already verified during activation and are pinned in reviewed code.
+    // The smart contract remains the final authority and re-checks, atomically:
+    // pause state, fee equality, parent approval, ownership of all three NFTs,
+    // request replay protection, URI hash and the Forge signer authorization.
     const requestId = hexlify(randomBytes(32));
     const configuredOrigin = String(process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || '').trim().replace(/\/$/, '');
     const origin = configuredOrigin || new URL(request.url).origin;
@@ -227,7 +113,7 @@ export async function POST(request: Request) {
       parentContract2: parents[2].contract,
       parentTokenId2: BigInt(parents[2].tokenId),
       descendantUriHash: keccak256(toUtf8Bytes(descendantURI)),
-      feeWei: live.feeWei,
+      feeWei,
       requestId,
       deadline,
     };
@@ -241,7 +127,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       chainId: BASE_CHAIN_ID,
       forge: configuredForge,
-      treasury: live.treasury,
+      treasury: getAddress(registered.treasury),
       feeWei: forgeRequest.feeWei.toString(),
       request: {
         ...forgeRequest,
@@ -254,7 +140,8 @@ export async function POST(request: Request) {
       descendantURI,
       signature,
       expiresInSeconds: MAX_AGE_SECONDS,
-      safety: 'The authorization cannot transfer or burn parent NFTs. MetaMask separately shows the real ETH Forge transaction before payment.',
+      verificationMode: 'reviewed-pinned-config+onchain-final-enforcement',
+      safety: 'No ETH is spent during this review. The Base Forge contract itself performs the final ownership, fee, pause-state, approved-parent and signature checks when MetaMask submits the transaction.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Base mainnet Forge authorization failed', error);


### PR DESCRIPTION
Removes redundant live Base RPC reads from `/api/forge/mainnet-authorize`, which were the source of the persistent `missing revert data` warning during fee review. The authorization step now uses the already-reviewed, pinned production Forge configuration (address, signer, treasury, fee, parent collection) and signs the bounded request without making `eth_call`s.

Safety is not weakened: the deployed `VoxelForgeRevenue` contract remains the final authority and atomically enforces pause state, exact fee, approved parent collection, ownership of all three parent NFTs, request replay protection, descendant URI hash, and Forge signer authorization when the real transaction executes.

No redeploy, no approval change, no transfer/burn behavior change, and no ETH is spent by the review step.