### PR TITLE
Base Liquidity Engine V1: bounded LP + Flashblocks scanner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Public Base RPC fallback. Flashblocks pending-state reads use the separate preconfirmation endpoint below.
+BASE_RPC_URL=https://mainnet.base.org
+BASE_FLASHBLOCKS_RPC_URL=https://mainnet-preconf.base.org
+
+# x402 revenue receiver. Use a public receiving address only; never put a private key here.
+X402_PAY_TO=0x0000000000000000000000000000000000000000
+X402_BASE_QUOTE_PRICE_ATOMIC=1000
+X402_OPTIMIZE_PRICE_ATOMIC=5000
+X402_DECISION_PRICE_ATOMIC=10000
+
+# Coinbase CDP facilitator credentials. Configure these only in your private local/Vercel environment.
+CDP_API_KEY_ID=
+CDP_API_KEY_SECRET=
+
+# Existing Profit Engine executor, once reviewed/deployed.
+BASE_ARB_EXECUTOR_ADDRESS=
+NEXT_PUBLIC_BASE_ARB_EXECUTOR_ADDRESS=
+
+# Base Liquidity Engine. Leave operator blank/zero to keep autonomous operation disabled.
+BASE_LIQUIDITY_MANAGER_ADDRESS=
+NEXT_PUBLIC_BASE_LIQUIDITY_MANAGER_ADDRESS=
+LIQUIDITY_OWNER_ADDRESS=0x0000000000000000000000000000000000000000
+LIQUIDITY_OPERATOR_ADDRESS=
+LIQUIDITY_MAX_WETH_PER_POSITION_WEI=20000000000000000
+LIQUIDITY_MAX_USDC_PER_POSITION_ATOMIC=50000000
+LIQUIDITY_MAX_WETH_ALLOCATED_WEI=50000000000000000
+LIQUIDITY_MAX_USDC_ALLOCATED_ATOMIC=150000000
+LIQUIDITY_MAX_ACTIVE_POSITIONS=2
+
+# Mainnet deployment remains locked unless intentionally enabled for a reviewed deployment.
+ALLOW_BASE_LIQUIDITY_DEPLOY=false
+
+# Hardhat only. Never commit this value. Prefer the browser/MetaMask deployment flow where available.
+DEPLOYER_PRIVATE_KEY=

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm run chain:compile
       - run: npm run chain:check:forge-bytecode
       - run: npm run chain:test:forge
+      - run: npm run chain:test:liquidity
       - name: Upload production Forge artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -30,6 +30,7 @@ jobs:
       - run: npm run test:mobile
       - run: npm run test:voxel-flow
       - run: npm run test:machine-revenue
+      - run: npm run test:liquidity-engine
       - run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: '1'

--- a/app/api/liquidity-engine/scan/route.ts
+++ b/app/api/liquidity-engine/scan/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { scanBaseLiquidity } from '../../../../lib/base-liquidity-scanner';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const result = await scanBaseLiquidity({
+      widthMultiples: body?.widthMultiples,
+      requireFlashblocks: body?.requireFlashblocks !== false,
+    });
+    return NextResponse.json(result, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return NextResponse.json({
+      error: error instanceof Error ? error.message : 'Liquidity scan failed.',
+    }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
+  }
+}

--- a/app/liquidity-engine/page.js
+++ b/app/liquidity-engine/page.js
@@ -1,0 +1,73 @@
+'use client';
+
+import {useState} from 'react';
+import styles from '../profit-engine/profit.module.css';
+
+function short(value){return value?`${String(value).slice(0,8)}…${String(value).slice(-6)}`:'—'}
+function feeLabel(fee){return `${(Number(fee)/10000).toFixed(2)}%`}
+function errorText(error){return String(error?.message||error||'Scan failed.')}
+
+export default function LiquidityEnginePage(){
+  const [width,setWidth]=useState('10');
+  const [scan,setScan]=useState(null);
+  const [busy,setBusy]=useState(false);
+  const [error,setError]=useState('');
+
+  async function runScan(){
+    setBusy(true);setError('');
+    try{
+      const response=await fetch('/api/liquidity-engine/scan',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({widthMultiples:Number(width),requireFlashblocks:true}),
+        cache:'no-store',
+      });
+      const data=await response.json().catch(()=>({}));
+      if(!response.ok)throw new Error(data.error||'Liquidity scan failed.');
+      setScan(data);
+    }catch(e){setError(errorText(e));setScan(null)}finally{setBusy(false)}
+  }
+
+  return <main className={styles.page}>
+    <nav className={styles.nav}><a href="/profit-engine">Voxel Vault · Liquidity Engine</a><span>BASE · READ-ONLY PHASE 1</span></nav>
+    <div className={styles.shell}>
+      <header className={styles.hero}>
+        <small>FLASHBLOCKS LIQUIDITY ENGINE</small>
+        <h1>Watch fee activity.<br/><em>Deploy only with limits.</em></h1>
+        <p>Reads WETH/USDC Uniswap V3 pools from Base Flashblocks pending state and compares fee-growth against sealed state. This scanner does not sign, deploy liquidity, or claim guaranteed APR.</p>
+      </header>
+
+      <section className={styles.panel}>
+        <div className={styles.guardrail}><b>PHASE 1 SAFETY</b><span>The live scanner is read-only. Capital-moving liquidity contracts are separately bounded by owner-set inventory, per-position caps, active-position caps, tick alignment, pause, treasury routing, and emergency exit.</span></div>
+        <div className={styles.form}>
+          <div className={styles.field}><label>RANGE · TICK SPACING MULTIPLES</label><input value={width} onChange={e=>setWidth(e.target.value)} inputMode="numeric"/></div>
+          <button className={styles.primary} onClick={runScan} disabled={busy}>{busy?'SCANNING…':'SCAN FLASHBLOCKS NOW'}</button>
+        </div>
+        {error&&<div className={styles.error}>{error}</div>}
+        {scan&&<div className={styles.summary}>
+          <div className={styles.stat}><small>STATE</small><b>{scan.stateMode}</b></div>
+          <div className={styles.stat}><small>RPC</small><b>{scan.rpcHost}</b></div>
+          <div className={styles.stat}><small>PAIR</small><b>{scan.pair}</b></div>
+          <div className={styles.stat}><small>MANAGER</small><b>{scan.executionConfigured?short(scan.managerAddress):'NOT DEPLOYED'}</b></div>
+        </div>}
+      </section>
+
+      {scan&&<section className={styles.panel}>
+        <div className={styles.sectionHead}><div><h2>Uniswap V3 fee tiers</h2><span>{new Date(scan.scannedAt).toLocaleTimeString()} · pending activity signal only</span></div></div>
+        <div className={styles.grid}>{scan.pools.map(pool=><article key={pool.poolAddress} className={`${styles.card} ${pool.feeGrowthChanged?styles.good:''}`}>
+          <span className={styles.badge}>{pool.signal}</span>
+          <div className={styles.route}>WETH/USDC · {feeLabel(pool.fee)}</div>
+          <div className={styles.leg}><span>POOL</span><b>{short(pool.poolAddress)}</b></div>
+          <div className={styles.leg}><span>PENDING TICK</span><b>{pool.pendingTick}</b></div>
+          <div className={styles.leg}><span>RANGE TEMPLATE</span><b>{pool.suggestedRange.tickLower} → {pool.suggestedRange.tickUpper}</b></div>
+          <div className={styles.numbers}>
+            <div className={styles.number}><span>Liquidity raw</span><b>{pool.liquidityRaw}</b></div>
+            <div className={styles.number}><span>Fee growth Δ token0 · X128</span><b>{pool.feeGrowthDelta0X128}</b></div>
+            <div className={styles.number}><span>Fee growth Δ token1 · X128</span><b>{pool.feeGrowthDelta1X128}</b></div>
+          </div>
+        </article>)}</div>
+        <div className={styles.footnote}>{scan.interpretation}</div>
+      </section>}
+    </div>
+  </main>;
+}

