### PR TITLE
Fix x402 receiver wallet fallback

### DIFF
--- a/lib/x402-resource.ts
+++ b/lib/x402-resource.ts
@@ -5,6 +5,8 @@ import { NextResponse } from 'next/server';
 export const X402_VERSION = 2;
 export const X402_NETWORK = 'eip155:8453';
 export const BASE_USDC = getAddress('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+export const DEFAULT_X402_PAY_TO = getAddress('0x02f93c7547309ca50EEAB446DaEBE8ce8E694cBb');
+const ZERO_ADDRESS = getAddress('0x0000000000000000000000000000000000000000');
 
 export type X402RouteConfig = {
   amountAtomic: string;
@@ -65,7 +67,11 @@ type SettlementResponse = {
 
 function configuredPayTo() {
   const raw = String(process.env.X402_PAY_TO || process.env.PAY_TO || '').trim();
-  return isAddress(raw) ? getAddress(raw) : '';
+  if (isAddress(raw)) {
+    const normalized = getAddress(raw);
+    if (normalized !== ZERO_ADDRESS) return normalized;
+  }
+  return DEFAULT_X402_PAY_TO;
 }
 
 function facilitatorBaseUrl() {
@@ -284,7 +290,8 @@ export async function withX402Json<T>(
   if (!runtime.configured) {
     return NextResponse.json({
       error: 'Machine payments are not activated on this deployment yet.',
-      requiredConfiguration: ['X402_PAY_TO', 'X402_FACILITATOR_URL or CDP_API_KEY_ID + CDP_API_KEY_SECRET'],
+      requiredConfiguration: ['X402_FACILITATOR_URL or CDP_API_KEY_ID + CDP_API_KEY_SECRET'],
+      receiver: runtime.payTo,
       network: X402_NETWORK,
     }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
   }

--- a/scripts/test-machine-revenue-layer.mjs
+++ b/scripts/test-machine-revenue-layer.mjs
@@ -77,6 +77,10 @@ requireText(payments, "facilitatorCall('verify'", 'x402 payments must be verifie
 requireText(payments, "facilitatorCall('settle'", 'x402 payments must be settled before paid output is returned');
 requireText(payments, "'PAYMENT-RESPONSE'", 'x402 settlement receipt header must be returned');
 requireText(payments, "return 'https://api.cdp.coinbase.com/platform/v2/x402'", 'CDP Base-mainnet facilitator path must be supported');
+requireText(payments, "DEFAULT_X402_PAY_TO = getAddress('0x02f93c7547309ca50EEAB446DaEBE8ce8E694cBb')", 'x402 must pin the reviewed public receiver fallback');
+requireText(payments, "ZERO_ADDRESS = getAddress('0x0000000000000000000000000000000000000000')", 'x402 must explicitly detect the zero-address placeholder');
+requireText(payments, 'if (normalized !== ZERO_ADDRESS) return normalized;', 'x402 must ignore zero-address receiver placeholders');
+requireText(payments, 'return DEFAULT_X402_PAY_TO;', 'x402 must fall back to the reviewed public receiver when env receiver is blank or placeholder');
 forbidText(payments, 'VOXELFLIP_MINT_SIGNER_PRIVATE_KEY', 'x402 must not reuse mint signer keys');
 forbidText(payments, 'VOXELFORGE_SIGNER_PRIVATE_KEY', 'x402 must not reuse Forge signer keys');
 


### PR DESCRIPTION
Pins the reviewed public Base wallet as the built-in x402 receiver fallback.

What changed:
- Adds `DEFAULT_X402_PAY_TO` using the provided public Base wallet.
- Ignores the zero-address placeholder if `X402_PAY_TO` or `PAY_TO` is blank/placeholder.
- Leaves real non-zero Vercel `X402_PAY_TO` overrides supported.
- Updates the not-configured response so missing facilitator credentials are the remaining blocker.
- Adds a release safety guard so the fallback cannot be removed silently.

Safety:
- Public wallet address only.
- No private key, seed phrase, signing wallet, transaction submission, or secret handling.
- x402 still requires facilitator/CDP configuration before machine payments can fully settle.