### PR TITLE
Add bounded Agent Coordinator V1

### DIFF
--- a/app/api/agent/decision/route.ts
+++ b/app/api/agent/decision/route.ts
@@ -1,0 +1,34 @@
+import { coordinateBaseAgentDecision } from '../../../../lib/agent-coordinator';
+import { withX402Json } from '../../../../lib/x402-resource';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function priceAtomic() {
+  const configured = String(process.env.X402_DECISION_PRICE_ATOMIC || '10000').trim();
+  return /^\d+$/.test(configured) && BigInt(configured) > BigInt(0) ? configured : '10000';
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  return withX402Json(request, {
+    amountAtomic: priceAtomic(),
+    description: 'Convert a live Base Flashblocks arbitrage scan into a bounded short-lived execution candidate ticket.',
+    tags: ['base', 'defi', 'agent', 'decision', 'simulation'],
+  }, async () => {
+    const result = await coordinateBaseAgentDecision({
+      amountEth: body?.amountEth || '0.01',
+      targetBps: body?.targetBps,
+      slippageBps: body?.slippageBps,
+      requireFlashblocks: body?.requireFlashblocks !== false,
+      ticketLifetimeMs: body?.ticketLifetimeMs,
+    });
+    return {
+      service: 'voxel-vault-agent-decision',
+      version: 1,
+      ...result,
+      safety: 'Tickets are deterministic quote envelopes, not signatures or spending authorizations. The endpoint never submits a transaction.',
+    };
+  });
+}

