### PR TITLE
Profit Engine: instant device executor activation

### DIFF
--- a/app/profit-engine/deploy/page.js
+++ b/app/profit-engine/deploy/page.js
@@ -8,6 +8,7 @@ import styles from '../profit.module.css';
 const BASE_CHAIN_ID='0x2105';
 const BASE_RPC='https://mainnet.base.org';
 const BASE_EXPLORER='https://basescan.org';
+const EXECUTOR_STORAGE_KEY='voxelvault.baseArbExecutor.v1';
 const APPROVED_OWNER=getAddress('0x02f93c7547309ca50EEAB446DaEBE8ce8E694cBb');
 const EXPECTED_BYTECODE_SHA256='b7a78ec53347fac65957dfd0c0c4092031b85244fe1b23ce14ceba3b00fd1e47';
 const CONSTRUCTOR_ABI=['constructor(address initialOwner)'];
@@ -107,8 +108,6 @@ export default function ProfitEngineDeployPage(){
       await contract.waitForDeployment();
       const address=getAddress(await contract.getAddress());
 
-      // Record the confirmed address BEFORE any follow-up RPC reads. If a wallet
-      // RPC fails during verification, the UI still prevents an accidental redeploy.
       setDeployment({address,txHash:tx.hash,verified:false});
       setStatus(`Executor deployed at ${short(address)}. Verifying live constants one at a time…`);
 
@@ -124,8 +123,9 @@ export default function ProfitEngineDeployPage(){
         throw new Error('Deployment confirmed, but live executor constants did not match the reviewed production configuration. Do not fund, use, or redeploy this contract.');
       }
 
+      window.localStorage.setItem(EXECUTOR_STORAGE_KEY,address);
       setDeployment({address,txHash:tx.hash,verified:true});
-      setStatus('BaseArbExecutor deployed and live constants verified. Do not redeploy. The address now needs to be pinned into Profit Engine production before live execution is unlocked.');
+      setStatus('BaseArbExecutor deployed, live constants verified, and activated on this device. Return to Profit Engine and scan now. Every trade still requires a fresh simulation and your MetaMask approval.');
     }catch(e){setError(errorText(e));setStatus(deployment?'The deployment address above already exists. Do not redeploy; resolve the verification message first.':'')}finally{setBusy(false)}
   }
 
