### PR TITLE
Require authoritative property identity before verification

### DIFF
--- a/app/admin/property-claims/page.js
+++ b/app/admin/property-claims/page.js
@@ -18,6 +18,7 @@ export default function PropertyClaimsAdminPage() {
   const [message, setMessage] = useState('');
   const [notes, setNotes] = useState({});
   const [evidenceReviewed, setEvidenceReviewed] = useState({});
+  const [authoritative, setAuthoritative] = useState({});
   const clientRef = useRef(null);
 
   async function refresh(accessToken) {
@@ -101,12 +102,21 @@ export default function PropertyClaimsAdminPage() {
   async function decide(claim, decision) {
     if (!session?.access_token || busy) return;
     const reviewerNote = String(notes[claim.id] ?? claim.reviewerNote ?? '').trim();
+    const authoritativeValue = authoritative[claim.id] || {};
+    const authoritativeNamespace = String(authoritativeValue.namespace || '').trim();
+    const authoritativeParcelId = String(authoritativeValue.parcelId || '').trim();
+    const authoritativeSource = String(authoritativeValue.source || '').trim();
+
     if (reviewerNote.length < 20) {
       setMessage('Add a reviewer note of at least 20 characters describing what was checked.');
       return;
     }
     if (decision === 'verified' && evidenceReviewed[claim.id] !== true) {
       setMessage('Confirm that you independently reviewed the external evidence before verifying this claim.');
+      return;
+    }
+    if (decision === 'verified' && (!authoritativeNamespace || !authoritativeParcelId || authoritativeSource.length < 5)) {
+      setMessage('Enter the official jurisdiction namespace/code, authoritative parcel/APN, and the source you checked before verifying.');
       return;
     }
 
@@ -124,18 +134,32 @@ export default function PropertyClaimsAdminPage() {
           decision,
           reviewerNote,
           evidenceVerified: decision === 'verified' && evidenceReviewed[claim.id] === true,
+          authoritativeNamespace: decision === 'verified' ? authoritativeNamespace : '',
+          authoritativeParcelId: decision === 'verified' ? authoritativeParcelId : '',
+          authoritativeSource: decision === 'verified' ? authoritativeSource : '',
         }),
       });
       const data = await response.json().catch(() => ({}));
       if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Claim decision failed.');
       setMessage(data?.nextStep || `Claim marked ${decision}.`);
       setEvidenceReviewed((current) => ({ ...current, [claim.id]: false }));
+      setAuthoritative((current) => ({ ...current, [claim.id]: {} }));
       await refresh(session.access_token);
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'Claim decision failed.');
     } finally {
       setBusy('');
     }
