### PR TITLE
Recover existing Base executor after RPC verification hiccup

### DIFF
--- a/app/profit-engine/deploy/page.js
+++ b/app/profit-engine/deploy/page.js
@@ -126,7 +126,10 @@ export default function ProfitEngineDeployPage(){
       window.localStorage.setItem(EXECUTOR_STORAGE_KEY,address);
       setDeployment({address,txHash:tx.hash,verified:true});
       setStatus('BaseArbExecutor deployed, live constants verified, and activated on this device. Return to Profit Engine and scan now. Every trade still requires a fresh simulation and your MetaMask approval.');
-    }catch(e){setError(errorText(e));setStatus(deployment?'The deployment address above already exists. Do not redeploy; resolve the verification message first.':'')}finally{setBusy(false)}
+    }catch(e){
+      setError(errorText(e));
+      setStatus(deployment?'Deployment exists. Do not redeploy. Use the verification recovery link below; it sends no transaction.':'');
+    }finally{setBusy(false)}
   }
 
   return <main className={styles.page}>
@@ -144,7 +147,7 @@ export default function ProfitEngineDeployPage(){
         {!deployment&&<button className={styles.primary} style={{width:'100%',marginTop:16}} onClick={wallet?deploy:connect} disabled={busy}>{busy?'WORKING…':wallet&&bytecodeReady?'DEPLOY BASE ARB EXECUTOR':'CONNECT OWNER + VERIFY'}</button>}
         {status&&<div className={styles.status}>{status}</div>}
         {error&&<div className={styles.error}>{error}</div>}
-        {deployment&&<div className={styles.tx}><b>{deployment.verified?'✓ EXECUTOR DEPLOYED + DEVICE ACTIVATED':'✓ EXECUTOR DEPLOYED · VERIFYING/REVIEW NEEDED'}</b><br/>Contract: {deployment.address}<br/>Transaction: <a style={{color:'inherit'}} href={`${BASE_EXPLORER}/tx/${deployment.txHash}`} target="_blank" rel="noreferrer">{deployment.txHash}</a><br/>{deployment.verified?<><a style={{color:'inherit',fontWeight:800}} href="/profit-engine">OPEN PROFIT ENGINE →</a><br/></>:null}<b>Do not deploy another copy.</b></div>}
+        {deployment&&<div className={styles.tx}><b>{deployment.verified?'✓ EXECUTOR DEPLOYED + DEVICE ACTIVATED':'✓ EXECUTOR DEPLOYED · VERIFYING/REVIEW NEEDED'}</b><br/>Contract: {deployment.address}<br/>Transaction: <a style={{color:'inherit'}} href={`${BASE_EXPLORER}/tx/${deployment.txHash}`} target="_blank" rel="noreferrer">{deployment.txHash}</a><br/>{deployment.verified?<><a style={{color:'inherit',fontWeight:800}} href="/profit-engine">OPEN PROFIT ENGINE →</a><br/></>:<><a style={{color:'inherit',fontWeight:800}} href={`/profit-engine?executor=${deployment.address}`}>VERIFY EXISTING EXECUTOR →</a><br/></>}<b>Do not deploy another copy.</b></div>}
       </section>
     </div>
   </main>;

--- a/app/profit-engine/page.js
+++ b/app/profit-engine/page.js
@@ -36,6 +36,7 @@ function errText(error){return String(error?.shortMessage||error?.reason||error?
 function prettyEth(value){try{return Number(formatEther(BigInt(value))).toFixed(8)}catch{return '—'}}
 function prettyPct(bps){return `${(Number(bps)/100).toFixed(2)}%`}
 function short(value){return value?`${String(value).slice(0,6)}…${String(value).slice(-4)}`:'—'}
+function wait(ms){return new Promise(resolve=>setTimeout(resolve,ms))}
 
 async function ensureBase(provider){
   let chain=String(await provider.request({method:'eth_chainId'})||'').toLowerCase();
@@ -51,17 +52,30 @@ async function ensureBase(provider){
 }
 
 async function verifyExecutor(address,browserProvider){
-  const verify=new Contract(getAddress(address),VERIFY_ABI,browserProvider);
-  const owner=await verify.owner();
-  const chainId=await verify.BASE_CHAIN_ID();
-  const weth=await verify.WETH();
-  const usdc=await verify.USDC();
-  const uni=await verify.UNISWAP_SWAP_ROUTER_02();
-  const aero=await verify.AERODROME_ROUTER();
-  const aeroFactory=await verify.AERODROME_FACTORY();
-  const ok=getAddress(owner)===APPROVED_OWNER&&BigInt(chainId)===BigInt(8453)&&getAddress(weth)===EXPECTED.weth&&getAddress(usdc)===EXPECTED.usdc&&getAddress(uni)===EXPECTED.uni&&getAddress(aero)===EXPECTED.aero&&getAddress(aeroFactory)===EXPECTED.factory;
-  if(!ok)throw new Error('Executor verification failed. Trading blocked.');
-  return getAddress(address);
+  const candidate=getAddress(address);
+  let lastError=null;
+  for(let attempt=0;attempt<5;attempt+=1){
+    try{
+      const code=await browserProvider.getCode(candidate);
+      if(!code||code==='0x')throw new Error('Executor code is not visible from the wallet RPC yet.');
+      const verify=new Contract(candidate,VERIFY_ABI,browserProvider);
+      const owner=await verify.owner();
+      const chainId=await verify.BASE_CHAIN_ID();
+      const weth=await verify.WETH();
+      const usdc=await verify.USDC();
+      const uni=await verify.UNISWAP_SWAP_ROUTER_02();
+      const aero=await verify.AERODROME_ROUTER();
+      const aeroFactory=await verify.AERODROME_FACTORY();
+      const ok=getAddress(owner)===APPROVED_OWNER&&BigInt(chainId)===BigInt(8453)&&getAddress(weth)===EXPECTED.weth&&getAddress(usdc)===EXPECTED.usdc&&getAddress(uni)===EXPECTED.uni&&getAddress(aero)===EXPECTED.aero&&getAddress(aeroFactory)===EXPECTED.factory;
+      if(!ok)throw new Error('Executor verification failed. Trading blocked.');
+      return candidate;
+    }catch(error){
+      lastError=error;
+      if(/Executor verification failed/i.test(errText(error)))break;
+      if(attempt<4)await wait(700*(attempt+1));
+    }
+  }
+  throw lastError||new Error('Executor verification failed. Trading blocked.');
 }
 
 export default function ProfitEnginePage(){
@@ -75,12 +89,20 @@ export default function ProfitEnginePage(){
   const [wallet,setWallet]=useState('');
   const [injected,setInjected]=useState(null);
   const [localExecutor,setLocalExecutor]=useState('');
+  const [executorVerified,setExecutorVerified]=useState(false);
   const [tx,setTx]=useState(null);
 
   useEffect(()=>{
     try{
+      const params=new URLSearchParams(window.location.search);
+      const fromUrl=params.get('executor');
       const saved=window.localStorage.getItem(EXECUTOR_STORAGE_KEY);
-      if(saved)setLocalExecutor(getAddress(saved));
+      if(saved){setLocalExecutor(getAddress(saved));setExecutorVerified(true);return}
+      if(fromUrl){
+        setLocalExecutor(getAddress(fromUrl));
+        setExecutorVerified(false);
+        setStatus('Existing executor detected. Verify it now—this does not deploy or spend anything.');
+      }
     }catch{}
   },[]);
 
@@ -105,12 +127,39 @@ export default function ProfitEnginePage(){
     const address=getAddress(accounts[0]);
     if(address!==APPROVED_OWNER)throw new Error(`Connect the reviewed Profit Engine owner wallet ${APPROVED_OWNER}.`);
     setInjected(provider);setWallet(address);
+    return {provider,address};
+  }
+
+  async function activateExecutor(){
+    if(!localExecutor)throw new Error('No existing executor address was provided.');
+    setBusy(true);setError('');setTx(null);
+    try{
+      let provider=injected;
+      if(!provider){
+        const connected=await connect();
+        if(!connected)return;
+        provider=connected.provider;
+      }
+      await ensureBase(provider);
+      const browserProvider=new BrowserProvider(provider);
+      setStatus('Re-reading the deployed executor from Base. No transaction will be sent…');
+      const verified=await verifyExecutor(localExecutor,browserProvider);
+      window.localStorage.setItem(EXECUTOR_STORAGE_KEY,verified);
+      setLocalExecutor(verified);setExecutorVerified(true);
+      setStatus('Executor verified and activated on this device. Scan Flashblocks now.');
+    }catch(e){
+      if(/Executor verification failed/i.test(errText(e))){
+        try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
+        setExecutorVerified(false);
+      }
+      setError(errText(e));setStatus('');
+    }finally{setBusy(false)}
   }
 
   async function execute(op){
     if(!op?.passes)throw new Error('This route does not clear the profit floor.');
-    const candidate=scan?.executorAddress||localExecutor;
-    if(!candidate)throw new Error('Deploy the reviewed BaseArbExecutor first.');
+    const candidate=scan?.executorAddress||(executorVerified?localExecutor:'');
+    if(!candidate)throw new Error('Verify the existing BaseArbExecutor first.');
     setBusy(true);setError('');setTx(null);
     try{
       let provider=injected;
@@ -128,7 +177,7 @@ export default function ProfitEnginePage(){
       const executorAddress=await verifyExecutor(candidate,browserProvider);
       if(!scan?.executorAddress){
         window.localStorage.setItem(EXECUTOR_STORAGE_KEY,executorAddress);
-        setLocalExecutor(executorAddress);
+        setLocalExecutor(executorAddress);setExecutorVerified(true);
       }
       const signer=await browserProvider.getSigner(connectedWallet);
       const contract=new Contract(executorAddress,EXECUTOR_ABI,signer);
@@ -158,13 +207,13 @@ export default function ProfitEnginePage(){
     }catch(e){
       if(!scan?.executorAddress&&/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
-        setLocalExecutor('');
+        setExecutorVerified(false);
       }
       setError(errText(e));setStatus('');
     }finally{setBusy(false)}
   }
 
-  const executorReady=Boolean(scan?.executionEnabled||localExecutor);
+  const executorReady=Boolean(scan?.executionEnabled||(localExecutor&&executorVerified));
   const displayedExecutor=scan?.executionEnabled?scan.executorAddress:localExecutor;
 
   return <main className={styles.page}>
@@ -186,9 +235,10 @@ export default function ProfitEnginePage(){
           <div className={styles.stat}><small>PAIR</small><b>{scan.pair}</b></div>
           <div className={styles.stat}><small>STATE</small><b>{scan.flashblocks?'FLASHBLOCKS':'SEALED FALLBACK'}</b></div>
           <div className={styles.stat}><small>NET TARGET</small><b>{prettyPct(scan.targetBps)}</b></div>
-          <div className={styles.stat}><small>EXECUTOR</small><b>{executorReady?`${short(displayedExecutor)}${scan.executionEnabled?'':' · DEVICE'}`:'LOCKED'}</b></div>
+          <div className={styles.stat}><small>EXECUTOR</small><b>{executorReady?`${short(displayedExecutor)}${scan.executionEnabled?'':' · DEVICE'}`:localExecutor?`${short(localExecutor)} · VERIFY`:'LOCKED'}</b></div>
         </div>}
-        {!executorReady&&<a className={styles.secondary} style={{display:'block',textAlign:'center',textDecoration:'none',marginTop:14}} href="/profit-engine/deploy">DEPLOY REVIEWED EXECUTOR →</a>}
+        {localExecutor&&!executorVerified&&!scan?.executionEnabled&&<button className={styles.secondary} style={{width:'100%',marginTop:14}} onClick={()=>activateExecutor()} disabled={busy}>{busy?'VERIFYING…':'VERIFY EXISTING EXECUTOR →'}</button>}
+        {!localExecutor&&!scan?.executionEnabled&&<a className={styles.secondary} style={{display:'block',textAlign:'center',textDecoration:'none',marginTop:14}} href="/profit-engine/deploy">DEPLOY REVIEWED EXECUTOR →</a>}
       </section>
 
       {scan&&<section className={styles.panel}>
@@ -205,7 +255,7 @@ export default function ProfitEnginePage(){
             <div className={styles.number}><span>Conservative gas</span><b>-{prettyEth(op.gasBudgetWei)} ETH</b></div>
             <div className={styles.number}><span>Net after gas</span><b className={BigInt(op.netAfterGasWei)>0n?styles.positive:styles.negative}>{prettyEth(op.netAfterGasWei)} ETH</b></div>
           </div>
-          {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/><a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>; it activates on this device immediately after verification.</div>:null}
+          {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/>{localExecutor?'Verify the existing executor above.':<a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>}</div>:null}
         </article>)}</div>
         <div className={styles.footnote}>The scanner prefers the official Base Flashblocks pre-confirmation RPC and quotes against pending sequencer state. A quote is never a profit guarantee. No wallet transaction is offered unless the candidate clears the configured net target, and the final executor call is simulated again immediately before MetaMask.</div>
       </section>}

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -66,8 +66,13 @@ requireText(deployPage, "window.localStorage.setItem(EXECUTOR_STORAGE_KEY,addres
 requireText(deployPage, 'getAddress(owner)!==APPROVED_OWNER', 'deployment must verify the reviewed owner before device activation');
 requireText(deployPage, 'getAddress(uni)!==EXPECTED.uni', 'deployment must verify the reviewed Uniswap router');
 requireText(deployPage, 'getAddress(aero)!==EXPECTED.aero', 'deployment must verify the reviewed Aerodrome router');
+requireText(deployPage, 'VERIFY EXISTING EXECUTOR', 'failed post-deploy reads must offer recovery instead of redeployment');
+requireText(deployPage, '/profit-engine?executor=', 'recovery must pass only the public deployed contract address');
 forbidText(deployPage, 'PRIVATE_KEY', 'browser deployment page must never read private keys');
 
+requireText(profitPage, "const fromUrl=params.get('executor')", 'profit page must accept an existing executor recovery address');
+requireText(profitPage, 'setExecutorVerified(false)', 'recovered executor must start unverified');
+requireText(profitPage, 'const code=await browserProvider.getCode(candidate)', 'verification must first confirm deployed bytecode exists');
 requireText(profitPage, 'const executorAddress=await verifyExecutor(candidate,browserProvider);', 'device executor must be re-verified live before use');
 requireText(profitPage, 'getAddress(connectedWallet)!==APPROVED_OWNER', 'execution must require the reviewed owner wallet');
 requireText(profitPage, 'fn.staticCall(...args', 'execution must run a fresh no-spend static simulation');


### PR DESCRIPTION
Fixes the post-deploy recovery path seen on iPhone when the Base deployment succeeds but the immediate wallet RPC read returns `could not decode result data`.

Changes:
- Never suggests redeploying an already-confirmed executor.
- Deployment page exposes `VERIFY EXISTING EXECUTOR` for an already-created contract when post-deploy reads fail.
- Profit Engine accepts that public executor address as an unverified recovery candidate only.
- Recovery checks `eth_getCode`, retries transient RPC reads, then verifies owner, Base chain constant, WETH/USDC, Uniswap router, Aerodrome router, and Aerodrome factory before saving the address locally.
- A recovered address cannot execute until verification succeeds.
- Existing fresh static simulation, gas estimate, profit-floor check, reviewed owner wallet requirement, and MetaMask approval remain unchanged.
- Machine-revenue safety regression now enforces the recovery invariants.

No new deployment or funding is performed by this change.