### PR TITLE
Complete Digital REIT sandbox funding loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ DINARI_API_SECRET_KEY=
 DINARI_ENTITY_ID=
 DINARI_ACCOUNT_ID=
 DINARI_REAL_ESTATE_SYMBOLS=VNQ,SCHH,XLRE,REET,O,PLD,AMT,WELL
+# Preview-only test controls. The faucet mints provider sandbox mock tokens with no real-world value.
+DINARI_SANDBOX_FAUCET_ENABLED=false
 # Allows only capped Dinari SANDBOX orders (currently max $25). No real money can execute.
 DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=false
 # This flag cannot unlock production trading by itself. Production is also code-locked.

--- a/app/api/digital-reits/sandbox-fund/route.ts
+++ b/app/api/digital-reits/sandbox-fund/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getDinariConfig, mintSandboxFunds } from '../../../../lib/real-estate/dinari';
+
+export const dynamic = 'force-dynamic';
+
+function sameOrigin(request: Request) {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  return origin === new URL(request.url).origin;
+}
+
+export async function POST(request: Request) {
+  const config = getDinariConfig(process.env);
+
+  if (config.environment !== 'sandbox') {
+    return NextResponse.json({ ok: false, error: 'Live Dinari environments are not accepted by this route.' }, { status: 423 });
+  }
+
+  if (!sameOrigin(request)) {
+    return NextResponse.json({ ok: false, error: 'Sandbox funding request must originate from this Voxel Vault deployment.' }, { status: 403 });
+  }
+
+  if (!config.sandboxFaucetEnabled) {
+    return NextResponse.json({
+      ok: false,
+      error: 'Dinari sandbox faucet is locked. Configure sandbox credentials, account ID and DINARI_SANDBOX_FAUCET_ENABLED=true in Preview only.',
+    }, { status: 423 });
+  }
+
+  try {
+    const funding = await mintSandboxFunds(process.env);
+    return NextResponse.json({ ok: true, environment: 'sandbox', ...funding });
+  } catch (error: any) {
+    return NextResponse.json({ ok: false, error: error?.message || 'Sandbox funding failed.' }, { status: 422 });
+  }
+}

--- a/app/api/property-platform/status/route.ts
+++ b/app/api/property-platform/status/route.ts
@@ -28,6 +28,7 @@ export async function GET() {
       environment: dinari.environment,
       credentialsConfigured: dinari.credentialsConfigured,
       accountConfigured: dinari.accountConfigured,
+      sandboxFaucetEnabled: dinari.sandboxFaucetEnabled,
       sandboxTradingEnabled: dinari.sandboxTradingEnabled,
       productionTradingEnabled: dinari.productionTradingEnabled,
       symbols: dinari.symbols,
@@ -45,7 +46,9 @@ export async function GET() {
       dinariDigitalReitProviderAdapter: true,
       providerBackedReitCatalog: true,
       providerBackedPortfolioRead: true,
+      providerBackedCashRead: true,
       providerBackedDividendRead: true,
+      sandboxMockFunding: true,
       cappedSandboxSecurityOrders: true,
       jurisdictionAcquisitionGate: true,
       regulatedLaunchGateEngine: true,
@@ -63,9 +66,10 @@ export async function GET() {
       acquisitionStatus: '/api/property-platform/acquisition',
       digitalReitVault: '/real-estate/reits',
       digitalReitStatus: '/api/digital-reits',
+      digitalReitSandboxFunding: '/api/digital-reits/sandbox-fund',
     },
     note: launch.liveInvestingEnabled
       ? 'Controlled live mode is active through the approved production integration.'
-      : 'Fail-closed regulated launch build: sandbox tokenized-security testing is supported, but no live investor funds, live securities purchase, automated property acquisition or public security-token sale can execute from this code.',
+      : 'Fail-closed regulated launch build: sandbox tokenized-security testing and mock funding are supported, but no live investor funds, live securities purchase, automated property acquisition or public security-token sale can execute from this code.',
   });
 }