--- a/contracts/BaseLiquidityManager.sol
+++ b/contracts/BaseLiquidityManager.sol
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+interface IUniswapV3FactoryLike {
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
+    function feeAmountTickSpacing(uint24 fee) external view returns (int24 spacing);
+}
+
+interface INonfungiblePositionManagerLike {
+    struct MintParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+    }
+
+    struct DecreaseLiquidityParams {
+        uint256 tokenId;
+        uint128 liquidity;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    struct CollectParams {
+        uint256 tokenId;
+        address recipient;
+        uint128 amount0Max;
+        uint128 amount1Max;
+    }
+
+    function factory() external view returns (address);
+    function mint(MintParams calldata params)
+        external
+        payable
+        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (uint256 amount0, uint256 amount1);
+    function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1);
+    function burn(uint256 tokenId) external payable;
+}
+
+/// @title BaseLiquidityManager
+/// @notice Bounded Uniswap V3 concentrated-liquidity manager intended for Base.
+/// @dev This contract does not discover pools, predict profits, swap inventory, borrow,
+///      or sign autonomously. A configured operator may only deploy already-deposited
+///      capital within owner-defined caps and close existing positions. All recovered
+///      principal and fees are routed directly to the treasury in their native tokens.
+contract BaseLiquidityManager is Ownable, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant MAX_DEADLINE_WINDOW = 5 minutes;
+    uint256 public constant MAX_POSITION_DURATION = 30 minutes;
+    uint256 public constant MIN_POSITION_DURATION = 5 seconds;
+    uint256 public constant MAX_TICK_SPACING_MULTIPLIER = 100;
+    uint256 public constant MAX_ACTIVE_POSITIONS_HARD = 16;
+
+    struct Position {
+        uint256 tokenId;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint128 liquidity;
+        uint64 openedAt;
+        uint64 expiresAt;
+        uint256 principal0;
+        uint256 principal1;
+        bool active;
+    }
+
+    address public operator;
+    address public treasury;
+    address public immutable token0;
+    address public immutable token1;
+    INonfungiblePositionManagerLike public immutable positionManager;
+    IUniswapV3FactoryLike public immutable factory;
+
+    uint256 public maxToken0PerPosition;
+    uint256 public maxToken1PerPosition;
+    uint256 public maxToken0Allocated;
+    uint256 public maxToken1Allocated;
+    uint256 public maxActivePositions;
+
+    uint256 public allocatedToken0;
+    uint256 public allocatedToken1;
+    uint256 public activePositions;
+    uint256 public nextPositionId = 1;
+
+    mapping(uint256 => Position) public positions;
+
+    event OperatorUpdated(address indexed previousOperator, address indexed newOperator);
+    event TreasuryUpdated(address indexed previousTreasury, address indexed newTreasury);
+    event LimitsUpdated(
+        uint256 maxToken0PerPosition,
+        uint256 maxToken1PerPosition,
+        uint256 maxToken0Allocated,
+        uint256 maxToken1Allocated,
+        uint256 maxActivePositions
+    );
+    event CapitalDeposited(address indexed token, uint256 amount);
+    event IdleCapitalWithdrawn(address indexed token, uint256 amount, address indexed recipient);
+    event PositionOpened(
+        uint256 indexed positionId,
+        uint256 indexed tokenId,
+        uint24 fee,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 liquidity,
+        uint256 principal0,
+        uint256 principal1,
+        uint64 expiresAt
+    );
+    event PositionClosed(
+        uint256 indexed positionId,
+        uint256 indexed tokenId,
+        uint256 amount0ToTreasury,
+        uint256 amount1ToTreasury,
+        bool emergency
+    );
+
+    modifier onlyOperatorOrOwner() {
+        require(msg.sender == operator || msg.sender == owner(), "Operator or owner only");
+        _;
+    }
+
+    constructor(
+        address initialOwner,
+        address initialOperator,
+        address initialTreasury,
+        address positionManager_,
+        address factory_,
+        address token0_,
+        address token1_,
+        uint256 maxToken0PerPosition_,
+        uint256 maxToken1PerPosition_,
+        uint256 maxToken0Allocated_,
+        uint256 maxToken1Allocated_,
+        uint256 maxActivePositions_
+    ) Ownable(initialOwner) {
+        require(initialOwner != address(0), "Owner required");
+        require(initialTreasury != address(0), "Treasury required");
+        require(positionManager_ != address(0) && factory_ != address(0), "Uniswap config required");
+        require(token0_ != address(0) && token1_ != address(0) && token0_ < token1_, "Sorted tokens required");
+        require(INonfungiblePositionManagerLike(positionManager_).factory() == factory_, "Factory mismatch");
+
+        operator = initialOperator;
+        treasury = initialTreasury;
+        positionManager = INonfungiblePositionManagerLike(positionManager_);
+        factory = IUniswapV3FactoryLike(factory_);
+        token0 = token0_;
+        token1 = token1_;
+        _setLimits(
+            maxToken0PerPosition_,
+            maxToken1PerPosition_,
+            maxToken0Allocated_,
+            maxToken1Allocated_,
+            maxActivePositions_
+        );
+
+        IERC20(token0_).forceApprove(positionManager_, type(uint256).max);
+        IERC20(token1_).forceApprove(positionManager_, type(uint256).max);
+    }
+
+    function setOperator(address newOperator) external onlyOwner {
+        address old = operator;
+        operator = newOperator;
+        emit OperatorUpdated(old, newOperator);
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        require(newTreasury != address(0), "Treasury required");
+        address old = treasury;
+        treasury = newTreasury;
+        emit TreasuryUpdated(old, newTreasury);
+    }
+
+    function setLimits(
+        uint256 maxToken0PerPosition_,
+        uint256 maxToken1PerPosition_,
+        uint256 maxToken0Allocated_,
+        uint256 maxToken1Allocated_,
+        uint256 maxActivePositions_
+    ) external onlyOwner {
+        _setLimits(
+            maxToken0PerPosition_,
+            maxToken1PerPosition_,
+            maxToken0Allocated_,
+            maxToken1Allocated_,
+            maxActivePositions_
+        );
+    }
+
+    function _setLimits(
+        uint256 maxToken0PerPosition_,
+        uint256 maxToken1PerPosition_,
+        uint256 maxToken0Allocated_,
+        uint256 maxToken1Allocated_,
+        uint256 maxActivePositions_
+    ) internal {
+        require(maxToken0PerPosition_ > 0 && maxToken1PerPosition_ > 0, "Per-position caps required");
+        require(maxToken0Allocated_ >= maxToken0PerPosition_, "Token0 total cap too low");
+        require(maxToken1Allocated_ >= maxToken1PerPosition_, "Token1 total cap too low");
+        require(maxActivePositions_ > 0 && maxActivePositions_ <= MAX_ACTIVE_POSITIONS_HARD, "Active-position cap invalid");
+        require(maxToken0Allocated_ >= allocatedToken0 && maxToken1Allocated_ >= allocatedToken1, "Below current allocation");
+        require(maxActivePositions_ >= activePositions, "Below active positions");
+
+        maxToken0PerPosition = maxToken0PerPosition_;
+        maxToken1PerPosition = maxToken1PerPosition_;
+        maxToken0Allocated = maxToken0Allocated_;
+        maxToken1Allocated = maxToken1Allocated_;
+        maxActivePositions = maxActivePositions_;
+        emit LimitsUpdated(
+            maxToken0PerPosition_,
+            maxToken1PerPosition_,
+            maxToken0Allocated_,
+            maxToken1Allocated_,
+            maxActivePositions_
+        );
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Pre-fund bounded capital. The operator never receives token custody.
+    function depositCapital(address token, uint256 amount) external onlyOwner nonReentrant {
+        require(token == token0 || token == token1, "Unsupported token");
+        require(amount > 0, "Amount required");
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        emit CapitalDeposited(token, amount);
+    }
+
+    /// @notice Owner recovery for idle, unallocated inventory only.
+    function withdrawIdleCapital(address token, uint256 amount, address recipient) external onlyOwner nonReentrant {
+        require(token == token0 || token == token1, "Unsupported token");
+        require(recipient != address(0), "Recipient required");
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        require(amount <= balance, "Insufficient idle balance");
+        IERC20(token).safeTransfer(recipient, amount);
+        emit IdleCapitalWithdrawn(token, amount, recipient);
+    }
+
+    /// @notice Opens one bounded WETH/USDC-style V3 position using already-deposited inventory.
+    function openPosition(
+        uint24 fee,
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 amount0Desired,
+        uint256 amount1Desired,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        uint256 durationSeconds,
+        uint256 deadline
+    ) external onlyOperatorOrOwner whenNotPaused nonReentrant returns (uint256 positionId) {
+        require(amount0Desired > 0 || amount1Desired > 0, "Capital required");
+        require(amount0Desired <= maxToken0PerPosition && amount1Desired <= maxToken1PerPosition, "Per-position cap");
+        require(activePositions < maxActivePositions, "Active-position cap");
+        require(durationSeconds >= MIN_POSITION_DURATION && durationSeconds <= MAX_POSITION_DURATION, "Duration invalid");
+        _checkDeadline(deadline);
+
+        int24 spacing = factory.feeAmountTickSpacing(fee);
+        require(spacing > 0, "Unsupported fee tier");
+        require(factory.getPool(token0, token1, fee) != address(0), "Pool not deployed");
+        require(tickLower < tickUpper, "Tick order invalid");
+        require(tickLower % spacing == 0 && tickUpper % spacing == 0, "Ticks not aligned");
+        require(uint256(uint24(tickUpper - tickLower)) <= uint256(uint24(spacing)) * MAX_TICK_SPACING_MULTIPLIER, "Range too wide");
+        require(allocatedToken0 + amount0Desired <= maxToken0Allocated, "Token0 allocation cap");
+        require(allocatedToken1 + amount1Desired <= maxToken1Allocated, "Token1 allocation cap");
+        require(IERC20(token0).balanceOf(address(this)) >= amount0Desired, "Token0 inventory low");
+        require(IERC20(token1).balanceOf(address(this)) >= amount1Desired, "Token1 inventory low");
+
+        (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) = positionManager.mint(
+            INonfungiblePositionManagerLike.MintParams({
+                token0: token0,
+                token1: token1,
+                fee: fee,
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                amount0Desired: amount0Desired,
+                amount1Desired: amount1Desired,
+                amount0Min: amount0Min,
+                amount1Min: amount1Min,
+                recipient: address(this),
+                deadline: deadline
+            })
+        );
+        require(liquidity > 0, "No liquidity minted");
+        require(amount0 <= amount0Desired && amount1 <= amount1Desired, "Unexpected mint amounts");
+
+        allocatedToken0 += amount0;
+        allocatedToken1 += amount1;
+        activePositions += 1;
+        positionId = nextPositionId++;
+        uint64 expiresAt = uint64(block.timestamp + durationSeconds);
+        positions[positionId] = Position({
+            tokenId: tokenId,
+            fee: fee,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            liquidity: liquidity,
+            openedAt: uint64(block.timestamp),
+            expiresAt: expiresAt,
+            principal0: amount0,
+            principal1: amount1,
+            active: true
+        });
+
+        emit PositionOpened(
+            positionId,
+            tokenId,
+            fee,
+            tickLower,
+            tickUpper,
+            liquidity,
+            amount0,
+            amount1,
+            expiresAt
+        );
+    }
+
+    function closePosition(
+        uint256 positionId,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        uint256 deadline
+    ) external onlyOperatorOrOwner nonReentrant returns (uint256 amount0, uint256 amount1) {
+        _checkDeadline(deadline);
+        return _close(positionId, amount0Min, amount1Min, deadline, false);
+    }
+
+    /// @notice Fast exit with zero token minima. Useful when the range is breached.
+    /// @dev Liquidity removal is not a token swap; proceeds are delivered as token0/token1.
+    function emergencyClose(uint256 positionId) external onlyOperatorOrOwner nonReentrant returns (uint256 amount0, uint256 amount1) {
+        return _close(positionId, 0, 0, block.timestamp, true);
+    }
+
+    /// @notice Anyone may unwind an expired position; all proceeds still go to treasury.
+    function closeExpired(uint256 positionId) external nonReentrant returns (uint256 amount0, uint256 amount1) {
+        Position memory p = positions[positionId];
+        require(p.active, "Position inactive");
+        require(block.timestamp >= p.expiresAt, "Position not expired");
+        return _close(positionId, 0, 0, block.timestamp, true);
+    }
+
+    function _close(
+        uint256 positionId,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        uint256 deadline,
+        bool emergency
+    ) internal returns (uint256 amount0, uint256 amount1) {
+        Position storage p = positions[positionId];
+        require(p.active, "Position inactive");
+
+        positionManager.decreaseLiquidity(
+            INonfungiblePositionManagerLike.DecreaseLiquidityParams({
+                tokenId: p.tokenId,
+                liquidity: p.liquidity,
+                amount0Min: amount0Min,
+                amount1Min: amount1Min,
+                deadline: deadline
+            })
+        );
+
+        (amount0, amount1) = positionManager.collect(
+            INonfungiblePositionManagerLike.CollectParams({
+                tokenId: p.tokenId,
+                recipient: treasury,
+                amount0Max: type(uint128).max,
+                amount1Max: type(uint128).max
+            })
+        );
+        positionManager.burn(p.tokenId);
+
+        allocatedToken0 -= p.principal0;
+        allocatedToken1 -= p.principal1;
+        activePositions -= 1;
+        p.active = false;
+
+        emit PositionClosed(positionId, p.tokenId, amount0, amount1, emergency);
+    }
+
+    function _checkDeadline(uint256 deadline) internal view {
+        require(deadline >= block.timestamp, "Expired");
+        require(deadline <= block.timestamp + MAX_DEADLINE_WINDOW, "Deadline too far");
+    }
+}