@@ -144,7 +144,7 @@ export default function ProfitEngineDeployPage(){
         {!deployment&&<button className={styles.primary} style={{width:'100%',marginTop:16}} onClick={wallet?deploy:connect} disabled={busy}>{busy?'WORKING…':wallet&&bytecodeReady?'DEPLOY BASE ARB EXECUTOR':'CONNECT OWNER + VERIFY'}</button>}
         {status&&<div className={styles.status}>{status}</div>}
         {error&&<div className={styles.error}>{error}</div>}
-        {deployment&&<div className={styles.tx}><b>{deployment.verified?'✓ EXECUTOR DEPLOYED + VERIFIED':'✓ EXECUTOR DEPLOYED · VERIFYING/REVIEW NEEDED'}</b><br/>Contract: {deployment.address}<br/>Transaction: <a style={{color:'inherit'}} href={`${BASE_EXPLORER}/tx/${deployment.txHash}`} target="_blank" rel="noreferrer">{deployment.txHash}</a><br/><b>Do not deploy another copy.</b></div>}
+        {deployment&&<div className={styles.tx}><b>{deployment.verified?'✓ EXECUTOR DEPLOYED + DEVICE ACTIVATED':'✓ EXECUTOR DEPLOYED · VERIFYING/REVIEW NEEDED'}</b><br/>Contract: {deployment.address}<br/>Transaction: <a style={{color:'inherit'}} href={`${BASE_EXPLORER}/tx/${deployment.txHash}`} target="_blank" rel="noreferrer">{deployment.txHash}</a><br/>{deployment.verified?<><a style={{color:'inherit',fontWeight:800}} href="/profit-engine">OPEN PROFIT ENGINE →</a><br/></>:null}<b>Do not deploy another copy.</b></div>}
       </section>
     </div>
   </main>;

--- a/app/profit-engine/page.js
+++ b/app/profit-engine/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import {useState} from 'react';
+import {useEffect,useState} from 'react';
 import {BrowserProvider,Contract,Interface,formatEther,getAddress} from 'ethers';
 import {discoverMetaMaskProvider,getMetaMaskDeepLink} from '../../lib/wallet-connect';
 import styles from './profit.module.css';
@@ -8,11 +8,29 @@ import styles from './profit.module.css';
 const BASE_CHAIN_ID='0x2105';
 const BASE_RPC='https://mainnet.base.org';
 const BASE_EXPLORER='https://basescan.org';
+const EXECUTOR_STORAGE_KEY='voxelvault.baseArbExecutor.v1';
+const APPROVED_OWNER=getAddress('0x02f93c7547309ca50EEAB446DaEBE8ce8E694cBb');
 const EXECUTOR_ABI=[
   'function executeUniThenAero(uint24 uniFee,bool aeroStable,uint256 minUsdcOut,uint256 minWethOut,uint256 minProfitWei,uint256 deadline) payable returns (uint256 grossProfitWei)',
   'function executeAeroThenUni(uint24 uniFee,bool aeroStable,uint256 minUsdcOut,uint256 minWethOut,uint256 minProfitWei,uint256 deadline) payable returns (uint256 grossProfitWei)',
   'event ArbitrageExecuted(bytes32 indexed route,uint256 capitalWei,uint256 finalWei,uint256 grossProfitWei,uint256 minProfitWei)',
 ];
+const VERIFY_ABI=[
+  'function owner() view returns (address)',
+  'function BASE_CHAIN_ID() view returns (uint256)',
+  'function WETH() view returns (address)',
+  'function USDC() view returns (address)',
+  'function UNISWAP_SWAP_ROUTER_02() view returns (address)',
+  'function AERODROME_ROUTER() view returns (address)',
+  'function AERODROME_FACTORY() view returns (address)',
+];
+const EXPECTED={
+  weth:getAddress('0x4200000000000000000000000000000000000006'),
+  usdc:getAddress('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
+  uni:getAddress('0x2626664c2603336E57B271c5C0b26F421741e481'),
+  aero:getAddress('0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43'),
+  factory:getAddress('0x420DD381b31aEf6683db6B902084cB0FFECe40Da'),
+};
 
 function errText(error){return String(error?.shortMessage||error?.reason||error?.message||error||'Action failed.')}
 function prettyEth(value){try{return Number(formatEther(BigInt(value))).toFixed(8)}catch{return '—'}}
@@ -32,6 +50,20 @@ async function ensureBase(provider){
   if(chain!==BASE_CHAIN_ID)throw new Error('Switch MetaMask to Base before execution.');
 }
 
+async function verifyExecutor(address,browserProvider){
+  const verify=new Contract(getAddress(address),VERIFY_ABI,browserProvider);
+  const owner=await verify.owner();
+  const chainId=await verify.BASE_CHAIN_ID();
+  const weth=await verify.WETH();
+  const usdc=await verify.USDC();
+  const uni=await verify.UNISWAP_SWAP_ROUTER_02();
+  const aero=await verify.AERODROME_ROUTER();
+  const aeroFactory=await verify.AERODROME_FACTORY();
+  const ok=getAddress(owner)===APPROVED_OWNER&&BigInt(chainId)===BigInt(8453)&&getAddress(weth)===EXPECTED.weth&&getAddress(usdc)===EXPECTED.usdc&&getAddress(uni)===EXPECTED.uni&&getAddress(aero)===EXPECTED.aero&&getAddress(aeroFactory)===EXPECTED.factory;
+  if(!ok)throw new Error('Executor verification failed. Trading blocked.');
+  return getAddress(address);
+}
+
 export default function ProfitEnginePage(){
   const [amountEth,setAmountEth]=useState('0.01');
   const [targetBps,setTargetBps]=useState('25');
@@ -42,7 +74,15 @@ export default function ProfitEnginePage(){
   const [error,setError]=useState('');
   const [wallet,setWallet]=useState('');
   const [injected,setInjected]=useState(null);
+  const [localExecutor,setLocalExecutor]=useState('');
   const [tx,setTx]=useState(null);
+
+  useEffect(()=>{
+    try{
+      const saved=window.localStorage.getItem(EXECUTOR_STORAGE_KEY);
+      if(saved)setLocalExecutor(getAddress(saved));
+    }catch{}
+  },[]);
 
   async function runScan(){
     setBusy(true);setError('');setStatus('Reading Base Flashblocks pending state and live WETH/USDC routes…');setTx(null);
@@ -62,12 +102,15 @@ export default function ProfitEnginePage(){
     if(!provider){window.location.href=getMetaMaskDeepLink(window.location.href);return}
     const accounts=await provider.request({method:'eth_requestAccounts'});
     if(!accounts?.[0])throw new Error('Wallet connection was cancelled.');
-    setInjected(provider);setWallet(getAddress(accounts[0]));
+    const address=getAddress(accounts[0]);
+    if(address!==APPROVED_OWNER)throw new Error(`Connect the reviewed Profit Engine owner wallet ${APPROVED_OWNER}.`);
+    setInjected(provider);setWallet(address);
   }
 
   async function execute(op){
     if(!op?.passes)throw new Error('This route does not clear the profit floor.');
-    if(!scan?.executorAddress)throw new Error('The atomic executor is not deployed/activated yet.');
+    const candidate=scan?.executorAddress||localExecutor;
+    if(!candidate)throw new Error('Deploy the reviewed BaseArbExecutor first.');
     setBusy(true);setError('');setTx(null);
     try{
       let provider=injected;
@@ -79,10 +122,16 @@ export default function ProfitEnginePage(){
         if(!accounts?.[0])throw new Error('Wallet connection was cancelled.');
         connectedWallet=getAddress(accounts[0]);setInjected(provider);setWallet(connectedWallet);
       }
+      if(getAddress(connectedWallet)!==APPROVED_OWNER)throw new Error(`Connect the reviewed Profit Engine owner wallet ${APPROVED_OWNER}.`);
       await ensureBase(provider);
       const browserProvider=new BrowserProvider(provider);
+      const executorAddress=await verifyExecutor(candidate,browserProvider);
+      if(!scan?.executorAddress){
+        window.localStorage.setItem(EXECUTOR_STORAGE_KEY,executorAddress);
+        setLocalExecutor(executorAddress);
+      }
       const signer=await browserProvider.getSigner(connectedWallet);
-      const contract=new Contract(getAddress(scan.executorAddress),EXECUTOR_ABI,signer);
+      const contract=new Contract(executorAddress,EXECUTOR_ABI,signer);
       const deadline=Math.floor(Date.now()/1000)+Number(op.params.deadlineSeconds||90);
       const args=[Number(op.params.uniFee),Boolean(op.params.aeroStable),BigInt(op.params.minUsdcOut),BigInt(op.params.minWethOut),BigInt(op.params.minProfitWei),BigInt(deadline)];
       const fn=contract.getFunction(op.method);
@@ -106,16 +155,25 @@ export default function ProfitEnginePage(){
       const net=BigInt(grossProfit)-actualGas;
       setTx({hash:receipt.hash||sent.hash,pending:false,grossProfitWei:grossProfit,gasWei:actualGas.toString(),netWei:net.toString()});
       setStatus(`Confirmed. Gross spread captured: ${prettyEth(grossProfit)} ETH; transaction gas: ${prettyEth(actualGas)} ETH; estimated wallet net: ${prettyEth(net)} ETH. Scan again for the next opportunity.`);
-    }catch(e){setError(errText(e));setStatus('')}finally{setBusy(false)}
+    }catch(e){
+      if(!scan?.executorAddress&&/Executor verification failed/i.test(errText(e))){
+        try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
+        setLocalExecutor('');
+      }
+      setError(errText(e));setStatus('');
+    }finally{setBusy(false)}
   }
+
+  const executorReady=Boolean(scan?.executionEnabled||localExecutor);
+  const displayedExecutor=scan?.executionEnabled?scan.executorAddress:localExecutor;
 
   return <main className={styles.page}>
     <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V2 MACHINE LAYER</span></nav>
     <div className={styles.shell}>
-      <header className={styles.hero}><small>PROFIT ENGINE V2 · FLASHBLOCKS + X402</small><h1>See sooner.<br/><em>Sell the intelligence.</em></h1><p>The scanner now prefers Base pre-confirmed Flashblocks state, still enforces the net-profit gate, and exposes separate read-only x402 endpoints that autonomous agents can pay in USDC to consume.</p></header>
+      <header className={styles.hero}><small>PROFIT ENGINE V2 · FLASHBLOCKS + X402</small><h1>See sooner.<br/><em>Sell the intelligence.</em></h1><p>The scanner prefers Base pre-confirmed Flashblocks state, enforces the net-profit gate, and can immediately use a reviewed executor verified on this device after deployment.</p></header>
 
       <section className={styles.panel}>
-        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>Machine endpoints only sell market intelligence. They cannot sign or submit trades. Your wallet execution path stays separate: a candidate must clear the scanner, then the exact executor call must pass a fresh no-spend simulation and wallet gas estimate before MetaMask can submit it.</span></div>
+        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>A candidate must clear the scanner, the executor address is re-verified live against the reviewed owner/router constants, and the exact call must pass a fresh no-spend simulation plus wallet gas estimate before MetaMask can submit it.</span></div>
         <div className={styles.form}>
           <div className={styles.field}><label>CAPITAL · ETH</label><input value={amountEth} onChange={e=>setAmountEth(e.target.value)} inputMode="decimal"/></div>
           <div className={styles.field}><label>MIN NET · BPS</label><input value={targetBps} onChange={e=>setTargetBps(e.target.value)} inputMode="numeric"/></div>
@@ -128,8 +186,9 @@ export default function ProfitEnginePage(){
           <div className={styles.stat}><small>PAIR</small><b>{scan.pair}</b></div>
           <div className={styles.stat}><small>STATE</small><b>{scan.flashblocks?'FLASHBLOCKS':'SEALED FALLBACK'}</b></div>
           <div className={styles.stat}><small>NET TARGET</small><b>{prettyPct(scan.targetBps)}</b></div>
-          <div className={styles.stat}><small>EXECUTOR</small><b>{scan.executionEnabled?short(scan.executorAddress):'LOCKED'}</b></div>
+          <div className={styles.stat}><small>EXECUTOR</small><b>{executorReady?`${short(displayedExecutor)}${scan.executionEnabled?'':' · DEVICE'}`:'LOCKED'}</b></div>
         </div>}
+        {!executorReady&&<a className={styles.secondary} style={{display:'block',textAlign:'center',textDecoration:'none',marginTop:14}} href="/profit-engine/deploy">DEPLOY REVIEWED EXECUTOR →</a>}
       </section>
 
       {scan&&<section className={styles.panel}>
@@ -146,9 +205,9 @@ export default function ProfitEnginePage(){
             <div className={styles.number}><span>Conservative gas</span><b>-{prettyEth(op.gasBudgetWei)} ETH</b></div>
             <div className={styles.number}><span>Net after gas</span><b className={BigInt(op.netAfterGasWei)>0n?styles.positive:styles.negative}>{prettyEth(op.netAfterGasWei)} ETH</b></div>
           </div>
-          {op.passes&&scan.executionEnabled?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/>Scanner works now. Live spending stays disabled until the reviewed BaseArbExecutor deployment address is pinned in production.</div>:null}
+          {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/><a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>; it activates on this device immediately after verification.</div>:null}
         </article>)}</div>
-        <div className={styles.footnote}>V2 prefers the official Base Flashblocks pre-confirmation RPC and quotes against the pending sequencer state. If that service is unavailable it falls back to sealed Base RPC state and labels the response accordingly. A quote is never a profit guarantee; live execution remains blocked unless the atomic transaction itself simulates successfully at the current wallet state.</div>
+        <div className={styles.footnote}>The scanner prefers the official Base Flashblocks pre-confirmation RPC and quotes against pending sequencer state. A quote is never a profit guarantee. No wallet transaction is offered unless the candidate clears the configured net target, and the final executor call is simulated again immediately before MetaMask.</div>
       </section>}
 
       <section className={styles.panel}>

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -10,6 +10,8 @@ const decision = read('app/api/agent/decision/route.ts');
 const health = read('app/api/agent/health/route.ts');
 const manifest = read('app/api/agent/manifest/route.ts');
 const openapi = read('app/api/agent/openapi/route.ts');
+const profitPage = read('app/profit-engine/page.js');
+const deployPage = read('app/profit-engine/deploy/page.js');
 
 function requireText(source, value, label) {
   if (!source.includes(value)) throw new Error(`Machine revenue check failed: ${label}`);
@@ -59,5 +61,19 @@ requireText(health, 'signsTransactions: false', 'health endpoint must disclose n
 requireText(manifest, 'authorizesSpending: false', 'manifest must disclose that tickets do not authorize spending');
 requireText(openapi, '/api/agent/decision', 'OpenAPI must document the decision endpoint');
 requireText(openapi, 'PAYMENT-SIGNATURE', 'OpenAPI must document x402 payment header');
+
+requireText(deployPage, "window.localStorage.setItem(EXECUTOR_STORAGE_KEY,address)", 'verified deployment must be activatable on the same device without a server secret');
+requireText(deployPage, 'getAddress(owner)!==APPROVED_OWNER', 'deployment must verify the reviewed owner before device activation');
+requireText(deployPage, 'getAddress(uni)!==EXPECTED.uni', 'deployment must verify the reviewed Uniswap router');
+requireText(deployPage, 'getAddress(aero)!==EXPECTED.aero', 'deployment must verify the reviewed Aerodrome router');
+forbidText(deployPage, 'PRIVATE_KEY', 'browser deployment page must never read private keys');
+
+requireText(profitPage, 'const executorAddress=await verifyExecutor(candidate,browserProvider);', 'device executor must be re-verified live before use');
+requireText(profitPage, 'getAddress(connectedWallet)!==APPROVED_OWNER', 'execution must require the reviewed owner wallet');
+requireText(profitPage, 'fn.staticCall(...args', 'execution must run a fresh no-spend static simulation');
+requireText(profitPage, 'fn.estimateGas(...args', 'execution must run a fresh wallet gas estimate');
+requireText(profitPage, 'simulatedGross-estimatedWalletGas<target', 'wallet execution must still clear the net target after estimated gas');
+forbidText(profitPage, 'PRIVATE_KEY', 'browser execution page must never read private keys');
+forbidText(profitPage, 'eth_sendRawTransaction', 'browser execution page must not bypass wallet signing');
 
 console.log('Machine revenue layer safety checks passed.');


### PR DESCRIPTION
Removes the post-deployment Vercel-config delay from the existing owner-approved Base arbitrage path.

Changes:
- After the reviewed BaseArbExecutor is deployed and its live owner/router constants verify, the deployment page stores only the public contract address in browser localStorage.
- Profit Engine can immediately use that device-stored executor address when the server-side executor env is not pinned yet.
- Before any trade, the page re-verifies the live executor owner, Base chain constant, WETH/USDC addresses, Uniswap router, Aerodrome router, and factory.
- Execution still requires the reviewed owner wallet, a fresh staticCall simulation, a fresh gas estimate, the net-profit floor after estimated gas, and an explicit MetaMask signature.
- No private key or signing secret is stored in browser/server code.
- Machine-revenue regression tests now enforce these invariants.

This does not auto-spend funds or guarantee profit. It only removes configuration latency between a verified deployment and an owner-approved arbitrage attempt.