### PR TITLE
Profit Engine V5: boss batch scan and burst watch

### DIFF
--- a/app/api/profit-engine/scan/route.ts
+++ b/app/api/profit-engine/scan/route.ts
@@ -14,9 +14,11 @@ const MAX_INPUT = parseUnits('10', 18);
 function adaptiveAmounts(amountEth: unknown) {
   const normalized = normalizeAmountEth(amountEth || '0.01');
   const values = [
+    normalized.inputWei / BigInt(16),
     normalized.inputWei / BigInt(8),
     normalized.inputWei / BigInt(4),
     normalized.inputWei / BigInt(2),
+    (normalized.inputWei * BigInt(3)) / BigInt(4),
     normalized.inputWei,
   ].map(value => value < MIN_INPUT ? MIN_INPUT : value > MAX_INPUT ? MAX_INPUT : value);
 
@@ -67,9 +69,10 @@ export async function POST(request: Request) {
         scanStateMode: scan.stateMode,
         scanRpcSource: scan.rpcSource,
       })))
-      .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
+      .sort((a, b) => BigInt(a.marginToProfitFloorWei) > BigInt(b.marginToProfitFloorWei) ? -1 : BigInt(a.marginToProfitFloorWei) < BigInt(b.marginToProfitFloorWei) ? 1 : 0);
 
     const profitable = opportunities.filter(opportunity => opportunity.passes);
+    const bestQuoted = opportunities[0] || null;
     const wideMarkets = mode === 'wide' && wideResult.status === 'fulfilled' ? wideResult.value : null;
     const wideScanError = mode === 'wide' && wideResult.status === 'rejected'
       ? (wideResult.reason instanceof Error ? wideResult.reason.message : String(wideResult.reason))
@@ -77,14 +80,19 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       ...anchor,
-      scanMode: mode === 'fast' ? 'FAST_EXECUTION_V4' : 'ADAPTIVE_WIDE_V4',
+      scanMode: mode === 'fast' ? 'BOSS_FAST_V5' : 'BOSS_WIDE_V5',
       requestedMode: mode,
       maxCapitalEth: sizes.requested,
       requestedAmountsEth: sizes.amountsEth,
       executionSizesScanned: grid.scans.length,
       executionScanPartial: grid.partial,
+      batchLatencyMs: grid.batchLatencyMs,
       best: profitable[0] || null,
-      bestQuoted: opportunities[0] || null,
+      bestQuoted,
+      nearMiss: profitable[0] ? null : bestQuoted,
+      marketHeat: grid.marketHeat,
+      suggestedCadenceMs: grid.suggestedCadenceMs,
+      closestMarginBps: grid.closestMarginBps,
       opportunities,
       wideMarkets,
       wideScanError,
@@ -99,7 +107,7 @@ export async function POST(request: Request) {
         aerodromePoolTypes: wideMarkets?.coverage?.aerodromePoolTypes || ['volatile', 'stable'],
         slipstreamTickSpacings: wideMarkets?.coverage?.slipstreamTickSpacings || [],
       },
-      rule: 'NO_TRADE unless an executable WETH/USDC candidate at or below the user capital cap clears conservative gas + target profit and then passes a fresh wallet static simulation. FAST mode only refreshes executable routes; WIDE mode also refreshes read-only market radar.',
+      rule: 'NO_TRADE unless an executable WETH/USDC candidate at or below the user capital cap clears conservative gas + target profit and then passes a fresh wallet static simulation. V5 speeds read-only scans near the profit floor but never auto-executes.',
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     console.error('Profit Engine scan failed', error);