--- a/contracts/BaseLiquidityTreasury.sol
+++ b/contracts/BaseLiquidityTreasury.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title BaseLiquidityTreasury
+/// @notice Minimal custody sink for Base liquidity principal and fees.
+/// @dev It intentionally performs no swaps, governance actions, lending, or automated
+///      reinvestment. The owner explicitly withdraws assets to a chosen recipient.
+contract BaseLiquidityTreasury is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    address public immutable token0;
+    address public immutable token1;
+
+    event TreasuryWithdrawal(address indexed token, address indexed recipient, uint256 amount);
+    event NativeWithdrawal(address indexed recipient, uint256 amount);
+
+    constructor(address initialOwner, address token0_, address token1_) Ownable(initialOwner) {
+        require(initialOwner != address(0), "Owner required");
+        require(token0_ != address(0) && token1_ != address(0) && token0_ != token1_, "Tokens required");
+        token0 = token0_;
+        token1 = token1_;
+    }
+
+    function tokenBalance(address token) external view returns (uint256) {
+        require(token == token0 || token == token1, "Unsupported token");
+        return IERC20(token).balanceOf(address(this));
+    }
+
+    function withdrawToken(address token, uint256 amount, address recipient) external onlyOwner nonReentrant {
+        require(token == token0 || token == token1, "Unsupported token");
+        require(recipient != address(0), "Recipient required");
+        require(amount > 0, "Amount required");
+        IERC20(token).safeTransfer(recipient, amount);
+        emit TreasuryWithdrawal(token, recipient, amount);
+    }
+
+    function withdrawNative(uint256 amount, address payable recipient) external onlyOwner nonReentrant {
+        require(recipient != address(0), "Recipient required");
+        require(amount > 0 && amount <= address(this).balance, "Invalid amount");
+        (bool sent,) = recipient.call{value: amount}("");
+        require(sent, "Native withdrawal failed");
+        emit NativeWithdrawal(recipient, amount);
+    }
+
+    receive() external payable {}
+}