--- a/app/real-estate/reits/DigitalReitDashboard.js
+++ b/app/real-estate/reits/DigitalReitDashboard.js
@@ -26,13 +26,35 @@ function shellCard(extra = {}) {
 export default function DigitalReitDashboard({ snapshot }) {
   const router = useRouter();
   const [busyId, setBusyId] = useState('');
+  const [funding, setFunding] = useState(false);
   const [message, setMessage] = useState('');
 
   const portfolioBySymbol = new Map((snapshot.portfolio || []).map((position) => [position.symbol, position]));
   const paidDividends = (snapshot.dividends || []).reduce((sum, item) => sum + Number(item.amount || 0), 0);
+  const sandboxCash = (snapshot.cash || []).reduce((sum, item) => sum + Number(item.amount || 0), 0);
+
+  async function fundSandbox() {
+    if (!snapshot.sandboxFaucetEnabled || funding || busyId) return;
+    const accepted = window.confirm('Mint Dinari sandbox test funds to this configured account? These are mock tokens only and have no real-world value.');
+    if (!accepted) return;
+
+    setFunding(true);
+    setMessage('');
+    try {
+      const response = await fetch('/api/digital-reits/sandbox-fund', { method: 'POST' });
+      const payload = await response.json();
+      if (!response.ok || !payload.ok) throw new Error(payload.error || 'Sandbox funding failed.');
+      setMessage(`Added ${payload.amount || 1000} ${payload.symbol || 'mockUSD'} test funds. Refreshing provider balances…`);
+      router.refresh();
+    } catch (error) {
+      setMessage(error?.message || 'Sandbox funding failed.');
+    } finally {
+      setFunding(false);
+    }
+  }
 
   async function sandboxBuy(asset, amount) {
-    if (!snapshot.sandboxTradingEnabled || busyId) return;
+    if (!snapshot.sandboxTradingEnabled || busyId || funding) return;
     const accepted = window.confirm(`Place a $${amount} Dinari SANDBOX market buy for ${asset.symbol}? This uses test funds only.`);
     if (!accepted) return;
 
@@ -58,7 +80,7 @@ export default function DigitalReitDashboard({ snapshot }) {
 
   return (
     <div style={{display:'grid',gap:20}}>
-      <section style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(210px,1fr))',gap:12}}>
+      <section style={{display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(190px,1fr))',gap:12}}>
         <div style={shellCard()}>
           <div style={label}>PROVIDER</div>
           <div style={value}>{snapshot.provider}</div>
@@ -75,9 +97,14 @@ export default function DigitalReitDashboard({ snapshot }) {
           <div style={sub}>Configured account only</div>
         </div>
         <div style={shellCard()}>
+          <div style={label}>SANDBOX CASH</div>
+          <div style={value}>{usd(sandboxCash)}</div>
+          <div style={sub}>{snapshot.cash?.length || 0} payment-token balance(s)</div>
+        </div>
+        <div style={shellCard()}>
           <div style={label}>DIVIDENDS OBSERVED</div>
           <div style={value}>{usd(paidDividends)}</div>
-          <div style={sub}>{snapshot.dividends.length} provider payment record(s)</div>
+          <div style={sub}>{snapshot.dividends.length} verified real-estate payment record(s)</div>
         </div>
       </section>
 
@@ -87,10 +114,31 @@ export default function DigitalReitDashboard({ snapshot }) {
         <section style={shellCard({padding:28})}>
           <div style={label}>CONNECTION REQUIRED</div>
           <h2 style={{fontSize:'clamp(1.8rem,4vw,3rem)',letterSpacing:'-.05em',margin:'9px 0'}}>The Digital REIT Vault is built. Dinari sandbox credentials are the missing plug.</h2>
-          <p style={copy}>Once the server-side API key, secret and account ID are configured, this page stops using placeholders and pulls the live provider catalog, account positions and dividend records. Credentials never go to the browser.</p>
+          <p style={copy}>Once the server-side API key, secret and account ID are configured, this page stops using placeholders and pulls the provider catalog, account positions, cash balances and dividend records. Credentials never go to the browser.</p>
           <div style={{display:'flex',gap:8,flexWrap:'wrap',marginTop:18}}>
             {snapshot.symbols.map((symbol) => <span key={symbol} style={chip}>{symbol}</span>)}
           </div>
+        </section>
+      ) : null}
+
+      {snapshot.environment === 'sandbox' && snapshot.credentialsConfigured && snapshot.accountConfigured ? (
+        <section style={shellCard({borderColor:'#435434',padding:26})}>
+          <div style={label}>SANDBOX TEST WALLET</div>
+          <div style={{display:'grid',gridTemplateColumns:'minmax(0,1fr) auto',gap:18,alignItems:'center',marginTop:8}}>
+            <div>
+              <h2 style={{fontSize:26,letterSpacing:'-.045em',margin:'0 0 6px'}}>Fund → buy → verify holding.</h2>
+              <p style={{...copy,margin:0}}>Dinari's official sandbox faucet mints 1,000 mockUSD-equivalent test tokens to the configured account. They have no real-world value. After funding, the $5 buttons can exercise the managed sandbox order flow.</p>
+            </div>
+            <button
+              type="button"
+              onClick={fundSandbox}
+              disabled={!snapshot.sandboxFaucetEnabled || funding || Boolean(busyId)}
+              style={{...buyButton,width:'auto',minWidth:190,marginTop:0,opacity:(!snapshot.sandboxFaucetEnabled || funding || busyId) ? .42 : 1,cursor:(!snapshot.sandboxFaucetEnabled || funding || busyId) ? 'not-allowed':'pointer'}}
+            >
+              {funding ? 'FUNDING…' : 'ADD 1,000 TEST FUNDS'}
+            </button>
+          </div>
+          {!snapshot.sandboxFaucetEnabled ? <p style={{...copy,margin:'12px 0 0',fontSize:11}}>Faucet is locked until <b>DINARI_SANDBOX_FAUCET_ENABLED=true</b> is set in the Preview environment.</p> : null}
         </section>
       ) : null}
 
@@ -132,9 +180,9 @@ export default function DigitalReitDashboard({ snapshot }) {
                   </div>
                   <button
                     type="button"
-                    disabled={!snapshot.sandboxTradingEnabled || Boolean(busyId)}
+                    disabled={!snapshot.sandboxTradingEnabled || Boolean(busyId) || funding}
                     onClick={() => sandboxBuy(asset, 5)}
-                    style={{...buyButton,opacity:(!snapshot.sandboxTradingEnabled || busyId) ? .42 : 1,cursor:(!snapshot.sandboxTradingEnabled || busyId) ? 'not-allowed':'pointer'}}
+                    style={{...buyButton,opacity:(!snapshot.sandboxTradingEnabled || busyId || funding) ? .42 : 1,cursor:(!snapshot.sandboxTradingEnabled || busyId || funding) ? 'not-allowed':'pointer'}}
                   >
                     {busyId === asset.id ? 'SUBMITTING…' : 'BUY $5 · SANDBOX'}
                   </button>
@@ -156,15 +204,15 @@ export default function DigitalReitDashboard({ snapshot }) {
           <div key={item.id || `${item.symbol}-${index}`} style={{display:'grid',gridTemplateColumns:'1fr auto auto',gap:12,padding:'11px 0',borderTop:'1px solid #222a21',fontSize:13,alignItems:'center'}}>
             <b>{item.symbol || 'Real-estate security'}</b>
             <span style={{color:'#9ba897'}}>{item.payableDate || item.status || 'Provider record'}</span>
-            <b>{usd(item.amount)}</b>
+            <b>{usd(item.amount)} {item.currency && item.currency !== 'USD' ? item.currency : ''}</b>
           </div>
-        )) : <p style={{...copy,margin:0}}>No real provider dividend payments are available for the configured account yet.</p>}
+        )) : <p style={{...copy,margin:0}}>No provider dividend payments tied to the confirmed real-estate catalog are available for the configured account yet.</p>}
       </section>
 
       <section style={shellCard({borderColor:'#3b4933'})}>
         <div style={label}>PRODUCTION BOUNDARY</div>
         <h3 style={{fontSize:24,margin:'7px 0'}}>Sandbox can execute. Production cannot.</h3>
-        <p style={{...copy,margin:0}}>The sandbox button sends a real request to Dinari's sandbox order API when explicitly enabled. The production trading implementation is still hard-disabled in code, so changing an environment variable alone cannot turn this into unattended real-money trading.</p>
+        <p style={{...copy,margin:0}}>Sandbox funding and buy controls call Dinari's real sandbox API when explicitly enabled. They use mock assets only. The production trading implementation is still hard-disabled in code, so changing environment variables alone cannot turn this into unattended real-money trading.</p>
       </section>
     </div>
   );