+  }
+
+  function setAuthoritativeField(claimId, field, value) {
+    setAuthoritative((current) => ({
+      ...current,
+      [claimId]: {
+        ...(current[claimId] || {}),
+        [field]: value,
+      },
+    }));
   }
 
   return (
@@ -152,7 +176,7 @@ export default function PropertyClaimsAdminPage() {
         <header className="max-w-5xl pb-10 pt-16 md:pt-24">
           <div className="text-[10px] font-black tracking-[.22em] text-amber-100/50">OWNER TOOL · PROPERTY CLAIM REVIEW</div>
           <h1 className="mt-4 text-5xl font-black leading-[.86] tracking-[-.07em] md:text-7xl">Verify evidence.<br /><span className="text-[#9ff5df]">Never guess ownership.</span></h1>
-          <p className="mt-6 max-w-3xl text-base leading-7 text-white/50">This console can approve or reject the off-chain canonical claim after evidence is independently checked. It cannot mark the Base registry verified, mint a Property Passport, transfer a deed or create rent rights.</p>
+          <p className="mt-6 max-w-3xl text-base leading-7 text-white/50">This console can approve or reject the off-chain canonical claim after evidence is independently checked. Approval also requires one authoritative assessor/title parcel key. It cannot mark the Base registry verified, mint a Property Passport, transfer a deed or create rent rights.</p>
         </header>
 
         {message ? <div className="mb-5 rounded-2xl border border-white/10 bg-white/[.035] p-4 text-sm leading-6 text-white/65">{message}</div> : null}
@@ -177,16 +201,21 @@ export default function PropertyClaimsAdminPage() {
               <Stat label="PASSPORT MINTS HERE" value="0" />
             </section>
 
-            {!claims.length && busy !== 'refresh' ? <StateCard title="No claims in the queue" copy="User-submitted official property claims will appear here after migrations 015 and 016 are applied." /> : null}
+            {!claims.length && busy !== 'refresh' ? <StateCard title="No claims in the queue" copy="User-submitted official property claims will appear here after migrations 015, 016 and 018 are applied." /> : null}
 
             <div className="grid gap-4">
               {claims.map((claim) => {
                 const locked = ['verified', 'rejected', 'withdrawn'].includes(claim.status);
                 const evidenceComplete = requiredEvidence.every((type) => claim.evidenceTypes.includes(type));
                 const noteValue = notes[claim.id] ?? claim.reviewerNote ?? '';
+                const authoritativeValue = authoritative[claim.id] || {};
+                const authoritativeComplete = String(authoritativeValue.namespace || '').trim().length > 0
+                  && String(authoritativeValue.parcelId || '').trim().length > 0
+                  && String(authoritativeValue.source || '').trim().length >= 5;
                 const canVerify = claim.status === 'under-review'
                   && evidenceComplete
                   && evidenceReviewed[claim.id] === true
+                  && authoritativeComplete
                   && String(noteValue).trim().length >= 20;
 
                 return (
@@ -196,7 +225,8 @@ export default function PropertyClaimsAdminPage() {
                         <div className="flex flex-wrap gap-2 text-[9px] font-black tracking-[.12em]">
                           <span className="rounded-full border border-[#9ff5df]/15 px-3 py-1.5 text-[#bffff0]">{String(claim.status || '').toUpperCase()}</span>
                           <span className="rounded-full border border-white/10 px-3 py-1.5 text-white/40">{String(claim.claimantRole || '').toUpperCase()}</span>
-                          <span className="rounded-full border border-white/10 px-3 py-1.5 text-white/40">FINGERPRINT …{claim.identity?.fingerprintSuffix}</span>
+                          <span className="rounded-full border border-white/10 px-3 py-1.5 text-white/40">CANDIDATE …{claim.identity?.fingerprintSuffix}</span>
+                          {claim.identity?.verifiedPropertyFingerprintSuffix ? <span className="rounded-full border border-emerald-200/15 px-3 py-1.5 text-emerald-100/60">AUTHORITATIVE …{claim.identity.verifiedPropertyFingerprintSuffix}</span> : null}
                         </div>
                         <h2 className="mt-4 text-3xl font-black tracking-[-.05em]">{claim.propertyLabel || 'Property claim'}</h2>
                         <p className="mt-1 text-sm text-white/40">{claim.locality || 'No locality label'} · claimant …{claim.claimantUserSuffix || 'unknown'}</p>
@@ -204,8 +234,10 @@ export default function PropertyClaimsAdminPage() {
                         <div className="mt-5 grid gap-2 text-xs sm:grid-cols-2">
                           <Detail label="COUNTRY" value={claim.identity?.countryCode || '—'} />
                           <Detail label="SUBDIVISION" value={claim.identity?.subdivisionCode || '—'} />
-                          <Detail label="ASSESSOR JURISDICTION" value={claim.identity?.countyCode || '—'} />
-                          <Detail label="NORMALIZED PARCEL / APN" value={claim.identity?.parcelIdNormalized || '—'} />
+                          <Detail label="CLAIMED ASSESSOR JURISDICTION" value={claim.identity?.countyCode || '—'} />
+                          <Detail label="CLAIMED NORMALIZED PARCEL / APN" value={claim.identity?.parcelIdNormalized || '—'} />
+                          <Detail label="AUTHORITATIVE NAMESPACE" value={claim.identity?.verifiedPropertyNamespace || 'NOT VERIFIED'} />
+                          <Detail label="AUTHORITATIVE SOURCE" value={claim.identity?.verifiedPropertySource || 'NOT VERIFIED'} />
                           <Detail label="REGISTRY VERIFIED" value={claim.identity?.registryVerified ? 'YES' : 'NO'} />
                           <Detail label="PASSPORT TOKEN" value={claim.identity?.passportTokenId || 'NONE'} />
                         </div>
@@ -223,9 +255,19 @@ export default function PropertyClaimsAdminPage() {
                         <textarea value={noteValue} onChange={(event) => setNotes((current) => ({ ...current, [claim.id]: event.target.value }))} disabled={locked} placeholder="Required reviewer note (20+ characters): what was checked, source/date, and why the decision is justified." className="mt-4 min-h-32 w-full rounded-2xl border border-white/10 bg-black/30 p-4 text-sm text-white outline-none placeholder:text-white/20 disabled:opacity-50" />
 
                         {!locked && claim.status === 'under-review' ? (
+                          <div className="mt-4 rounded-2xl border border-[#9ff5df]/12 bg-[#9ff5df]/[.025] p-4">
+                            <div className="text-[9px] font-black tracking-[.14em] text-[#bffff0]/65">AUTHORITATIVE PARCEL KEY · REQUIRED</div>
+                            <p className="mt-2 text-[11px] leading-5 text-white/45">Use a stable official jurisdiction namespace/code such as state + county FIPS, SWIS, or assessor-system ID. Do not use a free-form county name or street address.</p>
+                            <input value={authoritativeValue.namespace || ''} onChange={(event) => setAuthoritativeField(claim.id, 'namespace', event.target.value)} placeholder="Official jurisdiction namespace/code" className="mt-3 w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2.5 text-xs text-white outline-none placeholder:text-white/20" />
+                            <input value={authoritativeValue.parcelId || ''} onChange={(event) => setAuthoritativeField(claim.id, 'parcelId', event.target.value)} placeholder="Authoritative parcel / APN exactly from source" className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2.5 text-xs text-white outline-none placeholder:text-white/20" />
+                            <input value={authoritativeValue.source || ''} onChange={(event) => setAuthoritativeField(claim.id, 'source', event.target.value)} placeholder="Official source checked + date" className="mt-2 w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2.5 text-xs text-white outline-none placeholder:text-white/20" />
+                          </div>
+                        ) : null}
+
+                        {!locked && claim.status === 'under-review' ? (
                           <label className="mt-4 flex cursor-pointer gap-3 rounded-2xl border border-amber-100/12 bg-amber-100/[.025] p-4 text-xs leading-5 text-white/55">
                             <input type="checkbox" checked={evidenceReviewed[claim.id] === true} onChange={(event) => setEvidenceReviewed((current) => ({ ...current, [claim.id]: event.target.checked }))} className="mt-1" />
-                            <span>I independently reviewed the external parcel record, ownership/control evidence, and 3D capture authorization. I understand this approval verifies only the Voxel Vault off-chain identity and does not change the deed or mint a token.</span>
+                            <span>I independently reviewed the external parcel record, ownership/control evidence, 3D capture authorization, and the authoritative jurisdiction + parcel key. I understand this approval verifies only the Voxel Vault off-chain identity and does not change the deed or mint a token.</span>
                           </label>
                         ) : null}
 

--- a/app/api/admin/property-claims/route.ts
+++ b/app/api/admin/property-claims/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultAdmin } from '../../../../lib/admin-auth';
+import {
+  authoritativePropertyFingerprint,
+  canonicalizeAuthoritativePropertyIdentity,
+} from '../../../../lib/vault/verified-property-identity.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -45,8 +49,20 @@ function safeClaim(row: any) {
       registryPropertyId: String(identity?.registry_property_id || ''),
       passportTokenId: String(identity?.canonical_passport_token_id || ''),
       verifiedClaimId: String(identity?.verified_claim_id || ''),
+      verifiedPropertyFingerprintSuffix: String(identity?.verified_property_fingerprint || '').slice(-12),
+      verifiedPropertyNamespace: String(identity?.verified_property_namespace || ''),
+      verifiedPropertySource: String(identity?.verified_property_source || ''),
+      verifiedPropertySourceCheckedAt: identity?.verified_property_source_checked_at || null,
     },
   };
+}
+
+function setupRequiredResponse() {
+  return response({
+    ok: false,
+    setupRequired: true,
+    error: 'Apply Supabase migrations 015, 016 and 018 before reviewing property claims.',
+  }, 503);
 }
 
 export async function GET(request: Request) {
@@ -55,12 +71,12 @@ export async function GET(request: Request) {
 
   const { data, error } = await auth.admin
     .from('vault_property_claims')
-    .select('id,user_id,claimant_role,owner_authorized,property_label,locality,claim_status,evidence_manifest,reviewer_note,submitted_at,reviewed_at,vault_property_identities!inner(id,property_fingerprint,country_code,subdivision_code,county_code,parcel_id_normalized,canonical_state,registry_verified,registry_property_id,canonical_passport_token_id,verified_claim_id)')
+    .select('id,user_id,claimant_role,owner_authorized,property_label,locality,claim_status,evidence_manifest,reviewer_note,submitted_at,reviewed_at,vault_property_identities!inner(id,property_fingerprint,country_code,subdivision_code,county_code,parcel_id_normalized,canonical_state,registry_verified,registry_property_id,canonical_passport_token_id,verified_claim_id,verified_property_fingerprint,verified_property_namespace,verified_property_source,verified_property_source_checked_at)')
     .order('submitted_at', { ascending: false })
     .limit(100);
 
   if (error) {
-    if (setupMissing(error)) return response({ ok: false, setupRequired: true, error: 'Apply Supabase migrations 015 and 016 before reviewing property claims.' }, 503);
+    if (setupMissing(error)) return setupRequiredResponse();
     return response({ ok: false, error: 'Property claims could not be loaded for review.' }, 500);
   }
 
@@ -73,6 +89,7 @@ export async function GET(request: Request) {
       canSetOnchainRegistryVerified: false,
       canChangeDeed: false,
       humanEvidenceReviewRequired: true,
+      authoritativeParcelKeyRequired: true,
       competingVerifiedClaimsAllowed: false,
     },
   });
@@ -87,6 +104,9 @@ export async function POST(request: Request) {
   const decision = String(body?.decision || '').trim().toLowerCase();
   const reviewerNote = String(body?.reviewerNote || '').trim();
   const evidenceVerified = body?.evidenceVerified === true;
+  const authoritativeNamespaceInput = String(body?.authoritativeNamespace || '').trim();
+  const authoritativeParcelIdInput = String(body?.authoritativeParcelId || '').trim();
+  const authoritativeSource = String(body?.authoritativeSource || '').trim();
 
   if (!claimId) return response({ ok: false, error: 'claimId is required.' }, 400);
   if (!['verified', 'rejected', 'needs-evidence'].includes(decision)) return response({ ok: false, error: 'Decision must be verified, rejected or needs-evidence.' }, 400);
@@ -94,11 +114,40 @@ export async function POST(request: Request) {
     return response({ ok: false, error: 'Reviewer note must be between 20 and 1000 characters and describe the evidence checked.' }, 400);
   }
 
-  if (decision === 'verified' && !evidenceVerified) {
-    return response({
-      ok: false,
-      error: 'Verification requires an explicit reviewer confirmation that the external parcel, ownership/control, and model-capture evidence was actually checked.',
-    }, 409);
+  let authoritativeFingerprintValue = '';
+  let authoritativeNamespace = '';
+
+  if (decision === 'verified') {
+    if (!evidenceVerified) {
+      return response({
+        ok: false,
+        error: 'Verification requires an explicit reviewer confirmation that the external parcel, ownership/control, and model-capture evidence was actually checked.',
+      }, 409);
+    }
+
+    if (authoritativeSource.length < 5 || authoritativeSource.length > 240) {
+      return response({
+        ok: false,
+        error: 'Verification requires the official assessor/title source used for the authoritative parcel identity.',
+      }, 400);
+    }
+
+    try {
+      const canonical = canonicalizeAuthoritativePropertyIdentity({
+        namespace: authoritativeNamespaceInput,
+        parcelId: authoritativeParcelIdInput,
+      });
+      authoritativeNamespace = canonical.namespace;
+      authoritativeFingerprintValue = authoritativePropertyFingerprint({
+        namespace: canonical.namespace,
+        parcelId: canonical.parcelId,
+      });
+    } catch (error) {
+      return response({
+        ok: false,
+        error: error instanceof Error ? error.message : 'Authoritative parcel identity is invalid.',
+      }, 400);
+    }
   }
 
   if (decision === 'needs-evidence') {
@@ -112,7 +161,7 @@ export async function POST(request: Request) {
       .maybeSingle();
 
     if (updated.error) {
-      if (setupMissing(updated.error)) return response({ ok: false, setupRequired: true, error: 'Apply Supabase migrations 015 and 016 before reviewing property claims.' }, 503);
+      if (setupMissing(updated.error)) return setupRequiredResponse();
       return response({ ok: false, error: 'The request for additional evidence could not be stored.' }, 500);
     }
 
@@ -141,14 +190,23 @@ export async function POST(request: Request) {
     p_decision: rpcDecision,
     p_reviewer_user_id: auth.user.id,
     p_reviewer_note: reviewerNote,
+    p_authoritative_fingerprint: authoritativeFingerprintValue,
+    p_authoritative_namespace: authoritativeNamespace,
+    p_authoritative_source: decision === 'verified' ? authoritativeSource : '',
   });
 
   if (error) {
-    if (setupMissing(error)) return response({ ok: false, setupRequired: true, error: 'Apply Supabase migrations 015 and 016 before reviewing property claims.' }, 503);
+    if (setupMissing(error)) return setupRequiredResponse();
 
     const message = String(error.message || '');
+    if (/PROPERTY_AUTHORITATIVE_IDENTITY_CONFLICT|PROPERTY_AUTHORITATIVE_IDENTITY_ALREADY_ASSIGNED|23505/i.test(`${message} ${error.code || ''}`)) {
+      return response({ ok: false, error: 'This authoritative parcel identity is already bound to a different canonical property. The claim was not approved.' }, 409);
+    }
     if (/PROPERTY_ALREADY_VERIFIED_BY_ANOTHER_CLAIM/i.test(message)) {
       return response({ ok: false, error: 'This parcel already has a different verified canonical claim. The competing claim was not approved.' }, 409);
+    }
+    if (/AUTHORITATIVE_PROPERTY_(FINGERPRINT|NAMESPACE|SOURCE)_REQUIRED/i.test(message)) {
+      return response({ ok: false, error: 'The authoritative assessor/title parcel key is incomplete, so this claim cannot be verified.' }, 409);
     }
     if (/CLAIM_NOT_READY_FOR_APPROVAL|REQUIRED_EVIDENCE_METADATA_MISSING|OWNER_AUTHORIZATION_REQUIRED/i.test(message)) {
       return response({ ok: false, error: 'This claim is not eligible for approval yet. Required authorization/evidence gates are incomplete.' }, 409);
@@ -172,7 +230,7 @@ export async function POST(request: Request) {
     deedChanged: false,
     propertyRightsCreated: false,
     nextStep: decision === 'verified'
-      ? 'The off-chain canonical identity is human-verified. A separate controlled registry-anchor step is still required before the non-transferable canonical Property Passport can be minted.'
+      ? 'The off-chain canonical identity is human-verified and bound to one authoritative parcel fingerprint. A separate controlled registry-anchor step is still required before the non-transferable canonical Property Passport can be minted.'
       : 'The claim is rejected and remains outside the canonical Property Passport path.',
   });
 }

--- a/lib/vault/verified-property-identity.js
+++ b/lib/vault/verified-property-identity.js
@@ -1,0 +1,27 @@
+import crypto from 'node:crypto';
+
+function normalizePart(value, label, maxLength) {
+  const normalized = String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+
+  if (!normalized) throw new Error(`${label} is required.`);
+  if (normalized.length > maxLength) throw new Error(`${label} is too long.`);
+  return normalized;
+}
+
+export function canonicalizeAuthoritativePropertyIdentity({ namespace, parcelId }) {
+  const canonicalNamespace = normalizePart(namespace, 'Authoritative jurisdiction namespace', 96);
+  const canonicalParcelId = normalizePart(parcelId, 'Authoritative parcel/APN', 128);
+  return {
+    namespace: canonicalNamespace,
+    parcelId: canonicalParcelId,
+    canonicalKey: `${canonicalNamespace}:${canonicalParcelId}`,
+  };
+}
+
+export function authoritativePropertyFingerprint(input) {
+  const identity = canonicalizeAuthoritativePropertyIdentity(input);
+  return crypto.createHash('sha256').update(identity.canonicalKey).digest('hex');
+}

--- a/scripts/test-property-claim-verification.mjs
+++ b/scripts/test-property-claim-verification.mjs
@@ -7,6 +7,10 @@ import {
   propertyFingerprint,
   PROPERTY_REVIEW_RULES,
 } from '../lib/vault/property-claim.js';
+import {
+  authoritativePropertyFingerprint,
+  canonicalizeAuthoritativePropertyIdentity,
+} from '../lib/vault/verified-property-identity.js';
 
 const first = {
   countryCode: 'us',
@@ -29,6 +33,27 @@ assert.equal(propertyFingerprint(first), propertyFingerprint(sameParcelDifferent
 
 const sameParcelDifferentAddressText = { ...sameParcelDifferentFormatting, address: 'Completely Different Address Text' };
 assert.equal(propertyFingerprint(first), propertyFingerprint(sameParcelDifferentAddressText), 'Street-address text must not control the canonical property identity.');
+
+const freeTextAliasA = { ...first, countyCode: 'ERIE' };
+const freeTextAliasB = { ...first, countyCode: 'ERIE COUNTY' };
+assert.notEqual(propertyFingerprint(freeTextAliasA), propertyFingerprint(freeTextAliasB), 'Candidate fingerprints may diverge when claimants use different free-text jurisdiction aliases.');
+
+const authoritativeA = canonicalizeAuthoritativePropertyIdentity({
+  namespace: 'US-NY-FIPS-029',
+  parcelId: '12-34.500',
+});
+const authoritativeB = canonicalizeAuthoritativePropertyIdentity({
+  namespace: 'us ny fips 029',
+  parcelId: '12 34 500',
+});
+assert.equal(authoritativeA.canonicalKey, 'USNYFIPS029:1234500');
+assert.equal(
+  authoritativePropertyFingerprint(authoritativeA),
+  authoritativePropertyFingerprint(authoritativeB),
+  'Reviewer-supplied official jurisdiction namespace + parcel must converge despite formatting differences.',
+);
+assert.throws(() => canonicalizeAuthoritativePropertyIdentity({ namespace: '', parcelId: '123' }), /jurisdiction namespace/i);
+assert.throws(() => canonicalizeAuthoritativePropertyIdentity({ namespace: 'US-NY-FIPS-029', parcelId: '' }), /parcel\/APN/i);
 
 assert.throws(() => canonicalizePropertyIdentity({ countryCode: 'US', countyCode: 'ERIE', parcelId: '123' }), /state\/subdivision/i, 'U.S. claims require a state/subdivision.');
 assert.throws(() => canonicalizePropertyIdentity({ countryCode: 'US', subdivisionCode: 'NY', parcelId: '123' }), /assessor jurisdiction\/county/i, 'Claims require an assessor jurisdiction.');
@@ -92,8 +117,18 @@ assert.match(migration016, /PROPERTY_ALREADY_VERIFIED_BY_ANOTHER_CLAIM/i, 'Compe
 assert.match(migration016, /claim_status = 'verified'/i);
 assert.match(migration016, /canonical_state = 'verified'/i);
 assert.doesNotMatch(migration016, /registry_verified\s*=\s*true/i, 'Human review must never silently mark the blockchain registry verified.');
-assert.match(migration016, /revoke all on function public\.admin_review_property_claim.*authenticated/is, 'Authenticated clients must not call the privileged review function directly.');
-assert.match(migration016, /grant execute on function public\.admin_review_property_claim.*service_role/is, 'Only the server service role may execute the review transaction.');
+
+const migration018 = fs.readFileSync(new URL('../supabase/migrations/018_authoritative_verified_property_identity.sql', import.meta.url), 'utf8');
+assert.match(migration018, /verified_property_fingerprint text/i, 'Verified identities need a second authoritative property fingerprint.');
+assert.match(migration018, /unique index[\s\S]*verified_property_fingerprint/i, 'Authoritative property fingerprints must be unique across canonical identities.');
+assert.match(migration018, /drop function if exists public\.admin_review_property_claim\(uuid, text, uuid, text\)/i, 'The legacy approval signature must be removed so it cannot bypass the authoritative key gate.');
+assert.match(migration018, /AUTHORITATIVE_PROPERTY_FINGERPRINT_REQUIRED/i);
+assert.match(migration018, /PROPERTY_AUTHORITATIVE_IDENTITY_CONFLICT/i);
+assert.match(migration018, /p_authoritative_fingerprint text/i);
+assert.match(migration018, /verified_property_fingerprint = v_fingerprint/i);
+assert.doesNotMatch(migration018, /registry_verified\s*=\s*true/i, 'Authoritative identity approval must remain off-chain.');
+assert.match(migration018, /revoke all on function public\.admin_review_property_claim.*authenticated/is, 'Authenticated clients must not call the privileged authoritative review function directly.');
+assert.match(migration018, /grant execute on function public\.admin_review_property_claim.*service_role/is, 'Only the server service role may execute the authoritative review transaction.');
 
 const route = fs.readFileSync(new URL('../app/api/vault/property-claims/route.ts', import.meta.url), 'utf8');
 assert.match(route, /requireVoxelVaultUser/);
@@ -117,6 +152,11 @@ const adminRoute = fs.readFileSync(new URL('../app/api/admin/property-claims/rou
 assert.match(adminRoute, /requireVoxelVaultAdmin/);
 assert.match(adminRoute, /reviewer note must be between 20 and 1000 characters/i);
 assert.match(adminRoute, /evidenceVerified/);
+assert.match(adminRoute, /authoritativePropertyFingerprint/);
+assert.match(adminRoute, /canonicalizeAuthoritativePropertyIdentity/);
+assert.match(adminRoute, /p_authoritative_fingerprint: authoritativeFingerprintValue/);
+assert.match(adminRoute, /p_authoritative_namespace: authoritativeNamespace/);
+assert.match(adminRoute, /official assessor\/title source/i);
 assert.match(adminRoute, /rpc\('admin_review_property_claim'/, 'Approval/rejection must use the transactional database transition.');
 assert.match(adminRoute, /\.in\('claim_status', \['needs-evidence', 'under-review'\]\)/, 'Needs-evidence transitions must not overwrite a concurrently terminal claim.');
 assert.match(adminRoute, /This claim is no longer reviewable/i, 'Race-lost admin updates must fail closed.');
@@ -130,6 +170,8 @@ assert.doesNotMatch(adminRoute, /setVerified\s*\(/, 'Reviewer API must not set t
 const adminPage = fs.readFileSync(new URL('../app/admin/property-claims/page.js', import.meta.url), 'utf8');
 assert.match(adminPage, /Never guess ownership/i);
 assert.match(adminPage, /claimant-supplied metadata, not proof/i);
+assert.match(adminPage, /AUTHORITATIVE PARCEL KEY/i);
+assert.match(adminPage, /Official jurisdiction namespace\/code/i);
 assert.match(adminPage, /I independently reviewed the external parcel record/i, 'Verify action must require explicit human evidence confirmation.');
 assert.match(adminPage, /PASSPORT MINTS HERE/i);
 

--- a/supabase/migrations/018_authoritative_verified_property_identity.sql
+++ b/supabase/migrations/018_authoritative_verified_property_identity.sql
@@ -1,0 +1,191 @@
+-- Bind human-approved property claims to one authoritative parcel identity.
+-- Candidate claim fingerprints may still use user-entered jurisdiction labels, but a
+-- claim cannot become verified until an admin supplies a stable official jurisdiction
+-- namespace/code plus parcel/APN from an independently checked source.
+
+alter table public.vault_property_identities
+  add column if not exists verified_property_fingerprint text,
+  add column if not exists verified_property_namespace text,
+  add column if not exists verified_property_source text,
+  add column if not exists verified_property_source_checked_at timestamptz;
+
+alter table public.vault_property_identities
+  drop constraint if exists vault_property_identities_verified_property_fingerprint_check;
+
+alter table public.vault_property_identities
+  add constraint vault_property_identities_verified_property_fingerprint_check
+  check (
+    verified_property_fingerprint is null
+    or verified_property_fingerprint ~ '^[0-9a-f]{64}$'
+  );
+
+create unique index if not exists vault_property_identities_verified_property_fingerprint_idx
+  on public.vault_property_identities(verified_property_fingerprint)
+  where verified_property_fingerprint is not null;
+
+-- Remove the old approval signature so there is no alternate path that can approve a
+-- claim without an authoritative property fingerprint.
+drop function if exists public.admin_review_property_claim(uuid, text, uuid, text);
+drop function if exists public.admin_review_property_claim(uuid, text, uuid, text, text, text, text);
+
+create function public.admin_review_property_claim(
+  p_claim_id uuid,
+  p_decision text,
+  p_reviewer_user_id uuid,
+  p_reviewer_note text,
+  p_authoritative_fingerprint text,
+  p_authoritative_namespace text,
+  p_authoritative_source text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_claim public.vault_property_claims%rowtype;
+  v_identity public.vault_property_identities%rowtype;
+  v_conflict_identity uuid;
+  v_decision text := lower(trim(coalesce(p_decision, '')));
+  v_note text := trim(coalesce(p_reviewer_note, ''));
+  v_fingerprint text := lower(trim(coalesce(p_authoritative_fingerprint, '')));
+  v_namespace text := trim(coalesce(p_authoritative_namespace, ''));
+  v_source text := trim(coalesce(p_authoritative_source, ''));
+begin
+  if p_reviewer_user_id is null then
+    raise exception 'REVIEWER_REQUIRED';
+  end if;
+
+  if v_decision not in ('approve', 'reject') then
+    raise exception 'INVALID_REVIEW_DECISION';
+  end if;
+
+  if char_length(v_note) < 20 or char_length(v_note) > 1000 then
+    raise exception 'REVIEWER_NOTE_LENGTH_INVALID';
+  end if;
+
+  select * into v_claim
+  from public.vault_property_claims
+  where id = p_claim_id
+  for update;
+
+  if not found then
+    raise exception 'PROPERTY_CLAIM_NOT_FOUND';
+  end if;
+
+  select * into v_identity
+  from public.vault_property_identities
+  where id = v_claim.property_identity_id
+  for update;
+
+  if not found then
+    raise exception 'PROPERTY_IDENTITY_NOT_FOUND';
+  end if;
+
+  if v_decision = 'approve' then
+    if v_claim.claim_status <> 'under-review' then
+      raise exception 'CLAIM_NOT_READY_FOR_APPROVAL';
+    end if;
+
+    if v_claim.owner_authorized is not true then
+      raise exception 'OWNER_AUTHORIZATION_REQUIRED';
+    end if;
+
+    if not (
+      coalesce(v_claim.evidence_manifest->'types', '[]'::jsonb) ? 'parcel-record'
+      and coalesce(v_claim.evidence_manifest->'types', '[]'::jsonb) ? 'ownership-or-control'
+      and coalesce(v_claim.evidence_manifest->'types', '[]'::jsonb) ? 'model-capture-rights'
+    ) then
+      raise exception 'REQUIRED_EVIDENCE_METADATA_MISSING';
+    end if;
+
+    if v_fingerprint !~ '^[0-9a-f]{64}$' then
+      raise exception 'AUTHORITATIVE_PROPERTY_FINGERPRINT_REQUIRED';
+    end if;
+
+    if char_length(v_namespace) < 2 or char_length(v_namespace) > 96 then
+      raise exception 'AUTHORITATIVE_PROPERTY_NAMESPACE_REQUIRED';
+    end if;
+
+    if char_length(v_source) < 5 or char_length(v_source) > 240 then
+      raise exception 'AUTHORITATIVE_PROPERTY_SOURCE_REQUIRED';
+    end if;
+
+    if v_identity.verified_claim_id is not null and v_identity.verified_claim_id <> v_claim.id then
+      raise exception 'PROPERTY_ALREADY_VERIFIED_BY_ANOTHER_CLAIM';
+    end if;
+
+    if v_identity.verified_property_fingerprint is not null
+       and v_identity.verified_property_fingerprint <> v_fingerprint then
+      raise exception 'PROPERTY_AUTHORITATIVE_IDENTITY_ALREADY_ASSIGNED';
+    end if;
+
+    select id into v_conflict_identity
+    from public.vault_property_identities
+    where verified_property_fingerprint = v_fingerprint
+      and id <> v_identity.id
+    limit 1
+    for update;
+
+    if v_conflict_identity is not null then
+      raise exception 'PROPERTY_AUTHORITATIVE_IDENTITY_CONFLICT';
+    end if;
+
+    update public.vault_property_claims
+    set claim_status = 'verified',
+        reviewer_note = v_note,
+        reviewed_at = now(),
+        updated_at = now()
+    where id = v_claim.id;
+
+    update public.vault_property_identities
+    set canonical_state = 'verified',
+        verified_claim_id = v_claim.id,
+        verified_at = now(),
+        verified_by = p_reviewer_user_id,
+        verified_property_fingerprint = v_fingerprint,
+        verified_property_namespace = v_namespace,
+        verified_property_source = v_source,
+        verified_property_source_checked_at = now(),
+        updated_at = now()
+    where id = v_identity.id;
+
+    return jsonb_build_object(
+      'claimId', v_claim.id,
+      'status', 'verified',
+      'canonicalState', 'verified',
+      'verifiedPropertyFingerprintSuffix', right(v_fingerprint, 12),
+      'registryVerified', v_identity.registry_verified,
+      'passportMinted', false,
+      'deedChanged', false,
+      'propertyRightsCreated', false
+    );
+  end if;
+
+  if v_claim.claim_status not in ('needs-evidence', 'under-review') then
+    raise exception 'CLAIM_NOT_REVIEWABLE';
+  end if;
+
+  update public.vault_property_claims
+  set claim_status = 'rejected',
+      reviewer_note = v_note,
+      reviewed_at = now(),
+      updated_at = now()
+  where id = v_claim.id;
+
+  return jsonb_build_object(
+    'claimId', v_claim.id,
+    'status', 'rejected',
+    'canonicalState', v_identity.canonical_state,
+    'registryVerified', v_identity.registry_verified,
+    'passportMinted', false,
+    'deedChanged', false,
+    'propertyRightsCreated', false
+  );
+end;
+$$;
+
+revoke all on function public.admin_review_property_claim(uuid, text, uuid, text, text, text, text) from public;
+revoke all on function public.admin_review_property_claim(uuid, text, uuid, text, text, text, text) from anon;
+revoke all on function public.admin_review_property_claim(uuid, text, uuid, text, text, text, text) from authenticated;
+grant execute on function public.admin_review_property_claim(uuid, text, uuid, text, text, text, text) to service_role;


### PR DESCRIPTION
Hardens the real-property claim flow so free-text jurisdiction aliases cannot produce multiple verified identities for the same real parcel.

Changes:
- adds a server-side authoritative jurisdiction+parcel fingerprint helper
- adds migration 018 with a unique authoritative verified-property fingerprint
- removes the legacy admin review RPC signature so there is no bypass around the authoritative key gate
- installs the hardened admin review RPC (also filling the currently missing production review function from manual reconciliation)
- requires official jurisdiction namespace/code, authoritative parcel/APN, and source before admin verification
- keeps registry verification, Passport minting, deed transfer, and property rights creation locked/separate
- expands property-claim regression tests for alias convergence and uniqueness

Do not apply migration 018 to production until this PR head is fully green.