### PR TITLE
Harden production payment and release gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,11 @@ SUPABASE_URL=
 SUPABASE_SECRET_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Third-party marketplace seller payouts remain locked until migration 017 is applied
+# and a server-controlled Stripe Connect onboarding flow has verified seller accounts.
+# Checkout also re-reads charges/payout/details state directly from Stripe.
+MARKETPLACE_SELLER_PAYOUTS_ENABLED=false
+
 # Owner-only server tools. If blank, the Dinari admin wizard falls back to the existing
 # NEURAL_CORE_ADMIN_EMAILS / NEURAL_CORE_ADMIN_USER_IDS allowlist.
 VOXEL_VAULT_ADMIN_EMAILS=

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           node-version: 22
       - run: npm install --no-audit --no-fund
+      - run: npm run test:collection
+      - run: npm run test:commerce
+      - run: npm run test:routes
       - run: npm run test:rewards
       - run: npm run test:universal
       - run: npm run test:media

--- a/app/api/checkout-secure/route.ts
+++ b/app/api/checkout-secure/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { stripe, platformFee } from '../../../lib/stripe-server';
 import { getSupabaseAdmin } from '../../../lib/supabase-admin';
+import { verifyMarketplaceSellerPayoutReadiness } from '../../../lib/marketplace-seller-readiness';
 
 export async function POST(request: Request) {
   try {
@@ -33,11 +34,20 @@ export async function POST(request: Request) {
       .maybeSingle();
     if (existing) return NextResponse.json({ error: 'Already purchased' }, { status: 409 });
 
-    const { data: seller } = await supabaseAdmin
+    const { data: seller, error: sellerError } = await supabaseAdmin
       .from('seller_accounts')
-      .select('stripe_account_id,charges_enabled,payouts_enabled')
+      .select('stripe_account_id')
       .eq('user_id', asset.seller_id)
       .maybeSingle();
+    if (sellerError) return NextResponse.json({ error: 'Seller payout state could not be verified.' }, { status: 503 });
+
+    const payout = await verifyMarketplaceSellerPayoutReadiness(seller);
+    if (!payout.ready) {
+      return NextResponse.json({
+        error: 'This seller is not currently payout-ready, so checkout is paused. No payment session was created.',
+        sellerPayoutReady: false,
+      }, { status: 409 });
+    }
 
     const fee = platformFee(asset.price_cents);
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxel-vault.vercel.app';
@@ -52,10 +62,8 @@ export async function POST(request: Request) {
       metadata: { asset_id: asset.id, buyer_id: user.id },
       payment_intent_data: {
         metadata: { asset_id: asset.id, buyer_id: user.id },
-        ...(seller?.stripe_account_id && seller.charges_enabled && seller.payouts_enabled ? {
-          application_fee_amount: fee,
-          transfer_data: { destination: seller.stripe_account_id },
-        } : {}),
+        application_fee_amount: fee,
+        transfer_data: { destination: payout.destination },
       },
       success_url: `${appUrl}/purchases?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${appUrl}/assets/${encodeURIComponent(asset.id)}?checkout=cancelled`,

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { stripe, platformFee } from '../../../lib/stripe-server';
 import { getSupabaseAdmin } from '../../../lib/supabase-admin';
+import { verifyMarketplaceSellerPayoutReadiness } from '../../../lib/marketplace-seller-readiness';
 
 export async function POST(request: Request) {
   try {
@@ -8,19 +9,68 @@ export async function POST(request: Request) {
     const auth = request.headers.get('authorization');
     const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
     if (!token) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+
     const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
     if (authError || !user) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+
     const { assetId } = await request.json();
     if (!assetId) return NextResponse.json({ error: 'assetId is required' }, { status: 400 });
-    const { data: asset, error: assetError } = await supabaseAdmin.from('assets').select('id,title,price_cents,currency,seller_id,status').eq('id', String(assetId)).eq('status', 'published').single();
+
+    const { data: asset, error: assetError } = await supabaseAdmin
+      .from('assets')
+      .select('id,title,price_cents,currency,seller_id,status')
+      .eq('id', String(assetId))
+      .eq('status', 'published')
+      .single();
     if (assetError || !asset) return NextResponse.json({ error: 'Asset unavailable' }, { status: 404 });
     if (asset.seller_id === user.id) return NextResponse.json({ error: 'You cannot purchase your own asset' }, { status: 400 });
-    const { data: existing } = await supabaseAdmin.from('download_entitlements').select('id').eq('buyer_id', user.id).eq('asset_id', asset.id).maybeSingle();
+
+    const { data: existing } = await supabaseAdmin
+      .from('download_entitlements')
+      .select('id')
+      .eq('buyer_id', user.id)
+      .eq('asset_id', asset.id)
+      .maybeSingle();
     if (existing) return NextResponse.json({ error: 'Already purchased' }, { status: 409 });
-    const { data: seller } = await supabaseAdmin.from('seller_accounts').select('stripe_account_id,charges_enabled,payouts_enabled').eq('user_id', asset.seller_id).maybeSingle();
+
+    const { data: seller, error: sellerError } = await supabaseAdmin
+      .from('seller_accounts')
+      .select('stripe_account_id')
+      .eq('user_id', asset.seller_id)
+      .maybeSingle();
+    if (sellerError) return NextResponse.json({ error: 'Seller payout state could not be verified.' }, { status: 503 });
+
+    const payout = await verifyMarketplaceSellerPayoutReadiness(seller);
+    if (!payout.ready) {
+      return NextResponse.json({
+        error: 'This seller is not currently payout-ready, so checkout is paused. No payment session was created.',
+        sellerPayoutReady: false,
+      }, { status: 409 });
+    }
+
     const fee = platformFee(asset.price_cents);
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxel-vault.vercel.app';
-    const session = await stripe.checkout.sessions.create({ mode: 'payment', customer_email: user.email || undefined, line_items: [{ quantity: 1, price_data: { currency: asset.currency, unit_amount: asset.price_cents, product_data: { name: asset.title } } }], metadata: { asset_id: asset.id, buyer_id: user.id }, payment_intent_data: { metadata: { asset_id: asset.id, buyer_id: user.id }, ...(seller?.stripe_account_id && seller.charges_enabled && seller.payouts_enabled ? { application_fee_amount: fee, transfer_data: { destination: seller.stripe_account_id } } : {}) }, success_url: `${appUrl}/?checkout=success&session_id={CHECKOUT_SESSION_ID}`, cancel_url: `${appUrl}/?checkout=cancelled` });
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      customer_email: user.email || undefined,
+      line_items: [{
+        quantity: 1,
+        price_data: {
+          currency: asset.currency,
+          unit_amount: asset.price_cents,
+          product_data: { name: asset.title },
+        },
+      }],
+      metadata: { asset_id: asset.id, buyer_id: user.id },
+      payment_intent_data: {
+        metadata: { asset_id: asset.id, buyer_id: user.id },
+        application_fee_amount: fee,
+        transfer_data: { destination: payout.destination },
+      },
+      success_url: `${appUrl}/?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${appUrl}/?checkout=cancelled`,
+    });
+
     return NextResponse.json({ url: session.url });
   } catch (error) {
     console.error('checkout creation failed', error);

--- a/app/api/receipt-mint/route.ts
+++ b/app/api/receipt-mint/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from 'next/server';
-import { stripe } from '../../../lib/stripe-server';
 import { getSupabaseAdmin } from '../../../lib/supabase-admin';
-
-const MINT_PRICE_CENTS = 299;
 
 export async function POST(request: Request) {
   try {
@@ -10,32 +7,47 @@ export async function POST(request: Request) {
     const auth = request.headers.get('authorization');
     const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
     if (!token) return NextResponse.json({ error: 'Sign in to mint a collectible.' }, { status: 401 });
+
     const { data: { user }, error } = await supabase.auth.getUser(token);
     if (error || !user) return NextResponse.json({ error: 'Sign in to mint a collectible.' }, { status: 401 });
 
     const body = await request.json();
     const receiptId = typeof body.receiptId === 'string' ? body.receiptId.trim() : '';
     const collectibleId = typeof body.collectibleId === 'string' ? body.collectibleId.trim() : '';
-    if (!receiptId || !collectibleId || receiptId.length > 128 || collectibleId.length > 128) return NextResponse.json({ error: 'Invalid receipt or collectible.' }, { status: 400 });
+    if (!receiptId || !collectibleId || receiptId.length > 128 || collectibleId.length > 128) {
+      return NextResponse.json({ error: 'Invalid receipt or collectible.' }, { status: 400 });
+    }
 
     // Do not trust the browser to assert that a receipt was paid. A production merchant adapter
-    // must verify the receipt and persist the verified purchase before this checkout can mint.
-    const { data: verifiedReceipt } = await supabase.from('verified_receipts').select('id,status').eq('id', receiptId).eq('user_id', user.id).eq('status', 'verified').maybeSingle();
-    if (!verifiedReceipt) return NextResponse.json({ error: 'This receipt has not been verified by a participating merchant yet.' }, { status: 409 });
+    // must verify the receipt and persist the verified purchase before any collectible flow begins.
+    const { data: verifiedReceipt, error: receiptError } = await supabase
+      .from('verified_receipts')
+      .select('id,status')
+      .eq('id', receiptId)
+      .eq('user_id', user.id)
+      .eq('status', 'verified')
+      .maybeSingle();
 
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxel-vault.vercel.app';
-    const session = await stripe.checkout.sessions.create({
-      mode: 'payment',
-      customer_email: user.email || undefined,
-      line_items: [{ quantity: 1, price_data: { currency: 'usd', unit_amount: MINT_PRICE_CENTS, product_data: { name: 'Voxel Vault collectible mint' } } }],
-      metadata: { kind: 'receipt_collectible_mint', receipt_id: receiptId, collectible_id: collectibleId, buyer_id: user.id },
-      payment_intent_data: { metadata: { kind: 'receipt_collectible_mint', receipt_id: receiptId, collectible_id: collectibleId, buyer_id: user.id } },
-      success_url: `${appUrl}/room?mint=processing`,
-      cancel_url: `${appUrl}/receipt?mint=cancelled`,
-    });
-    return NextResponse.json({ url: session.url });
+    if (receiptError) {
+      return NextResponse.json({ error: 'Receipt verification state could not be loaded.' }, { status: 503 });
+    }
+    if (!verifiedReceipt) {
+      return NextResponse.json({ error: 'This receipt has not been verified by a participating merchant yet.' }, { status: 409 });
+    }
+
+    // Fail closed until a signed Stripe webhook (or another verified settlement rail)
+    // has a durable fulfillment consumer for receipt_collectible_mint. The previous
+    // implementation could create a $2.99 Checkout Session without any post-payment
+    // mint/entitlement handler. Do not take money for an incomplete fulfillment path.
+    return NextResponse.json({
+      error: 'Receipt collectible mint checkout is not activated yet because post-payment mint fulfillment is not installed. No charge has been created.',
+      checkoutEnabled: false,
+      paymentSessionCreated: false,
+      receiptVerified: true,
+      collectibleId,
+    }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
-    console.error('receipt mint checkout failed', error);
-    return NextResponse.json({ error: 'Unable to start mint checkout.' }, { status: 500 });
+    console.error('receipt mint availability check failed', error);
+    return NextResponse.json({ error: 'Receipt minting is temporarily unavailable. No charge has been created.' }, { status: 500 });
   }
 }

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -9,9 +9,19 @@ Security review is a separate gate from build success. A production release is n
 - **Wallet authority:** client proximity detection is treated as UX/eligibility input, not as permission to sign, mint, transfer, or grant ownership.
 - **Rewards:** USD rewards require verified payment state before crediting; reward transitions are state-gated and regression-tested.
 - **Checkout:** the client requests a server checkout URL and does not treat a client-side success flag as proof of payment.
+- **Marketplace payouts:** third-party marketplace checkout fails closed unless a server-only activation flag is enabled and Stripe itself confirms the connected account has charges, payouts and onboarding enabled. Browser/database readiness flags are not treated as payment authority.
+- **Seller payout row writes:** migration 017 removes authenticated-user insert/update policies from `seller_accounts`; payout routing fields are intended to be written only by trusted server/service-role onboarding after Stripe verification.
+- **Incomplete paid routes:** receipt collectible mint checkout is disabled until a durable post-payment fulfillment/mint consumer exists. The disabled route cannot create a Stripe Checkout Session.
 - **NFT media:** broken/unsupported media must degrade to a visible recovery state instead of silently producing an empty card.
 - **WebGL:** passive gallery rendering is subject to the mobile/WebGL guard; full inspection remains an explicit user action.
-- **CI mutation risk:** the previous mobile WebGL workflow could write directly to `main`. This is not an acceptable release pattern and is scheduled for replacement with a read-only verification workflow.
+- **CI mutation risk:** Mobile WebGL Guard is now read-only (`permissions: contents: read`) and has no repository write step.
+- **Release-test coverage:** the primary Quality Gate runs collection integrity, commerce hardening and route-integrity tests in addition to the existing product/security suites and production build.
+
+## External configuration that code cannot prove
+
+- A successful Supabase migration workflow run is not proof that migrations reached the database when the workflow skipped CLI/link/push steps because credentials were absent. Migration application must be verified against the target project before database-dependent features are called live.
+- Historical migration filenames include reused numeric prefixes. Do not rename or replay historical migrations until the target database migration history has been reconciled.
+- The repository ruleset requires pull requests and blocks force-push/deletion of `main`, but it does not currently require approving reviews or CI status checks. Until that is changed in repository settings, release operators must verify all checks against the exact PR head SHA before merge.
 
 ## Dependency audit note
 
@@ -26,4 +36,4 @@ For this release we do **not** silently run `npm audit fix --force`. Instead:
 
 ## Release rule
 
-**Green build never means finished.** The live deployment, rendered UI, critical flows, security state, and expected commit must all agree before release.
+**Green build never means finished.** The live deployment, rendered UI, critical flows, security state, database migration state and expected commit must all agree before release.

--- a/lib/marketplace-seller-readiness.ts
+++ b/lib/marketplace-seller-readiness.ts
@@ -10,15 +10,29 @@ export type MarketplaceSellerPayoutReadiness = {
   reason: string;
 };
 
+function payoutsActivated() {
+  return String(process.env.MARKETPLACE_SELLER_PAYOUTS_ENABLED || '').trim().toLowerCase() === 'true';
+}
+
 /**
  * Marketplace checkout must not trust browser-writable seller status flags.
  * The Stripe account itself is the authority for whether destination charges
- * and payouts are currently usable. If Stripe cannot confirm the account,
- * checkout fails closed and no customer payment session is created.
+ * and payouts are currently usable. A separate server-only activation switch
+ * stays OFF until seller payout rows are server-controlled and Connect onboarding
+ * has been reviewed. If any gate cannot be confirmed, checkout fails closed and
+ * no customer payment session is created.
  */
 export async function verifyMarketplaceSellerPayoutReadiness(
   seller: SellerAccountRow,
 ): Promise<MarketplaceSellerPayoutReadiness> {
+  if (!payoutsActivated()) {
+    return {
+      ready: false,
+      destination: '',
+      reason: 'Marketplace seller payouts are not activated on this deployment.',
+    };
+  }
+
   const destination = String(seller?.stripe_account_id || '').trim();
   if (!destination.startsWith('acct_')) {
     return {

--- a/lib/marketplace-seller-readiness.ts
+++ b/lib/marketplace-seller-readiness.ts
@@ -1,0 +1,49 @@
+import { stripe } from './stripe-server';
+
+type SellerAccountRow = {
+  stripe_account_id?: unknown;
+} | null | undefined;
+
+export type MarketplaceSellerPayoutReadiness = {
+  ready: boolean;
+  destination: string;
+  reason: string;
+};
+
+/**
+ * Marketplace checkout must not trust browser-writable seller status flags.
+ * The Stripe account itself is the authority for whether destination charges
+ * and payouts are currently usable. If Stripe cannot confirm the account,
+ * checkout fails closed and no customer payment session is created.
+ */
+export async function verifyMarketplaceSellerPayoutReadiness(
+  seller: SellerAccountRow,
+): Promise<MarketplaceSellerPayoutReadiness> {
+  const destination = String(seller?.stripe_account_id || '').trim();
+  if (!destination.startsWith('acct_')) {
+    return {
+      ready: false,
+      destination: '',
+      reason: 'Seller payouts are not configured.',
+    };
+  }
+
+  try {
+    const account = await stripe.accounts.retrieve(destination);
+    const ready = account.charges_enabled === true
+      && account.payouts_enabled === true
+      && account.details_submitted === true;
+
+    return {
+      ready,
+      destination: ready ? destination : '',
+      reason: ready ? '' : 'Seller Stripe onboarding is not fully payout-ready.',
+    };
+  } catch {
+    return {
+      ready: false,
+      destination: '',
+      reason: 'Seller Stripe account could not be verified.',
+    };
+  }
+}

--- a/scripts/test-commerce-hardening.mjs
+++ b/scripts/test-commerce-hardening.mjs
@@ -9,6 +9,12 @@ const preflight = fs.readFileSync('lib/fulfillment-preflight.js', 'utf8');
 const fulfillmentCallback = fs.readFileSync('app/api/fulfillment/status/route.ts', 'utf8');
 const orders = fs.readFileSync('app/api/orders/route.ts', 'utf8');
 const migration = fs.readFileSync('supabase/migrations/005_one_sku_delivery_claim_pipeline.sql', 'utf8');
+const marketplaceCheckout = fs.readFileSync('app/api/checkout/route.ts', 'utf8');
+const marketplaceSecureCheckout = fs.readFileSync('app/api/checkout-secure/route.ts', 'utf8');
+const sellerReadiness = fs.readFileSync('lib/marketplace-seller-readiness.ts', 'utf8');
+const sellerPayoutMigration = fs.readFileSync('supabase/migrations/017_lock_seller_payout_fields.sql', 'utf8');
+const receiptMint = fs.readFileSync('app/api/receipt-mint/route.ts', 'utf8');
+const envExample = fs.readFileSync('.env.example', 'utf8');
 
 const required = [
   ['catalog source URLs', /sourceUrl:/g, catalog],
@@ -36,9 +42,43 @@ for (const [label, pattern, source] of required) {
   if (!pattern.test(source)) throw new Error(`Missing commerce hardening: ${label}`);
 }
 
+function requireText(source, value, label) {
+  if (!source.includes(value)) throw new Error(`Missing commerce hardening: ${label}`);
+}
+
+function forbidText(source, value, label) {
+  if (source.includes(value)) throw new Error(`Unsafe commerce behavior present: ${label}`);
+}
+
+for (const [label, source] of [
+  ['marketplace checkout', marketplaceCheckout],
+  ['secure marketplace checkout', marketplaceSecureCheckout],
+]) {
+  requireText(source, 'verifyMarketplaceSellerPayoutReadiness', `${label} must verify seller payout readiness`);
+  requireText(source, 'sellerPayoutReady: false', `${label} must fail closed before charging an unready seller`);
+  requireText(source, 'transfer_data: { destination: payout.destination }', `${label} must use the verified Stripe destination`);
+  forbidText(source, 'seller?.stripe_account_id && seller.charges_enabled', `${label} must not trust database payout flags`);
+}
+
+requireText(sellerReadiness, 'MARKETPLACE_SELLER_PAYOUTS_ENABLED', 'marketplace payouts must have an explicit server-side activation gate');
+requireText(sellerReadiness, 'stripe.accounts.retrieve', 'seller readiness must be verified directly with Stripe');
+requireText(sellerReadiness, 'account.charges_enabled === true', 'Stripe charges state must be verified');
+requireText(sellerReadiness, 'account.payouts_enabled === true', 'Stripe payouts state must be verified');
+requireText(sellerReadiness, 'account.details_submitted === true', 'Stripe onboarding completion must be verified');
+requireText(envExample, 'MARKETPLACE_SELLER_PAYOUTS_ENABLED=false', 'example environment must keep third-party marketplace payouts locked');
+
+requireText(sellerPayoutMigration, 'drop policy if exists "user manages own seller account"', 'seller payout insert policy must be removed');
+requireText(sellerPayoutMigration, 'drop policy if exists "user updates own seller account"', 'seller payout update policy must be removed');
+forbidText(sellerPayoutMigration, 'for update to authenticated', 'authenticated users must not regain direct payout-row updates');
+
+requireText(receiptMint, 'checkoutEnabled: false', 'incomplete receipt mint checkout must be explicitly disabled');
+requireText(receiptMint, 'No charge has been created', 'disabled receipt mint must tell callers no charge was created');
+forbidText(receiptMint, 'stripe.checkout.sessions.create', 'receipt mint must not charge until post-payment fulfillment exists');
+forbidText(receiptMint, "from '../../../lib/stripe-server'", 'disabled receipt mint must not initialize Stripe checkout code');
+
 const sourceCount = (catalog.match(/sourceUrl:/g) || []).length;
 const realityCount = (catalog.match(/realityBasis:/g) || []).length;
 if (sourceCount < 8 || realityCount !== sourceCount) throw new Error(`Catalog provenance mismatch: ${sourceCount} sources / ${realityCount} reality records`);
 if (fs.existsSync('app/api/stripe/webhook/route.js')) throw new Error('Duplicate Stripe webhook route must not exist');
 
-console.log(`Commerce hardening smoke test passed: ${sourceCount} source-verified products`);
+console.log(`Commerce hardening smoke test passed: ${sourceCount} source-verified products; marketplace payouts and incomplete paid routes fail closed.`);

--- a/supabase/migrations/017_lock_seller_payout_fields.sql
+++ b/supabase/migrations/017_lock_seller_payout_fields.sql
@@ -1,0 +1,13 @@
+-- Seller payout routing is security-sensitive. A normal authenticated user must not
+-- be able to self-certify Stripe account IDs or charges/payout readiness flags that
+-- server checkout code uses to route marketplace money.
+--
+-- Seller onboarding should write these fields only through a trusted server/service
+-- role after Stripe Connect account state has been verified directly with Stripe.
+
+drop policy if exists "user manages own seller account" on public.seller_accounts;
+drop policy if exists "user updates own seller account" on public.seller_accounts;
+
+-- Keep read access to the seller's own account record from 001_marketplace.sql.
+-- No INSERT/UPDATE policy is intentionally created for authenticated users.
+-- The service role bypasses RLS and remains the only supported writer.


### PR DESCRIPTION
## Full production-review fixes

This PR addresses concrete findings from a broad review of current `main` and does not enable any new autonomous spending, property purchase, registry verification, or token issuance.

### Marketplace checkout
- Fail closed unless `MARKETPLACE_SELLER_PAYOUTS_ENABLED=true` is deliberately configured server-side.
- Verify the destination Stripe Connect account directly with Stripe before charging.
- Require `charges_enabled`, `payouts_enabled`, and `details_submitted` from Stripe itself.
- Remove the old fallback where a customer could be charged to the platform account when a seller was not payout-ready.
- Migration 017 removes authenticated-user INSERT/UPDATE policies from `seller_accounts`; payout routing is intended to become service-role/server controlled.

### Incomplete paid route
- Disable `/api/receipt-mint` checkout until a durable post-payment mint/entitlement consumer exists.
- Verified receipts remain readable, but no Stripe Checkout Session can be created by this incomplete flow.

### Release verification
- Add `test:collection`, `test:commerce`, and `test:routes` to the primary Quality Gate.
- Expand commerce regression coverage for Stripe-authoritative seller readiness, payout activation, seller-row RLS, and the disabled receipt-mint charge path.
- Update the security review to reflect current read-only Mobile WebGL CI and unresolved external configuration risks.

### External blockers intentionally not hidden by this PR
- Supabase migrations are not considered applied until the target project is verified; the existing migration workflow has skipped push steps when credentials are absent.
- Historical duplicate migration-number prefixes need database-history reconciliation before automated migration deployment is trusted.
- GitHub main rules require PRs but do not currently require status checks or approving reviews; exact-head CI verification remains mandatory before merge.