--- a/docs/DIGITAL_REITS_DINARI.md
+++ b/docs/DIGITAL_REITS_DINARI.md
@@ -7,12 +7,15 @@ Voxel Vault's first real tokenized-securities provider adapter targets Dinari's 
 - `/real-estate/reits` Digital REIT Vault.
 - Server-side Dinari API authentication.
 - Provider-backed stock/ETF catalog filtering for a configurable real-estate watchlist.
-- Provider-backed account portfolio reads.
-- Provider-backed dividend-payment reads.
+- Provider-backed account portfolio and cash-balance reads.
+- Provider-backed dividend-payment reads using Dinari's required date window.
+- Dividend records are fail-closed to stock IDs returned in the confirmed real-estate catalog.
 - `/api/digital-reits` safe status/snapshot endpoint with no credentials exposed.
-- `/api/digital-reits/sandbox-buy` same-origin, sandbox-only managed market-buy endpoint.
+- `/api/digital-reits/sandbox-fund` same-origin, sandbox-only faucet route.
+- `/api/digital-reits/sandbox-buy` same-origin, sandbox-only managed market-buy route.
+- Official sandbox faucet flow mints 1,000 mockUSD test funds to the configured managed account.
 - Hard $25 sandbox order cap.
-- Production trading hard-disabled in code.
+- Production trading and production funding remain hard-disabled in code.
 
 ## Dinari environment
 
