### PR TITLE
Profit Engine V4: continuous fast auto-watch

### DIFF
--- a/app/api/profit-engine/scan/route.ts
+++ b/app/api/profit-engine/scan/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { formatEther, parseUnits } from 'ethers';
-import { normalizeAmountEth, scanBaseArbitrageGrid } from '../../../../lib/base-profit-engine';
+import { normalizeAmountEth } from '../../../../lib/base-profit-engine';
+import { scanBaseArbitrageGridParallel } from '../../../../lib/base-fast-grid';
 import { scanBaseWideMarkets } from '../../../../lib/base-wide-scanner';
 
 export const runtime = 'nodejs';
@@ -36,18 +37,20 @@ export async function POST(request: Request) {
     const targetBps = body?.targetBps;
     const slippageBps = body?.slippageBps;
     const preferFlashblocks = body?.preferFlashblocks !== false;
+    const mode = body?.mode === 'fast' ? 'fast' : 'wide';
+
+    const gridPromise = scanBaseArbitrageGridParallel({
+      amountsEth: sizes.amountsEth,
+      targetBps,
+      slippageBps,
+      preferFlashblocks,
+    });
 
     const [gridResult, wideResult] = await Promise.allSettled([
-      scanBaseArbitrageGrid({
-        amountsEth: sizes.amountsEth,
-        targetBps,
-        slippageBps,
-        preferFlashblocks,
-      }),
-      scanBaseWideMarkets({
-        maxCapitalEth: sizes.requested,
-        preferFlashblocks,
-      }),
+      gridPromise,
+      mode === 'wide'
+        ? scanBaseWideMarkets({ maxCapitalEth: sizes.requested, preferFlashblocks })
+        : Promise.resolve(null),
     ]);
 
     if (gridResult.status !== 'fulfilled') throw gridResult.reason;
@@ -67,17 +70,19 @@ export async function POST(request: Request) {
       .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
 
     const profitable = opportunities.filter(opportunity => opportunity.passes);
-    const wideMarkets = wideResult.status === 'fulfilled' ? wideResult.value : null;
-    const wideScanError = wideResult.status === 'rejected'
+    const wideMarkets = mode === 'wide' && wideResult.status === 'fulfilled' ? wideResult.value : null;
+    const wideScanError = mode === 'wide' && wideResult.status === 'rejected'
       ? (wideResult.reason instanceof Error ? wideResult.reason.message : String(wideResult.reason))
       : null;
 
     return NextResponse.json({
       ...anchor,
-      scanMode: 'ADAPTIVE_WIDE_V3',
+      scanMode: mode === 'fast' ? 'FAST_EXECUTION_V4' : 'ADAPTIVE_WIDE_V4',
+      requestedMode: mode,
       maxCapitalEth: sizes.requested,
       requestedAmountsEth: sizes.amountsEth,
       executionSizesScanned: grid.scans.length,
+      executionScanPartial: grid.partial,
       best: profitable[0] || null,
       bestQuoted: opportunities[0] || null,
       opportunities,
@@ -94,7 +99,7 @@ export async function POST(request: Request) {
         aerodromePoolTypes: wideMarkets?.coverage?.aerodromePoolTypes || ['volatile', 'stable'],
         slipstreamTickSpacings: wideMarkets?.coverage?.slipstreamTickSpacings || [],
       },
-      rule: 'NO_TRADE unless an executable WETH/USDC candidate at or below the user capital cap clears conservative gas + target profit and then passes a fresh wallet static simulation. Wide-market signals are discovery-only until a separately reviewed executor supports them.',
+      rule: 'NO_TRADE unless an executable WETH/USDC candidate at or below the user capital cap clears conservative gas + target profit and then passes a fresh wallet static simulation. FAST mode only refreshes executable routes; WIDE mode also refreshes read-only market radar.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Profit Engine scan failed', error);

--- a/app/profit-engine/page.js
+++ b/app/profit-engine/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect,useState} from 'react';
+import {useEffect,useRef,useState} from 'react';
 import {BrowserProvider,Contract,Interface,formatEther,getAddress} from 'ethers';
 import {discoverMetaMaskProvider,getMetaMaskDeepLink} from '../../lib/wallet-connect';
 import styles from './profit.module.css';
@@ -88,7 +88,7 @@ async function verifyExecutor(address,browserProvider){
 
 export default function ProfitEnginePage(){
   const [amountEth,setAmountEth]=useState('0.01');
-  const [targetBps,setTargetBps]=useState('25');
+  const [targetBps,setTargetBps]=useState('5');
   const [slippageBps,setSlippageBps]=useState('15');
   const [scan,setScan]=useState(null);
   const [busy,setBusy]=useState(false);
@@ -99,6 +99,11 @@ export default function ProfitEnginePage(){
   const [localExecutor,setLocalExecutor]=useState('');
   const [executorVerified,setExecutorVerified]=useState(false);
   const [tx,setTx]=useState(null);
+  const [autoWatch,setAutoWatch]=useState(true);
+  const [scanCount,setScanCount]=useState(0);
+  const [lastScanAt,setLastScanAt]=useState('');
+  const scanInFlightRef=useRef(false);
+  const autoCycleRef=useRef(0);
 
   useEffect(()=>{
     try{
@@ -114,21 +119,70 @@ export default function ProfitEnginePage(){
     }catch{}
   },[]);
 
-  async function runScan(){
-    setBusy(true);setError('');setStatus('Scanning Base Flashblocks across multiple capital sizes, major liquid pairs, Uniswap V3, Aerodrome and Slipstream…');setTx(null);
+  useEffect(()=>{
+    if(!autoWatch)return undefined;
+    let cancelled=false;
+    let timer=null;
+    const tick=async()=>{
+      if(cancelled)return;
+      autoCycleRef.current+=1;
+      const mode=autoCycleRef.current===1||autoCycleRef.current%5===0?'wide':'fast';
+      await runScan({mode,automatic:true});
+      if(!cancelled)timer=setTimeout(tick,12000);
+    };
+    timer=setTimeout(tick,700);
+    return()=>{cancelled=true;if(timer)clearTimeout(timer)};
+  },[autoWatch,amountEth,targetBps,slippageBps]);
+
+  async function runScan({mode='wide',automatic=false}={}){
+    if(scanInFlightRef.current)return;
+    scanInFlightRef.current=true;
+    if(!automatic)setBusy(true);
+    setError('');
+    if(!automatic)setTx(null);
+    if(!automatic)setStatus(mode==='wide'?'Running full Base scan: executable matrix + wide market radar…':'Refreshing executable matrix…');
     try{
-      const response=await fetch('/api/profit-engine/scan',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({amountEth,targetBps:Number(targetBps),slippageBps:Number(slippageBps),preferFlashblocks:true}),cache:'no-store'});
+      const response=await fetch('/api/profit-engine/scan',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({amountEth,targetBps:Number(targetBps),slippageBps:Number(slippageBps),preferFlashblocks:true,mode}),cache:'no-store'});
       const data=await response.json().catch(()=>({}));
       if(!response.ok)throw new Error(data.error||'Base scan failed.');
-      setScan(data);
+      setScan(previous=>{
+        if(mode!=='fast'||!previous?.wideMarkets)return data;
+        return {
+          ...data,
+          wideMarkets:previous.wideMarkets,
+          wideScanError:previous.wideScanError,
+          coverage:{
+            ...data.coverage,
+            widePairsRequested:previous.coverage?.widePairsRequested||0,
+            widePairsQuoted:previous.coverage?.widePairsQuoted||0,
+            wideVenues:previous.coverage?.wideVenues||[],
+            slipstreamTickSpacings:previous.coverage?.slipstreamTickSpacings||[],
+          },
+        };
+      });
+      setScanCount(value=>value+1);
+      setLastScanAt(new Date().toLocaleTimeString());
       const source=data.flashblocks?'Flashblocks pending state':'sealed Base state fallback';
       const sizes=data.executionSizesScanned||1;
-      const wideQuoted=data.coverage?.widePairsQuoted||0;
-      const wideRequested=data.coverage?.widePairsRequested||0;
-      setStatus(data.best
-        ?`Executable candidate found on ${source} after checking ${sizes} capital sizes. It still must pass the fresh wallet simulation before MetaMask can submit it.`
-        :`No executable trade right now. Checked ${sizes} capital sizes plus ${wideQuoted}/${wideRequested} wide Base pairs. Wide-radar signals below are discovery only, not permission to trade.`);
-    }catch(e){setError(errText(e));setStatus('');setScan(null)}finally{setBusy(false)}
+      if(data.best){
+        setStatus(`PROFITABLE CANDIDATE FOUND on ${source} after checking ${sizes} sizes. Auto-watch paused. Tap SIMULATE + EXECUTE ATOMICALLY; the wallet will re-check it before any transaction.`);
+        if(automatic)setAutoWatch(false);
+      }else if(automatic){
+        setStatus(`AUTO WATCHING · last executable scan checked ${sizes} sizes on ${source}. No trade cleared gas + ${prettyPct(data.targetBps)} net yet.`);
+      }else{
+        const wideQuoted=data.coverage?.widePairsQuoted||0;
+        const wideRequested=data.coverage?.widePairsRequested||0;
+        setStatus(mode==='wide'
+          ?`No executable trade right now. Checked ${sizes} sizes plus ${wideQuoted}/${wideRequested} wide Base pairs. Auto-watch will keep checking.`
+          :`No executable trade right now after checking ${sizes} sizes. Auto-watch will keep checking.`);
+      }
+    }catch(e){
+      if(!automatic){setError(errText(e));setStatus('')}
+      else setStatus(`AUTO WATCH retrying · last scan error: ${errText(e)}`);
+    }finally{
+      scanInFlightRef.current=false;
+      if(!automatic)setBusy(false);
+    }
   }
 
   async function connect(){
@@ -159,7 +213,7 @@ export default function ProfitEnginePage(){
       const verified=await verifyExecutor(localExecutor,browserProvider);
       window.localStorage.setItem(EXECUTOR_STORAGE_KEY,verified);
       setLocalExecutor(verified);setExecutorVerified(true);
-      setStatus('Executor verified and activated on this device. Run the wide scan now.');
+      setStatus('Executor verified and activated on this device. Auto-watch can now keep scanning.');
     }catch(e){
       if(/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
@@ -173,7 +227,7 @@ export default function ProfitEnginePage(){
     if(!op?.passes)throw new Error('This route does not clear the profit floor.');
     const candidate=scan?.executorAddress||(executorVerified?localExecutor:'');
     if(!candidate)throw new Error('Verify the existing BaseArbExecutor first.');
-    setBusy(true);setError('');setTx(null);
+    setBusy(true);setError('');setTx(null);setAutoWatch(false);
     try{
       let provider=injected;
       let connectedWallet=wallet;
@@ -216,7 +270,7 @@ export default function ProfitEnginePage(){
       const actualGas=(receipt.gasUsed||0n)*(receipt.gasPrice||feePerGas||0n);
       const net=BigInt(grossProfit)-actualGas;
       setTx({hash:receipt.hash||sent.hash,pending:false,grossProfitWei:grossProfit,gasWei:actualGas.toString(),netWei:net.toString()});
-      setStatus(`Confirmed. Gross spread captured: ${prettyEth(grossProfit)} ETH; transaction gas: ${prettyEth(actualGas)} ETH; estimated wallet net: ${prettyEth(net)} ETH. Scan again for the next opportunity.`);
+      setStatus(`Confirmed. Gross spread captured: ${prettyEth(grossProfit)} ETH; transaction gas: ${prettyEth(actualGas)} ETH; estimated wallet net: ${prettyEth(net)} ETH. Turn AUTO WATCH back on for the next opportunity.`);
     }catch(e){
       if(!scan?.executorAddress&&/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
@@ -231,24 +285,29 @@ export default function ProfitEnginePage(){
   const widePairs=scan?.wideMarkets?.pairs||[];
 
   return <main className={styles.page}>
-    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V3 WIDE SCAN</span></nav>
+    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V4 AUTO WATCH</span></nav>
     <div className={styles.shell}>
-      <header className={styles.hero}><small>PROFIT ENGINE V3 · ADAPTIVE + WIDE</small><h1>Scan more.<br/><em>Trade only what clears.</em></h1><p>The main scan now checks several capital sizes at or below your cap and also sweeps major Base markets across Uniswap V3, Aerodrome classic pools, and Aerodrome Slipstream.</p></header>
+      <header className={styles.hero}><small>PROFIT ENGINE V4 · FAST + WIDE</small><h1>Stop tapping.<br/><em>Keep watching.</em></h1><p>V4 checks executable WETH/USDC sizes repeatedly while this page stays active, and periodically refreshes the broader Base radar across Uniswap V3, Aerodrome and Slipstream.</p></header>
 
       <section className={styles.panel}>
-        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>The wide radar can discover more markets, but only the separately reviewed WETH/USDC executor matrix can ever show an execution button. A candidate still needs conservative gas + profit clearance, live executor verification, fresh static simulation, fresh gas estimate, and your MetaMask approval.</span></div>
+        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>Auto-watch only reads quotes. It never signs or submits anything. A candidate still needs conservative gas + profit clearance, live executor verification, fresh static simulation, fresh gas estimate, and your MetaMask approval.</span></div>
         <div className={styles.form}>
           <div className={styles.field}><label>MAX CAPITAL · ETH</label><input value={amountEth} onChange={e=>setAmountEth(e.target.value)} inputMode="decimal"/></div>
           <div className={styles.field}><label>MIN NET · BPS</label><input value={targetBps} onChange={e=>setTargetBps(e.target.value)} inputMode="numeric"/></div>
           <div className={styles.field}><label>SLIPPAGE · BPS</label><input value={slippageBps} onChange={e=>setSlippageBps(e.target.value)} inputMode="numeric"/></div>
-          <button className={styles.primary} onClick={runScan} disabled={busy}>{busy?'SCANNING BASE…':'SCAN BASE WIDE NOW'}</button>
+          <button className={styles.primary} onClick={()=>runScan({mode:'wide',automatic:false})} disabled={busy}>{busy?'SCANNING BASE…':'RUN FULL WIDE SCAN'}</button>
+          <button className={styles.secondary} style={{width:'100%'}} onClick={()=>setAutoWatch(value=>!value)} disabled={busy}>{autoWatch?'AUTO WATCH · ON':'AUTO WATCH · OFF'}</button>
         </div>
+        <div className={styles.footnote}>AUTO WATCH refreshes the executable matrix about every 12 seconds and the full wide radar periodically while this browser tab remains active. iPhone may suspend page timers when the browser is backgrounded.</div>
         {status&&<div className={styles.status}>{status}</div>}
         {error&&<div className={styles.error}>{error}</div>}
         {scan&&<div className={styles.summary}>
           <div className={styles.stat}><small>EXECUTION SIZES</small><b>{scan.executionSizesScanned||1}</b></div>
           <div className={styles.stat}><small>WIDE PAIRS</small><b>{scan.coverage?.widePairsQuoted||0}/{scan.coverage?.widePairsRequested||0}</b></div>
           <div className={styles.stat}><small>NET TARGET</small><b>{prettyPct(scan.targetBps)}</b></div>
+          <div className={styles.stat}><small>AUTO WATCH</small><b>{autoWatch?'ON':'PAUSED'}</b></div>
+          <div className={styles.stat}><small>SCANS THIS PAGE</small><b>{scanCount}</b></div>
+          <div className={styles.stat}><small>LAST CHECK</small><b>{lastScanAt||'—'}</b></div>
           <div className={styles.stat}><small>EXECUTOR</small><b>{executorReady?`${short(displayedExecutor)}${scan.executionEnabled?'':' · DEVICE'}`:localExecutor?`${short(localExecutor)} · VERIFY`:'LOCKED'}</b></div>
         </div>}
         {localExecutor&&!executorVerified&&!scan?.executionEnabled&&<button className={styles.secondary} style={{width:'100%',marginTop:14}} onClick={()=>activateExecutor()} disabled={busy}>{busy?'VERIFYING…':'VERIFY EXISTING EXECUTOR →'}</button>}
@@ -271,7 +330,7 @@ export default function ProfitEnginePage(){
           </div>
           {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/>{localExecutor?'Verify the existing executor above.':<a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>}</div>:null}
         </article>)}</div>
-        <div className={styles.footnote}>This is the only execution-capable section. Sizes never exceed the MAX CAPITAL value you entered. No wallet transaction is offered unless the quoted WETH/USDC round trip clears the configured net target after the conservative gas budget, and the exact transaction is simulated again immediately before MetaMask.</div>
+        <div className={styles.footnote}>This is the only execution-capable section. Sizes never exceed MAX CAPITAL. The default net target is now 5 bps, but conservative gas is still added on top, so lowering the target does not turn a losing route into a trade. Every actual attempt still gets a fresh wallet simulation immediately before MetaMask.</div>
       </section>}
 
       {scan&&<section className={styles.panel}>
@@ -295,7 +354,7 @@ export default function ProfitEnginePage(){
             </>:<p className={styles.footnote}>No complete cross-venue round trip was quotable for this pair on this state.</p>}
           </article>;
         })}</div>:<div className={styles.status}>No additional wide-market routes were available on this scan.</div>}
-        <div className={styles.footnote}>Radar values are raw quote differences before a route-specific gas model, slippage reserve, contract compatibility check, or wallet simulation. They are intentionally not executable. The radar currently covers major liquid Base quote markets and multiple Uniswap fee tiers, Aerodrome stable/volatile pools, and Slipstream tick spacings rather than blindly touching every unknown token contract.</div>
+        <div className={styles.footnote}>Radar values are raw quote differences before a route-specific gas model, slippage reserve, contract compatibility check, or wallet simulation. They are intentionally not executable. This avoids treating a raw price discrepancy as guaranteed profit.</div>
       </section>}
 
       <section className={styles.panel}>

--- a/lib/base-fast-grid.ts
+++ b/lib/base-fast-grid.ts
@@ -1,0 +1,52 @@
+import { scanBaseArbitrage } from './base-profit-engine';
+
+export async function scanBaseArbitrageGridParallel(input: {
+  amountsEth: unknown[];
+  targetBps?: unknown;
+  slippageBps?: unknown;
+  preferFlashblocks?: boolean;
+}) {
+  const raw = Array.isArray(input.amountsEth) ? input.amountsEth : [];
+  const unique = Array.from(new Set(raw.map(value => String(value).trim()).filter(Boolean))).slice(0, 4);
+  if (!unique.length) throw new Error('Provide at least one ETH amount to optimize.');
+
+  const settled = await Promise.allSettled(unique.map(amountEth => scanBaseArbitrage({
+    amountEth,
+    targetBps: input.targetBps,
+    slippageBps: input.slippageBps,
+    preferFlashblocks: input.preferFlashblocks,
+  })));
+
+  const scans = settled
+    .filter((result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof scanBaseArbitrage>>> => result.status === 'fulfilled')
+    .map(result => result.value);
+
+  if (!scans.length) {
+    const lastFailure = settled.findLast(result => result.status === 'rejected');
+    const reason = lastFailure?.status === 'rejected'
+      ? (lastFailure.reason instanceof Error ? lastFailure.reason.message : String(lastFailure.reason))
+      : 'No executable size completed.';
+    throw new Error(`Parallel Base execution scan failed. ${reason}`);
+  }
+
+  const profitable = scans
+    .flatMap(scan => scan.opportunities.map(opportunity => ({
+      ...opportunity,
+      scanInputEth: scan.inputEth,
+      stateMode: scan.stateMode,
+      scannedAt: scan.scannedAt,
+    })))
+    .filter(opportunity => opportunity.passes)
+    .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
+
+  return {
+    chainId: scans[0].chainId,
+    pair: 'WETH/USDC',
+    requestedAmountsEth: unique,
+    completedAmountsEth: scans.map(scan => scan.inputEth),
+    best: profitable[0] || null,
+    scans,
+    partial: scans.length !== unique.length,
+    rule: 'Parallel optimization scans up to four sizes concurrently and never executes or signs anything.',
+  };
+}

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 
 const read = path => fs.readFileSync(path, 'utf8');
 const core = read('lib/base-profit-engine.ts');
+const fastGrid = read('lib/base-fast-grid.ts');
 const wide = read('lib/base-wide-scanner.ts');
 const scanRoute = read('app/api/profit-engine/scan/route.ts');
 const payments = read('lib/x402-resource.ts');
@@ -31,6 +32,14 @@ requireText(core, "rule: 'NO_TRADE", 'profit engine must keep a hard no-trade ru
 forbidText(core, 'eth_sendRawTransaction', 'market-data core must never submit transactions');
 forbidText(core, 'DEPLOYER_PRIVATE_KEY', 'market-data core must never read deployer private keys');
 
+requireText(fastGrid, 'Promise.allSettled', 'fast grid must scan execution sizes concurrently');
+requireText(fastGrid, 'scanBaseArbitrage', 'fast grid must reuse the reviewed executable quote engine');
+requireText(fastGrid, 'never executes or signs anything', 'parallel scan must remain read-only');
+forbidText(fastGrid, 'sendTransaction', 'parallel scan must never submit transactions');
+forbidText(fastGrid, 'eth_sendRawTransaction', 'parallel scan must never submit raw transactions');
+forbidText(fastGrid, 'PRIVATE_KEY', 'parallel scan must never read private keys');
+forbidText(fastGrid, 'new Wallet', 'parallel scan must never instantiate a signing wallet');
+
 requireText(wide, "'Aerodrome Slipstream'", 'wide scanner must include Slipstream discovery');
 requireText(wide, "symbol: 'cbBTC'", 'wide scanner must include cbBTC discovery');
 requireText(wide, "symbol: 'cbETH'", 'wide scanner must include cbETH discovery');
@@ -45,9 +54,12 @@ forbidText(wide, 'new Wallet', 'wide scanner must never instantiate a signing wa
 requireText(scanRoute, 'normalized.inputWei / BigInt(8)', 'adaptive scan must test smaller capital sizes');
 requireText(scanRoute, 'normalized.inputWei,', 'adaptive scan must include the user capital cap itself');
 forbidText(scanRoute, 'normalized.inputWei * BigInt(2)', 'adaptive scan must never exceed the user capital cap');
-requireText(scanRoute, "scanMode: 'ADAPTIVE_WIDE_V3'", 'scan endpoint must disclose adaptive wide mode');
-requireText(scanRoute, 'scanBaseArbitrageGrid', 'scan endpoint must run multi-size executable quotes');
-requireText(scanRoute, 'scanBaseWideMarkets', 'scan endpoint must run wide read-only discovery');
+requireText(scanRoute, "body?.mode === 'fast' ? 'fast' : 'wide'", 'scan endpoint must split fast and wide modes');
+requireText(scanRoute, 'scanBaseArbitrageGridParallel', 'scan endpoint must use parallel multi-size executable quotes');
+requireText(scanRoute, "scanMode: mode === 'fast' ? 'FAST_EXECUTION_V4' : 'ADAPTIVE_WIDE_V4'", 'scan endpoint must disclose V4 scan mode');
+requireText(scanRoute, 'scanBaseWideMarkets', 'wide mode must still run read-only discovery');
+forbidText(scanRoute, 'sendTransaction', 'scan route must remain read-only');
+forbidText(scanRoute, 'PRIVATE_KEY', 'scan route must never read private keys');
 
 requireText(payments, "'PAYMENT-REQUIRED'", 'x402 402 challenge header must be emitted');
 requireText(payments, "request.headers.get('PAYMENT-SIGNATURE')", 'x402 payment payload header must be consumed');
@@ -92,16 +104,24 @@ forbidText(deployPage, 'PRIVATE_KEY', 'browser deployment page must never read p
 
 requireText(profitPage, "const fromUrl=params.get('executor')", 'profit page must accept an existing executor recovery address');
 requireText(profitPage, 'setExecutorVerified(false)', 'recovered executor must start unverified');
+requireText(profitPage, "const [targetBps,setTargetBps]=useState('5')", 'V4 UI should use the smaller net-profit target by default');
+requireText(profitPage, 'const [autoWatch,setAutoWatch]=useState(true)', 'V4 auto-watch must start enabled');
+requireText(profitPage, "setTimeout(tick,12000)", 'auto-watch cadence must remain bounded');
+requireText(profitPage, "const mode=autoCycleRef.current===1||autoCycleRef.current%5===0?'wide':'fast'", 'auto-watch must use fast scans between periodic wide scans');
+requireText(profitPage, 'if(data.best)', 'auto-watch must detect profitable candidates');
+requireText(profitPage, 'if(automatic)setAutoWatch(false)', 'auto-watch must pause when a candidate is found');
 requireText(profitPage, 'const code=await browserProvider.getCode(candidate)', 'verification must first confirm deployed bytecode exists');
 requireText(profitPage, 'const executorAddress=await verifyExecutor(candidate,browserProvider);', 'device executor must be re-verified live before use');
 requireText(profitPage, 'getAddress(connectedWallet)!==APPROVED_OWNER', 'execution must require the reviewed owner wallet');
 requireText(profitPage, 'fn.staticCall(...args', 'execution must run a fresh no-spend static simulation');
 requireText(profitPage, 'fn.estimateGas(...args', 'execution must run a fresh wallet gas estimate');
 requireText(profitPage, 'simulatedGross-estimatedWalletGas<target', 'wallet execution must still clear the net target after estimated gas');
+requireText(profitPage, 'Auto-watch only reads quotes', 'UI must disclose that auto-watch cannot execute');
 requireText(profitPage, 'Wide market radar', 'UI must clearly separate wide discovery from execution');
 requireText(profitPage, 'This is the only execution-capable section', 'UI must identify the only execution-capable section');
 requireText(profitPage, 'WATCH ONLY', 'wide signals must be visibly non-executable');
 forbidText(profitPage, 'PRIVATE_KEY', 'browser execution page must never read private keys');
 forbidText(profitPage, 'eth_sendRawTransaction', 'browser execution page must not bypass wallet signing');
+forbidText(profitPage, 'new Wallet', 'auto-watch page must not instantiate a signing wallet');
 
 console.log('Machine revenue layer safety checks passed.');


### PR DESCRIPTION
Makes the Profit Engine useful without repeated manual tapping while preserving the wallet execution boundary.

Changes:
- Adds a parallel executable grid scanner for up to four capital sizes at or below MAX CAPITAL.
- Splits scan API into FAST execution mode and WIDE radar mode.
- Profit Engine auto-watches executable WETH/USDC routes about every 12 seconds while the page remains active.
- Refreshes the full wide Base radar periodically rather than on every fast cycle.
- Auto-watch pauses when a candidate clears the configured profit gate so the user can run the required fresh wallet simulation.
- Changes the UI default minimum net target from 25 bps to 5 bps; conservative gas remains added on top.
- Adds scan count / last-check visibility and a clear AUTO WATCH on/off control.
- No automatic signing, transaction submission, private-key access, or wallet bypass.
- Existing live executor verification, staticCall, gas estimate, owner check, and MetaMask approval remain mandatory.

This improves opportunity capture speed but does not manufacture or guarantee profitable market spreads.