--- a/app/api/agent/health/route.ts
+++ b/app/api/agent/health/route.ts
@@ -1,0 +1,34 @@
+import { getAddress, isAddress } from 'ethers';
+import { NextResponse } from 'next/server';
+import { x402RuntimeStatus } from '../../../../lib/x402-resource';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const executorRaw = String(process.env.NEXT_PUBLIC_BASE_ARB_EXECUTOR_ADDRESS || process.env.BASE_ARB_EXECUTOR_ADDRESS || '').trim();
+  const executorAddress = isAddress(executorRaw) ? getAddress(executorRaw) : '';
+  const x402 = x402RuntimeStatus();
+
+  return NextResponse.json({
+    service: 'voxel-vault-agent-coordinator',
+    version: 1,
+    status: 'online',
+    network: 'Base',
+    chainId: 8453,
+    coordinator: {
+      readOnly: true,
+      requiresFlashblocksByDefault: true,
+      maxQuoteEth: String(process.env.AGENT_MAX_QUOTE_ETH || '0.05'),
+      defaultTicketLifetimeMs: 1200,
+      signsTransactions: false,
+      submitsTransactions: false,
+    },
+    execution: {
+      enabled: Boolean(executorAddress),
+      executorAddress,
+      mode: executorAddress ? 'OWNER_WALLET_SIMULATION_REQUIRED' : 'LOCKED',
+    },
+    x402,
+  }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/app/api/agent/manifest/route.ts
+++ b/app/api/agent/manifest/route.ts
@@ -9,42 +9,55 @@ export async function GET(request: Request) {
   const x402 = x402RuntimeStatus();
   const quotePrice = String(process.env.X402_BASE_QUOTE_PRICE_ATOMIC || '1000');
   const optimizePrice = String(process.env.X402_OPTIMIZE_PRICE_ATOMIC || '5000');
+  const decisionPrice = String(process.env.X402_DECISION_PRICE_ATOMIC || '10000');
 
   return NextResponse.json({
     name: 'Voxel Vault Machine Revenue API',
-    version: '2.0.0',
+    version: '2.1.0',
     network: 'Base',
     chainId: 8453,
     capabilities: [
       'flashblocks-pending-state-quotes',
       'weth-usdc-cross-dex-arbitrage-validation',
       'multi-size-net-profit-optimization',
+      'short-lived-agent-execution-tickets',
       'x402-usdc-pay-per-request',
     ],
     safety: {
       readOnly: true,
       signsTransactions: false,
       submitsTransactions: false,
+      authorizesSpending: false,
       bridgeAtomicityClaimed: false,
-      note: 'Paid machine endpoints return market intelligence only. Live execution remains a separate owner-controlled atomic executor flow.',
+      note: 'Paid machine endpoints return market intelligence and non-authorizing quote tickets only. Live execution remains a separate owner-controlled atomic executor flow with fresh simulation required.',
+    },
+    coordinator: {
+      defaultMaxQuoteEth: String(process.env.AGENT_MAX_QUOTE_ETH || '0.05'),
+      requireFlashblocksByDefault: true,
+      defaultTicketLifetimeMs: 1200,
+      ticketIsAuthorization: false,
     },
     x402: {
       ...x402,
       prices: {
         baseQuoteAtomicUsdc: quotePrice,
         optimizeAtomicUsdc: optimizePrice,
+        decisionAtomicUsdc: decisionPrice,
       },
     },
     endpoints: {
       publicScan: `${origin}/api/profit-engine/scan`,
+      health: `${origin}/api/agent/health`,
       paidBaseQuote: `${origin}/api/agent/base-quote`,
       paidOptimize: `${origin}/api/agent/optimize`,
+      paidDecision: `${origin}/api/agent/decision`,
       openapi: `${origin}/api/agent/openapi`,
       manifest: `${origin}/api/agent/manifest`,
     },
     requestExamples: {
       baseQuote: { amountEth: '0.01', targetBps: 25, slippageBps: 15, preferFlashblocks: true },
       optimize: { amountsEth: ['0.005', '0.01', '0.025', '0.05'], targetBps: 25, slippageBps: 15, preferFlashblocks: true },
+      decision: { amountEth: '0.01', targetBps: 25, slippageBps: 15, requireFlashblocks: true, ticketLifetimeMs: 1200 },
     },
   }, { headers: { 'Cache-Control': 'public, max-age=60, s-maxage=60' } });
 }

--- a/app/api/agent/openapi/route.ts
+++ b/app/api/agent/openapi/route.ts
@@ -5,12 +5,18 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const origin = new URL(request.url).origin;
+  const paidResponses = {
+    '200': { description: 'Paid response returned after x402 verify and settlement.' },
+    '402': { description: 'Payment required or payment settlement failed.' },
+    '503': { description: 'Payment facilitator or Base market-data source unavailable.' },
+  };
+
   return NextResponse.json({
     openapi: '3.1.0',
     info: {
       title: 'Voxel Vault Machine Revenue API',
-      version: '2.0.0',
-      description: 'Read-only Base market intelligence with Flashblocks-aware quoting and x402 USDC payment gates.',
+      version: '2.1.0',
+      description: 'Read-only Base market intelligence, Flashblocks-aware quoting, bounded agent decision tickets, and x402 USDC payment gates.',
     },
     servers: [{ url: origin }],
     paths: {
@@ -18,6 +24,12 @@ export async function GET(request: Request) {
         get: {
           summary: 'Discover service capabilities and payment configuration.',
           responses: { '200': { description: 'Machine-readable service manifest.' } },
+        },
+      },
+      '/api/agent/health': {
+        get: {
+          summary: 'Read coordinator, executor, and x402 activation status.',
+          responses: { '200': { description: 'Read-only service health and safety state.' } },
         },
       },
       '/api/agent/base-quote': {
@@ -40,11 +52,7 @@ export async function GET(request: Request) {
               },
             },
           },
-          responses: {
-            '200': { description: 'Paid quote returned after x402 verify and settlement.' },
-            '402': { description: 'Payment required or payment settlement failed.' },
-            '503': { description: 'Payment facilitator or Base market-data source unavailable.' },
-          },
+          responses: paidResponses,
         },
       },
       '/api/agent/optimize': {
@@ -72,11 +80,31 @@ export async function GET(request: Request) {
               },
             },
           },