@@ -25,7 +28,7 @@ Voxel Vault defaults to sandbox.
 
 ## Required sandbox variables
 
-Configure these as server-side Vercel environment variables. Never prefix credentials with `NEXT_PUBLIC_`.
+Configure these as server-side Vercel **Preview** environment variables first. Never prefix credentials with `NEXT_PUBLIC_`.
 
 ```text
 DINARI_ENVIRONMENT=sandbox
@@ -34,6 +37,7 @@ DINARI_API_SECRET_KEY=...
 DINARI_ENTITY_ID=...
 DINARI_ACCOUNT_ID=...
 DINARI_REAL_ESTATE_SYMBOLS=VNQ,SCHH,XLRE,REET,O,PLD,AMT,WELL
+DINARI_SANDBOX_FAUCET_ENABLED=false
 DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=false
 DINARI_PRODUCTION_TRADING_ENABLED=false
 ```
@@ -42,24 +46,28 @@ The watchlist is only a query filter. The UI labels an asset provider-confirmed 
 
 ## Activation order
 
-1. Create the Dinari partner/sandbox account.
+1. Create the Dinari partner/sandbox account at the official partner dashboard.
 2. Generate sandbox API Key ID and API Secret Key.
 3. Create or identify a sandbox Entity.
-4. Complete the provider's required sandbox KYC path.
+4. Complete Dinari's required sandbox KYC path.
 5. Create or identify an Account with a Dinari-managed wallet for the current managed-order test flow.
 6. Configure the server-side values in Vercel Preview first.
-7. Leave `DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=false` and verify catalog/portfolio/dividend reads.
-8. Enable the sandbox-order flag only after the account has test funds.
-9. Submit a $5 sandbox buy from `/real-estate/reits` and reconcile the resulting order/portfolio.
-10. Keep production trading disabled until the U.S. partner/compliance arrangement, onboarding flow, customer ownership model, disclosures, reconciliation, security review and production API configuration are approved.
+7. Leave both sandbox action flags `false` and verify catalog, portfolio, cash and dividend reads.
+8. Set `DINARI_SANDBOX_FAUCET_ENABLED=true` in Preview and use **ADD 1,000 TEST FUNDS**.
+9. Verify the provider cash balance appears in the Digital REIT Vault.
+10. Set `DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=true` in Preview.
+11. Submit a $5 sandbox buy from `/real-estate/reits` and reconcile the resulting provider order and portfolio holding.
+12. Keep production trading disabled until the U.S. partner/compliance arrangement, onboarding flow, customer ownership model, disclosures, reconciliation, security review and production API configuration are approved.
 
 ## Safety invariants
 
 - `DINARI_LIVE_TRADING_IMPLEMENTATION_READY` is `false`.
 - No environment variable can unlock live trading.
-- The sandbox-buy server function refuses `DINARI_ENVIRONMENT=live`.
+- Sandbox funding and buying refuse `DINARI_ENVIRONMENT=live`.
 - Sandbox buys are capped at $25 per request.
+- The faucet uses mock tokens only; it cannot fund a production account.
 - The browser never receives the API key ID or API secret.
+- Dividend records are not assumed to be real-estate distributions unless their `stock_id` is in the provider-confirmed real-estate catalog.
 - The live property-acquisition engine remains a separate legal/title workflow.
 - Digital REIT/dShare ownership is not represented as ownership of a specific deed.
 