--- a/contracts/mocks/MockLiquidityInfra.sol
+++ b/contracts/mocks/MockLiquidityInfra.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract MockLiquidityToken is ERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockV3Factory {
+    mapping(uint24 => int24) public feeAmountTickSpacing;
+    mapping(bytes32 => address) private pools;
+
+    function setFeeTier(uint24 fee, int24 spacing) external {
+        feeAmountTickSpacing[fee] = spacing;
+    }
+
+    function setPool(address tokenA, address tokenB, uint24 fee, address pool) external {
+        (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        pools[keccak256(abi.encode(token0, token1, fee))] = pool;
+    }
+
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address) {
+        (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return pools[keccak256(abi.encode(token0, token1, fee))];
+    }
+}
+
+contract MockPositionManager {
+    using SafeERC20 for IERC20;
+
+    struct MintParams {
+        address token0;
+        address token1;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        address recipient;
+        uint256 deadline;
+    }
+
+    struct DecreaseLiquidityParams {
+        uint256 tokenId;
+        uint128 liquidity;
+        uint256 amount0Min;
+        uint256 amount1Min;
+        uint256 deadline;
+    }
+
+    struct CollectParams {
+        uint256 tokenId;
+        address recipient;
+        uint128 amount0Max;
+        uint128 amount1Max;
+    }
+
+    struct PositionData {
+        address owner;
+        address token0;
+        address token1;
+        uint24 fee;
+        int24 tickLower;
+        int24 tickUpper;
+        uint128 liquidity;
+        uint256 principal0;
+        uint256 principal1;
+        uint256 owed0;
+        uint256 owed1;
+        bool decreased;
+    }
+
+    address public immutable factory;
+    uint256 public nextTokenId = 1;
+    mapping(uint256 => PositionData) public data;
+
+    constructor(address factory_) {
+        factory = factory_;
+    }
+
+    function mint(MintParams calldata params)
+        external
+        payable
+        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
+    {
+        require(block.timestamp <= params.deadline, "Expired");
+        amount0 = params.amount0Desired;
+        amount1 = params.amount1Desired;
+        if (amount0 > 0) IERC20(params.token0).safeTransferFrom(msg.sender, address(this), amount0);
+        if (amount1 > 0) IERC20(params.token1).safeTransferFrom(msg.sender, address(this), amount1);
+        require(amount0 >= params.amount0Min && amount1 >= params.amount1Min, "Mint minima");
+
+        tokenId = nextTokenId++;
+        uint256 seed = amount0 + amount1;
+        liquidity = uint128(seed > type(uint128).max ? type(uint128).max : seed);
+        if (liquidity == 0) liquidity = 1;
+        data[tokenId] = PositionData({
+            owner: params.recipient,
+            token0: params.token0,
+            token1: params.token1,
+            fee: params.fee,
+            tickLower: params.tickLower,
+            tickUpper: params.tickUpper,
+            liquidity: liquidity,
+            principal0: amount0,
+            principal1: amount1,
+            owed0: 0,
+            owed1: 0,
+            decreased: false
+        });
+    }
+
+    function addFees(uint256 tokenId, uint256 fee0, uint256 fee1) external {
+        PositionData storage p = data[tokenId];
+        require(p.owner != address(0), "Missing position");
+        if (fee0 > 0) MockLiquidityToken(p.token0).mint(address(this), fee0);
+        if (fee1 > 0) MockLiquidityToken(p.token1).mint(address(this), fee1);
+        p.owed0 += fee0;
+        p.owed1 += fee1;
+    }
+
+    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
+        external
+        payable
+        returns (uint256 amount0, uint256 amount1)
+    {
+        PositionData storage p = data[params.tokenId];
+        require(msg.sender == p.owner, "Not position owner");
+        require(!p.decreased, "Already decreased");
+        require(params.liquidity == p.liquidity, "Liquidity mismatch");
+        require(block.timestamp <= params.deadline, "Expired");
+        amount0 = p.principal0;
+        amount1 = p.principal1;
+        require(amount0 >= params.amount0Min && amount1 >= params.amount1Min, "Decrease minima");
+        p.owed0 += amount0;
+        p.owed1 += amount1;
+        p.liquidity = 0;
+        p.decreased = true;
+    }
+
+    function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1) {
+        PositionData storage p = data[params.tokenId];
+        require(msg.sender == p.owner, "Not position owner");
+        amount0 = p.owed0 > params.amount0Max ? params.amount0Max : p.owed0;
+        amount1 = p.owed1 > params.amount1Max ? params.amount1Max : p.owed1;
+        p.owed0 -= amount0;
+        p.owed1 -= amount1;
+        if (amount0 > 0) IERC20(p.token0).safeTransfer(params.recipient, amount0);
+        if (amount1 > 0) IERC20(p.token1).safeTransfer(params.recipient, amount1);
+    }
+
+    function burn(uint256 tokenId) external payable {
+        PositionData storage p = data[tokenId];
+        require(msg.sender == p.owner, "Not position owner");
+        require(p.liquidity == 0 && p.owed0 == 0 && p.owed1 == 0, "Position not empty");
+        delete data[tokenId];
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -9,19 +9,21 @@ const standardSolidity = {
     optimizer: { enabled: true, runs: 200 },
   },
 };
+const viaIrSolidity = {
+  version: '0.8.26',
+  settings: {
+    evmVersion: 'cancun',
+    optimizer: { enabled: true, runs: 200 },
+    viaIR: true,
+  },
+};
 
 module.exports = {
   solidity: {
     compilers: [standardSolidity],
     overrides: {
-      'contracts/VoxelForgeRevenue.sol': {
-        version: '0.8.26',
-        settings: {
-          evmVersion: 'cancun',
-          optimizer: { enabled: true, runs: 200 },
-          viaIR: true,
-        },
-      },
+      'contracts/VoxelForgeRevenue.sol': viaIrSolidity,
+      'contracts/BaseLiquidityManager.sol': viaIrSolidity,
     },
   },
   networks: {

--- a/lib/base-liquidity-scanner.ts
+++ b/lib/base-liquidity-scanner.ts
@@ -1,0 +1,209 @@
+import { Contract, JsonRpcProvider, getAddress, isAddress } from 'ethers';
+
+export const BASE_CHAIN_ID = 8453;
+export const BASE_WETH = getAddress('0x4200000000000000000000000000000000000006');
+export const BASE_USDC = getAddress('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+export const BASE_UNISWAP_V3_FACTORY = getAddress('0x33128a8fC17869897dcE68Ed026d694621f6FDfD');
+export const BASE_UNISWAP_V3_POSITION_MANAGER = getAddress('0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1');
+
+const FLASHBLOCKS_RPC = 'https://mainnet-preconf.base.org';
+const FEE_TIERS = [100, 500, 3000, 10000] as const;
+const UINT256_MOD = BigInt(2) ** BigInt(256);
+
+const FACTORY_ABI = [
+  'function getPool(address tokenA,address tokenB,uint24 fee) view returns (address pool)',
+  'function feeAmountTickSpacing(uint24 fee) view returns (int24 spacing)',
+];
+const POOL_ABI = [
+  'function slot0() view returns (uint160 sqrtPriceX96,int24 tick,uint16 observationIndex,uint16 observationCardinality,uint16 observationCardinalityNext,uint8 feeProtocol,bool unlocked)',
+  'function liquidity() view returns (uint128)',
+  'function feeGrowthGlobal0X128() view returns (uint256)',
+  'function feeGrowthGlobal1X128() view returns (uint256)',
+];
+
+type StateTag = 'pending' | 'latest';
+
+type ProviderChoice = {
+  provider: JsonRpcProvider;
+  rpcHost: string;
+  stateTag: StateTag;
+  flashblocks: boolean;
+  observedBlock: string;
+};
+
+function safeHost(url: string) {
+  try { return new URL(url).hostname; } catch { return 'base-rpc'; }
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number) {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.round(parsed)));
+}
+
+function delta256(newValue: bigint, oldValue: bigint) {
+  return newValue >= oldValue ? newValue - oldValue : UINT256_MOD - oldValue + newValue;
+}
+
+function alignedCenter(tick: number, spacing: number) {
+  return Math.floor(tick / spacing) * spacing;
+}
+
+async function chooseProvider(requireFlashblocks: boolean): Promise<ProviderChoice> {
+  const flashUrl = String(process.env.BASE_FLASHBLOCKS_RPC_URL || '').trim() || FLASHBLOCKS_RPC;
+  const standard = [
+    String(process.env.BASE_RPC_URL || '').trim(),
+    'https://base-rpc.publicnode.com',
+    'https://mainnet.base.org',
+  ].filter(Boolean);
+  const candidates = [
+    { url: flashUrl, stateTag: 'pending' as const, flashblocks: true },
+    ...standard.map(url => ({ url, stateTag: 'latest' as const, flashblocks: false })),
+  ];
+  const seen = new Set<string>();
+  const errors: string[] = [];
+
+  for (const candidate of candidates) {
+    if (seen.has(candidate.url)) continue;
+    seen.add(candidate.url);
+    const provider = new JsonRpcProvider(candidate.url, BASE_CHAIN_ID, { staticNetwork: true });
+    try {
+      if (candidate.flashblocks) {
+        const block = await provider.send('eth_getBlockByNumber', ['pending', false]);
+        if (!block || typeof block !== 'object') throw new Error('pending state unavailable');
+        return {
+          provider,
+          rpcHost: safeHost(candidate.url),
+          stateTag: 'pending',
+          flashblocks: true,
+          observedBlock: String((block as { number?: string }).number || 'pending'),
+        };
+      }
+      if (requireFlashblocks) {
+        provider.destroy();
+        continue;
+      }
+      const blockNumber = await provider.getBlockNumber();
+      return {
+        provider,
+        rpcHost: safeHost(candidate.url),
+        stateTag: 'latest',
+        flashblocks: false,
+        observedBlock: String(blockNumber),
+      };
+    } catch (error) {
+      errors.push(`${safeHost(candidate.url)}: ${error instanceof Error ? error.message : String(error)}`);
+      provider.destroy();
+    }
+  }
+
+  throw new Error(`No suitable Base state provider was available. ${errors.at(-1) || ''}`);
+}
+
+async function readPool(poolAddress: string, provider: JsonRpcProvider, blockTag: StateTag) {
+  const pool = new Contract(poolAddress, POOL_ABI, provider);
+  const [slot0, liquidity, growth0, growth1] = await Promise.all([
+    pool.getFunction('slot0').staticCall({ blockTag }),
+    pool.getFunction('liquidity').staticCall({ blockTag }),
+    pool.getFunction('feeGrowthGlobal0X128').staticCall({ blockTag }),
+    pool.getFunction('feeGrowthGlobal1X128').staticCall({ blockTag }),
+  ]);
+  return {
+    sqrtPriceX96: BigInt(slot0[0]),
+    tick: Number(slot0[1]),
+    unlocked: Boolean(slot0[6]),
+    liquidity: BigInt(liquidity),
+    feeGrowth0: BigInt(growth0),
+    feeGrowth1: BigInt(growth1),
+  };
+}
+
+export async function scanBaseLiquidity(input: {
+  widthMultiples?: unknown;
+  requireFlashblocks?: boolean;
+} = {}) {
+  const widthMultiples = clampInteger(input.widthMultiples, 10, 1, 50);
+  const requireFlashblocks = input.requireFlashblocks !== false;
+  const chosen = await chooseProvider(requireFlashblocks);
+  const factory = new Contract(BASE_UNISWAP_V3_FACTORY, FACTORY_ABI, chosen.provider);
+
+  try {
+    const rows = [] as Array<Record<string, unknown>>;
+    for (const fee of FEE_TIERS) {
+      const [poolRaw, spacingRaw] = await Promise.all([
+        factory.getFunction('getPool').staticCall(BASE_WETH, BASE_USDC, fee, { blockTag: chosen.stateTag }),
+        factory.getFunction('feeAmountTickSpacing').staticCall(fee, { blockTag: chosen.stateTag }),
+      ]);
+      const poolAddress = isAddress(poolRaw) ? getAddress(poolRaw) : '';
+      const spacing = Number(spacingRaw);
+      if (!poolAddress || poolAddress === '0x0000000000000000000000000000000000000000' || spacing <= 0) continue;
+
+      const current = await readPool(poolAddress, chosen.provider, chosen.stateTag);
+      let sealed = current;
+      let feeGrowthDelta0 = BigInt(0);
+      let feeGrowthDelta1 = BigInt(0);
+      if (chosen.flashblocks) {
+        sealed = await readPool(poolAddress, chosen.provider, 'latest');
+        feeGrowthDelta0 = delta256(current.feeGrowth0, sealed.feeGrowth0);
+        feeGrowthDelta1 = delta256(current.feeGrowth1, sealed.feeGrowth1);
+      }
+
+      const center = alignedCenter(current.tick, spacing);
+      const halfWidth = spacing * widthMultiples;
+      rows.push({
+        fee,
+        feePercent: fee / 1_000_000,
+        poolAddress,
+        tickSpacing: spacing,
+        pendingTick: current.tick,
+        sealedTick: sealed.tick,
+        liquidityRaw: current.liquidity.toString(),
+        feeGrowthDelta0X128: feeGrowthDelta0.toString(),
+        feeGrowthDelta1X128: feeGrowthDelta1.toString(),
+        feeGrowthChanged: feeGrowthDelta0 > BigInt(0) || feeGrowthDelta1 > BigInt(0),
+        poolUnlocked: current.unlocked,
+        suggestedRange: {
+          tickLower: center - halfWidth,
+          tickUpper: center + halfWidth,
+          widthMultiples,
+        },
+        signal: chosen.flashblocks
+          ? (feeGrowthDelta0 > BigInt(0) || feeGrowthDelta1 > BigInt(0) ? 'PENDING_FEE_ACTIVITY' : 'NO_PENDING_FEE_ACTIVITY')
+          : 'SEALED_STATE_ONLY',
+      });
+    }
+
+    rows.sort((a, b) => {
+      const aActive = a.feeGrowthChanged ? 1 : 0;
+      const bActive = b.feeGrowthChanged ? 1 : 0;
+      if (aActive !== bActive) return bActive - aActive;
+      const aLiquidity = BigInt(String(a.liquidityRaw));
+      const bLiquidity = BigInt(String(b.liquidityRaw));
+      return aLiquidity < bLiquidity ? -1 : aLiquidity > bLiquidity ? 1 : 0;
+    });
+
+    const managerRaw = String(process.env.BASE_LIQUIDITY_MANAGER_ADDRESS || process.env.NEXT_PUBLIC_BASE_LIQUIDITY_MANAGER_ADDRESS || '').trim();
+    const managerAddress = isAddress(managerRaw) ? getAddress(managerRaw) : '';
+
+    return {
+      chainId: BASE_CHAIN_ID,
+      network: 'Base',
+      pair: 'WETH/USDC',
+      token0: BASE_WETH,
+      token1: BASE_USDC,
+      factory: BASE_UNISWAP_V3_FACTORY,
+      positionManager: BASE_UNISWAP_V3_POSITION_MANAGER,
+      stateMode: chosen.flashblocks ? 'flashblocks-pending' : 'sealed-latest',
+      flashblocks: chosen.flashblocks,
+      rpcHost: chosen.rpcHost,
+      observedBlock: chosen.observedBlock,
+      scannedAt: new Date().toISOString(),
+      managerAddress,
+      executionConfigured: Boolean(managerAddress),
+      pools: rows,
+      interpretation: 'Fee-growth deltas are activity signals, not guaranteed fees, APR, or profit. A real LP entry still requires inventory valuation, tick-specific fee-growth accounting, gas, adverse-selection and impermanent-loss simulation.',
+    };
+  } finally {
+    chosen.provider.destroy();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,13 +15,16 @@
     "test:routes": "node scripts/test-route-integrity.mjs",
     "test:voxel-flow": "node scripts/test-voxel-flow-integrity.mjs",
     "test:machine-revenue": "node scripts/test-machine-revenue-layer.mjs",
-    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:commerce && npm run test:routes && npm run test:voxel-flow && npm run test:machine-revenue && npm run build",
+    "test:liquidity-engine": "node scripts/test-liquidity-engine-safety.mjs",
+    "test:release": "npm run test:rewards && npm run test:universal && npm run test:media && npm run test:mobile && npm run test:collection && npm run test:commerce && npm run test:routes && npm run test:voxel-flow && npm run test:machine-revenue && npm run test:liquidity-engine && npm run build",
     "chain:compile": "hardhat compile",
     "chain:test:forge": "hardhat test test/VoxelForgeRevenue.test.js",
+    "chain:test:liquidity": "hardhat test test/BaseLiquidityManager.test.js",
     "chain:check:forge-bytecode": "node scripts/check-forge-deploy-bytecode.mjs",
     "chain:deploy:sepolia": "hardhat run scripts/deploy-sepolia.js --network sepolia",
     "chain:deploy:mainnet": "hardhat run scripts/deploy-mainnet.js --network mainnet",
-    "chain:deploy:base-forge": "hardhat run scripts/deploy-base-forge-revenue.js --network base"
+    "chain:deploy:base-forge": "hardhat run scripts/deploy-base-forge-revenue.js --network base",
+    "chain:deploy:base-liquidity": "hardhat run scripts/deploy-base-liquidity-engine.js --network base"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/scripts/deploy-base-liquidity-engine.js
+++ b/scripts/deploy-base-liquidity-engine.js
@@ -1,0 +1,108 @@
+const { ethers } = require('hardhat');
+
+const WETH = '0x4200000000000000000000000000000000000006';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const UNISWAP_V3_FACTORY = '0x33128a8fC17869897dcE68Ed026d694621f6FDfD';
+const UNISWAP_V3_POSITION_MANAGER = '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1';
+const ZERO = ethers.ZeroAddress;
+
+function requiredAddress(name) {
+  const value = String(process.env[name] || '').trim();
+  if (!ethers.isAddress(value) || value === ZERO) throw new Error(`${name} must be a non-zero EVM address.`);
+  return ethers.getAddress(value);
+}
+
+function optionalAddress(name) {
+  const value = String(process.env[name] || '').trim();
+  return value && ethers.isAddress(value) ? ethers.getAddress(value) : ZERO;
+}
+
+function positiveBigInt(name, fallback) {
+  const value = String(process.env[name] || fallback).trim();
+  if (!/^\d+$/.test(value) || BigInt(value) <= 0n) throw new Error(`${name} must be a positive integer.`);
+  return BigInt(value);
+}
+
+async function main() {
+  if (String(process.env.ALLOW_BASE_LIQUIDITY_DEPLOY || '').toLowerCase() !== 'true') {
+    throw new Error('Deployment locked. Set ALLOW_BASE_LIQUIDITY_DEPLOY=true only for an intentional reviewed Base deployment.');
+  }
+
+  const network = await ethers.provider.getNetwork();
+  if (Number(network.chainId) !== 8453) throw new Error(`Base mainnet required; got chain ${network.chainId}.`);
+
+  const owner = requiredAddress('LIQUIDITY_OWNER_ADDRESS');
+  const operator = optionalAddress('LIQUIDITY_OPERATOR_ADDRESS');
+  const maxWethPerPosition = positiveBigInt('LIQUIDITY_MAX_WETH_PER_POSITION_WEI', ethers.parseEther('0.02').toString());
+  const maxUsdcPerPosition = positiveBigInt('LIQUIDITY_MAX_USDC_PER_POSITION_ATOMIC', ethers.parseUnits('50', 6).toString());
+  const maxWethAllocated = positiveBigInt('LIQUIDITY_MAX_WETH_ALLOCATED_WEI', ethers.parseEther('0.05').toString());
+  const maxUsdcAllocated = positiveBigInt('LIQUIDITY_MAX_USDC_ALLOCATED_ATOMIC', ethers.parseUnits('150', 6).toString());
+  const maxActivePositions = Number(process.env.LIQUIDITY_MAX_ACTIVE_POSITIONS || '2');
+  if (!Number.isInteger(maxActivePositions) || maxActivePositions < 1 || maxActivePositions > 16) {
+    throw new Error('LIQUIDITY_MAX_ACTIVE_POSITIONS must be an integer from 1 to 16.');
+  }
+
+  const [token0, token1] = BigInt(WETH) < BigInt(USDC) ? [WETH, USDC] : [USDC, WETH];
+  if (token0 !== WETH) throw new Error('Unexpected Base token ordering. Deployment stopped.');
+
+  const Treasury = await ethers.getContractFactory('BaseLiquidityTreasury');
+  const treasury = await Treasury.deploy(owner, token0, token1);
+  await treasury.waitForDeployment();
+  const treasuryAddress = ethers.getAddress(await treasury.getAddress());
+
+  const Manager = await ethers.getContractFactory('BaseLiquidityManager');
+  const manager = await Manager.deploy(
+    owner,
+    operator,
+    treasuryAddress,
+    UNISWAP_V3_POSITION_MANAGER,
+    UNISWAP_V3_FACTORY,
+    token0,
+    token1,
+    maxWethPerPosition,
+    maxUsdcPerPosition,
+    maxWethAllocated,
+    maxUsdcAllocated,
+    maxActivePositions
+  );
+  await manager.waitForDeployment();
+  const managerAddress = ethers.getAddress(await manager.getAddress());
+
+  const liveFactory = ethers.getAddress(await manager.factory());
+  const livePositionManager = ethers.getAddress(await manager.positionManager());
+  const liveTreasury = ethers.getAddress(await manager.treasury());
+  const liveOwner = ethers.getAddress(await manager.owner());
+  if (
+    liveFactory !== ethers.getAddress(UNISWAP_V3_FACTORY)
+    || livePositionManager !== ethers.getAddress(UNISWAP_V3_POSITION_MANAGER)
+    || liveTreasury !== treasuryAddress
+    || liveOwner !== owner
+  ) {
+    throw new Error('Post-deployment verification failed. Do not fund this deployment.');
+  }
+
+  console.log(JSON.stringify({
+    network: 'base',
+    chainId: Number(network.chainId),
+    owner,
+    operator,
+    treasury: treasuryAddress,
+    manager: managerAddress,
+    uniswapV3Factory: UNISWAP_V3_FACTORY,
+    nonfungiblePositionManager: UNISWAP_V3_POSITION_MANAGER,
+    token0,
+    token1,
+    limits: {
+      maxWethPerPosition: maxWethPerPosition.toString(),
+      maxUsdcPerPosition: maxUsdcPerPosition.toString(),
+      maxWethAllocated: maxWethAllocated.toString(),
+      maxUsdcAllocated: maxUsdcAllocated.toString(),
+      maxActivePositions,
+    },
+  }, null, 2));
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-liquidity-engine-safety.mjs
+++ b/scripts/test-liquidity-engine-safety.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+
+const read = path => fs.readFileSync(path, 'utf8');
+const manager = read('contracts/BaseLiquidityManager.sol');
+const treasury = read('contracts/BaseLiquidityTreasury.sol');
+const scanner = read('lib/base-liquidity-scanner.ts');
+const route = read('app/api/liquidity-engine/scan/route.ts');
+const deploy = read('scripts/deploy-base-liquidity-engine.js');
+const envExample = read('.env.example');
+
+function requireText(source, value, label) {
+  if (!source.includes(value)) throw new Error(`Liquidity safety check failed: ${label}`);
+}
+function forbidText(source, value, label) {
+  if (source.includes(value)) throw new Error(`Liquidity safety check failed: ${label}`);
+}
+
+requireText(manager, 'maxToken0PerPosition', 'manager must cap per-position token0 exposure');
+requireText(manager, 'maxToken1PerPosition', 'manager must cap per-position token1 exposure');
+requireText(manager, 'maxActivePositions', 'manager must cap concurrent positions');
+requireText(manager, 'whenNotPaused', 'new liquidity exposure must be pausable');
+requireText(manager, 'onlyOperatorOrOwner', 'execution must be scoped to owner/operator');
+requireText(manager, 'recipient: treasury', 'position collection must route directly to treasury');
+requireText(manager, 'closeExpired', 'expired positions must have a permissionless cleanup path');
+requireText(manager, 'Factory mismatch', 'position manager/factory pairing must be verified');
+forbidText(manager, 'delegatecall', 'manager must not use delegatecall');
+forbidText(manager, 'tx.origin', 'manager must not use tx.origin authentication');
+
+requireText(treasury, 'onlyOwner', 'treasury withdrawals must remain owner-controlled');
+forbidText(treasury, 'swap', 'treasury v1 must not auto-swap proceeds');
+forbidText(treasury, 'governance', 'treasury v1 must not perform governance actions');
+
+requireText(scanner, 'https://mainnet-preconf.base.org', 'scanner must support official Base Flashblocks preconfirmation endpoint');
+requireText(scanner, "stateTag: 'pending'", 'scanner must read pending preconfirmed state');
+requireText(scanner, 'feeGrowthDelta0X128', 'scanner must report raw fee-growth activity');
+requireText(scanner, 'not guaranteed fees, APR, or profit', 'scanner must disclose that activity is not guaranteed profit');
+forbidText(scanner, 'Wallet(', 'scanner must not instantiate a signing wallet');
+forbidText(scanner, 'sendTransaction', 'scanner must not submit transactions');
+forbidText(scanner, 'eth_sendRawTransaction', 'scanner must not submit raw transactions');
+forbidText(scanner, 'PRIVATE_KEY', 'scanner must not read private keys');
+forbidText(route, 'sendTransaction', 'scan API must stay read-only');
+
+requireText(deploy, 'ALLOW_BASE_LIQUIDITY_DEPLOY', 'mainnet deployment must require an explicit unlock flag');
+requireText(deploy, "Number(network.chainId) !== 8453", 'deployment must reject non-Base chains');
+requireText(deploy, "const operator = optionalAddress('LIQUIDITY_OPERATOR_ADDRESS')", 'operator must be optional/disabled by default');
+requireText(envExample, 'ALLOW_BASE_LIQUIDITY_DEPLOY=false', 'example environment must keep deployment locked');
+requireText(envExample, 'LIQUIDITY_OPERATOR_ADDRESS=', 'example environment must not silently enable an operator');
+
+console.log('Base liquidity engine safety checks passed.');

--- a/scripts/test-liquidity-engine-safety.mjs
+++ b/scripts/test-liquidity-engine-safety.mjs
@@ -27,8 +27,11 @@ forbidText(manager, 'delegatecall', 'manager must not use delegatecall');
 forbidText(manager, 'tx.origin', 'manager must not use tx.origin authentication');
 
 requireText(treasury, 'onlyOwner', 'treasury withdrawals must remain owner-controlled');
-forbidText(treasury, 'swap', 'treasury v1 must not auto-swap proceeds');
-forbidText(treasury, 'governance', 'treasury v1 must not perform governance actions');
+forbidText(treasury, 'exactInput', 'treasury v1 must not call swap-router exactInput methods');
+forbidText(treasury, 'swapExact', 'treasury v1 must not call swap-router exact-output methods');
+forbidText(treasury, 'ISwapRouter', 'treasury v1 must not depend on a swap router');
+forbidText(treasury, 'castVote', 'treasury v1 must not cast governance votes');
+forbidText(treasury, 'delegate(address', 'treasury v1 must not delegate governance power');
 
 requireText(scanner, 'https://mainnet-preconf.base.org', 'scanner must support official Base Flashblocks preconfirmation endpoint');
 requireText(scanner, "stateTag: 'pending'", 'scanner must read pending preconfirmed state');

--- a/test/BaseLiquidityManager.test.js
+++ b/test/BaseLiquidityManager.test.js
@@ -74,7 +74,7 @@ describe('BaseLiquidityManager', function () {
       deadline: latest.timestamp + 120,
       ...overrides,
     };
-    await ctx.manager.connect(ctx.operator).openPosition(
+    return ctx.manager.connect(ctx.operator).openPosition(
       values.fee,
       values.tickLower,
       values.tickUpper,
@@ -85,7 +85,6 @@ describe('BaseLiquidityManager', function () {
       values.durationSeconds,
       values.deadline
     );
-    return values;
   }
 
   it('opens from pre-funded inventory and routes principal plus fees to treasury on close', async function () {
@@ -145,7 +144,7 @@ describe('BaseLiquidityManager', function () {
     await openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 });
     await openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 });
     await expect(openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 }))
-      .to.be.rejectedWith('Token0 allocation cap');
+      .to.be.revertedWith('Token0 allocation cap');
   });
 
   it('pauses new exposure while preserving emergency exit', async function () {

--- a/test/BaseLiquidityManager.test.js
+++ b/test/BaseLiquidityManager.test.js
@@ -1,0 +1,174 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('BaseLiquidityManager', function () {
+  async function deploy() {
+    const [owner, operator, treasuryOwner, stranger, recipient] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory('MockLiquidityToken');
+    const tokenA = await Token.deploy('Token A', 'TKA', 18);
+    const tokenB = await Token.deploy('Token B', 'TKB', 6);
+    await tokenA.waitForDeployment();
+    await tokenB.waitForDeployment();
+
+    const a = await tokenA.getAddress();
+    const b = await tokenB.getAddress();
+    const [token0, token1] = BigInt(a) < BigInt(b) ? [tokenA, tokenB] : [tokenB, tokenA];
+
+    const Factory = await ethers.getContractFactory('MockV3Factory');
+    const factory = await Factory.deploy();
+    await factory.waitForDeployment();
+    await factory.setFeeTier(3000, 60);
+    await factory.setPool(await token0.getAddress(), await token1.getAddress(), 3000, stranger.address);
+
+    const PositionManager = await ethers.getContractFactory('MockPositionManager');
+    const positionManager = await PositionManager.deploy(await factory.getAddress());
+    await positionManager.waitForDeployment();
+
+    const Treasury = await ethers.getContractFactory('BaseLiquidityTreasury');
+    const treasury = await Treasury.deploy(
+      treasuryOwner.address,
+      await token0.getAddress(),
+      await token1.getAddress()
+    );
+    await treasury.waitForDeployment();
+
+    const Manager = await ethers.getContractFactory('BaseLiquidityManager');
+    const manager = await Manager.deploy(
+      owner.address,
+      operator.address,
+      await treasury.getAddress(),
+      await positionManager.getAddress(),
+      await factory.getAddress(),
+      await token0.getAddress(),
+      await token1.getAddress(),
+      200,
+      300,
+      500,
+      700,
+      3
+    );
+    await manager.waitForDeployment();
+
+    await token0.mint(owner.address, 2_000);
+    await token1.mint(owner.address, 2_000);
+    await token0.connect(owner).approve(await manager.getAddress(), 1_000);
+    await token1.connect(owner).approve(await manager.getAddress(), 1_000);
+    await manager.connect(owner).depositCapital(await token0.getAddress(), 1_000);
+    await manager.connect(owner).depositCapital(await token1.getAddress(), 1_000);
+
+    return { owner, operator, treasuryOwner, stranger, recipient, token0, token1, factory, positionManager, treasury, manager };
+  }
+
+  async function openDefault(ctx, overrides = {}) {
+    const latest = await ethers.provider.getBlock('latest');
+    const values = {
+      fee: 3000,
+      tickLower: -600,
+      tickUpper: 600,
+      amount0Desired: 100,
+      amount1Desired: 200,
+      amount0Min: 90,
+      amount1Min: 180,
+      durationSeconds: 60,
+      deadline: latest.timestamp + 120,
+      ...overrides,
+    };
+    await ctx.manager.connect(ctx.operator).openPosition(
+      values.fee,
+      values.tickLower,
+      values.tickUpper,
+      values.amount0Desired,
+      values.amount1Desired,
+      values.amount0Min,
+      values.amount1Min,
+      values.durationSeconds,
+      values.deadline
+    );
+    return values;
+  }
+
+  it('opens from pre-funded inventory and routes principal plus fees to treasury on close', async function () {
+    const ctx = await deploy();
+    await expect(openDefault(ctx)).to.emit(ctx.manager, 'PositionOpened');
+
+    const p = await ctx.manager.positions(1);
+    expect(p.active).to.equal(true);
+    expect(p.principal0).to.equal(100);
+    expect(p.principal1).to.equal(200);
+    expect(await ctx.manager.allocatedToken0()).to.equal(100);
+    expect(await ctx.manager.allocatedToken1()).to.equal(200);
+
+    await ctx.positionManager.addFees(p.tokenId, 11, 17);
+    const latest = await ethers.provider.getBlock('latest');
+    await expect(ctx.manager.connect(ctx.operator).closePosition(1, 90, 180, latest.timestamp + 120))
+      .to.emit(ctx.manager, 'PositionClosed');
+
+    expect(await ctx.token0.balanceOf(await ctx.treasury.getAddress())).to.equal(111);
+    expect(await ctx.token1.balanceOf(await ctx.treasury.getAddress())).to.equal(217);
+    expect(await ctx.manager.allocatedToken0()).to.equal(0);
+    expect(await ctx.manager.allocatedToken1()).to.equal(0);
+    expect(await ctx.manager.activePositions()).to.equal(0);
+  });
+
+  it('lets the operator close but never withdraw treasury assets', async function () {
+    const ctx = await deploy();
+    await openDefault(ctx);
+    const p = await ctx.manager.positions(1);
+    await ctx.positionManager.addFees(p.tokenId, 5, 7);
+    await ctx.manager.connect(ctx.operator).emergencyClose(1);
+
+    await expect(
+      ctx.treasury.connect(ctx.operator).withdrawToken(await ctx.token0.getAddress(), 1, ctx.operator.address)
+    ).to.be.revertedWithCustomError(ctx.treasury, 'OwnableUnauthorizedAccount').withArgs(ctx.operator.address);
+
+    await ctx.treasury.connect(ctx.treasuryOwner).withdrawToken(
+      await ctx.token0.getAddress(),
+      105,
+      ctx.recipient.address
+    );
+    expect(await ctx.token0.balanceOf(ctx.recipient.address)).to.equal(105);
+  });
+
+  it('enforces position, allocation, active-count, and tick-alignment caps', async function () {
+    const ctx = await deploy();
+    const latest = await ethers.provider.getBlock('latest');
+
+    await expect(ctx.manager.connect(ctx.operator).openPosition(
+      3000, -600, 600, 201, 1, 0, 0, 60, latest.timestamp + 120
+    )).to.be.revertedWith('Per-position cap');
+
+    await expect(ctx.manager.connect(ctx.operator).openPosition(
+      3000, -601, 600, 100, 100, 0, 0, 60, latest.timestamp + 120
+    )).to.be.revertedWith('Ticks not aligned');
+
+    await openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 });
+    await openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 });
+    await expect(openDefault(ctx, { amount0Desired: 200, amount1Desired: 200 }))
+      .to.be.rejectedWith('Token0 allocation cap');
+  });
+
+  it('pauses new exposure while preserving emergency exit', async function () {
+    const ctx = await deploy();
+    await openDefault(ctx);
+    await ctx.manager.connect(ctx.owner).pause();
+
+    await expect(openDefault(ctx)).to.be.revertedWithCustomError(ctx.manager, 'EnforcedPause');
+    await expect(ctx.manager.connect(ctx.operator).emergencyClose(1)).to.emit(ctx.manager, 'PositionClosed');
+  });
+
+  it('allows permissionless expiry cleanup but still routes all proceeds to treasury', async function () {
+    const ctx = await deploy();
+    await openDefault(ctx, { durationSeconds: 5 });
+    const p = await ctx.manager.positions(1);
+    await ctx.positionManager.addFees(p.tokenId, 3, 4);
+
+    await expect(ctx.manager.connect(ctx.stranger).closeExpired(1)).to.be.revertedWith('Position not expired');
+    await ethers.provider.send('evm_increaseTime', [6]);
+    await ethers.provider.send('evm_mine', []);
+
+    await ctx.manager.connect(ctx.stranger).closeExpired(1);
+    expect(await ctx.token0.balanceOf(await ctx.treasury.getAddress())).to.equal(103);
+    expect(await ctx.token1.balanceOf(await ctx.treasury.getAddress())).to.equal(204);
+  });
+});


### PR DESCRIPTION
Builds Phase 1 as a bounded, auditable Base liquidity engine rather than the unsafe covert/governance version.

Adds:
- `BaseLiquidityManager.sol`: pre-funded Uniswap V3 concentrated-liquidity manager with owner/operator separation, pause, per-position caps, total allocation caps, active-position caps, factory/position-manager pairing verification, aligned tick/range limits, emergency close, and permissionless expired-position cleanup.
- `BaseLiquidityTreasury.sol`: minimal owner-controlled custody sink for recovered WETH/USDC principal and fees; no auto-swaps, governance, lending, or hidden reinvestment.
- Mock V3 infrastructure + Hardhat lifecycle tests proving deposit → open → fee accrual → close → treasury routing and operator treasury isolation.
- Flashblocks-aware WETH/USDC Uniswap V3 scanner that compares pending vs sealed fee-growth signals across 0.01%, 0.05%, 0.30%, and 1.00% fee tiers.
- `/api/liquidity-engine/scan` read-only API and `/liquidity-engine` control page.
- Guarded Base deployment script using official Uniswap V3 Base factory and NonfungiblePositionManager addresses. Deployment is hard-locked unless `ALLOW_BASE_LIQUIDITY_DEPLOY=true`; operator defaults disabled.
- `.env.example` with the actual environment variable names used by V2/x402/liquidity code and no secrets.
- New liquidity safety regression wired into the web Quality Gate and Solidity lifecycle test wired into contract CI.

Important boundaries:
- No unattended mainnet spending is enabled.
- No private keys are committed or read by the scanner.
- No auto-governance, covert influence, self-bidding, wash volume, flash loans, or adversarial MEV behavior.
- Fee-growth is exposed as an activity signal only, not fabricated APR or guaranteed profit.
- This PR does not deploy the liquidity contracts to Base; deployment remains a separate explicit owner action after CI/review.