### PR TITLE
Profit Engine V3: adaptive wide Base scanner

### DIFF
--- a/app/api/profit-engine/scan/route.ts
+++ b/app/api/profit-engine/scan/route.ts
@@ -1,20 +1,100 @@
 import { NextResponse } from 'next/server';
-import { scanBaseArbitrage } from '../../../../lib/base-profit-engine';
+import { formatEther, parseUnits } from 'ethers';
+import { normalizeAmountEth, scanBaseArbitrageGrid } from '../../../../lib/base-profit-engine';
+import { scanBaseWideMarkets } from '../../../../lib/base-wide-scanner';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
+const MIN_INPUT = parseUnits('0.0005', 18);
+const MAX_INPUT = parseUnits('10', 18);
+
+function adaptiveAmounts(amountEth: unknown) {
+  const normalized = normalizeAmountEth(amountEth || '0.01');
+  const values = [
+    normalized.inputWei / BigInt(4),
+    normalized.inputWei / BigInt(2),
+    normalized.inputWei,
+    normalized.inputWei * BigInt(2),
+  ].map(value => value < MIN_INPUT ? MIN_INPUT : value > MAX_INPUT ? MAX_INPUT : value);
+
+  const unique = Array.from(new Set(values.map(value => value.toString())))
+    .map(value => BigInt(value))
+    .sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
+
+  return {
+    requested: normalized.amount,
+    amountsEth: unique.map(value => formatEther(value)),
+  };
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json().catch(() => ({}));
-    const result = await scanBaseArbitrage({
-      amountEth: body?.amountEth || '0.01',
-      targetBps: body?.targetBps,
-      slippageBps: body?.slippageBps,
-      preferFlashblocks: body?.preferFlashblocks !== false,
-    });
-    return NextResponse.json(result, { headers: { 'Cache-Control': 'no-store' } });
+    const sizes = adaptiveAmounts(body?.amountEth || '0.01');
+    const targetBps = body?.targetBps;
+    const slippageBps = body?.slippageBps;
+    const preferFlashblocks = body?.preferFlashblocks !== false;
+
+    const [gridResult, wideResult] = await Promise.allSettled([
+      scanBaseArbitrageGrid({
+        amountsEth: sizes.amountsEth,
+        targetBps,
+        slippageBps,
+        preferFlashblocks,
+      }),
+      scanBaseWideMarkets({
+        maxCapitalEth: sizes.requested,
+        preferFlashblocks,
+      }),
+    ]);
+
+    if (gridResult.status !== 'fulfilled') throw gridResult.reason;
+
+    const grid = gridResult.value;
+    const anchor = grid.scans.find(scan => scan.inputEth === sizes.requested) || grid.scans[0];
+    if (!anchor) throw new Error('Adaptive execution scan returned no results.');
+
+    const opportunities = grid.scans
+      .flatMap(scan => scan.opportunities.map(opportunity => ({
+        ...opportunity,
+        id: `${opportunity.id}-${scan.inputWei}`,
+        scanInputEth: scan.inputEth,
+        scanStateMode: scan.stateMode,
+        scanRpcSource: scan.rpcSource,
+      })))
+      .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
+
+    const profitable = opportunities.filter(opportunity => opportunity.passes);
+    const wideMarkets = wideResult.status === 'fulfilled' ? wideResult.value : null;
+    const wideScanError = wideResult.status === 'rejected'
+      ? (wideResult.reason instanceof Error ? wideResult.reason.message : String(wideResult.reason))
+      : null;
+
+    return NextResponse.json({
+      ...anchor,
+      scanMode: 'ADAPTIVE_WIDE_V3',
+      requestedAmountsEth: sizes.amountsEth,
+      executionSizesScanned: grid.scans.length,
+      best: profitable[0] || null,
+      bestQuoted: opportunities[0] || null,
+      opportunities,
+      wideMarkets,
+      wideScanError,
+      coverage: {
+        executionPair: 'WETH/USDC',
+        executionSizesEth: sizes.amountsEth,
+        executionRoutesPerSize: 2,
+        widePairsRequested: wideMarkets?.coverage?.pairsRequested || 0,
+        widePairsQuoted: wideMarkets?.coverage?.pairsQuoted || 0,
+        wideVenues: wideMarkets?.coverage?.venues || [],
+        uniswapFeeTiers: wideMarkets?.coverage?.uniswapFeeTiers || [100, 500, 3000, 10000],
+        aerodromePoolTypes: wideMarkets?.coverage?.aerodromePoolTypes || ['volatile', 'stable'],
+        slipstreamTickSpacings: wideMarkets?.coverage?.slipstreamTickSpacings || [],
+      },
+      rule: 'NO_TRADE unless an executable WETH/USDC candidate clears conservative gas + target profit and then passes a fresh wallet static simulation. Wide-market signals are discovery-only until a separately reviewed executor supports them.',
+    }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Profit Engine scan failed', error);
     const message = error instanceof Error ? error.message : 'Profit Engine scan failed.';

--- a/app/api/profit-engine/scan/route.ts
+++ b/app/api/profit-engine/scan/route.ts
@@ -13,10 +13,10 @@ const MAX_INPUT = parseUnits('10', 18);
 function adaptiveAmounts(amountEth: unknown) {
   const normalized = normalizeAmountEth(amountEth || '0.01');
   const values = [
+    normalized.inputWei / BigInt(8),
     normalized.inputWei / BigInt(4),
     normalized.inputWei / BigInt(2),
     normalized.inputWei,
-    normalized.inputWei * BigInt(2),
   ].map(value => value < MIN_INPUT ? MIN_INPUT : value > MAX_INPUT ? MAX_INPUT : value);
 
   const unique = Array.from(new Set(values.map(value => value.toString())))
@@ -75,6 +75,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       ...anchor,
       scanMode: 'ADAPTIVE_WIDE_V3',
+      maxCapitalEth: sizes.requested,
       requestedAmountsEth: sizes.amountsEth,
       executionSizesScanned: grid.scans.length,
       best: profitable[0] || null,
@@ -93,7 +94,7 @@ export async function POST(request: Request) {
         aerodromePoolTypes: wideMarkets?.coverage?.aerodromePoolTypes || ['volatile', 'stable'],
         slipstreamTickSpacings: wideMarkets?.coverage?.slipstreamTickSpacings || [],
       },
-      rule: 'NO_TRADE unless an executable WETH/USDC candidate clears conservative gas + target profit and then passes a fresh wallet static simulation. Wide-market signals are discovery-only until a separately reviewed executor supports them.',
+      rule: 'NO_TRADE unless an executable WETH/USDC candidate at or below the user capital cap clears conservative gas + target profit and then passes a fresh wallet static simulation. Wide-market signals are discovery-only until a separately reviewed executor supports them.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Profit Engine scan failed', error);

--- a/app/profit-engine/page.js
+++ b/app/profit-engine/page.js
@@ -35,8 +35,16 @@ const EXPECTED={
 function errText(error){return String(error?.shortMessage||error?.reason||error?.message||error||'Action failed.')}
 function prettyEth(value){try{return Number(formatEther(BigInt(value))).toFixed(8)}catch{return '—'}}
 function prettyPct(bps){return `${(Number(bps)/100).toFixed(2)}%`}
+function prettyBps(value){const n=Number(value);return Number.isFinite(n)?`${n} bps`:'—'}
 function short(value){return value?`${String(value).slice(0,6)}…${String(value).slice(-4)}`:'—'}
 function wait(ms){return new Promise(resolve=>setTimeout(resolve,ms))}
+function venueMeta(quote){
+  if(!quote)return '—';
+  if(quote.fee!==null&&quote.fee!==undefined)return `${quote.venue} · fee ${quote.fee}`;
+  if(quote.stable!==null&&quote.stable!==undefined)return `${quote.venue} · ${quote.stable?'stable':'volatile'}`;
+  if(quote.tickSpacing!==null&&quote.tickSpacing!==undefined)return `${quote.venue} · tick ${quote.tickSpacing}`;
+  return quote.venue;
+}
 
 async function ensureBase(provider){
   let chain=String(await provider.request({method:'eth_chainId'})||'').toLowerCase();
@@ -107,14 +115,19 @@ export default function ProfitEnginePage(){
   },[]);
 
   async function runScan(){
-    setBusy(true);setError('');setStatus('Reading Base Flashblocks pending state and live WETH/USDC routes…');setTx(null);
+    setBusy(true);setError('');setStatus('Scanning Base Flashblocks across multiple capital sizes, major liquid pairs, Uniswap V3, Aerodrome and Slipstream…');setTx(null);
     try{
       const response=await fetch('/api/profit-engine/scan',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({amountEth,targetBps:Number(targetBps),slippageBps:Number(slippageBps),preferFlashblocks:true}),cache:'no-store'});
       const data=await response.json().catch(()=>({}));
       if(!response.ok)throw new Error(data.error||'Base scan failed.');
       setScan(data);
       const source=data.flashblocks?'Flashblocks pending state':'sealed Base state fallback';
-      setStatus(data.best?`Candidate found on ${source}. Quote clears the ${prettyPct(data.targetBps)} target after the conservative gas budget.`:`No trade on ${source}. Neither cross-DEX route clears your net-profit threshold right now.`);
+      const sizes=data.executionSizesScanned||1;
+      const wideQuoted=data.coverage?.widePairsQuoted||0;
+      const wideRequested=data.coverage?.widePairsRequested||0;
+      setStatus(data.best
+        ?`Executable candidate found on ${source} after checking ${sizes} capital sizes. It still must pass the fresh wallet simulation before MetaMask can submit it.`
+        :`No executable trade right now. Checked ${sizes} capital sizes plus ${wideQuoted}/${wideRequested} wide Base pairs. Wide-radar signals below are discovery only, not permission to trade.`);
     }catch(e){setError(errText(e));setStatus('');setScan(null)}finally{setBusy(false)}
   }
 
@@ -146,7 +159,7 @@ export default function ProfitEnginePage(){
       const verified=await verifyExecutor(localExecutor,browserProvider);
       window.localStorage.setItem(EXECUTOR_STORAGE_KEY,verified);
       setLocalExecutor(verified);setExecutorVerified(true);
-      setStatus('Executor verified and activated on this device. Scan Flashblocks now.');
+      setStatus('Executor verified and activated on this device. Run the wide scan now.');
     }catch(e){
       if(/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
@@ -215,25 +228,26 @@ export default function ProfitEnginePage(){
 
   const executorReady=Boolean(scan?.executionEnabled||(localExecutor&&executorVerified));
   const displayedExecutor=scan?.executionEnabled?scan.executorAddress:localExecutor;
+  const widePairs=scan?.wideMarkets?.pairs||[];
 
   return <main className={styles.page}>
-    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V2 MACHINE LAYER</span></nav>
+    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V3 WIDE SCAN</span></nav>
     <div className={styles.shell}>
-      <header className={styles.hero}><small>PROFIT ENGINE V2 · FLASHBLOCKS + X402</small><h1>See sooner.<br/><em>Sell the intelligence.</em></h1><p>The scanner prefers Base pre-confirmed Flashblocks state, enforces the net-profit gate, and can immediately use a reviewed executor verified on this device after deployment.</p></header>
+      <header className={styles.hero}><small>PROFIT ENGINE V3 · ADAPTIVE + WIDE</small><h1>Scan more.<br/><em>Trade only what clears.</em></h1><p>The main scan now checks several capital sizes at or below your cap and also sweeps major Base markets across Uniswap V3, Aerodrome classic pools, and Aerodrome Slipstream.</p></header>
 
       <section className={styles.panel}>
-        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>A candidate must clear the scanner, the executor address is re-verified live against the reviewed owner/router constants, and the exact call must pass a fresh no-spend simulation plus wallet gas estimate before MetaMask can submit it.</span></div>
+        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>The wide radar can discover more markets, but only the separately reviewed WETH/USDC executor matrix can ever show an execution button. A candidate still needs conservative gas + profit clearance, live executor verification, fresh static simulation, fresh gas estimate, and your MetaMask approval.</span></div>
         <div className={styles.form}>
-          <div className={styles.field}><label>CAPITAL · ETH</label><input value={amountEth} onChange={e=>setAmountEth(e.target.value)} inputMode="decimal"/></div>
+          <div className={styles.field}><label>MAX CAPITAL · ETH</label><input value={amountEth} onChange={e=>setAmountEth(e.target.value)} inputMode="decimal"/></div>
           <div className={styles.field}><label>MIN NET · BPS</label><input value={targetBps} onChange={e=>setTargetBps(e.target.value)} inputMode="numeric"/></div>
           <div className={styles.field}><label>SLIPPAGE · BPS</label><input value={slippageBps} onChange={e=>setSlippageBps(e.target.value)} inputMode="numeric"/></div>
-          <button className={styles.primary} onClick={runScan} disabled={busy}>{busy?'SCANNING…':'SCAN FLASHBLOCKS NOW'}</button>
+          <button className={styles.primary} onClick={runScan} disabled={busy}>{busy?'SCANNING BASE…':'SCAN BASE WIDE NOW'}</button>
         </div>
         {status&&<div className={styles.status}>{status}</div>}
         {error&&<div className={styles.error}>{error}</div>}
         {scan&&<div className={styles.summary}>
-          <div className={styles.stat}><small>PAIR</small><b>{scan.pair}</b></div>
-          <div className={styles.stat}><small>STATE</small><b>{scan.flashblocks?'FLASHBLOCKS':'SEALED FALLBACK'}</b></div>
+          <div className={styles.stat}><small>EXECUTION SIZES</small><b>{scan.executionSizesScanned||1}</b></div>
+          <div className={styles.stat}><small>WIDE PAIRS</small><b>{scan.coverage?.widePairsQuoted||0}/{scan.coverage?.widePairsRequested||0}</b></div>
           <div className={styles.stat}><small>NET TARGET</small><b>{prettyPct(scan.targetBps)}</b></div>
           <div className={styles.stat}><small>EXECUTOR</small><b>{executorReady?`${short(displayedExecutor)}${scan.executionEnabled?'':' · DEVICE'}`:localExecutor?`${short(localExecutor)} · VERIFY`:'LOCKED'}</b></div>
         </div>}
@@ -242,14 +256,14 @@ export default function ProfitEnginePage(){
       </section>
 
       {scan&&<section className={styles.panel}>
-        <div className={styles.sectionHead}><div><h2>Live routes</h2><span>{new Date(scan.scannedAt).toLocaleTimeString()} · {scan.stateMode} · {scan.rpcSource}</span></div>{!wallet&&<button className={styles.secondary} onClick={()=>connect().catch(e=>setError(errText(e)))}>CONNECT METAMASK</button>}</div>
+        <div className={styles.sectionHead}><div><h2>Executable matrix</h2><span>{scan.executionSizesScanned||1} sizes · WETH/USDC · {scan.stateMode} · {scan.rpcSource}</span></div>{!wallet&&<button className={styles.secondary} onClick={()=>connect().catch(e=>setError(errText(e)))}>CONNECT METAMASK</button>}</div>
         <div className={styles.grid}>{scan.opportunities.map(op=><article key={op.id} className={`${styles.card} ${op.passes?styles.good:''}`}>
           <span className={styles.badge}>{op.passes?'PROFIT FLOOR CLEARED':'NO TRADE'}</span>
           <div className={styles.route}>{op.first.venue} → {op.second.venue}</div>
-          <div className={styles.leg}><span>LEG 1</span><b>{op.first.venue}{op.first.fee?` · fee ${op.first.fee}`:''}{op.first.stable!==null?` · ${op.first.stable?'stable':'volatile'}`:''}</b></div>
-          <div className={styles.leg}><span>LEG 2</span><b>{op.second.venue}{op.second.fee?` · fee ${op.second.fee}`:''}{op.second.stable!==null?` · ${op.second.stable?'stable':'volatile'}`:''}</b></div>
+          <div className={styles.leg}><span>CAPITAL</span><b>{prettyEth(op.inputWei)} ETH</b></div>
+          <div className={styles.leg}><span>LEG 1</span><b>{venueMeta(op.first)}</b></div>
+          <div className={styles.leg}><span>LEG 2</span><b>{venueMeta(op.second)}</b></div>
           <div className={styles.numbers}>
-            <div className={styles.number}><span>Start</span><b>{prettyEth(op.inputWei)} ETH</b></div>
             <div className={styles.number}><span>Quoted final</span><b>{prettyEth(op.finalWei)} WETH</b></div>
             <div className={styles.number}><span>Gross spread</span><b className={BigInt(op.grossProfitWei)>0n?styles.positive:styles.negative}>{prettyEth(op.grossProfitWei)} ETH</b></div>
             <div className={styles.number}><span>Conservative gas</span><b>-{prettyEth(op.gasBudgetWei)} ETH</b></div>
@@ -257,7 +271,31 @@ export default function ProfitEnginePage(){
           </div>
           {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/>{localExecutor?'Verify the existing executor above.':<a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>}</div>:null}
         </article>)}</div>
-        <div className={styles.footnote}>The scanner prefers the official Base Flashblocks pre-confirmation RPC and quotes against pending sequencer state. A quote is never a profit guarantee. No wallet transaction is offered unless the candidate clears the configured net target, and the final executor call is simulated again immediately before MetaMask.</div>
+        <div className={styles.footnote}>This is the only execution-capable section. Sizes never exceed the MAX CAPITAL value you entered. No wallet transaction is offered unless the quoted WETH/USDC round trip clears the configured net target after the conservative gas budget, and the exact transaction is simulated again immediately before MetaMask.</div>
+      </section>}
+
+      {scan&&<section className={styles.panel}>
+        <div className={styles.sectionHead}><div><h2>Wide market radar</h2><span>{scan.coverage?.widePairsQuoted||0}/{scan.coverage?.widePairsRequested||0} pairs · {(scan.coverage?.wideVenues||[]).join(' + ')||'read-only discovery'}</span></div></div>
+        {scan.wideScanError&&<div className={styles.status}>Wide radar was partial on this scan: {scan.wideScanError}</div>}
+        {widePairs.length?<div className={styles.grid}>{widePairs.map(pair=>{
+          const signal=pair.bestRaw;
+          const positive=signal&&BigInt(signal.grossSpreadWei)>0n;
+          return <article key={pair.pair} className={`${styles.card} ${positive?styles.good:''}`}>
+            <span className={styles.badge}>{signal?'RAW MARKET SIGNAL':'NO ROUTE'}</span>
+            <div className={styles.route}>{pair.pair}</div>
+            {signal?<>
+              <div className={styles.leg}><span>LEG 1</span><b>{venueMeta(signal.first)}</b></div>
+              <div className={styles.leg}><span>LEG 2</span><b>{venueMeta(signal.second)}</b></div>
+              <div className={styles.numbers}>
+                <div className={styles.number}><span>Sample size</span><b>{pair.sampleInputEth} ETH</b></div>
+                <div className={styles.number}><span>Raw spread</span><b className={positive?styles.positive:styles.negative}>{prettyEth(signal.grossSpreadWei)} ETH</b></div>
+                <div className={styles.number}><span>Raw spread rate</span><b className={positive?styles.positive:styles.negative}>{prettyBps(signal.grossSpreadBps)}</b></div>
+                <div className={styles.number}><span>Status</span><b>{signal.executionCompatibility==='CURRENT_EXECUTOR'?'CHECKED AGAIN ABOVE':'WATCH ONLY'}</b></div>
+              </div>
+            </>:<p className={styles.footnote}>No complete cross-venue round trip was quotable for this pair on this state.</p>}
+          </article>;
+        })}</div>:<div className={styles.status}>No additional wide-market routes were available on this scan.</div>}
+        <div className={styles.footnote}>Radar values are raw quote differences before a route-specific gas model, slippage reserve, contract compatibility check, or wallet simulation. They are intentionally not executable. The radar currently covers major liquid Base quote markets and multiple Uniswap fee tiers, Aerodrome stable/volatile pools, and Slipstream tick spacings rather than blindly touching every unknown token contract.</div>
       </section>}
 
       <section className={styles.panel}>

--- a/lib/base-wide-scanner.ts
+++ b/lib/base-wide-scanner.ts
@@ -1,0 +1,323 @@
+import { Contract, JsonRpcProvider, formatEther, formatUnits, getAddress, parseUnits } from 'ethers';
+import {
+  AERODROME_FACTORY,
+  AERODROME_ROUTER,
+  BASE_CHAIN_ID,
+  UNISWAP_QUOTER_V2,
+  WETH,
+} from './base-profit-engine';
+
+const BASE_FLASHBLOCKS_RPC = 'https://mainnet-preconf.base.org';
+const AERODROME_MIXED_QUOTER = getAddress('0x0A5aA5D3a4d28014f967Bf0f29EAA3FF9807D5c6');
+const UNI_FEE_TIERS = [100, 500, 3000, 10000];
+const SLIPSTREAM_TICK_SPACINGS = [1, 50, 100, 200, 2000];
+const ZERO = BigInt(0);
+const BPS = BigInt(10000);
+const MIN_SAMPLE = parseUnits('0.0005', 18);
+const MAX_SAMPLE = parseUnits('0.01', 18);
+
+const UNI_QUOTER_ABI = [
+  'function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96) params) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+];
+const AERO_ROUTER_ABI = [
+  'function getAmountsOut(uint256 amountIn,(address from,address to,bool stable,address factory)[] routes) view returns (uint256[] amounts)',
+];
+const SLIPSTREAM_QUOTER_ABI = [
+  'function quoteExactInputSingleV3((address tokenIn,address tokenOut,int24 tickSpacing,uint256 amountIn,uint160 sqrtPriceLimitX96) params) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+];
+
+type StateTag = 'pending' | 'latest';
+type VenueName = 'Uniswap V3' | 'Aerodrome' | 'Aerodrome Slipstream';
+type Token = { symbol: string; address: string; decimals: number };
+type VenueQuote = {
+  venue: VenueName;
+  amountOut: bigint;
+  fee?: number;
+  stable?: boolean;
+  tickSpacing?: number;
+};
+
+type ProviderCandidate = {
+  url: string;
+  stateTag: StateTag;
+  flashblocks: boolean;
+};
+
+const TOKENS: Token[] = [
+  { symbol: 'USDC', address: getAddress('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'), decimals: 6 },
+  { symbol: 'cbBTC', address: getAddress('0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf'), decimals: 8 },
+  { symbol: 'cbETH', address: getAddress('0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22'), decimals: 18 },
+  { symbol: 'AERO', address: getAddress('0x940181a94A35A4569E4529A3CDfB74e38FD98631'), decimals: 18 },
+];
+
+function rpcCandidates(preferFlashblocks: boolean): ProviderCandidate[] {
+  const flashblocks = String(process.env.BASE_FLASHBLOCKS_RPC_URL || '').trim() || BASE_FLASHBLOCKS_RPC;
+  const standard = [
+    String(process.env.BASE_RPC_URL || '').trim(),
+    String(process.env.VOXELFLIP_RPC_URL || '').trim(),
+    'https://mainnet.base.org',
+    'https://base-rpc.publicnode.com',
+  ].filter(Boolean);
+  const raw = [
+    ...(preferFlashblocks ? [{ url: flashblocks, stateTag: 'pending' as const, flashblocks: true }] : []),
+    ...standard.map(url => ({ url, stateTag: 'latest' as const, flashblocks: false })),
+  ];
+  const seen = new Set<string>();
+  return raw.filter(candidate => {
+    if (seen.has(candidate.url)) return false;
+    seen.add(candidate.url);
+    return true;
+  });
+}
+
+function safeRpcLabel(value: string) {
+  try {
+    return new URL(value).hostname || 'Base RPC';
+  } catch {
+    return 'Base RPC';
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function quoteUni(
+  provider: JsonRpcProvider,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+  blockTag: StateTag,
+): Promise<VenueQuote | null> {
+  const quoter = new Contract(UNISWAP_QUOTER_V2, UNI_QUOTER_ABI, provider);
+  const results = await Promise.all(UNI_FEE_TIERS.map(async fee => {
+    try {
+      const result = await withTimeout(
+        quoter.getFunction('quoteExactInputSingle').staticCall(
+          { tokenIn, tokenOut, amountIn, fee, sqrtPriceLimitX96: 0 },
+          { blockTag },
+        ),
+        3_000,
+        `Uniswap ${fee} quote`,
+      );
+      const amountOut = BigInt(result[0]);
+      return amountOut > ZERO ? { venue: 'Uniswap V3' as const, amountOut, fee } : null;
+    } catch {
+      return null;
+    }
+  }));
+  return results.filter((item): item is VenueQuote => Boolean(item))
+    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+}
+
+async function quoteAero(
+  provider: JsonRpcProvider,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+  blockTag: StateTag,
+): Promise<VenueQuote | null> {
+  const router = new Contract(AERODROME_ROUTER, AERO_ROUTER_ABI, provider);
+  const results = await Promise.all([false, true].map(async stable => {
+    try {
+      const routes = [{ from: tokenIn, to: tokenOut, stable, factory: AERODROME_FACTORY }];
+      const amounts = await withTimeout(
+        router.getFunction('getAmountsOut').staticCall(amountIn, routes, { blockTag }),
+        3_000,
+        `Aerodrome ${stable ? 'stable' : 'volatile'} quote`,
+      );
+      const amountOut = BigInt(amounts?.[amounts.length - 1] || 0);
+      return amountOut > ZERO ? { venue: 'Aerodrome' as const, amountOut, stable } : null;
+    } catch {
+      return null;
+    }
+  }));
+  return results.filter((item): item is VenueQuote => Boolean(item))
+    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+}
+
+async function quoteSlipstream(
+  provider: JsonRpcProvider,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+  blockTag: StateTag,
+): Promise<VenueQuote | null> {
+  const quoter = new Contract(AERODROME_MIXED_QUOTER, SLIPSTREAM_QUOTER_ABI, provider);
+  const results = await Promise.all(SLIPSTREAM_TICK_SPACINGS.map(async tickSpacing => {
+    try {
+      const result = await withTimeout(
+        quoter.getFunction('quoteExactInputSingleV3').staticCall(
+          { tokenIn, tokenOut, tickSpacing, amountIn, sqrtPriceLimitX96: 0 },
+          { blockTag },
+        ),
+        3_000,
+        `Slipstream ${tickSpacing} quote`,
+      );
+      const amountOut = BigInt(result[0]);
+      return amountOut > ZERO ? { venue: 'Aerodrome Slipstream' as const, amountOut, tickSpacing } : null;
+    } catch {
+      return null;
+    }
+  }));
+  return results.filter((item): item is VenueQuote => Boolean(item))
+    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+}
+
+const VENUES = [
+  { name: 'Uniswap V3' as const, quote: quoteUni },
+  { name: 'Aerodrome' as const, quote: quoteAero },
+  { name: 'Aerodrome Slipstream' as const, quote: quoteSlipstream },
+];
+
+function serializeVenueQuote(quote: VenueQuote, decimals: number) {
+  return {
+    venue: quote.venue,
+    amountOut: quote.amountOut.toString(),
+    amountOutFormatted: formatUnits(quote.amountOut, decimals),
+    fee: quote.fee ?? null,
+    stable: quote.stable ?? null,
+    tickSpacing: quote.tickSpacing ?? null,
+  };
+}
+
+async function scanPair(
+  provider: JsonRpcProvider,
+  token: Token,
+  amountIn: bigint,
+  blockTag: StateTag,
+) {
+  const firstLegs = await Promise.all(VENUES.map(async venue => ({
+    venue,
+    quote: await venue.quote(provider, WETH, token.address, amountIn, blockTag),
+  })));
+
+  const routes = [];
+  for (const first of firstLegs) {
+    if (!first.quote) continue;
+    const secondVenues = VENUES.filter(venue => venue.name !== first.venue.name);
+    const secondLegs = await Promise.all(secondVenues.map(async venue => ({
+      venue,
+      quote: await venue.quote(provider, token.address, WETH, first.quote!.amountOut, blockTag),
+    })));
+    for (const second of secondLegs) {
+      if (!second.quote) continue;
+      const finalOut = second.quote.amountOut;
+      const grossSpread = finalOut - amountIn;
+      const grossBps = Number((grossSpread * BPS) / amountIn);
+      routes.push({
+        id: `${token.symbol}-${first.venue.name}-${second.venue.name}`.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+        pair: `WETH/${token.symbol}`,
+        inputWei: amountIn.toString(),
+        inputEth: formatEther(amountIn),
+        first: serializeVenueQuote(first.quote, token.decimals),
+        second: serializeVenueQuote(second.quote, 18),
+        finalWei: finalOut.toString(),
+        finalEth: formatEther(finalOut),
+        grossSpreadWei: grossSpread.toString(),
+        grossSpreadEth: formatEther(grossSpread),
+        grossSpreadBps: grossBps,
+        executionCompatibility: token.symbol === 'USDC' &&
+          ((first.venue.name === 'Uniswap V3' && second.venue.name === 'Aerodrome') ||
+           (first.venue.name === 'Aerodrome' && second.venue.name === 'Uniswap V3'))
+          ? 'CURRENT_EXECUTOR'
+          : 'WATCH_ONLY',
+      });
+    }
+  }
+
+  routes.sort((a, b) => BigInt(a.finalWei) > BigInt(b.finalWei) ? -1 : BigInt(a.finalWei) < BigInt(b.finalWei) ? 1 : 0);
+  return {
+    pair: `WETH/${token.symbol}`,
+    quoteToken: token.symbol,
+    sampleInputEth: formatEther(amountIn),
+    routes: routes.slice(0, 4),
+    bestRaw: routes[0] || null,
+  };
+}
+
+export async function scanBaseWideMarkets(input: {
+  maxCapitalEth?: unknown;
+  preferFlashblocks?: boolean;
+}) {
+  const amountRaw = String(input.maxCapitalEth ?? '0.01').trim();
+  if (!/^\d+(\.\d{1,18})?$/.test(amountRaw)) throw new Error('Enter a valid ETH amount.');
+  const maxWei = parseUnits(amountRaw, 18);
+  let sampleWei = maxWei / BigInt(2);
+  if (sampleWei < MIN_SAMPLE) sampleWei = MIN_SAMPLE;
+  if (sampleWei > MAX_SAMPLE) sampleWei = MAX_SAMPLE;
+
+  const candidates = rpcCandidates(input.preferFlashblocks !== false);
+  const errors: string[] = [];
+
+  for (const candidate of candidates) {
+    const provider = new JsonRpcProvider(candidate.url, BASE_CHAIN_ID, { staticNetwork: true });
+    try {
+      let observedBlock = '';
+      if (candidate.flashblocks) {
+        const pending = await withTimeout(
+          provider.send('eth_getBlockByNumber', ['pending', false]),
+          4_000,
+          'Flashblocks wide-scan health check',
+        );
+        observedBlock = String((pending as { number?: string })?.number || 'pending');
+      } else {
+        observedBlock = String(await withTimeout(provider.getBlockNumber(), 3_500, 'Base wide-scan health check'));
+      }
+
+      const pairResults = await withTimeout(
+        Promise.allSettled(TOKENS.map(token => scanPair(provider, token, sampleWei, candidate.stateTag))),
+        18_000,
+        'Wide Base market scan',
+      );
+      const pairs = pairResults
+        .filter((result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof scanPair>>> => result.status === 'fulfilled')
+        .map(result => result.value)
+        .filter(pair => pair.routes.length > 0);
+      if (!pairs.length) throw new Error('No wide-market routes could be quoted.');
+
+      const rawSignals = pairs.flatMap(pair => pair.routes)
+        .sort((a, b) => BigInt(a.grossSpreadWei) > BigInt(b.grossSpreadWei) ? -1 : BigInt(a.grossSpreadWei) < BigInt(b.grossSpreadWei) ? 1 : 0);
+
+      return {
+        stateMode: candidate.flashblocks ? 'flashblocks-pending' : 'sealed-latest',
+        stateTag: candidate.stateTag,
+        stateObservedBlock: observedBlock,
+        flashblocks: candidate.flashblocks,
+        rpcSource: safeRpcLabel(candidate.url),
+        sampleInputWei: sampleWei.toString(),
+        sampleInputEth: formatEther(sampleWei),
+        pairs,
+        bestRawSignal: rawSignals[0] || null,
+        coverage: {
+          pairsRequested: TOKENS.length,
+          pairsQuoted: pairs.length,
+          venues: VENUES.map(venue => venue.name),
+          uniswapFeeTiers: UNI_FEE_TIERS,
+          aerodromePoolTypes: ['volatile', 'stable'],
+          slipstreamTickSpacings: SLIPSTREAM_TICK_SPACINGS,
+        },
+        contracts: {
+          aerodromeMixedQuoter: AERODROME_MIXED_QUOTER,
+        },
+        rule: 'WIDE_SCAN_IS_READ_ONLY. Raw cross-venue spread is not gas-adjusted and never authorizes a trade. Current execution remains limited to the separately simulated WETH/USDC Uniswap V3 <-> Aerodrome executor.',
+      };
+    } catch (error) {
+      errors.push(`${safeRpcLabel(candidate.url)}: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      provider.destroy();
+    }
+  }
+
+  throw new Error(`Wide Base scan could not complete across ${candidates.length} RPCs. ${errors.at(-1) || ''}`);
+}

--- a/lib/base-wide-scanner.ts
+++ b/lib/base-wide-scanner.ts
@@ -116,8 +116,8 @@ async function quoteUni(
       return null;
     }
   }));
-  return results.filter((item): item is VenueQuote => Boolean(item))
-    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+  const viable = results.filter(Boolean) as VenueQuote[];
+  return viable.sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
 }
 
 async function quoteAero(
@@ -142,8 +142,8 @@ async function quoteAero(
       return null;
     }
   }));
-  return results.filter((item): item is VenueQuote => Boolean(item))
-    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+  const viable = results.filter(Boolean) as VenueQuote[];
+  return viable.sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
 }
 
 async function quoteSlipstream(
@@ -170,8 +170,8 @@ async function quoteSlipstream(
       return null;
     }
   }));
-  return results.filter((item): item is VenueQuote => Boolean(item))
-    .sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
+  const viable = results.filter(Boolean) as VenueQuote[];
+  return viable.sort((a, b) => a.amountOut > b.amountOut ? -1 : a.amountOut < b.amountOut ? 1 : 0)[0] || null;
 }
 
 const VENUES = [

--- a/lib/base-wide-scanner.ts
+++ b/lib/base-wide-scanner.ts
@@ -10,7 +10,7 @@ import {
 const BASE_FLASHBLOCKS_RPC = 'https://mainnet-preconf.base.org';
 const AERODROME_MIXED_QUOTER = getAddress('0x0A5aA5D3a4d28014f967Bf0f29EAA3FF9807D5c6');
 const UNI_FEE_TIERS = [100, 500, 3000, 10000];
-const SLIPSTREAM_TICK_SPACINGS = [1, 50, 100, 200, 2000];
+const SLIPSTREAM_TICK_SPACINGS = [1, 10, 50, 100, 200, 2000];
 const ZERO = BigInt(0);
 const BPS = BigInt(10000);
 const MIN_SAMPLE = parseUnits('0.0005', 18);
@@ -23,7 +23,7 @@ const AERO_ROUTER_ABI = [
   'function getAmountsOut(uint256 amountIn,(address from,address to,bool stable,address factory)[] routes) view returns (uint256[] amounts)',
 ];
 const SLIPSTREAM_QUOTER_ABI = [
-  'function quoteExactInputSingleV3((address tokenIn,address tokenOut,int24 tickSpacing,uint256 amountIn,uint160 sqrtPriceLimitX96) params) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+  'function quoteExactInputSingleV3((address tokenIn,address tokenOut,uint256 amountIn,int24 tickSpacing,uint160 sqrtPriceLimitX96) params) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
 ];
 
 type StateTag = 'pending' | 'latest';
@@ -158,7 +158,7 @@ async function quoteSlipstream(
     try {
       const result = await withTimeout(
         quoter.getFunction('quoteExactInputSingleV3').staticCall(
-          { tokenIn, tokenOut, tickSpacing, amountIn, sqrtPriceLimitX96: 0 },
+          { tokenIn, tokenOut, amountIn, tickSpacing, sqrtPriceLimitX96: 0 },
           { blockTag },
         ),
         3_000,

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 
 const read = path => fs.readFileSync(path, 'utf8');
 const core = read('lib/base-profit-engine.ts');
+const wide = read('lib/base-wide-scanner.ts');
+const scanRoute = read('app/api/profit-engine/scan/route.ts');
 const payments = read('lib/x402-resource.ts');
 const coordinator = read('lib/agent-coordinator.ts');
 const quote = read('app/api/agent/base-quote/route.ts');
@@ -28,6 +30,24 @@ requireText(core, "stateMode: used.flashblocks ? 'flashblocks-pending' : 'sealed
 requireText(core, "rule: 'NO_TRADE", 'profit engine must keep a hard no-trade rule');
 forbidText(core, 'eth_sendRawTransaction', 'market-data core must never submit transactions');
 forbidText(core, 'DEPLOYER_PRIVATE_KEY', 'market-data core must never read deployer private keys');
+
+requireText(wide, "'Aerodrome Slipstream'", 'wide scanner must include Slipstream discovery');
+requireText(wide, "symbol: 'cbBTC'", 'wide scanner must include cbBTC discovery');
+requireText(wide, "symbol: 'cbETH'", 'wide scanner must include cbETH discovery');
+requireText(wide, "symbol: 'AERO'", 'wide scanner must include AERO discovery');
+requireText(wide, "executionCompatibility: token.symbol === 'USDC'", 'wide scanner must explicitly separate current-executor routes from watch-only routes');
+requireText(wide, 'WIDE_SCAN_IS_READ_ONLY', 'wide scanner must declare itself read-only');
+forbidText(wide, 'sendTransaction', 'wide scanner must never submit transactions');
+forbidText(wide, 'eth_sendRawTransaction', 'wide scanner must never submit raw transactions');
+forbidText(wide, 'PRIVATE_KEY', 'wide scanner must never read private keys');
+forbidText(wide, 'new Wallet', 'wide scanner must never instantiate a signing wallet');
+
+requireText(scanRoute, 'normalized.inputWei / BigInt(8)', 'adaptive scan must test smaller capital sizes');
+requireText(scanRoute, 'normalized.inputWei,', 'adaptive scan must include the user capital cap itself');
+forbidText(scanRoute, 'normalized.inputWei * BigInt(2)', 'adaptive scan must never exceed the user capital cap');
+requireText(scanRoute, "scanMode: 'ADAPTIVE_WIDE_V3'", 'scan endpoint must disclose adaptive wide mode');
+requireText(scanRoute, 'scanBaseArbitrageGrid', 'scan endpoint must run multi-size executable quotes');
+requireText(scanRoute, 'scanBaseWideMarkets', 'scan endpoint must run wide read-only discovery');
 
 requireText(payments, "'PAYMENT-REQUIRED'", 'x402 402 challenge header must be emitted');
 requireText(payments, "request.headers.get('PAYMENT-SIGNATURE')", 'x402 payment payload header must be consumed');
@@ -78,6 +98,9 @@ requireText(profitPage, 'getAddress(connectedWallet)!==APPROVED_OWNER', 'executi
 requireText(profitPage, 'fn.staticCall(...args', 'execution must run a fresh no-spend static simulation');
 requireText(profitPage, 'fn.estimateGas(...args', 'execution must run a fresh wallet gas estimate');
 requireText(profitPage, 'simulatedGross-estimatedWalletGas<target', 'wallet execution must still clear the net target after estimated gas');
+requireText(profitPage, 'Wide market radar', 'UI must clearly separate wide discovery from execution');
+requireText(profitPage, 'This is the only execution-capable section', 'UI must identify the only execution-capable section');
+requireText(profitPage, 'WATCH ONLY', 'wide signals must be visibly non-executable');
 forbidText(profitPage, 'PRIVATE_KEY', 'browser execution page must never read private keys');
 forbidText(profitPage, 'eth_sendRawTransaction', 'browser execution page must not bypass wallet signing');
 


### PR DESCRIPTION
Upgrades the live Profit Engine scanner from a single WETH/USDC size into a broader Base market radar while keeping execution tightly bounded.

Changes:
- Adaptive execution scan checks up to four WETH/USDC capital sizes at or below the user-entered MAX CAPITAL.
- Keeps the existing conservative gas + target-profit gate for executable candidates.
- Adds a read-only wide Base scanner over major liquid quote markets: WETH/USDC, WETH/cbBTC, WETH/cbETH, and WETH/AERO.
- Wide scanner compares Uniswap V3 fee tiers, Aerodrome stable/volatile pools, and Aerodrome Slipstream tick spacings using Base Flashblocks pending state when available.
- Wide-market results are explicitly WATCH ONLY unless they match the already-reviewed WETH/USDC Uniswap V3 <-> Aerodrome executor path.
- UI separates "Executable matrix" from "Wide market radar" to avoid confusing raw discovery signals with executable profit.
- Existing executor live verification, fresh staticCall, fresh gas estimate, owner-wallet check, and MetaMask approval remain mandatory.
- Safety regression prevents wide scanner signing/submission/private-key access and prevents adaptive sizes above the user capital cap.

No new wallet permissions, private keys, contract deployments, or autonomous spending are introduced.