### PR TITLE
Fix owner auth for modern Supabase server secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ LIQUIDITY_MAX_ACTIVE_POSITIONS=2
 # Mainnet deployment remains locked unless intentionally enabled for a reviewed deployment.
 ALLOW_BASE_LIQUIDITY_DEPLOY=false
 
+# Supabase server authentication for owner-only routes.
+# Prefer the modern server-only SUPABASE_SECRET_KEY (sb_secret_...).
+# SUPABASE_SERVICE_ROLE_KEY remains supported as a legacy fallback.
+SUPABASE_URL=
+SUPABASE_SECRET_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
 # Owner-only server tools. If blank, the Dinari admin wizard falls back to the existing
 # NEURAL_CORE_ADMIN_EMAILS / NEURAL_CORE_ADMIN_USER_IDS allowlist.
 VOXEL_VAULT_ADMIN_EMAILS=

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -26,7 +26,13 @@ export async function requireVoxelVaultAdmin(request: Request): Promise<VoxelVau
   try {
     admin = getSupabaseAdmin();
   } catch {
-    return { ok: false, status: 503, error: 'Server authentication is not configured yet.', setupRequired: true };
+    return {
+      ok: false,
+      status: 503,
+      error:
+        'Server authentication is not configured yet. Add SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) plus SUPABASE_SECRET_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY) to Vercel, then redeploy.',
+      setupRequired: true,
+    };
   }
 
   const { data, error } = await admin.auth.getUser(token);
@@ -41,14 +47,22 @@ export async function requireVoxelVaultAdmin(request: Request): Promise<VoxelVau
     return {
       ok: false,
       status: 503,
-      error: 'Owner tools are locked until an admin allowlist is configured.',
+      error:
+        'Owner tools are locked until an admin allowlist is configured. Add VOXEL_VAULT_ADMIN_EMAILS or VOXEL_VAULT_ADMIN_USER_IDS to Vercel, then redeploy.',
       setupRequired: true,
     };
   }
 
   const email = String(data.user.email || '').toLowerCase();
   const allowed = allowedIds.has(data.user.id) || (Boolean(email) && allowedEmails.has(email));
-  if (!allowed) return { ok: false, status: 403, error: 'This Google account is not authorized for owner tools.' };
+  if (!allowed) {
+    return {
+      ok: false,
+      status: 403,
+      error:
+        'This Google account is not authorized for owner tools. Add the Google account email to VOXEL_VAULT_ADMIN_EMAILS (or its Supabase user ID to VOXEL_VAULT_ADMIN_USER_IDS), then redeploy.',
+    };
+  }
 
   return { ok: true, user: data.user, admin };
 }

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -2,10 +2,12 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 export function getSupabaseAdmin(): SupabaseClient {
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceRoleKey) throw new Error('Supabase server credentials are not configured');
+  const secretKey = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !secretKey) {
+    throw new Error('Supabase server credentials are not configured');
+  }
 
-  return createClient(url, serviceRoleKey, {
+  return createClient(url, secretKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 }


### PR DESCRIPTION
## What changed
- Accept `SUPABASE_SECRET_KEY` (modern `sb_secret_...` backend credential) with legacy `SUPABASE_SERVICE_ROLE_KEY` fallback.
- Make owner-auth errors actionable: distinguish missing server auth, missing owner allowlist, and unauthorized Google account.
- Document the required server-only Supabase env vars in `.env.example`.

## Safety
- No secret is exposed to the browser.
- Existing fail-closed owner allowlist remains required.
- Dinari production trading remains code-locked.