-          responses: {
-            '200': { description: 'Paid optimization response returned after x402 settlement.' },
-            '402': { description: 'Payment required or payment settlement failed.' },
-            '503': { description: 'Payment facilitator or Base market-data source unavailable.' },
+          responses: paidResponses,
+        },
+      },
+      '/api/agent/decision': {
+        post: {
+          summary: 'Paid bounded agent decision ticket.',
+          description: 'Requires Flashblocks by default, applies the coordinator quote cap, and returns a short-lived deterministic ticket only when the quote gate passes. Tickets are not signatures or spending authorizations.',
+          requestBody: {
+            required: false,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    amountEth: { type: 'string', default: '0.01' },
+                    targetBps: { type: 'integer', minimum: 1, maximum: 1000, default: 25 },
+                    slippageBps: { type: 'integer', minimum: 1, maximum: 100, default: 15 },
+                    requireFlashblocks: { type: 'boolean', default: true },
+                    ticketLifetimeMs: { type: 'integer', minimum: 400, maximum: 5000, default: 1200 },
+                  },
+                },
+              },
+            },
           },
+          responses: paidResponses,
         },
       },
     },

--- a/lib/agent-coordinator.ts
+++ b/lib/agent-coordinator.ts
@@ -1,0 +1,134 @@
+import { formatEther, keccak256, parseUnits, toUtf8Bytes } from 'ethers';
+import { normalizeAmountEth, scanBaseArbitrage } from './base-profit-engine';
+
+const DEFAULT_MAX_QUOTE_ETH = '0.05';
+const DEFAULT_TICKET_LIFETIME_MS = 1_200;
+const MIN_TICKET_LIFETIME_MS = 400;
+const MAX_TICKET_LIFETIME_MS = 5_000;
+
+export type AgentDecisionInput = {
+  amountEth?: unknown;
+  targetBps?: unknown;
+  slippageBps?: unknown;
+  requireFlashblocks?: boolean;
+  ticketLifetimeMs?: unknown;
+};
+
+function configuredMaxQuoteWei() {
+  const raw = String(process.env.AGENT_MAX_QUOTE_ETH || DEFAULT_MAX_QUOTE_ETH).trim();
+  try {
+    const value = parseUnits(raw, 18);
+    return value > BigInt(0) ? value : parseUnits(DEFAULT_MAX_QUOTE_ETH, 18);
+  } catch {
+    return parseUnits(DEFAULT_MAX_QUOTE_ETH, 18);
+  }
+}
+
+function ticketLifetimeMs(value: unknown) {
+  const parsed = Number(value ?? DEFAULT_TICKET_LIFETIME_MS);
+  if (!Number.isFinite(parsed)) return DEFAULT_TICKET_LIFETIME_MS;
+  return Math.min(MAX_TICKET_LIFETIME_MS, Math.max(MIN_TICKET_LIFETIME_MS, Math.round(parsed)));
+}
+
+function policyBlocked(reason: string, policy: Record<string, unknown>) {
+  return {
+    decision: 'POLICY_BLOCK' as const,
+    reason,
+    policy,
+    ticket: null,
+    scan: null,
+  };
+}
+
+export async function coordinateBaseAgentDecision(input: AgentDecisionInput) {
+  const { amount, inputWei } = normalizeAmountEth(input.amountEth || '0.01');
+  const maxQuoteWei = configuredMaxQuoteWei();
+  const requireFlashblocks = input.requireFlashblocks !== false;
+  const lifetimeMs = ticketLifetimeMs(input.ticketLifetimeMs);
+  const policy = {
+    mode: 'READ_ONLY_COORDINATOR',
+    maxQuoteWei: maxQuoteWei.toString(),
+    maxQuoteEth: formatEther(maxQuoteWei),
+    requireFlashblocks,
+    ticketLifetimeMs: lifetimeMs,
+    signsTransactions: false,
+    submitsTransactions: false,
+    authorizesSpending: false,
+    requiresFreshWalletSimulation: true,
+  };
+
+  if (inputWei > maxQuoteWei) {
+    return policyBlocked(`Requested ${amount} ETH exceeds the coordinator quote cap of ${formatEther(maxQuoteWei)} ETH.`, policy);
+  }
+
+  const scan = await scanBaseArbitrage({
+    amountEth: amount,
+    targetBps: input.targetBps,
+    slippageBps: input.slippageBps,
+    preferFlashblocks: true,
+  });
+
+  if (requireFlashblocks && !scan.flashblocks) {
+    return {
+      decision: 'POLICY_BLOCK' as const,
+      reason: 'Flashblocks pending state was unavailable, so the autonomous candidate gate refused a sealed-state fallback.',
+      policy,
+      ticket: null,
+      scan,
+    };
+  }
+
+  if (!scan.best) {
+    return {
+      decision: 'NO_TRADE' as const,
+      reason: 'No route cleared starting capital, conservative gas, and the requested net-profit floor.',
+      policy,
+      ticket: null,
+      scan,
+    };
+  }
+
+  const candidate = scan.best;
+  const scannedAtMs = Date.parse(scan.scannedAt);
+  const expiresAtMs = Number.isFinite(scannedAtMs) ? scannedAtMs + lifetimeMs : Date.now() + lifetimeMs;
+  const ticketCore = {
+    version: 1,
+    chainId: scan.chainId,
+    pair: scan.pair,
+    stateMode: scan.stateMode,
+    stateObservedBlock: scan.stateObservedBlock,
+    scannedAt: scan.scannedAt,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    executorAddress: scan.executorAddress || '',
+    method: candidate.method,
+    inputWei: candidate.inputWei,
+    targetProfitWei: candidate.targetProfitWei,
+    gasBudgetWei: candidate.gasBudgetWei,
+    quotedFinalWei: candidate.finalWei,
+    quotedNetAfterGasWei: candidate.netAfterGasWei,
+    uniFee: candidate.params.uniFee ?? null,
+    aeroStable: candidate.params.aeroStable ?? null,
+    minUsdcOut: candidate.params.minUsdcOut,
+    minWethOut: candidate.params.minWethOut,
+    minProfitWei: candidate.params.minProfitWei,
+  };
+  const ticketId = keccak256(toUtf8Bytes(JSON.stringify(ticketCore)));
+  const ticket = {
+    ...ticketCore,
+    ticketId,
+    authorization: false,
+    signature: null,
+    status: scan.executionEnabled ? 'SIMULATION_REQUIRED' : 'EXECUTOR_NOT_ACTIVE',
+    instructions: 'Treat this as an expiring quote envelope only. Before any transaction, re-run the exact executor staticCall and wallet gas estimate against current Base state.',
+  };
+
+  return {
+    decision: scan.executionEnabled ? 'EXECUTION_CANDIDATE' as const : 'EXECUTOR_NOT_ACTIVE' as const,
+    reason: scan.executionEnabled
+      ? 'The route cleared the quote gate and received a short-lived deterministic ticket. Fresh wallet simulation is still mandatory.'
+      : 'The route cleared the quote gate, but live execution remains locked because no reviewed executor address is active.',
+    policy,
+    ticket,
+    scan,
+  };
+}

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -3,8 +3,11 @@ import fs from 'node:fs';
 const read = path => fs.readFileSync(path, 'utf8');
 const core = read('lib/base-profit-engine.ts');
 const payments = read('lib/x402-resource.ts');
