### PR TITLE
Fix stale Dinari KYC entity selection

### DIFF
--- a/lib/real-estate/dinari-onboarding.js
+++ b/lib/real-estate/dinari-onboarding.js
@@ -1,5 +1,7 @@
 import { getDinariConfig } from './dinari.js';
 
+const DEFAULT_OWNER_REFERENCE_ID = 'voxel-vault-owner-sandbox';
+
 function clean(value) {
   return String(value || '').trim();
 }
@@ -106,6 +108,16 @@ export async function getDinariEntity(entity, env = process.env) {
   return safeEntity(await request(`/entities/${encodeURIComponent(id)}`, { env }));
 }
 
+export async function listDinariEntitiesByReference(referenceId = DEFAULT_OWNER_REFERENCE_ID, env = process.env) {
+  const reference = clean(referenceId);
+  if (!reference) return [];
+  const params = new URLSearchParams({ reference_id: reference, limit: '20', order: 'desc' });
+  const payload = await request(`/entities/?${params.toString()}`, { env });
+  return items(payload)
+    .map(safeEntity)
+    .filter((entity) => entity.id && entity.referenceId === reference);
+}
+
 export async function getDinariKyc(entity, env = process.env) {
   const id = entityId(entity);
   try {
@@ -126,12 +138,18 @@ export async function listDinariAccounts(entity, env = process.env) {
 
 export async function getDinariOnboardingSnapshot({ selectedEntityId = '' } = {}, env = process.env) {
   const config = getDinariConfig(env);
+  const browserEntityId = clean(selectedEntityId);
+  const referenceId = clean(env.DINARI_ENTITY_REFERENCE_ID) || DEFAULT_OWNER_REFERENCE_ID;
   const snapshot = {
     provider: config.provider,
     environment: config.environment,
     credentialsConfigured: config.credentialsConfigured,
     configuredEntityId: config.entityId || '',
     configuredAccountId: config.accountId || '',
+    browserEntityId,
+    canonicalReferenceId: referenceId,
+    entitySelectionSource: '',
+    recoveredFromStaleBrowserEntity: false,
     organization: null,
     entity: null,
     kyc: null,
@@ -148,7 +166,26 @@ export async function getDinariOnboardingSnapshot({ selectedEntityId = '' } = {}
     return snapshot;
   }
 
-  const id = clean(selectedEntityId || config.entityId);
+  let canonicalEntities = [];
+  try {
+    canonicalEntities = await listDinariEntitiesByReference(referenceId, env);
+  } catch (error) {
+    snapshot.errors.push(`entity-reference: ${error?.message || 'Canonical Entity lookup failed'}`);
+  }
+
+  const canonicalEntity = canonicalEntities[0] || null;
+  const id = clean(config.entityId || canonicalEntity?.id || browserEntityId);
+  snapshot.entitySelectionSource = config.entityId
+    ? 'server-configured'
+    : canonicalEntity?.id
+      ? 'provider-reference'
+      : browserEntityId
+        ? 'browser-fallback'
+        : '';
+  snapshot.recoveredFromStaleBrowserEntity = Boolean(
+    browserEntityId && id && browserEntityId !== id && (config.entityId || canonicalEntity?.id)
+  );
+
   if (!id) return snapshot;
 
   try {

--- a/scripts/test-dinari-onboarding.mjs
+++ b/scripts/test-dinari-onboarding.mjs
@@ -42,11 +42,22 @@ global.fetch = async (url, options = {}) => {
   if (href.endsWith('/entities/me') && method === 'GET') {
     return json({ id: 'partner-org', entity_type: 'ORGANIZATION', is_kyc_complete: true });
   }
+  if (href.includes('/entities/?') && method === 'GET') {
+    const parsed = new URL(href);
+    const reference = parsed.searchParams.get('reference_id');
+    if (reference === 'voxel-vault-owner-sandbox') {
+      return json({ data: [{ id: 'entity-1', entity_type: 'INDIVIDUAL', is_kyc_complete: kycPassed, reference_id: reference }] });
+    }
+    return json({ data: [] });
+  }
   if (href.endsWith('/entities/') && method === 'POST') {
     return json({ id: 'entity-1', entity_type: 'INDIVIDUAL', is_kyc_complete: false, reference_id: body?.reference_id });
   }
   if (href.endsWith('/entities/entity-1') && method === 'GET') {
-    return json({ id: 'entity-1', entity_type: 'INDIVIDUAL', is_kyc_complete: kycPassed, reference_id: 'owner-test' });
+    return json({ id: 'entity-1', entity_type: 'INDIVIDUAL', is_kyc_complete: kycPassed, reference_id: 'voxel-vault-owner-sandbox' });
+  }
+  if (href.endsWith('/entities/entity-stale') && method === 'GET') {
+    return json({ id: 'entity-stale', entity_type: 'INDIVIDUAL', is_kyc_complete: false, reference_id: 'old-owner-sandbox' });
   }
   if (href.endsWith('/entities/entity-1/kyc/url') && method === 'POST') {
     return json({ embed_url: 'https://kyc.example.test/session/1', expiration_dt: '2026-08-28T00:00:00Z' });
@@ -54,8 +65,14 @@ global.fetch = async (url, options = {}) => {
   if (href.endsWith('/entities/entity-1/kyc') && method === 'GET') {
     return json({ id: 'kyc-1', status: kycPassed ? 'PASS' : 'PENDING', jurisdiction: 'US', checked_dt: '2026-08-27T00:00:00Z' });
   }
+  if (href.endsWith('/entities/entity-stale/kyc') && method === 'GET') {
+    return json({ id: 'kyc-stale', status: 'PENDING', jurisdiction: 'US', checked_dt: '2026-08-26T00:00:00Z' });
+  }
   if (href.includes('/entities/entity-1/accounts') && method === 'GET') {
     return json({ data: accountCreated ? [{ id: 'account-1', entity_id: 'entity-1', is_active: true, jurisdiction: 'US' }] : [] });
+  }
+  if (href.includes('/entities/entity-stale/accounts') && method === 'GET') {
+    return json({ data: [] });
   }
   if (href.endsWith('/entities/entity-1/accounts') && method === 'POST') {
     accountCreated = true;
@@ -96,7 +113,22 @@ try {
   assert.equal(snapshot.entity.id, 'entity-1');
   assert.equal(snapshot.kyc.status, 'PASS');
   assert.equal(snapshot.accounts[0].id, 'account-1');
-  const serialized = JSON.stringify(snapshot);
+
+  const recovered = await getDinariOnboardingSnapshot({ selectedEntityId: 'entity-stale' }, sandboxEnv);
+  assert.equal(recovered.entity.id, 'entity-1', 'canonical provider reference must win over stale browser Entity ID');
+  assert.equal(recovered.kyc.status, 'PASS', 'recovery must read KYC from the canonical verified Entity');
+  assert.equal(recovered.entitySelectionSource, 'provider-reference');
+  assert.equal(recovered.recoveredFromStaleBrowserEntity, true);
+  assert.equal(recovered.browserEntityId, 'entity-stale');
+
+  const configured = await getDinariOnboardingSnapshot(
+    { selectedEntityId: 'entity-stale' },
+    { ...sandboxEnv, DINARI_ENTITY_ID: 'entity-1' },
+  );
+  assert.equal(configured.entity.id, 'entity-1', 'server-configured Entity must have highest priority');
+  assert.equal(configured.entitySelectionSource, 'server-configured');
+
+  const serialized = JSON.stringify(recovered);
   assert.equal(serialized.includes('sandbox-secret-never-return-this'), false, 'API secret must never be returned in onboarding snapshot');
   assert.equal(serialized.includes('sandbox-key-id'), false, 'API Key ID is not needed in browser onboarding snapshot');
 
@@ -106,4 +138,4 @@ try {
   global.fetch = originalFetch;
 }
 
-console.log('Dinari onboarding safety checks passed: live writes are blocked, secrets stay server-side, managed KYC uses US jurisdiction, accounts require KYC PASS, and existing accounts are reused.');
+console.log('Dinari onboarding safety checks passed: live writes are blocked, secrets stay server-side, stale browser Entity IDs recover to the canonical provider Entity, KYC PASS is read from that Entity, and existing accounts are reused.');


### PR DESCRIPTION
## What this fixes
The owner onboarding page could keep polling a stale Entity ID stored in the browser even when the canonical Voxel Vault sandbox Entity was different. That can make a completed KYC look permanently `PENDING` on our side.

## Changes
- Resolve the canonical Entity in this order:
  1. `DINARI_ENTITY_ID` configured server-side
  2. Dinari provider lookup by exact `reference_id=voxel-vault-owner-sandbox`
  3. browser/localStorage Entity ID only as a fallback
- Return selection diagnostics without exposing API credentials.
- Preserve `cache: no-store` provider reads.
- Add a regression test where the browser points at a stale `PENDING` Entity while the canonical provider Entity is `PASS`; Voxel Vault must recover to the verified Entity.

## Safety
- No KYC bypass.
- No production trading enabled.
- No secret values returned to the browser.
- Account creation still requires Dinari `PASS` plus `is_kyc_complete=true`.