@@ -67,6 +75,8 @@ The watchlist is only a query filter. The UI labels an asset provider-confirmed 
 
 - Quickstart: https://docs.dinari.com/docs/quickstart
 - Environments: https://docs.dinari.com/reference/environments
+- Funding accounts through wallets / sandbox faucet: https://docs.dinari.com/docs/funding-accounts-through-wallets
+- Cash balances: https://docs.dinari.com/reference/getaccountcash
 - Stock data: https://docs.dinari.com/docs/stock-data
 - Placing orders: https://docs.dinari.com/docs/placing-orders
 - KYC: https://docs.dinari.com/docs/managing-kyc

--- a/lib/real-estate/dinari.js
+++ b/lib/real-estate/dinari.js
@@ -3,6 +3,7 @@ const LIVE_BASE_URL = 'https://api-enterprise.sbt.dinari.com/api/v2';
 
 export const DINARI_LIVE_TRADING_IMPLEMENTATION_READY = false;
 export const DINARI_SANDBOX_ORDER_MAX_USD = 25;
+export const DINARI_SANDBOX_FAUCET_AMOUNT = 1000;
 
 const DEFAULT_REAL_ESTATE_SYMBOLS = Object.freeze([
   'VNQ',
@@ -33,6 +34,7 @@ export function getDinariConfig(env = {}) {
   const accountId = clean(env.DINARI_ACCOUNT_ID);
   const entityId = clean(env.DINARI_ENTITY_ID);
   const sandboxOrderFlag = env.DINARI_SANDBOX_ORDER_EXECUTION_ENABLED === 'true';
+  const sandboxFaucetFlag = env.DINARI_SANDBOX_FAUCET_ENABLED === 'true';
   const productionTradingFlag = env.DINARI_PRODUCTION_TRADING_ENABLED === 'true';
   const credentialsConfigured = Boolean(apiKeyId && apiSecretKey);
   const accountConfigured = Boolean(accountId);
@@ -50,7 +52,9 @@ export function getDinariConfig(env = {}) {
     accountConfigured,
     symbols,
     sandboxOrderFlag,
+    sandboxFaucetFlag,
     sandboxTradingEnabled: Boolean(environment === 'sandbox' && credentialsConfigured && accountConfigured && sandboxOrderFlag),
+    sandboxFaucetEnabled: Boolean(environment === 'sandbox' && credentialsConfigured && accountConfigured && sandboxFaucetFlag),
     productionTradingEnabled: Boolean(
       environment === 'live' &&
       credentialsConfigured &&
@@ -161,23 +165,62 @@ export async function getDigitalRealEstatePortfolio(env = process.env) {
   return normalizePortfolio(payload).filter((asset) => allowed.has(asset.symbol));
 }
 
-function normalizeDividendPayments(payload) {
-  return resultItems(payload).map((payment = {}) => ({
-    id: clean(payment.id),
-    stockId: clean(payment.stock_id || payment.stock?.id),
-    symbol: clean(payment.symbol || payment.stock?.symbol).toUpperCase(),
-    amount: Number(payment.amount || payment.payment_amount || payment.cash_amount || 0),
-    payableDate: clean(payment.payable_date || payment.payment_date || payment.created_at),
-    status: clean(payment.status),
-  }));
+function normalizeCash(payload) {
+  return resultItems(payload).map((balance = {}) => ({
+    symbol: clean(balance.symbol).toUpperCase(),
+    amount: Number(balance.amount || 0),
+    chainId: clean(balance.chain_id),
+    tokenAddress: clean(balance.token_address),
+  })).filter((balance) => balance.symbol);
 }
 
-export async function getDigitalRealEstateDividends(env = process.env) {
+export async function getDigitalRealEstateCash(env = process.env) {
   const config = getDinariConfig(env);
   if (!config.credentialsConfigured || !config.accountConfigured) return [];
-  const payload = await dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/dividend_payments?limit=100&order=desc`, { env });
-  const allowed = new Set(config.symbols);
-  return normalizeDividendPayments(payload).filter((payment) => !payment.symbol || allowed.has(payment.symbol));
+  const payload = await dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/cash`, { env });
+  return normalizeCash(payload);
+}
+
+function normalizeDividendPayments(payload, stockById = new Map()) {
+  return resultItems(payload).map((payment = {}) => {
+    const stockId = clean(payment.stock_id || payment.stock?.id);
+    const mapped = stockById.get(stockId);
+    return {
+      id: clean(payment.id || `${stockId}-${payment.payment_date || payment.payable_date || ''}`),
+      stockId,
+      symbol: clean(payment.symbol || payment.stock?.symbol || mapped?.symbol).toUpperCase(),
+      amount: Number(payment.amount || payment.payment_amount || payment.cash_amount || 0),
+      currency: clean(payment.currency || 'USD'),
+      payableDate: clean(payment.payable_date || payment.payment_date || payment.created_at),
+      status: clean(payment.status),
+    };
+  });
+}
+
+function dividendWindow(now = new Date()) {
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() + 1);
+  const start = new Date(now);
+  start.setUTCFullYear(start.getUTCFullYear() - 1);
+  const isoDate = (date) => date.toISOString().slice(0, 10);
+  return { startDate: isoDate(start), endDate: isoDate(end) };
+}
+
+export async function getDigitalRealEstateDividends(env = process.env, catalog = []) {
+  const config = getDinariConfig(env);
+  if (!config.credentialsConfigured || !config.accountConfigured || !catalog.length) return [];
+
+  const stockById = new Map(catalog.map((asset) => [asset.id, asset]));
+  const allowedStockIds = new Set(stockById.keys());
+  const { startDate, endDate } = dividendWindow();
+  const params = new URLSearchParams({
+    start_date: startDate,
+    end_date: endDate,
+    limit: '100',
+    order: 'desc',
+  });
+  const payload = await dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/dividend_payments?${params.toString()}`, { env });
+  return normalizeDividendPayments(payload, stockById).filter((payment) => allowedStockIds.has(payment.stockId));
 }
 
 export async function getDigitalReitSnapshot(env = process.env) {
@@ -188,30 +231,58 @@ export async function getDigitalReitSnapshot(env = process.env) {
     credentialsConfigured: config.credentialsConfigured,
     accountConfigured: config.accountConfigured,
     sandboxTradingEnabled: config.sandboxTradingEnabled,
+    sandboxFaucetEnabled: config.sandboxFaucetEnabled,
     productionTradingEnabled: config.productionTradingEnabled,
     productionTradingImplementationReady: DINARI_LIVE_TRADING_IMPLEMENTATION_READY,
     symbols: config.symbols,
     catalog: [],
     portfolio: [],
+    cash: [],
     dividends: [],
     errors: [],
   };
 
   if (!config.credentialsConfigured) return snapshot;
 
+  try {
+    snapshot.catalog = await listDigitalRealEstateAssets(env);
+  } catch (error) {
+    snapshot.errors.push(`catalog: ${error?.message || 'provider request failed'}`);
+  }
+
   const results = await Promise.allSettled([
-    listDigitalRealEstateAssets(env),
     getDigitalRealEstatePortfolio(env),
-    getDigitalRealEstateDividends(env),
+    getDigitalRealEstateCash(env),
+    getDigitalRealEstateDividends(env, snapshot.catalog),
   ]);
 
-  const keys = ['catalog', 'portfolio', 'dividends'];
+  const keys = ['portfolio', 'cash', 'dividends'];
   results.forEach((result, index) => {
     if (result.status === 'fulfilled') snapshot[keys[index]] = result.value;
     else snapshot.errors.push(`${keys[index]}: ${result.reason?.message || 'provider request failed'}`);
   });
 
   return snapshot;
+}
+
+export async function mintSandboxFunds(env = process.env) {
+  const config = getDinariConfig(env);
+  if (config.environment !== 'sandbox') throw new Error('Sandbox faucet refuses non-sandbox Dinari environments.');
+  if (!config.sandboxFaucetEnabled) throw new Error('Dinari sandbox faucet is not enabled.');
+
+  await dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/faucet`, {
+    env,
+    method: 'POST',
+    body: { chain_id: 'eip155:42161' },
+  });
+
+  return {
+    minted: true,
+    amount: DINARI_SANDBOX_FAUCET_AMOUNT,
+    symbol: 'mockUSD',
+    chainId: 'eip155:42161',
+    realMoney: false,
+  };
 }
 
 export async function createSandboxMarketBuy({ stockId, paymentAmount }, env = process.env) {

--- a/scripts/test-digital-reits.mjs
+++ b/scripts/test-digital-reits.mjs
@@ -62,7 +62,7 @@ global.fetch = async (url, options = {}) => {
     ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
   if (href.endsWith('/accounts/account-test/faucet')) {
-    return new Response('', { status: 204 });
+    return new Response(null, { status: 204 });
   }
   if (href.includes('/order_requests/market_buy')) {
     return new Response(JSON.stringify({ id: 'sandbox-order-1', status: 'PENDING' }), { status: 200, headers: { 'Content-Type': 'application/json' } });

--- a/scripts/test-digital-reits.mjs
+++ b/scripts/test-digital-reits.mjs
@@ -1,14 +1,19 @@
 import assert from 'node:assert/strict';
 import {
   DINARI_LIVE_TRADING_IMPLEMENTATION_READY,
+  DINARI_SANDBOX_FAUCET_AMOUNT,
   DINARI_SANDBOX_ORDER_MAX_USD,
   createSandboxMarketBuy,
+  getDigitalRealEstateCash,
+  getDigitalRealEstateDividends,
   getDinariConfig,
   listDigitalRealEstateAssets,
+  mintSandboxFunds,
 } from '../lib/real-estate/dinari.js';
 
 assert.equal(DINARI_LIVE_TRADING_IMPLEMENTATION_READY, false, 'production trading must remain code-locked');
 assert.equal(DINARI_SANDBOX_ORDER_MAX_USD, 25, 'sandbox order cap changed unexpectedly');
+assert.equal(DINARI_SANDBOX_FAUCET_AMOUNT, 1000, 'sandbox faucet amount changed unexpectedly');
 
 const live = getDinariConfig({
   DINARI_ENVIRONMENT: 'live',
@@ -16,10 +21,12 @@ const live = getDinariConfig({
   DINARI_API_SECRET_KEY: 'test-secret',
   DINARI_ACCOUNT_ID: 'account-test',
   DINARI_PRODUCTION_TRADING_ENABLED: 'true',
+  DINARI_SANDBOX_FAUCET_ENABLED: 'true',
 });
 assert.equal(live.environment, 'live');
 assert.equal(live.productionTradingEnabled, false, 'environment variables must not unlock production trading');
 assert.equal(live.sandboxTradingEnabled, false, 'live environment cannot use sandbox trading path');
+assert.equal(live.sandboxFaucetEnabled, false, 'live environment cannot use sandbox faucet path');
 
 const sandboxLocked = getDinariConfig({
   DINARI_ENVIRONMENT: 'sandbox',
@@ -28,19 +35,36 @@ const sandboxLocked = getDinariConfig({
   DINARI_ACCOUNT_ID: 'account-test',
 });
 assert.equal(sandboxLocked.sandboxTradingEnabled, false, 'sandbox trading requires explicit enable flag');
+assert.equal(sandboxLocked.sandboxFaucetEnabled, false, 'sandbox faucet requires explicit enable flag');
 assert.ok(sandboxLocked.symbols.includes('VNQ'), 'default real-estate watchlist should include VNQ');
 
 const originalFetch = global.fetch;
 const calls = [];
 global.fetch = async (url, options = {}) => {
-  calls.push({ url: String(url), options });
-  if (String(url).includes('/market_data/stocks/')) {
+  const href = String(url);
+  calls.push({ url: href, options });
+
+  if (href.includes('/market_data/stocks/')) {
     return new Response(JSON.stringify({ data: [
       { id: 'stock-vnq', symbol: 'VNQ', name: 'Example REIT ETF', is_fractionable: true },
       { id: 'stock-aapl', symbol: 'AAPL', name: 'Not real estate' },
     ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
-  if (String(url).includes('/order_requests/market_buy')) {
+  if (href.endsWith('/accounts/account-test/cash')) {
+    return new Response(JSON.stringify([
+      { symbol: 'mockUSD', amount: 1000, chain_id: 'eip155:42161', token_address: '0xmock' },
+    ]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (href.includes('/dividend_payments?')) {
+    return new Response(JSON.stringify({ data: [
+      { stock_id: 'stock-vnq', amount: 1.25, currency: 'USD', payment_date: '2026-08-01' },
+      { stock_id: 'stock-aapl', amount: 9.99, currency: 'USD', payment_date: '2026-08-01' },
+    ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (href.endsWith('/accounts/account-test/faucet')) {
+    return new Response('', { status: 204 });
+  }
+  if (href.includes('/order_requests/market_buy')) {
     return new Response(JSON.stringify({ id: 'sandbox-order-1', status: 'PENDING' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
   throw new Error(`Unexpected fetch: ${url}`);
@@ -53,6 +77,7 @@ try {
     DINARI_API_SECRET_KEY: 'test-secret',
     DINARI_ACCOUNT_ID: 'account-test',
     DINARI_SANDBOX_ORDER_EXECUTION_ENABLED: 'true',
+    DINARI_SANDBOX_FAUCET_ENABLED: 'true',
     DINARI_REAL_ESTATE_SYMBOLS: 'VNQ,SCHH',
   };
 
@@ -61,6 +86,27 @@ try {
   assert.equal(assets[0].symbol, 'VNQ');
   assert.ok(calls[0].url.startsWith('https://api-enterprise.sandbox.dinari.com/api/v2/'), 'sandbox adapter must use sandbox base URL');
   assert.equal(calls[0].options.headers['X-API-Key-Id'], 'test-key', 'provider auth header missing');
+
+  const cash = await getDigitalRealEstateCash(env);
+  assert.equal(cash.length, 1);
+  assert.equal(cash[0].symbol, 'MOCKUSD');
+  assert.equal(cash[0].amount, 1000);
+
+  const dividends = await getDigitalRealEstateDividends(env, assets);
+  assert.equal(dividends.length, 1, 'dividends for non-real-estate stocks must be excluded');
+  assert.equal(dividends[0].stockId, 'stock-vnq');
+  assert.equal(dividends[0].symbol, 'VNQ');
+  const dividendCall = calls.find((call) => call.url.includes('/dividend_payments?'));
+  assert.ok(dividendCall?.url.includes('start_date='), 'Dinari dividend request must include required start_date');
+  assert.ok(dividendCall?.url.includes('end_date='), 'Dinari dividend request must include required end_date');
+
+  const funding = await mintSandboxFunds(env);
+  assert.equal(funding.realMoney, false);
+  assert.equal(funding.amount, 1000);
+  const faucetCall = calls.find((call) => call.url.endsWith('/accounts/account-test/faucet'));
+  assert.ok(faucetCall, 'sandbox faucet endpoint was not called');
+  assert.equal(faucetCall.options.method, 'POST');
+  assert.deepEqual(JSON.parse(faucetCall.options.body), { chain_id: 'eip155:42161' });
 
   const order = await createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 5 }, env);
   assert.equal(order.id, 'sandbox-order-1');
@@ -82,8 +128,14 @@ try {
     /refuses non-sandbox/,
     'sandbox order function must refuse live environment',
   );
+
+  await assert.rejects(
+    () => mintSandboxFunds({ ...env, DINARI_ENVIRONMENT: 'live' }),
+    /refuses non-sandbox/,
+    'sandbox faucet must refuse live environment',
+  );
 } finally {
   global.fetch = originalFetch;
 }
 
-console.log('Digital REIT safety checks passed: provider catalog filtering works, secrets stay server-side, sandbox orders are capped and explicitly enabled, and production trading remains code-locked.');
+console.log('Digital REIT safety checks passed: provider catalog/dividends are real-estate filtered, cash and sandbox faucet flows are modeled, sandbox orders remain capped, and production trading/funding remain code-locked.');


### PR DESCRIPTION
## What this adds

- Adds Dinari sandbox cash-balance reads to the Digital REIT Vault.
- Adds `/api/digital-reits/sandbox-fund`, a same-origin sandbox-only faucet route.
- Adds an **ADD 1,000 TEST FUNDS** control for the official Dinari mockUSD sandbox faucet.
- Fixes dividend retrieval to include Dinari's required `start_date` and `end_date` query parameters.
- Maps dividend `stock_id` values against the provider-confirmed real-estate catalog and fails closed: unrelated stock dividends are excluded.
- Exposes sandbox faucet readiness through the property-platform status endpoint.
- Extends the Digital REIT safety regression to cover cash, faucet, date-range dividends, real-estate-only dividend filtering, sandbox-only funding, the $25 order cap, and the production lock.

## Intended sandbox loop

`Dinari sandbox credentials -> account -> faucet 1,000 mockUSD -> cash balance -> $5 provider market buy -> dShare portfolio holding -> provider dividend records`

## Safety boundary

- Faucet uses provider sandbox mock assets only.
- Faucet is disabled by default and requires `DINARI_SANDBOX_FAUCET_ENABLED=true`.
- Faucet refuses `DINARI_ENVIRONMENT=live`.
- Sandbox market buys remain capped at $25.
- Real-money production trading remains hard-disabled in code.
- No API credentials are exposed to the browser.