+const coordinator = read('lib/agent-coordinator.ts');
 const quote = read('app/api/agent/base-quote/route.ts');
 const optimize = read('app/api/agent/optimize/route.ts');
+const decision = read('app/api/agent/decision/route.ts');
+const health = read('app/api/agent/health/route.ts');
 const manifest = read('app/api/agent/manifest/route.ts');
 const openapi = read('app/api/agent/openapi/route.ts');
 
@@ -33,11 +36,28 @@ requireText(payments, "return 'https://api.cdp.coinbase.com/platform/v2/x402'", 
 forbidText(payments, 'VOXELFLIP_MINT_SIGNER_PRIVATE_KEY', 'x402 must not reuse mint signer keys');
 forbidText(payments, 'VOXELFORGE_SIGNER_PRIVATE_KEY', 'x402 must not reuse Forge signer keys');
 
+requireText(coordinator, "mode: 'READ_ONLY_COORDINATOR'", 'coordinator must remain explicitly read-only');
+requireText(coordinator, 'requireFlashblocks', 'coordinator must support a Flashblocks-required policy');
+requireText(coordinator, 'maxQuoteEth', 'coordinator must expose its quote cap');
+requireText(coordinator, 'ticketLifetimeMs', 'coordinator must bound ticket lifetime');
+requireText(coordinator, 'authorization: false', 'execution ticket must explicitly not authorize spending');
+requireText(coordinator, 'signature: null', 'execution ticket must never contain a coordinator signature');
+requireText(coordinator, 'requiresFreshWalletSimulation: true', 'execution candidate must require fresh wallet simulation');
+forbidText(coordinator, 'Wallet(', 'coordinator must never instantiate a signing wallet');
+forbidText(coordinator, 'sendTransaction', 'coordinator must never send a transaction');
+forbidText(coordinator, 'eth_sendRawTransaction', 'coordinator must never submit raw transactions');
+forbidText(coordinator, 'PRIVATE_KEY', 'coordinator must never read private keys');
+
 requireText(quote, 'withX402Json', 'base quote route must be x402-gated');
 requireText(optimize, 'withX402Json', 'optimizer route must be x402-gated');
+requireText(decision, 'withX402Json', 'agent decision route must be x402-gated');
+requireText(decision, 'coordinateBaseAgentDecision', 'decision route must use the bounded coordinator');
 forbidText(quote, 'executeUniThenAero', 'paid quote route must not execute trades');
 forbidText(optimize, 'executeAeroThenUni', 'paid optimizer route must not execute trades');
-requireText(manifest, 'signsTransactions: false', 'manifest must disclose that machine endpoints do not sign');
+forbidText(decision, 'executeUniThenAero', 'paid decision route must not execute trades');
+requireText(health, 'signsTransactions: false', 'health endpoint must disclose no signing');
+requireText(manifest, 'authorizesSpending: false', 'manifest must disclose that tickets do not authorize spending');
+requireText(openapi, '/api/agent/decision', 'OpenAPI must document the decision endpoint');
 requireText(openapi, 'PAYMENT-SIGNATURE', 'OpenAPI must document x402 payment header');
 
 console.log('Machine revenue layer safety checks passed.');


### PR DESCRIPTION
Adds the next agent-native layer on top of Profit Engine V2 without introducing autonomous wallet control.

What it adds:
- `lib/agent-coordinator.ts`: read-only decision coordinator that consumes the live Base scanner.
- Requires Flashblocks pending state by default for autonomous candidates.
- Applies a conservative default 0.05 ETH quote cap (`AGENT_MAX_QUOTE_ETH` can lower/adjust the quote-only policy).
- Creates deterministic keccak256 execution-ticket IDs from the exact route/state/limits.
- Tickets are deliberately short-lived (default 1200ms, bounded 400–5000ms).
- Every ticket explicitly has `authorization: false`, `signature: null`, and requires a fresh wallet staticCall + gas estimate.
- If the atomic executor is not active, a profitable route returns `EXECUTOR_NOT_ACTIVE`, not an executable instruction.
- `POST /api/agent/decision`: x402-paid bounded decision endpoint (default 0.01 USDC).
- `GET /api/agent/health`: free machine-readable coordinator/executor/x402 status.
- Manifest/OpenAPI upgraded to v2.1 and publish the decision/health surfaces.
- Machine-revenue regression checks now assert the coordinator cannot instantiate a wallet, read private keys, send transactions, submit raw transactions, sign tickets, or authorize spending.

This PR does not add a private key, agent wallet, flash-loan executor, bridge execution, unattended transaction submission, or adversarial MEV behavior. It advances the autonomous decision plane while keeping capital execution behind the existing owner-controlled fresh-simulation flow.