--- a/app/profit-engine/page.js
+++ b/app/profit-engine/page.js
@@ -104,6 +104,7 @@ export default function ProfitEnginePage(){
   const [lastScanAt,setLastScanAt]=useState('');
   const scanInFlightRef=useRef(false);
   const autoCycleRef=useRef(0);
+  const nextDelayRef=useRef(12000);
 
   useEffect(()=>{
     try{
@@ -126,9 +127,9 @@ export default function ProfitEnginePage(){
     const tick=async()=>{
       if(cancelled)return;
       autoCycleRef.current+=1;
-      const mode=autoCycleRef.current===1||autoCycleRef.current%5===0?'wide':'fast';
+      const mode=autoCycleRef.current===1||autoCycleRef.current%8===0?'wide':'fast';
       await runScan({mode,automatic:true});
-      if(!cancelled)timer=setTimeout(tick,12000);
+      if(!cancelled)timer=setTimeout(tick,nextDelayRef.current);
     };
     timer=setTimeout(tick,700);
     return()=>{cancelled=true;if(timer)clearTimeout(timer)};
@@ -140,7 +141,7 @@ export default function ProfitEnginePage(){
     if(!automatic)setBusy(true);
     setError('');
     if(!automatic)setTx(null);
-    if(!automatic)setStatus(mode==='wide'?'Running full Base scan: executable matrix + wide market radar…':'Refreshing executable matrix…');
+    if(!automatic)setStatus(mode==='wide'?'Running V5 boss scan: executable matrix + wide market radar…':'Refreshing boss executable matrix…');
     try{
       const response=await fetch('/api/profit-engine/scan',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({amountEth,targetBps:Number(targetBps),slippageBps:Number(slippageBps),preferFlashblocks:true,mode}),cache:'no-store'});
       const data=await response.json().catch(()=>({}));
@@ -162,21 +163,35 @@ export default function ProfitEnginePage(){
       });
       setScanCount(value=>value+1);
       setLastScanAt(new Date().toLocaleTimeString());
+      const suggested=Math.max(4000,Math.min(15000,Number(data.suggestedCadenceMs||12000)));
+      nextDelayRef.current=suggested;
       const source=data.flashblocks?'Flashblocks pending state':'sealed Base state fallback';
       const sizes=data.executionSizesScanned||1;
+      const heat=String(data.marketHeat||'COLD');
       if(data.best){
-        setStatus(`PROFITABLE CANDIDATE FOUND on ${source} after checking ${sizes} sizes. Auto-watch paused. Tap SIMULATE + EXECUTE ATOMICALLY; the wallet will re-check it before any transaction.`);
+        setStatus(`PROFIT FLOOR CLEARED on ${source} after checking ${sizes} sizes. Auto-watch paused. Tap SIMULATE + EXECUTE ATOMICALLY; the wallet will re-check the exact trade before anything is sent.`);
+        try{navigator.vibrate?.([200,100,200])}catch{}
+        try{document.title='PROFIT FOUND · Voxel Vault'}catch{}
         if(automatic)setAutoWatch(false);
-      }else if(automatic){
-        setStatus(`AUTO WATCHING · last executable scan checked ${sizes} sizes on ${source}. No trade cleared gas + ${prettyPct(data.targetBps)} net yet.`);
       }else{
-        const wideQuoted=data.coverage?.widePairsQuoted||0;
-        const wideRequested=data.coverage?.widePairsRequested||0;
-        setStatus(mode==='wide'
-          ?`No executable trade right now. Checked ${sizes} sizes plus ${wideQuoted}/${wideRequested} wide Base pairs. Auto-watch will keep checking.`
-          :`No executable trade right now after checking ${sizes} sizes. Auto-watch will keep checking.`);
+        try{document.title='Profit Engine V5 · Voxel Vault'}catch{}
+        const gap=Number(data.nearMiss?.distanceToProfitFloorBps??data.bestQuoted?.distanceToProfitFloorBps??0);
+        if(automatic&&heat==='HOT'){
+          setStatus(`BOSS BURST · closest executable route is about ${gap} bps short of gas + target. Scanning again in ~${Math.round(suggested/1000)}s.`);
+        }else if(automatic&&heat==='WARM'){
+          setStatus(`BOSS WATCH · market is warming. Closest route is about ${gap} bps short of the profit floor; next scan in ~${Math.round(suggested/1000)}s.`);
+        }else if(automatic){
+          setStatus(`AUTO WATCHING · ${sizes} sizes checked on ${source}. No trade clears gas + ${prettyPct(data.targetBps)} net yet; next scan in ~${Math.round(suggested/1000)}s.`);
+        }else{
+          const wideQuoted=data.coverage?.widePairsQuoted||0;
+          const wideRequested=data.coverage?.widePairsRequested||0;
+          setStatus(mode==='wide'
+            ?`No executable trade right now. Checked ${sizes} sizes plus ${wideQuoted}/${wideRequested} wide Base pairs. Boss auto-watch will keep hunting.`
+            :`No executable trade right now after checking ${sizes} sizes. Boss auto-watch will keep hunting.`);
+        }
       }
     }catch(e){
+      nextDelayRef.current=12000;
       if(!automatic){setError(errText(e));setStatus('')}
       else setStatus(`AUTO WATCH retrying · last scan error: ${errText(e)}`);
     }finally{
@@ -213,7 +228,7 @@ export default function ProfitEnginePage(){
       const verified=await verifyExecutor(localExecutor,browserProvider);
       window.localStorage.setItem(EXECUTOR_STORAGE_KEY,verified);
       setLocalExecutor(verified);setExecutorVerified(true);
-      setStatus('Executor verified and activated on this device. Auto-watch can now keep scanning.');
+      setStatus('Executor verified and activated on this device. Boss auto-watch can keep scanning.');
     }catch(e){
       if(/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
@@ -270,7 +285,7 @@ export default function ProfitEnginePage(){
       const actualGas=(receipt.gasUsed||0n)*(receipt.gasPrice||feePerGas||0n);
       const net=BigInt(grossProfit)-actualGas;
       setTx({hash:receipt.hash||sent.hash,pending:false,grossProfitWei:grossProfit,gasWei:actualGas.toString(),netWei:net.toString()});
-      setStatus(`Confirmed. Gross spread captured: ${prettyEth(grossProfit)} ETH; transaction gas: ${prettyEth(actualGas)} ETH; estimated wallet net: ${prettyEth(net)} ETH. Turn AUTO WATCH back on for the next opportunity.`);
+      setStatus(`Confirmed. Gross spread captured: ${prettyEth(grossProfit)} ETH; transaction gas: ${prettyEth(actualGas)} ETH; estimated wallet net: ${prettyEth(net)} ETH. Turn BOSS AUTO WATCH back on for the next opportunity.`);
     }catch(e){
       if(!scan?.executorAddress&&/Executor verification failed/i.test(errText(e))){
         try{window.localStorage.removeItem(EXECUTOR_STORAGE_KEY)}catch{}
@@ -283,28 +298,33 @@ export default function ProfitEnginePage(){
   const executorReady=Boolean(scan?.executionEnabled||(localExecutor&&executorVerified));
   const displayedExecutor=scan?.executionEnabled?scan.executorAddress:localExecutor;
   const widePairs=scan?.wideMarkets?.pairs||[];
+  const marketHeat=String(scan?.marketHeat||'COLD');
+  const nearMiss=scan?.nearMiss||(!scan?.best?scan?.bestQuoted:null);
 
   return <main className={styles.page}>
-    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V4 AUTO WATCH</span></nav>
+    <nav className={styles.nav}><a href="/studio">Voxel Vault · Profit Engine</a><span>BASE · V5 BOSS MODE</span></nav>
     <div className={styles.shell}>
-      <header className={styles.hero}><small>PROFIT ENGINE V4 · FAST + WIDE</small><h1>Stop tapping.<br/><em>Keep watching.</em></h1><p>V4 checks executable WETH/USDC sizes repeatedly while this page stays active, and periodically refreshes the broader Base radar across Uniswap V3, Aerodrome and Slipstream.</p></header>
+      <header className={styles.hero}><small>PROFIT ENGINE V5 · BOSS SCAN</small><h1>Hunt faster.<br/><em>Attack only real edge.</em></h1><p>V5 batches six capital sizes against one Base state source, parallelizes venue quotes, ranks every route by distance to the on-chain profit floor, and automatically enters burst mode when the market gets close.</p></header>
 
       <section className={styles.panel}>
-        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>Auto-watch only reads quotes. It never signs or submits anything. A candidate still needs conservative gas + profit clearance, live executor verification, fresh static simulation, fresh gas estimate, and your MetaMask approval.</span></div>
+        <div className={styles.guardrail}><b>EXECUTION RULE</b><span>Boss auto-watch only reads quotes. It never signs or submits anything. A candidate still needs conservative gas + profit clearance, live executor verification, a fresh static simulation, a fresh wallet gas estimate, and your MetaMask approval.</span></div>
         <div className={styles.form}>
           <div className={styles.field}><label>MAX CAPITAL · ETH</label><input value={amountEth} onChange={e=>setAmountEth(e.target.value)} inputMode="decimal"/></div>
           <div className={styles.field}><label>MIN NET · BPS</label><input value={targetBps} onChange={e=>setTargetBps(e.target.value)} inputMode="numeric"/></div>
           <div className={styles.field}><label>SLIPPAGE · BPS</label><input value={slippageBps} onChange={e=>setSlippageBps(e.target.value)} inputMode="numeric"/></div>
-          <button className={styles.primary} onClick={()=>runScan({mode:'wide',automatic:false})} disabled={busy}>{busy?'SCANNING BASE…':'RUN FULL WIDE SCAN'}</button>
-          <button className={styles.secondary} style={{width:'100%'}} onClick={()=>setAutoWatch(value=>!value)} disabled={busy}>{autoWatch?'AUTO WATCH · ON':'AUTO WATCH · OFF'}</button>
+          <button className={styles.primary} onClick={()=>runScan({mode:'wide',automatic:false})} disabled={busy}>{busy?'SCANNING BASE…':'RUN BOSS WIDE SCAN'}</button>
+          <button className={styles.secondary} style={{width:'100%'}} onClick={()=>setAutoWatch(value=>!value)} disabled={busy}>{autoWatch?`BOSS AUTO WATCH · ON · ${marketHeat}`:'BOSS AUTO WATCH · OFF'}</button>
         </div>
-        <div className={styles.footnote}>AUTO WATCH refreshes the executable matrix about every 12 seconds and the full wide radar periodically while this browser tab remains active. iPhone may suspend page timers when the browser is backgrounded.</div>
+        <div className={styles.footnote}>V5 dynamically watches about every 12 seconds in cold markets, about 7 seconds when warm, and as fast as about 4 seconds in HOT near-miss conditions. The full wide radar refreshes periodically. iPhone may suspend page timers when the browser is backgrounded.</div>
         {status&&<div className={styles.status}>{status}</div>}
         {error&&<div className={styles.error}>{error}</div>}
+        {nearMiss&&!scan?.best&&<div className={styles.status}>Closest executable: {nearMiss.first?.venue} → {nearMiss.second?.venue} at {nearMiss.inputEth} ETH. It is about {nearMiss.distanceToProfitFloorBps} bps ({prettyEth(nearMiss.distanceToProfitFloorWei)} ETH) short of gas + your profit target. V5 automatically speeds up as that gap closes.</div>}
         {scan&&<div className={styles.summary}>
           <div className={styles.stat}><small>EXECUTION SIZES</small><b>{scan.executionSizesScanned||1}</b></div>
+          <div className={styles.stat}><small>MARKET HEAT</small><b>{marketHeat}</b></div>
           <div className={styles.stat}><small>WIDE PAIRS</small><b>{scan.coverage?.widePairsQuoted||0}/{scan.coverage?.widePairsRequested||0}</b></div>
           <div className={styles.stat}><small>NET TARGET</small><b>{prettyPct(scan.targetBps)}</b></div>
+          <div className={styles.stat}><small>BATCH LATENCY</small><b>{scan.batchLatencyMs?`${scan.batchLatencyMs} ms`:'—'}</b></div>
           <div className={styles.stat}><small>AUTO WATCH</small><b>{autoWatch?'ON':'PAUSED'}</b></div>
           <div className={styles.stat}><small>SCANS THIS PAGE</small><b>{scanCount}</b></div>
           <div className={styles.stat}><small>LAST CHECK</small><b>{lastScanAt||'—'}</b></div>
@@ -317,7 +337,7 @@ export default function ProfitEnginePage(){
       {scan&&<section className={styles.panel}>
         <div className={styles.sectionHead}><div><h2>Executable matrix</h2><span>{scan.executionSizesScanned||1} sizes · WETH/USDC · {scan.stateMode} · {scan.rpcSource}</span></div>{!wallet&&<button className={styles.secondary} onClick={()=>connect().catch(e=>setError(errText(e)))}>CONNECT METAMASK</button>}</div>
         <div className={styles.grid}>{scan.opportunities.map(op=><article key={op.id} className={`${styles.card} ${op.passes?styles.good:''}`}>
-          <span className={styles.badge}>{op.passes?'PROFIT FLOOR CLEARED':'NO TRADE'}</span>
+          <span className={styles.badge}>{op.passes?'PROFIT FLOOR CLEARED':Number(op.distanceToProfitFloorBps)<=5?'NEAR MISS':'NO TRADE'}</span>
           <div className={styles.route}>{op.first.venue} → {op.second.venue}</div>
           <div className={styles.leg}><span>CAPITAL</span><b>{prettyEth(op.inputWei)} ETH</b></div>
           <div className={styles.leg}><span>LEG 1</span><b>{venueMeta(op.first)}</b></div>
@@ -325,12 +345,12 @@ export default function ProfitEnginePage(){
           <div className={styles.numbers}>
             <div className={styles.number}><span>Quoted final</span><b>{prettyEth(op.finalWei)} WETH</b></div>
             <div className={styles.number}><span>Gross spread</span><b className={BigInt(op.grossProfitWei)>0n?styles.positive:styles.negative}>{prettyEth(op.grossProfitWei)} ETH</b></div>
-            <div className={styles.number}><span>Conservative gas</span><b>-{prettyEth(op.gasBudgetWei)} ETH</b></div>
-            <div className={styles.number}><span>Net after gas</span><b className={BigInt(op.netAfterGasWei)>0n?styles.positive:styles.negative}>{prettyEth(op.netAfterGasWei)} ETH</b></div>
+            <div className={styles.number}><span>Net after gas</span><b className={BigInt(op.netAfterGasWei)>0n?styles.positive:styles.negative}>{prettyEth(op.netAfterGasWei)} ETH · {prettyBps(op.netAfterGasBps)}</b></div>
+            <div className={styles.number}><span>Profit-floor margin</span><b className={BigInt(op.marginToProfitFloorWei)>=0n?styles.positive:styles.negative}>{prettyBps(op.marginToProfitFloorBps)}</b></div>
           </div>
           {op.passes&&executorReady?<button className={styles.execute} disabled={busy} onClick={()=>execute(op)}>SIMULATE + EXECUTE ATOMICALLY</button>:op.passes?<div className={styles.lock}><b>EXECUTION LOCKED</b><br/>{localExecutor?'Verify the existing executor above.':<a style={{color:'inherit'}} href="/profit-engine/deploy">Deploy the reviewed executor</a>}</div>:null}
         </article>)}</div>
-        <div className={styles.footnote}>This is the only execution-capable section. Sizes never exceed MAX CAPITAL. The default net target is now 5 bps, but conservative gas is still added on top, so lowering the target does not turn a losing route into a trade. Every actual attempt still gets a fresh wallet simulation immediately before MetaMask.</div>
+        <div className={styles.footnote}>This is the only execution-capable section. Six adaptive sizes never exceed MAX CAPITAL. V5 ranks by margin to the actual contract profit floor, not by a raw price difference. Every real attempt still gets a fresh wallet simulation immediately before MetaMask.</div>
       </section>}
 
       {scan&&<section className={styles.panel}>
@@ -354,7 +374,7 @@ export default function ProfitEnginePage(){
             </>:<p className={styles.footnote}>No complete cross-venue round trip was quotable for this pair on this state.</p>}
           </article>;
         })}</div>:<div className={styles.status}>No additional wide-market routes were available on this scan.</div>}
-        <div className={styles.footnote}>Radar values are raw quote differences before a route-specific gas model, slippage reserve, contract compatibility check, or wallet simulation. They are intentionally not executable. This avoids treating a raw price discrepancy as guaranteed profit.</div>
+        <div className={styles.footnote}>Radar values are raw quote differences before a route-specific gas model, slippage reserve, contract compatibility check, or wallet simulation. They remain discovery-only so V5 never mistakes a raw price discrepancy for guaranteed profit.</div>
       </section>}
 
       <section className={styles.panel}>

--- a/lib/base-fast-grid.ts
+++ b/lib/base-fast-grid.ts
@@ -1,4 +1,4 @@
-import { scanBaseArbitrage } from './base-profit-engine';
+import { scanBaseArbitrageBatch } from './base-profit-engine';
 
 export async function scanBaseArbitrageGridParallel(input: {
   amountsEth: unknown[];
@@ -6,47 +6,56 @@ export async function scanBaseArbitrageGridParallel(input: {
   slippageBps?: unknown;
   preferFlashblocks?: boolean;
 }) {
-  const raw = Array.isArray(input.amountsEth) ? input.amountsEth : [];
-  const unique = Array.from(new Set(raw.map(value => String(value).trim()).filter(Boolean))).slice(0, 4);
-  if (!unique.length) throw new Error('Provide at least one ETH amount to optimize.');
-
-  const settled = await Promise.allSettled(unique.map(amountEth => scanBaseArbitrage({
-    amountEth,
+  const batch = await scanBaseArbitrageBatch({
+    amountsEth: input.amountsEth,
     targetBps: input.targetBps,
     slippageBps: input.slippageBps,
     preferFlashblocks: input.preferFlashblocks,
-  })));
+  });
 
-  const scans = settled
-    .filter((result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof scanBaseArbitrage>>> => result.status === 'fulfilled')
-    .map(result => result.value);
-
-  if (!scans.length) {
-    const lastFailure = settled.findLast(result => result.status === 'rejected');
-    const reason = lastFailure?.status === 'rejected'
-      ? (lastFailure.reason instanceof Error ? lastFailure.reason.message : String(lastFailure.reason))
-      : 'No executable size completed.';
-    throw new Error(`Parallel Base execution scan failed. ${reason}`);
-  }
-
-  const profitable = scans
+  const allOpportunities = batch.scans
     .flatMap(scan => scan.opportunities.map(opportunity => ({
       ...opportunity,
       scanInputEth: scan.inputEth,
       stateMode: scan.stateMode,
       scannedAt: scan.scannedAt,
     })))
-    .filter(opportunity => opportunity.passes)
-    .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
+    .sort((a, b) => BigInt(a.marginToProfitFloorWei) > BigInt(b.marginToProfitFloorWei) ? -1 : BigInt(a.marginToProfitFloorWei) < BigInt(b.marginToProfitFloorWei) ? 1 : 0);
+
+  const profitable = allOpportunities.filter(opportunity => opportunity.passes);
+  const bestQuoted = allOpportunities[0] || null;
+  const closestMarginBps = Number(bestQuoted?.marginToProfitFloorBps ?? -10000);
+  const marketHeat = profitable.length > 0
+    ? 'ACTIONABLE'
+    : closestMarginBps >= -5
+      ? 'HOT'
+      : closestMarginBps >= -20
+        ? 'WARM'
+        : 'COLD';
+  const suggestedCadenceMs = marketHeat === 'HOT'
+    ? 4000
+    : marketHeat === 'WARM'
+      ? 7000
+      : 12000;
 
   return {
-    chainId: scans[0].chainId,
-    pair: 'WETH/USDC',
-    requestedAmountsEth: unique,
-    completedAmountsEth: scans.map(scan => scan.inputEth),
+    chainId: batch.chainId,
+    pair: batch.pair,
+    requestedAmountsEth: batch.requestedAmountsEth,
+    completedAmountsEth: batch.completedAmountsEth,
     best: profitable[0] || null,
-    scans,
-    partial: scans.length !== unique.length,
-    rule: 'Parallel optimization scans up to four sizes concurrently and never executes or signs anything.',
+    bestQuoted,
+    nearMiss: profitable[0] ? null : bestQuoted,
+    marketHeat,
+    suggestedCadenceMs,
+    closestMarginBps,
+    scans: batch.scans,
+    partial: batch.partial,
+    batchLatencyMs: batch.batchLatencyMs,
+    stateMode: batch.stateMode,
+    stateObservedBlock: batch.stateObservedBlock,
+    rpcSource: batch.rpcSource,
+    flashblocks: batch.flashblocks,
+    rule: 'Boss scan ranks every executable quote by distance to the on-chain profit floor, speeds up read-only watching near an opportunity, and never executes or signs anything.',
   };
 }

--- a/lib/base-profit-engine.ts
+++ b/lib/base-profit-engine.ts
@@ -53,6 +53,13 @@ type Opportunity = {
   method: Method;
 };
 
+type ProviderScan = {
+  gasPrice: bigint;
+  gasBudgetWei: bigint;
+  targetProfitWei: bigint;
+  opportunities: Opportunity[];
+};
+
 export type SerializedOpportunity = ReturnType<typeof serializeOpportunity>;
 
 export function normalizeBps(value: unknown, fallback: number, min: number, max: number) {
@@ -137,24 +144,28 @@ async function quoteUni(
   blockTag: StateTag,
 ): Promise<Quote | null> {
   const quoter = new Contract(UNISWAP_QUOTER_V2, UNI_QUOTER_ABI, provider);
-  let best: Quote | null = null;
-  for (const fee of UNI_FEE_TIERS) {
+  const results = await Promise.all(UNI_FEE_TIERS.map(async fee => {
     try {
       const result = await withTimeout(
         quoter.getFunction('quoteExactInputSingle').staticCall(
           { tokenIn, tokenOut, amountIn, fee, sqrtPriceLimitX96: 0 },
           { blockTag },
         ),
-        4_500,
+        3_500,
         `Uniswap ${fee} ${blockTag} quote`,
       );
       const amountOut = BigInt(result[0]);
-      if (amountOut > ZERO && (!best || amountOut > best.amountOut)) {
-        best = { venue: 'Uniswap V3', amountOut, fee, quoteGas: BigInt(result[3] || 0) };
-      }
+      return amountOut > ZERO
+        ? { venue: 'Uniswap V3' as const, amountOut, fee, quoteGas: BigInt(result[3] || 0) }
+        : null;
     } catch {
-      // Missing fee tiers/pools are normal. Continue scanning the remaining tiers.
+      return null;
     }
+  }));
+
+  let best: Quote | null = null;
+  for (const result of results) {
+    if (result && (!best || result.amountOut > best.amountOut)) best = result;
   }
   return best;
 }
@@ -167,28 +178,35 @@ async function quoteAero(
   blockTag: StateTag,
 ): Promise<Quote | null> {
   const router = new Contract(AERODROME_ROUTER, AERO_ROUTER_ABI, provider);
-  let best: Quote | null = null;
-  for (const stable of [false, true]) {
+  const results = await Promise.all([false, true].map(async stable => {
     try {
       const route = [{ from: tokenIn, to: tokenOut, stable, factory: AERODROME_FACTORY }];
       const amounts = await withTimeout(
         router.getFunction('getAmountsOut').staticCall(amountIn, route, { blockTag }),
-        4_500,
+        3_500,
         `Aerodrome ${stable ? 'stable' : 'volatile'} ${blockTag} quote`,
       );
       const amountOut = BigInt(amounts?.[amounts.length - 1] || 0);
-      if (amountOut > ZERO && (!best || amountOut > best.amountOut)) {
-        best = { venue: 'Aerodrome', amountOut, stable };
-      }
+      return amountOut > ZERO ? { venue: 'Aerodrome' as const, amountOut, stable } : null;
     } catch {
-      // A missing stable/volatile pool is not fatal.
+      return null;
     }
+  }));
+
+  let best: Quote | null = null;
+  for (const result of results) {
+    if (result && (!best || result.amountOut > best.amountOut)) best = result;
   }
   return best;
 }
 
 function applySlippage(amount: bigint, bps: number) {
   return (amount * BigInt(10_000 - bps)) / BPS_DENOMINATOR;
+}
+
+function signedBps(value: bigint, input: bigint) {
+  if (input === ZERO) return 0;
+  return Number((value * BPS_DENOMINATOR) / input);
 }
 
 function serializeQuote(quote: Quote, outputDecimals: number) {
@@ -206,7 +224,9 @@ function serializeOpportunity(op: Opportunity) {
   const grossProfit = op.finalOut - op.input;
   const netAfterGas = grossProfit - op.gasBudgetWei;
   const requiredGross = op.gasBudgetWei + op.targetProfitWei;
-  const passes = grossProfit >= requiredGross;
+  const marginToProfitFloor = grossProfit - requiredGross;
+  const distanceToProfitFloor = marginToProfitFloor < ZERO ? -marginToProfitFloor : ZERO;
+  const passes = marginToProfitFloor >= ZERO;
   const minFirstOut = applySlippage(op.first.amountOut, op.slippageBps);
   const minFinalOut = applySlippage(op.finalOut, op.slippageBps);
 
@@ -223,13 +243,20 @@ function serializeOpportunity(op: Opportunity) {
     finalEth: formatEther(op.finalOut),
     grossProfitWei: grossProfit.toString(),
     grossProfitEth: formatEther(grossProfit),
+    grossProfitBps: signedBps(grossProfit, op.input),
     gasBudgetWei: op.gasBudgetWei.toString(),
     gasBudgetEth: formatEther(op.gasBudgetWei),
     targetProfitWei: op.targetProfitWei.toString(),
     targetProfitEth: formatEther(op.targetProfitWei),
     netAfterGasWei: netAfterGas.toString(),
     netAfterGasEth: formatEther(netAfterGas),
+    netAfterGasBps: signedBps(netAfterGas, op.input),
     requiredGrossProfitWei: requiredGross.toString(),
+    marginToProfitFloorWei: marginToProfitFloor.toString(),
+    marginToProfitFloorBps: signedBps(marginToProfitFloor, op.input),
+    distanceToProfitFloorWei: distanceToProfitFloor.toString(),
+    distanceToProfitFloorEth: formatEther(distanceToProfitFloor),
+    distanceToProfitFloorBps: Math.max(0, -signedBps(marginToProfitFloor, op.input)),
     minFirstOut: minFirstOut.toString(),
     minFinalOut: minFinalOut.toString(),
     minProfitWei: requiredGross.toString(),
@@ -245,6 +272,66 @@ function serializeOpportunity(op: Opportunity) {
   };
 }
 
+async function readGasPrice(provider: JsonRpcProvider) {
+  const feeData = await withTimeout(provider.getFeeData(), 3_500, 'Base fee data');
+  return feeData.maxFeePerGas || feeData.gasPrice || parseUnits('0.02', 'gwei');
+}
+
+async function scanOnProviderWithGas(
+  provider: JsonRpcProvider,
+  inputWei: bigint,
+  targetBps: number,
+  slippageBps: number,
+  blockTag: StateTag,
+  gasPrice: bigint,
+): Promise<ProviderScan> {
+  const gasBudgetWei = gasPrice * ESTIMATED_EXECUTOR_GAS + L1_DATA_FEE_BUFFER_WEI;
+  const targetProfitWei = (inputWei * BigInt(targetBps)) / BPS_DENOMINATOR;
+  const opportunities: Opportunity[] = [];
+
+  const [uniFirst, aeroFirst] = await Promise.all([
+    quoteUni(provider, WETH, USDC, inputWei, blockTag),
+    quoteAero(provider, WETH, USDC, inputWei, blockTag),
+  ]);
+
+  const [aeroSecond, uniSecond] = await Promise.all([
+    uniFirst ? quoteAero(provider, USDC, WETH, uniFirst.amountOut, blockTag) : Promise.resolve(null),
+    aeroFirst ? quoteUni(provider, USDC, WETH, aeroFirst.amountOut, blockTag) : Promise.resolve(null),
+  ]);
+
+  if (uniFirst && aeroSecond) {
+    opportunities.push({
+      id: 'uniswap-to-aerodrome',
+      first: uniFirst,
+      second: aeroSecond,
+      finalOut: aeroSecond.amountOut,
+      input: inputWei,
+      gasBudgetWei,
+      targetProfitWei,
+      slippageBps,
+      method: 'executeUniThenAero',
+    });
+  }
+
+  if (aeroFirst && uniSecond) {
+    opportunities.push({
+      id: 'aerodrome-to-uniswap',
+      first: aeroFirst,
+      second: uniSecond,
+      finalOut: uniSecond.amountOut,
+      input: inputWei,
+      gasBudgetWei,
+      targetProfitWei,
+      slippageBps,
+      method: 'executeAeroThenUni',
+    });
+  }
+
+  if (!opportunities.length) throw new Error('No complete WETH/USDC cross-DEX route could be quoted on this RPC.');
+  opportunities.sort((a, b) => (a.finalOut > b.finalOut ? -1 : a.finalOut < b.finalOut ? 1 : 0));
+  return { gasPrice, gasBudgetWei, targetProfitWei, opportunities };
+}
+
 async function scanOnProvider(
   provider: JsonRpcProvider,
   inputWei: bigint,
@@ -252,51 +339,65 @@ async function scanOnProvider(
   slippageBps: number,
   blockTag: StateTag,
 ) {
-  const feeData = await withTimeout(provider.getFeeData(), 4_000, 'Base fee data');
-  const gasPrice = feeData.maxFeePerGas || feeData.gasPrice || parseUnits('0.02', 'gwei');
-  const gasBudgetWei = gasPrice * ESTIMATED_EXECUTOR_GAS + L1_DATA_FEE_BUFFER_WEI;
-  const targetProfitWei = (inputWei * BigInt(targetBps)) / BPS_DENOMINATOR;
-  const opportunities: Opportunity[] = [];
+  const gasPrice = await readGasPrice(provider);
+  return scanOnProviderWithGas(provider, inputWei, targetBps, slippageBps, blockTag, gasPrice);
+}
 
-  const uniFirst = await quoteUni(provider, WETH, USDC, inputWei, blockTag);
-  if (uniFirst) {
-    const aeroSecond = await quoteAero(provider, USDC, WETH, uniFirst.amountOut, blockTag);
-    if (aeroSecond) {
-      opportunities.push({
-        id: 'uniswap-to-aerodrome',
-        first: uniFirst,
-        second: aeroSecond,
-        finalOut: aeroSecond.amountOut,
-        input: inputWei,
-        gasBudgetWei,
-        targetProfitWei,
-        slippageBps,
-        method: 'executeUniThenAero',
-      });
-    }
-  }
+function configuredExecutorAddress() {
+  const executorRaw = String(process.env.NEXT_PUBLIC_BASE_ARB_EXECUTOR_ADDRESS || process.env.BASE_ARB_EXECUTOR_ADDRESS || '').trim();
+  return isAddress(executorRaw) ? getAddress(executorRaw) : '';
+}
 
-  const aeroFirst = await quoteAero(provider, WETH, USDC, inputWei, blockTag);
-  if (aeroFirst) {
-    const uniSecond = await quoteUni(provider, USDC, WETH, aeroFirst.amountOut, blockTag);
-    if (uniSecond) {
-      opportunities.push({
-        id: 'aerodrome-to-uniswap',
-        first: aeroFirst,
-        second: uniSecond,
-        finalOut: uniSecond.amountOut,
-        input: inputWei,
-        gasBudgetWei,
-        targetProfitWei,
-        slippageBps,
-        method: 'executeAeroThenUni',
-      });
-    }
-  }
+function serializeScan(
+  inputWei: bigint,
+  targetBps: number,
+  slippageBps: number,
+  scanned: ProviderScan,
+  used: RpcCandidate,
+  observedState: string,
+  executorAddress: string,
+  scanLatencyMs: number,
+) {
+  const opportunities = scanned.opportunities.map(serializeOpportunity);
+  const profitable = opportunities
+    .filter(item => item.passes)
+    .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
+  const ranked = [...opportunities]
+    .sort((a, b) => BigInt(a.marginToProfitFloorWei) > BigInt(b.marginToProfitFloorWei) ? -1 : BigInt(a.marginToProfitFloorWei) < BigInt(b.marginToProfitFloorWei) ? 1 : 0);
 
-  if (!opportunities.length) throw new Error('No complete WETH/USDC cross-DEX route could be quoted on this RPC.');
-  opportunities.sort((a, b) => (a.finalOut > b.finalOut ? -1 : a.finalOut < b.finalOut ? 1 : 0));
-  return { gasPrice, gasBudgetWei, targetProfitWei, opportunities };
+  return {
+    chainId: BASE_CHAIN_ID,
+    pair: 'WETH/USDC',
+    inputWei: inputWei.toString(),
+    inputEth: formatEther(inputWei),
+    targetBps,
+    slippageBps,
+    estimatedExecutorGasUnits: ESTIMATED_EXECUTOR_GAS.toString(),
+    gasBudgetWei: scanned.gasBudgetWei.toString(),
+    gasBudgetEth: formatEther(scanned.gasBudgetWei),
+    targetProfitWei: scanned.targetProfitWei.toString(),
+    targetProfitEth: formatEther(scanned.targetProfitWei),
+    executorAddress,
+    executionEnabled: Boolean(executorAddress),
+    best: profitable[0] || null,
+    bestQuoted: ranked[0] || null,
+    opportunities,
+    scannedAt: new Date().toISOString(),
+    scanLatencyMs,
+    rpcSource: safeRpcLabel(used.url),
+    stateMode: used.flashblocks ? 'flashblocks-pending' : 'sealed-latest',
+    stateTag: used.stateTag,
+    stateObservedBlock: observedState,
+    flashblocks: used.flashblocks,
+    contracts: {
+      weth: WETH,
+      usdc: USDC,
+      uniswapQuoterV2: UNISWAP_QUOTER_V2,
+      aerodromeRouter: AERODROME_ROUTER,
+      aerodromeFactory: AERODROME_FACTORY,
+    },
+    rule: 'NO_TRADE unless quoted final WETH covers starting ETH + conservative gas budget + target profit. Live execution must still pass a fresh atomic executor simulation.',
+  };
 }
 
 export async function scanBaseArbitrage(input: {
@@ -305,12 +406,13 @@ export async function scanBaseArbitrage(input: {
   slippageBps?: unknown;
   preferFlashblocks?: boolean;
 }) {
+  const startedAt = Date.now();
   const { inputWei } = normalizeAmountEth(input.amountEth || '0.01');
   const targetBps = normalizeBps(input.targetBps, 25, 1, 1000);
   const slippageBps = normalizeBps(input.slippageBps, 15, 1, 100);
   const preferFlashblocks = input.preferFlashblocks !== false;
 
-  let scanned: Awaited<ReturnType<typeof scanOnProvider>> | null = null;
+  let scanned: ProviderScan | null = null;
   let used: RpcCandidate | null = null;
   let observedState = '';
   const errors: string[] = [];
@@ -334,45 +436,105 @@ export async function scanBaseArbitrage(input: {
     throw new Error(`Could not complete a live Base scan across ${candidates.length} RPCs. ${errors.at(-1) || ''}`);
   }
 
-  const executorRaw = String(process.env.NEXT_PUBLIC_BASE_ARB_EXECUTOR_ADDRESS || process.env.BASE_ARB_EXECUTOR_ADDRESS || '').trim();
-  const executorAddress = isAddress(executorRaw) ? getAddress(executorRaw) : '';
-  const opportunities = scanned.opportunities.map(serializeOpportunity);
-  const profitable = opportunities
-    .filter(item => item.passes)
-    .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
-
-  return {
-    chainId: BASE_CHAIN_ID,
-    pair: 'WETH/USDC',
-    inputWei: inputWei.toString(),
-    inputEth: formatEther(inputWei),
+  return serializeScan(
+    inputWei,
     targetBps,
     slippageBps,
-    estimatedExecutorGasUnits: ESTIMATED_EXECUTOR_GAS.toString(),
-    gasBudgetWei: scanned.gasBudgetWei.toString(),
-    gasBudgetEth: formatEther(scanned.gasBudgetWei),
-    targetProfitWei: scanned.targetProfitWei.toString(),
-    targetProfitEth: formatEther(scanned.targetProfitWei),
-    executorAddress,
-    executionEnabled: Boolean(executorAddress),
-    best: profitable[0] || null,
-    bestQuoted: opportunities[0] || null,
-    opportunities,
-    scannedAt: new Date().toISOString(),
-    rpcSource: safeRpcLabel(used.url),
-    stateMode: used.flashblocks ? 'flashblocks-pending' : 'sealed-latest',
-    stateTag: used.stateTag,
-    stateObservedBlock: observedState,
-    flashblocks: used.flashblocks,
-    contracts: {
-      weth: WETH,
-      usdc: USDC,
-      uniswapQuoterV2: UNISWAP_QUOTER_V2,
-      aerodromeRouter: AERODROME_ROUTER,
-      aerodromeFactory: AERODROME_FACTORY,
-    },
-    rule: 'NO_TRADE unless quoted final WETH covers starting ETH + conservative gas budget + target profit. Live execution must still pass a fresh atomic executor simulation.',
-  };
+    scanned,
+    used,
+    observedState,
+    configuredExecutorAddress(),
+    Date.now() - startedAt,
+  );
+}
+
+export async function scanBaseArbitrageBatch(input: {
+  amountsEth: unknown[];
+  targetBps?: unknown;
+  slippageBps?: unknown;
+  preferFlashblocks?: boolean;
+}) {
+  const startedAt = Date.now();
+  const normalized = Array.from(new Set((input.amountsEth || []).map(value => normalizeAmountEth(value).amount)))
+    .slice(0, 6)
+    .map(amount => normalizeAmountEth(amount));
+  if (!normalized.length) throw new Error('Provide at least one ETH amount to optimize.');
+
+  const targetBps = normalizeBps(input.targetBps, 25, 1, 1000);
+  const slippageBps = normalizeBps(input.slippageBps, 15, 1, 100);
+  const preferFlashblocks = input.preferFlashblocks !== false;
+  const executorAddress = configuredExecutorAddress();
+  const errors: string[] = [];
+  const candidates = rpcCandidates(preferFlashblocks);
+
+  for (const candidate of candidates) {
+    const provider = new JsonRpcProvider(candidate.url, BASE_CHAIN_ID, { staticNetwork: true });
+    try {
+      const [observedState, gasPrice] = await Promise.all([
+        stateHealth(provider, candidate),
+        readGasPrice(provider),
+      ]);
+      const settled = await Promise.allSettled(normalized.map(item => scanOnProviderWithGas(
+        provider,
+        item.inputWei,
+        targetBps,
+        slippageBps,
+        candidate.stateTag,
+        gasPrice,
+      )));
+
+      const elapsed = Date.now() - startedAt;
+      const scans = settled.flatMap((result, index) => {
+        if (result.status !== 'fulfilled') return [];
+        return [serializeScan(
+          normalized[index].inputWei,
+          targetBps,
+          slippageBps,
+          result.value,
+          candidate,
+          observedState,
+          executorAddress,
+          elapsed,
+        )];
+      });
+
+      if (!scans.length) throw new Error('No executable capital size completed on this RPC.');
+      const allOpportunities = scans.flatMap(scan => scan.opportunities.map(opportunity => ({
+        ...opportunity,
+        scanInputEth: scan.inputEth,
+        stateMode: scan.stateMode,
+        scannedAt: scan.scannedAt,
+      })));
+      const profitable = allOpportunities
+        .filter(opportunity => opportunity.passes)
+        .sort((a, b) => BigInt(a.marginToProfitFloorWei) > BigInt(b.marginToProfitFloorWei) ? -1 : BigInt(a.marginToProfitFloorWei) < BigInt(b.marginToProfitFloorWei) ? 1 : 0);
+      const ranked = [...allOpportunities]
+        .sort((a, b) => BigInt(a.marginToProfitFloorWei) > BigInt(b.marginToProfitFloorWei) ? -1 : BigInt(a.marginToProfitFloorWei) < BigInt(b.marginToProfitFloorWei) ? 1 : 0);
+
+      return {
+        chainId: BASE_CHAIN_ID,
+        pair: 'WETH/USDC',
+        requestedAmountsEth: normalized.map(item => item.amount),
+        completedAmountsEth: scans.map(scan => scan.inputEth),
+        best: profitable[0] || null,
+        bestQuoted: ranked[0] || null,
+        scans,
+        partial: scans.length !== normalized.length,
+        batchLatencyMs: elapsed,
+        stateMode: candidate.flashblocks ? 'flashblocks-pending' : 'sealed-latest',
+        stateObservedBlock: observedState,
+        rpcSource: safeRpcLabel(candidate.url),
+        flashblocks: candidate.flashblocks,
+        rule: 'Batch optimization shares one Base state source and one gas read across up to six concurrent capital sizes. It never executes or signs anything.',
+      };
+    } catch (error) {
+      errors.push(`${safeRpcLabel(candidate.url)}: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      provider.destroy();
+    }
+  }
+
+  throw new Error(`Could not complete a batch Base scan across ${candidates.length} RPCs. ${errors.at(-1) || ''}`);
 }
 
 export async function scanBaseArbitrageGrid(input: {
@@ -381,30 +543,13 @@ export async function scanBaseArbitrageGrid(input: {
   slippageBps?: unknown;
   preferFlashblocks?: boolean;
 }) {
-  const unique = Array.from(new Set((input.amountsEth || []).map(value => normalizeAmountEth(value).amount))).slice(0, 4);
-  if (!unique.length) throw new Error('Provide at least one ETH amount to optimize.');
-
-  const scans = [];
-  for (const amountEth of unique) {
-    scans.push(await scanBaseArbitrage({
-      amountEth,
-      targetBps: input.targetBps,
-      slippageBps: input.slippageBps,
-      preferFlashblocks: input.preferFlashblocks,
-    }));
-  }
-
-  const profitable = scans
-    .flatMap(scan => scan.opportunities.map(opportunity => ({ ...opportunity, scanInputEth: scan.inputEth, stateMode: scan.stateMode, scannedAt: scan.scannedAt })))
-    .filter(opportunity => opportunity.passes)
-    .sort((a, b) => BigInt(a.netAfterGasWei) > BigInt(b.netAfterGasWei) ? -1 : BigInt(a.netAfterGasWei) < BigInt(b.netAfterGasWei) ? 1 : 0);
-
+  const batch = await scanBaseArbitrageBatch(input);
   return {
-    chainId: BASE_CHAIN_ID,
-    pair: 'WETH/USDC',
-    requestedAmountsEth: unique,
-    best: profitable[0] || null,
-    scans,
-    rule: 'Optimization chooses the highest positive net-after-gas candidate across the requested sizes; it does not execute or sign anything.',
+    chainId: batch.chainId,
+    pair: batch.pair,
+    requestedAmountsEth: batch.requestedAmountsEth,
+    best: batch.best,
+    scans: batch.scans,
+    rule: 'Optimization chooses the highest positive margin-to-profit-floor candidate across the requested sizes; it does not execute or sign anything.',
   };
 }

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -29,16 +29,24 @@ requireText(core, "stateTag: 'pending'", 'Flashblocks must quote pending pre-con
 requireText(core, "{ blockTag }", 'DEX calls must receive an explicit state block tag');
 requireText(core, "stateMode: used.flashblocks ? 'flashblocks-pending' : 'sealed-latest'", 'responses must disclose state source');
 requireText(core, "rule: 'NO_TRADE", 'profit engine must keep a hard no-trade rule');
+requireText(core, 'Promise.all(UNI_FEE_TIERS.map', 'Uniswap fee tiers must quote concurrently');
+requireText(core, "Promise.all([false, true].map", 'Aerodrome pool types must quote concurrently');
+requireText(core, 'const [uniFirst, aeroFirst] = await Promise.all', 'both executable first legs must quote concurrently');
+requireText(core, 'export async function scanBaseArbitrageBatch', 'V5 must share state and gas across batch capital sizes');
+requireText(core, '.slice(0, 6)', 'batch scan must remain bounded to six capital sizes');
+requireText(core, 'marginToProfitFloorBps', 'executable quotes must expose distance to the actual profit floor');
 forbidText(core, 'eth_sendRawTransaction', 'market-data core must never submit transactions');
 forbidText(core, 'DEPLOYER_PRIVATE_KEY', 'market-data core must never read deployer private keys');
+forbidText(core, 'new Wallet', 'market-data core must never instantiate a signing wallet');
 
-requireText(fastGrid, 'Promise.allSettled', 'fast grid must scan execution sizes concurrently');
-requireText(fastGrid, 'scanBaseArbitrage', 'fast grid must reuse the reviewed executable quote engine');
-requireText(fastGrid, 'never executes or signs anything', 'parallel scan must remain read-only');
-forbidText(fastGrid, 'sendTransaction', 'parallel scan must never submit transactions');
-forbidText(fastGrid, 'eth_sendRawTransaction', 'parallel scan must never submit raw transactions');
-forbidText(fastGrid, 'PRIVATE_KEY', 'parallel scan must never read private keys');
-forbidText(fastGrid, 'new Wallet', 'parallel scan must never instantiate a signing wallet');
+requireText(fastGrid, 'scanBaseArbitrageBatch', 'boss grid must use the shared-state batch scanner');
+requireText(fastGrid, "? 'HOT'", 'boss grid must identify near-profit hot states');
+requireText(fastGrid, 'suggestedCadenceMs', 'boss grid must publish bounded watch cadence guidance');
+requireText(fastGrid, 'never executes or signs anything', 'boss grid must remain read-only');
+forbidText(fastGrid, 'sendTransaction', 'boss grid must never submit transactions');
+forbidText(fastGrid, 'eth_sendRawTransaction', 'boss grid must never submit raw transactions');
+forbidText(fastGrid, 'PRIVATE_KEY', 'boss grid must never read private keys');
+forbidText(fastGrid, 'new Wallet', 'boss grid must never instantiate a signing wallet');
 
 requireText(wide, "'Aerodrome Slipstream'", 'wide scanner must include Slipstream discovery');
 requireText(wide, "symbol: 'cbBTC'", 'wide scanner must include cbBTC discovery');
@@ -51,12 +59,14 @@ forbidText(wide, 'eth_sendRawTransaction', 'wide scanner must never submit raw t
 forbidText(wide, 'PRIVATE_KEY', 'wide scanner must never read private keys');
 forbidText(wide, 'new Wallet', 'wide scanner must never instantiate a signing wallet');
 
-requireText(scanRoute, 'normalized.inputWei / BigInt(8)', 'adaptive scan must test smaller capital sizes');
+requireText(scanRoute, 'normalized.inputWei / BigInt(16)', 'V5 adaptive scan must test a smaller capital size');
+requireText(scanRoute, '(normalized.inputWei * BigInt(3)) / BigInt(4)', 'V5 adaptive scan must test a three-quarter size');
 requireText(scanRoute, 'normalized.inputWei,', 'adaptive scan must include the user capital cap itself');
 forbidText(scanRoute, 'normalized.inputWei * BigInt(2)', 'adaptive scan must never exceed the user capital cap');
 requireText(scanRoute, "body?.mode === 'fast' ? 'fast' : 'wide'", 'scan endpoint must split fast and wide modes');
-requireText(scanRoute, 'scanBaseArbitrageGridParallel', 'scan endpoint must use parallel multi-size executable quotes');
-requireText(scanRoute, "scanMode: mode === 'fast' ? 'FAST_EXECUTION_V4' : 'ADAPTIVE_WIDE_V4'", 'scan endpoint must disclose V4 scan mode');
+requireText(scanRoute, 'scanBaseArbitrageGridParallel', 'scan endpoint must use boss multi-size executable quotes');
+requireText(scanRoute, "scanMode: mode === 'fast' ? 'BOSS_FAST_V5' : 'BOSS_WIDE_V5'", 'scan endpoint must disclose V5 boss mode');
+requireText(scanRoute, 'suggestedCadenceMs: grid.suggestedCadenceMs', 'scan endpoint must expose safe burst cadence guidance');
 requireText(scanRoute, 'scanBaseWideMarkets', 'wide mode must still run read-only discovery');
 forbidText(scanRoute, 'sendTransaction', 'scan route must remain read-only');
 forbidText(scanRoute, 'PRIVATE_KEY', 'scan route must never read private keys');
@@ -104,24 +114,28 @@ forbidText(deployPage, 'PRIVATE_KEY', 'browser deployment page must never read p
 
 requireText(profitPage, "const fromUrl=params.get('executor')", 'profit page must accept an existing executor recovery address');
 requireText(profitPage, 'setExecutorVerified(false)', 'recovered executor must start unverified');
-requireText(profitPage, "const [targetBps,setTargetBps]=useState('5')", 'V4 UI should use the smaller net-profit target by default');
-requireText(profitPage, 'const [autoWatch,setAutoWatch]=useState(true)', 'V4 auto-watch must start enabled');
-requireText(profitPage, "setTimeout(tick,12000)", 'auto-watch cadence must remain bounded');
-requireText(profitPage, "const mode=autoCycleRef.current===1||autoCycleRef.current%5===0?'wide':'fast'", 'auto-watch must use fast scans between periodic wide scans');
-requireText(profitPage, 'if(data.best)', 'auto-watch must detect profitable candidates');
-requireText(profitPage, 'if(automatic)setAutoWatch(false)', 'auto-watch must pause when a candidate is found');
+requireText(profitPage, "const [targetBps,setTargetBps]=useState('5')", 'V5 UI must keep a positive net-profit target by default');
+requireText(profitPage, 'const [autoWatch,setAutoWatch]=useState(true)', 'V5 boss auto-watch must start enabled');
+requireText(profitPage, 'const nextDelayRef=useRef(12000)', 'boss watcher must start from a bounded cadence');
+requireText(profitPage, 'Math.max(4000,Math.min(15000', 'boss watcher burst cadence must stay bounded between 4s and 15s');
+requireText(profitPage, "autoCycleRef.current%8===0?'wide':'fast'", 'boss watcher must use fast scans between periodic wide scans');
+requireText(profitPage, "heat==='HOT'", 'boss UI must react to near-profit hot states');
+requireText(profitPage, 'if(data.best)', 'boss watcher must detect profitable candidates');
+requireText(profitPage, 'if(automatic)setAutoWatch(false)', 'boss watcher must pause when a candidate is found');
+forbidText(profitPage, 'execute(data.best)', 'boss auto-watch must never execute a discovered candidate automatically');
 requireText(profitPage, 'const code=await browserProvider.getCode(candidate)', 'verification must first confirm deployed bytecode exists');
 requireText(profitPage, 'const executorAddress=await verifyExecutor(candidate,browserProvider);', 'device executor must be re-verified live before use');
 requireText(profitPage, 'getAddress(connectedWallet)!==APPROVED_OWNER', 'execution must require the reviewed owner wallet');
 requireText(profitPage, 'fn.staticCall(...args', 'execution must run a fresh no-spend static simulation');
 requireText(profitPage, 'fn.estimateGas(...args', 'execution must run a fresh wallet gas estimate');
 requireText(profitPage, 'simulatedGross-estimatedWalletGas<target', 'wallet execution must still clear the net target after estimated gas');
-requireText(profitPage, 'Auto-watch only reads quotes', 'UI must disclose that auto-watch cannot execute');
+requireText(profitPage, 'Boss auto-watch only reads quotes', 'UI must disclose that boss auto-watch cannot execute');
+requireText(profitPage, 'Closest executable:', 'UI must surface the nearest executable route instead of only NO TRADE');
 requireText(profitPage, 'Wide market radar', 'UI must clearly separate wide discovery from execution');
 requireText(profitPage, 'This is the only execution-capable section', 'UI must identify the only execution-capable section');
 requireText(profitPage, 'WATCH ONLY', 'wide signals must be visibly non-executable');
 forbidText(profitPage, 'PRIVATE_KEY', 'browser execution page must never read private keys');
 forbidText(profitPage, 'eth_sendRawTransaction', 'browser execution page must not bypass wallet signing');
-forbidText(profitPage, 'new Wallet', 'auto-watch page must not instantiate a signing wallet');
+forbidText(profitPage, 'new Wallet', 'boss auto-watch page must not instantiate a signing wallet');
 
 console.log('Machine revenue layer safety checks passed.');


### PR DESCRIPTION
Boss-level upgrade to the existing reviewed Base arbitrage scanner without changing wallet permissions or deploying a new executor.

Changes:
- Parallelizes Uniswap V3 fee-tier quotes and Aerodrome stable/volatile quotes.
- Evaluates both executable route directions concurrently.
- Adds a shared-state batch scanner so up to six capital sizes use one Base state source and one gas read.
- Expands adaptive sizing to six sizes at or below MAX CAPITAL, including 75% of cap.
- Scores each executable quote by margin/distance to the actual on-chain profit floor.
- Adds COLD/WARM/HOT/ACTIONABLE market heat and bounded read-only scan cadence guidance (12s/7s/4s).
- Boss auto-watch automatically enters faster burst cadence for HOT near-miss conditions.
- Surfaces the closest executable route, distance to profit floor, batch latency, net bps, and profit-floor margin in the phone UI.
- Auto-watch pauses on an actionable candidate and never calls execution itself.
- Existing live executor verification, fresh staticCall, fresh gas estimate, owner-wallet check, on-chain profit floor, and MetaMask approval remain mandatory.

No private keys, autonomous signing, raw transaction submission, new token approvals, or new contract deployment are introduced. This improves opportunity capture and ranking but cannot guarantee a profitable market spread exists at any given moment.