### PR TITLE
Make Digital Estate minting optional after purchase

### DIFF
--- a/app/api/digital-estates/checkout/route.ts
+++ b/app/api/digital-estates/checkout/route.ts
@@ -3,7 +3,7 @@ import { getAddress } from 'ethers';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { getStripe } from '../../../../lib/stripe-server';
 import { assertDigitalEstatePricing, DIGITAL_ESTATE_DISCLOSURE, estateCheckoutSupported, getDigitalEstate } from '../../../../lib/digital-estates';
-import { digitalEstateMintReady, isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
+import { isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
 import { acquireDigitalEstateReservation, releaseDigitalEstateReservation, updateDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
 
 export const runtime = 'nodejs';
@@ -32,19 +32,12 @@ export async function POST(request: Request) {
     const wallet = getAddress(walletRaw);
 
     if (!estateCheckoutSupported(estate)) {
-      return NextResponse.json({
-        error: 'This Digital Estate exceeds the instant hosted-checkout rail. Use a supported high-value settlement path instead.',
-        highValueSettlementRequired: true,
-      }, { status: 409 });
-    }
-    if (!digitalEstateMintReady()) {
-      return NextResponse.json({ error: 'Digital Estate minting is not configured, so payment is paused. No checkout was created.' }, { status: 503 });
+      return NextResponse.json({ error: 'This Digital Estate exceeds the instant hosted-checkout rail. Use a supported high-value settlement path instead.', highValueSettlementRequired: true }, { status: 409 });
     }
 
     let alreadyMinted = false;
-    try {
-      alreadyMinted = await isDigitalEstateMinted(estate.id);
-    } catch (error) {
+    try { alreadyMinted = await isDigitalEstateMinted(estate.id); }
+    catch (error) {
       console.error('Digital Estate availability check failed', error);
       return NextResponse.json({ error: 'Blockchain availability could not be verified. Checkout stopped before payment.' }, { status: 503 });
     }
@@ -61,30 +54,17 @@ export async function POST(request: Request) {
       const stripe = getStripe();
       const previous = await stripe.checkout.sessions.retrieve(hold.reservation.sourceId);
       if (previous.payment_status === 'paid') {
-        await updateDigitalEstateReservation({
-          estateId: estate.id,
-          buyerId: hold.reservation.buyerId,
-          wallet: hold.reservation.wallet,
-          state: 'paid',
-          source: 'stripe',
-          sourceId: previous.id,
-        });
+        await updateDigitalEstateReservation({ estateId: estate.id, buyerId: hold.reservation.buyerId, wallet: hold.reservation.wallet, state: 'paid', source: 'stripe', sourceId: previous.id });
         return NextResponse.json({ error: 'This Digital Estate has already been paid for.', sold: true }, { status: 409 });
       }
       if (previous.status === 'expired') {
-        await releaseDigitalEstateReservation({
-          estateId: estate.id,
-          buyerId: hold.reservation.buyerId,
-          wallet: hold.reservation.wallet,
-        });
+        await releaseDigitalEstateReservation({ estateId: estate.id, buyerId: hold.reservation.buyerId, wallet: hold.reservation.wallet });
         hold = await acquireDigitalEstateReservation({ estateId: estate.id, buyerId: user.id, wallet, source: 'stripe' });
       } else if (hold.reservedByYou && previous.status === 'open' && previous.url) {
         return NextResponse.json({ url: previous.url, resumed: true, estateId: estate.id });
       } else {
         return NextResponse.json({
-          error: previous.status === 'complete'
-            ? 'Payment for this Digital Estate is still being confirmed.'
-            : 'This Digital Estate is temporarily reserved by another checkout.',
+          error: previous.status === 'complete' ? 'Payment for this Digital Estate is still being confirmed.' : 'This Digital Estate is temporarily reserved by another checkout.',
           reserved: true,
           paymentPending: previous.status === 'complete',
         }, { status: 409 });
@@ -92,11 +72,7 @@ export async function POST(request: Request) {
     }
 
     if (!hold.acquired) {
-      return NextResponse.json({
-        error: hold.sold ? 'This Digital Estate has already been purchased.' : 'This Digital Estate is temporarily reserved by another checkout.',
-        sold: hold.sold,
-        reserved: !hold.sold,
-      }, { status: 409 });
+      return NextResponse.json({ error: hold.sold ? 'This Digital Estate has already been purchased.' : 'This Digital Estate is temporarily reserved by another checkout.', sold: hold.sold, reserved: !hold.sold }, { status: 409 });
     }
 
     reservation = { estateId: estate.id, buyerId: user.id, wallet };
@@ -110,6 +86,7 @@ export async function POST(request: Request) {
       purchase_price_cents: String(estate.purchasePriceCents),
       reference_value_cents: String(estate.referenceValueCents),
       rights: 'digital_only_no_real_property_rights',
+      minting: 'optional_after_purchase',
     };
 
     const session = await stripe.checkout.sessions.create({
@@ -118,17 +95,7 @@ export async function POST(request: Request) {
       billing_address_collection: 'required',
       phone_number_collection: { enabled: true },
       client_reference_id: user.id,
-      line_items: [{
-        quantity: 1,
-        price_data: {
-          currency: 'usd',
-          unit_amount: estate.purchasePriceCents,
-          product_data: {
-            name: estate.name,
-            description: `Unique Voxel Vault Digital Estate. ${DIGITAL_ESTATE_DISCLOSURE}`.slice(0, 500),
-          },
-        },
-      }],
+      line_items: [{ quantity: 1, price_data: { currency: 'usd', unit_amount: estate.purchasePriceCents, product_data: { name: estate.name, description: `Unique Voxel Vault Digital Estate. ${DIGITAL_ESTATE_DISCLOSURE}`.slice(0, 500) } } }],
       metadata,
       payment_intent_data: { metadata },
       success_url: `${origin}/vault/estates/success?session_id={CHECKOUT_SESSION_ID}`,
@@ -140,7 +107,7 @@ export async function POST(request: Request) {
     await updateDigitalEstateReservation({ estateId: estate.id, buyerId: user.id, wallet, state: 'checkout', source: 'stripe', sourceId: session.id });
     reservation = null;
 
-    return NextResponse.json({ url: session.url, estateId: estate.id, amountCents: estate.purchasePriceCents, paymentMethods: 'dynamic-eligible-methods' });
+    return NextResponse.json({ url: session.url, estateId: estate.id, amountCents: estate.purchasePriceCents, paymentMethods: 'dynamic-eligible-methods', mintOptional: true });
   } catch (error) {
     console.error('Digital Estate checkout failed', error);
     if (reservation) {

--- a/app/api/digital-estates/claim/route.ts
+++ b/app/api/digital-estates/claim/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getAddress } from 'ethers';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { getStripe } from '../../../../lib/stripe-server';
+import { assertDigitalEstatePricing, getDigitalEstate } from '../../../../lib/digital-estates';
 import { buildDigitalEstateVoucher, digitalEstateMintReady, isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
 import { readDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
 import {
@@ -23,15 +24,30 @@ async function authenticatedUser(request: Request) {
   return error ? null : user;
 }
 
-async function optionalMintResponse({ request, user, purchase, requestedWallet }: { request: Request; user: any; purchase: any; requestedWallet?: string }) {
-  if (purchase.buyerId !== user.id) {
-    return NextResponse.json({ error: 'This Digital Estate belongs to another Voxel Vault account.' }, { status: 403 });
+async function purchaseFromSecuredOwnership({ user, estateId, walletRaw }: { user: any; estateId: string; walletRaw: string }) {
+  const estate = assertDigitalEstatePricing(getDigitalEstate(estateId));
+  if (!ADDRESS_RE.test(walletRaw)) throw new Error('DIGITAL_ESTATE_WALLET_INVALID');
+  const wallet = getAddress(walletRaw);
+  const reservation = await readDigitalEstateReservation(estate.id);
+  if (!reservation || reservation.buyerId !== user.id || reservation.wallet !== wallet.toLowerCase()) {
+    throw new Error('DIGITAL_ESTATE_RESERVATION_MISMATCH');
   }
+  if (!['paid', 'paid-usdc', 'minted'].includes(reservation.state)) throw new Error('DIGITAL_ESTATE_RESERVATION_STATE_INVALID');
+  return {
+    estate,
+    buyerId: user.id,
+    wallet,
+    source: reservation.source,
+    sourceId: reservation.sourceId || null,
+    paymentTxHash: reservation.source === 'base-usdc' ? reservation.sourceId || null : null,
+  };
+}
 
-  if (requestedWallet) {
-    if (!ADDRESS_RE.test(requestedWallet) || getAddress(requestedWallet) !== getAddress(purchase.wallet)) {
-      return NextResponse.json({ error: 'Connect the same wallet that was bound when this Digital Estate was purchased.' }, { status: 403 });
-    }
+async function optionalMintResponse({ request, user, purchase, requestedWallet }: { request: Request; user: any; purchase: any; requestedWallet?: string }) {
+  if (purchase.buyerId !== user.id) return NextResponse.json({ error: 'This Digital Estate belongs to another Voxel Vault account.' }, { status: 403 });
+
+  if (requestedWallet && (!ADDRESS_RE.test(requestedWallet) || getAddress(requestedWallet) !== getAddress(purchase.wallet))) {
+    return NextResponse.json({ error: 'Connect the same wallet that was bound when this Digital Estate was purchased.' }, { status: 403 });
   }
 
   const reservation = await readDigitalEstateReservation(purchase.estate.id);
@@ -43,43 +59,15 @@ async function optionalMintResponse({ request, user, purchase, requestedWallet }
   }
 
   if (await isDigitalEstateMinted(purchase.estate.id)) {
-    return NextResponse.json({
-      ready: false,
-      ownershipSecured: true,
-      alreadyMinted: true,
-      mintOptional: true,
-      estate: purchase.estate,
-      wallet: purchase.wallet,
-      error: 'This Digital Estate has already been minted onchain.',
-    }, { status: 409 });
+    return NextResponse.json({ ready: false, ownershipSecured: true, alreadyMinted: true, mintOptional: true, estate: purchase.estate, wallet: purchase.wallet, error: 'This Digital Estate has already been minted onchain.' }, { status: 409 });
   }
 
   if (!digitalEstateMintReady()) {
-    return NextResponse.json({
-      ready: false,
-      ownershipSecured: true,
-      mintOptional: true,
-      estate: purchase.estate,
-      wallet: purchase.wallet,
-      error: 'Your Digital Estate is secured, but optional minting is temporarily unavailable. You can mint later without losing ownership.',
-    }, { status: 503 });
+    return NextResponse.json({ ready: false, ownershipSecured: true, mintOptional: true, estate: purchase.estate, wallet: purchase.wallet, error: 'Your Digital Estate is secured, but optional minting is temporarily unavailable. You can mint later without losing ownership.' }, { status: 503 });
   }
 
-  const voucher = await buildDigitalEstateVoucher({
-    estateId: purchase.estate.id,
-    wallet: purchase.wallet,
-    origin: new URL(request.url).origin,
-  });
-  return NextResponse.json({
-    ready: true,
-    ownershipSecured: true,
-    mintOptional: true,
-    source: purchase.source,
-    estate: purchase.estate,
-    wallet: purchase.wallet,
-    paymentTxHash: purchase.paymentTxHash || null,
-    ...voucher,
-  });
+  const voucher = await buildDigitalEstateVoucher({ estateId: purchase.estate.id, wallet: purchase.wallet, origin: new URL(request.url).origin });
+  return NextResponse.json({ ready: true, ownershipSecured: true, mintOptional: true, source: purchase.source, estate: purchase.estate, wallet: purchase.wallet, paymentTxHash: purchase.paymentTxHash || null, ...voucher });
 }
 
 export async function POST(request: Request) {
@@ -89,8 +77,8 @@ export async function POST(request: Request) {
 
     const body = await request.json().catch(() => ({}));
     const source = String(body?.source || '').trim().toLowerCase();
-    // Keep legacy callers safe during rollout: omission still means the old
-    // verify+mint preparation behavior. New UI explicitly sends "secure" first.
+    // Legacy callers still prepare minting when action is omitted. New UI sends
+    // action=secure immediately after payment, then source=owned for later minting.
     const action = String(body?.action || 'mint').trim().toLowerCase();
 
     let purchase;
@@ -101,12 +89,10 @@ export async function POST(request: Request) {
       const session = await stripe.checkout.sessions.retrieve(sessionId);
       purchase = await secureStripeDigitalEstatePurchase({ session, expectedBuyerId: user.id });
     } else if (source === 'base-usdc') {
-      purchase = await secureBaseUsdcDigitalEstatePurchase({
-        estateId: String(body?.estateId || ''),
-        buyerId: user.id,
-        wallet: String(body?.wallet || ''),
-        txHash: String(body?.txHash || ''),
-      });
+      purchase = await secureBaseUsdcDigitalEstatePurchase({ estateId: String(body?.estateId || ''), buyerId: user.id, wallet: String(body?.wallet || ''), txHash: String(body?.txHash || '') });
+    } else if (source === 'owned') {
+      if (action !== 'mint') return NextResponse.json({ error: 'Owned-estate access is only used for optional minting.' }, { status: 400 });
+      purchase = await purchaseFromSecuredOwnership({ user, estateId: String(body?.estateId || ''), walletRaw: String(body?.wallet || '') });
     } else {
       return NextResponse.json({ error: 'Unsupported Digital Estate payment source.' }, { status: 400 });
     }
@@ -125,12 +111,7 @@ export async function POST(request: Request) {
     }
 
     if (action !== 'mint') return NextResponse.json({ error: 'Unsupported Digital Estate purchase action.' }, { status: 400 });
-    return await optionalMintResponse({
-      request,
-      user,
-      purchase,
-      requestedWallet: String(body?.wallet || '').trim() || undefined,
-    });
+    return await optionalMintResponse({ request, user, purchase, requestedWallet: String(body?.wallet || '').trim() || undefined });
   } catch (error) {
     console.error('Digital Estate purchase verification failed', error);
     const message = digitalEstatePaymentErrorMessage(error);

--- a/app/api/digital-estates/claim/route.ts
+++ b/app/api/digital-estates/claim/route.ts
@@ -1,19 +1,18 @@
 import { NextResponse } from 'next/server';
-import { getAddress, Interface, JsonRpcProvider } from 'ethers';
+import { getAddress } from 'ethers';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { getStripe } from '../../../../lib/stripe-server';
-import { assertDigitalEstatePricing, getDigitalEstate } from '../../../../lib/digital-estates';
 import { buildDigitalEstateVoucher, digitalEstateMintReady, isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
-import { readDigitalEstateReservation, updateDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
-import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
+import { readDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
+import {
+  digitalEstatePaymentErrorMessage,
+  secureBaseUsdcDigitalEstatePurchase,
+  secureStripeDigitalEstatePurchase,
+} from '../../../../lib/digital-estate-purchases';
 
 export const runtime = 'nodejs';
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
-const TX_RE = /^0x[a-fA-F0-9]{64}$/;
-const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
-const USDC_PAYMENT_PROVIDER = 'digital-estate-usdc-payment';
-const USDC_INTERFACE = new Interface(['event Transfer(address indexed from,address indexed to,uint256 value)']);
 
 async function authenticatedUser(request: Request) {
   const auth = request.headers.get('authorization');
@@ -24,188 +23,118 @@ async function authenticatedUser(request: Request) {
   return error ? null : user;
 }
 
-function paymentEventType({ estateId, buyerId, wallet, amountUnits }: { estateId: string; buyerId: string; wallet: string; amountUnits: string }) {
-  return JSON.stringify({ kind: 'digital-estate-usdc', estateId, buyerId, wallet: wallet.toLowerCase(), amountUnits });
-}
+async function optionalMintResponse({ request, user, purchase, requestedWallet }: { request: Request; user: any; purchase: any; requestedWallet?: string }) {
+  if (purchase.buyerId !== user.id) {
+    return NextResponse.json({ error: 'This Digital Estate belongs to another Voxel Vault account.' }, { status: 403 });
+  }
 
-async function recordOrVerifyUsdcPayment({
-  txHash,
-  estateId,
-  buyerId,
-  wallet,
-  amountUnits,
-}: {
-  txHash: string;
-  estateId: string;
-  buyerId: string;
-  wallet: string;
-  amountUnits: string;
-}) {
-  const supabase = getSupabaseAdmin();
-  const expectedType = paymentEventType({ estateId, buyerId, wallet, amountUnits });
-  const { error } = await supabase.from('commerce_webhook_events').insert({
-    provider: USDC_PAYMENT_PROVIDER,
-    event_id: txHash.toLowerCase(),
-    event_type: expectedType,
-    processed_at: new Date().toISOString(),
+  if (requestedWallet) {
+    if (!ADDRESS_RE.test(requestedWallet) || getAddress(requestedWallet) !== getAddress(purchase.wallet)) {
+      return NextResponse.json({ error: 'Connect the same wallet that was bound when this Digital Estate was purchased.' }, { status: 403 });
+    }
+  }
+
+  const reservation = await readDigitalEstateReservation(purchase.estate.id);
+  if (!reservation || reservation.buyerId !== user.id || reservation.wallet !== purchase.wallet.toLowerCase()) {
+    return NextResponse.json({ error: 'The secured Digital Estate ownership record could not be verified.' }, { status: 409 });
+  }
+  if (!['paid', 'paid-usdc', 'minted'].includes(reservation.state)) {
+    return NextResponse.json({ error: 'This Digital Estate is not secured as a paid purchase yet.' }, { status: 409 });
+  }
+
+  if (await isDigitalEstateMinted(purchase.estate.id)) {
+    return NextResponse.json({
+      ready: false,
+      ownershipSecured: true,
+      alreadyMinted: true,
+      mintOptional: true,
+      estate: purchase.estate,
+      wallet: purchase.wallet,
+      error: 'This Digital Estate has already been minted onchain.',
+    }, { status: 409 });
+  }
+
+  if (!digitalEstateMintReady()) {
+    return NextResponse.json({
+      ready: false,
+      ownershipSecured: true,
+      mintOptional: true,
+      estate: purchase.estate,
+      wallet: purchase.wallet,
+      error: 'Your Digital Estate is secured, but optional minting is temporarily unavailable. You can mint later without losing ownership.',
+    }, { status: 503 });
+  }
+
+  const voucher = await buildDigitalEstateVoucher({
+    estateId: purchase.estate.id,
+    wallet: purchase.wallet,
+    origin: new URL(request.url).origin,
   });
-  if (!error) return;
-  if (error.code !== '23505') throw error;
-
-  const { data: existing, error: lookupError } = await supabase
-    .from('commerce_webhook_events')
-    .select('event_type')
-    .eq('provider', USDC_PAYMENT_PROVIDER)
-    .eq('event_id', txHash.toLowerCase())
-    .single();
-  if (lookupError || !existing) throw lookupError || new Error('USDC payment idempotency record could not be verified.');
-  if (String(existing.event_type) !== expectedType) throw new Error('This USDC transaction was already used for another purchase.');
-}
-
-async function claimFromStripe({ request, user, body }: { request: Request; user: any; body: any }) {
-  const sessionId = String(body?.sessionId || '').trim();
-  if (!sessionId.startsWith('cs_')) return NextResponse.json({ error: 'A valid Checkout Session is required.' }, { status: 400 });
-
-  const stripe = getStripe();
-  const session = await stripe.checkout.sessions.retrieve(sessionId);
-  if (session.payment_status !== 'paid') {
-    return NextResponse.json({ error: 'Payment is not confirmed yet. Voxel Vault will not issue a mint voucher until Stripe reports paid.', paymentPending: true }, { status: 409 });
-  }
-  if (session.metadata?.kind !== 'digital_estate' || session.metadata?.buyer_id !== user.id) {
-    return NextResponse.json({ error: 'This payment does not belong to your Digital Estate purchase.' }, { status: 403 });
-  }
-
-  const estate = assertDigitalEstatePricing(getDigitalEstate(session.metadata?.estate_id));
-  const walletRaw = String(session.metadata?.wallet || '');
-  if (!ADDRESS_RE.test(walletRaw)) return NextResponse.json({ error: 'The paid session is missing its bound wallet.' }, { status: 409 });
-  const wallet = getAddress(walletRaw);
-  const requestedWallet = String(body?.wallet || '').trim();
-  if (requestedWallet && (!ADDRESS_RE.test(requestedWallet) || getAddress(requestedWallet) !== wallet)) {
-    return NextResponse.json({ error: 'Connect the same wallet that was bound before checkout.' }, { status: 403 });
-  }
-  if (session.currency !== 'usd' || Number(session.amount_total) !== estate.purchasePriceCents) {
-    return NextResponse.json({ error: 'Paid amount does not match the server-authoritative Digital Estate price.' }, { status: 409 });
-  }
-  if (String(session.metadata?.purchase_price_cents || '') !== String(estate.purchasePriceCents)
-    || String(session.metadata?.reference_value_cents || '') !== String(estate.referenceValueCents)) {
-    return NextResponse.json({ error: 'Checkout metadata no longer matches the reviewed estate catalog.' }, { status: 409 });
-  }
-
-  const reservation = await readDigitalEstateReservation(estate.id);
-  if (!reservation || reservation.buyerId !== user.id || reservation.wallet !== wallet.toLowerCase()) {
-    return NextResponse.json({ error: 'The paid estate reservation could not be matched to your account and wallet.' }, { status: 409 });
-  }
-  if (reservation.sourceId && reservation.sourceId !== session.id) {
-    return NextResponse.json({ error: 'A different payment source already owns this estate reservation.' }, { status: 409 });
-  }
-  if (!['checkout', 'paid'].includes(reservation.state)) {
-    return NextResponse.json({ error: `Estate reservation is in unexpected state ${reservation.state}.` }, { status: 409 });
-  }
-  if (reservation.state !== 'paid') {
-    await updateDigitalEstateReservation({ estateId: estate.id, buyerId: user.id, wallet, state: 'paid', source: 'stripe', sourceId: session.id });
-  }
-
-  if (await isDigitalEstateMinted(estate.id)) {
-    return NextResponse.json({ ready: false, alreadyMinted: true, estateId: estate.id, wallet, error: 'This Digital Estate voucher has already been minted onchain.' }, { status: 409 });
-  }
-
-  const voucher = await buildDigitalEstateVoucher({ estateId: estate.id, wallet, origin: new URL(request.url).origin });
-  return NextResponse.json({ ready: true, source: 'stripe', estate, wallet, ...voucher });
-}
-
-async function claimFromBaseUsdc({ request, user, body }: { request: Request; user: any; body: any }) {
-  const estate = assertDigitalEstatePricing(getDigitalEstate(body?.estateId));
-  const walletRaw = String(body?.wallet || '').trim();
-  const txHash = String(body?.txHash || '').trim();
-  if (!ADDRESS_RE.test(walletRaw) || !TX_RE.test(txHash)) {
-    return NextResponse.json({ error: 'A valid wallet and Base USDC transaction hash are required.' }, { status: 400 });
-  }
-  const wallet = getAddress(walletRaw);
-  const reservation = await readDigitalEstateReservation(estate.id);
-  if (!reservation || reservation.buyerId !== user.id || reservation.wallet !== wallet.toLowerCase() || reservation.source !== 'base-usdc') {
-    return NextResponse.json({ error: 'No matching USDC reservation exists for this account, wallet, and estate.' }, { status: 409 });
-  }
-  if (reservation.state === 'paid-usdc' && reservation.sourceId && reservation.sourceId.toLowerCase() !== txHash.toLowerCase()) {
-    return NextResponse.json({ error: 'This estate was already paid with a different USDC transaction.' }, { status: 409 });
-  }
-  if (!['reserved', 'paid-usdc'].includes(reservation.state)) {
-    return NextResponse.json({ error: `Estate reservation is in unexpected state ${reservation.state}.` }, { status: 409 });
-  }
-
-  const deployment = await getVoxelFlipDeployment();
-  const recipientRaw = process.env.DIGITAL_ESTATE_USDC_RECIPIENT?.trim() || deployment.royaltyReceiver;
-  if (!ADDRESS_RE.test(recipientRaw)) return NextResponse.json({ error: 'Reviewed USDC recipient is unavailable.' }, { status: 503 });
-  const recipient = getAddress(recipientRaw);
-  const rpc = process.env.BASE_RPC_URL?.trim() || 'https://mainnet.base.org';
-  const provider = new JsonRpcProvider(rpc, 8453, { staticNetwork: true });
-  try {
-    const [transaction, receipt] = await Promise.all([
-      provider.getTransaction(txHash),
-      provider.getTransactionReceipt(txHash),
-    ]);
-    if (!transaction || !receipt || Number(receipt.status) !== 1) {
-      return NextResponse.json({ error: 'The Base USDC transaction is not confirmed successfully.' }, { status: 409 });
-    }
-    if (getAddress(transaction.from) !== wallet || !transaction.to || getAddress(transaction.to) !== getAddress(BASE_USDC)) {
-      return NextResponse.json({ error: 'The transaction sender or token contract does not match this purchase.' }, { status: 409 });
-    }
-
-    const block = await provider.getBlock(receipt.blockNumber);
-    if (!block) return NextResponse.json({ error: 'The USDC payment block could not be verified.' }, { status: 503 });
-    if (reservation.state === 'reserved') {
-      const reservedAtSeconds = Math.floor(Date.parse(reservation.processedAt) / 1000);
-      if (!Number.isFinite(reservedAtSeconds) || block.timestamp < reservedAtSeconds - 120 || block.timestamp > reservedAtSeconds + 45 * 60) {
-        return NextResponse.json({ error: 'This USDC transfer falls outside the active estate reservation window.' }, { status: 409 });
-      }
-    }
-
-    const expectedUnits = BigInt(estate.purchasePriceCents) * BigInt(10_000);
-    let exactTransfer = false;
-    for (const log of receipt.logs) {
-      if (getAddress(log.address) !== getAddress(BASE_USDC)) continue;
-      try {
-        const parsed = USDC_INTERFACE.parseLog({ topics: log.topics as string[], data: log.data });
-        if (!parsed || parsed.name !== 'Transfer') continue;
-        const from = getAddress(String(parsed.args[0]));
-        const to = getAddress(String(parsed.args[1]));
-        const value = BigInt(parsed.args[2].toString());
-        if (from === wallet && to === recipient && value === expectedUnits) {
-          exactTransfer = true;
-          break;
-        }
-      } catch {}
-    }
-    if (!exactTransfer) {
-      return NextResponse.json({ error: 'No exact USDC transfer from your wallet to the reviewed recipient was found in this transaction.' }, { status: 409 });
-    }
-
-    await recordOrVerifyUsdcPayment({ txHash, estateId: estate.id, buyerId: user.id, wallet, amountUnits: expectedUnits.toString() });
-    if (reservation.state !== 'paid-usdc') {
-      await updateDigitalEstateReservation({ estateId: estate.id, buyerId: user.id, wallet, state: 'paid-usdc', source: 'base-usdc', sourceId: txHash.toLowerCase() });
-    }
-
-    if (await isDigitalEstateMinted(estate.id)) {
-      return NextResponse.json({ ready: false, alreadyMinted: true, estateId: estate.id, wallet, error: 'This Digital Estate voucher has already been minted onchain.' }, { status: 409 });
-    }
-    const voucher = await buildDigitalEstateVoucher({ estateId: estate.id, wallet, origin: new URL(request.url).origin });
-    return NextResponse.json({ ready: true, source: 'base-usdc', estate, wallet, paymentTxHash: txHash, ...voucher });
-  } finally {
-    provider.destroy();
-  }
+  return NextResponse.json({
+    ready: true,
+    ownershipSecured: true,
+    mintOptional: true,
+    source: purchase.source,
+    estate: purchase.estate,
+    wallet: purchase.wallet,
+    paymentTxHash: purchase.paymentTxHash || null,
+    ...voucher,
+  });
 }
 
 export async function POST(request: Request) {
   try {
     const user = await authenticatedUser(request);
-    if (!user) return NextResponse.json({ error: 'Sign in before claiming a Digital Estate.' }, { status: 401 });
-    if (!digitalEstateMintReady()) return NextResponse.json({ error: 'Digital Estate mint signing is unavailable.' }, { status: 503 });
+    if (!user) return NextResponse.json({ error: 'Sign in before managing a Digital Estate purchase.' }, { status: 401 });
+
     const body = await request.json().catch(() => ({}));
     const source = String(body?.source || '').trim().toLowerCase();
-    if (source === 'stripe') return await claimFromStripe({ request, user, body });
-    if (source === 'base-usdc') return await claimFromBaseUsdc({ request, user, body });
-    return NextResponse.json({ error: 'Unsupported Digital Estate payment source.' }, { status: 400 });
+    // Keep legacy callers safe during rollout: omission still means the old
+    // verify+mint preparation behavior. New UI explicitly sends "secure" first.
+    const action = String(body?.action || 'mint').trim().toLowerCase();
+
+    let purchase;
+    if (source === 'stripe') {
+      const sessionId = String(body?.sessionId || '').trim();
+      if (!sessionId.startsWith('cs_')) return NextResponse.json({ error: 'A valid Checkout Session is required.' }, { status: 400 });
+      const stripe = getStripe();
+      const session = await stripe.checkout.sessions.retrieve(sessionId);
+      purchase = await secureStripeDigitalEstatePurchase({ session, expectedBuyerId: user.id });
+    } else if (source === 'base-usdc') {
+      purchase = await secureBaseUsdcDigitalEstatePurchase({
+        estateId: String(body?.estateId || ''),
+        buyerId: user.id,
+        wallet: String(body?.wallet || ''),
+        txHash: String(body?.txHash || ''),
+      });
+    } else {
+      return NextResponse.json({ error: 'Unsupported Digital Estate payment source.' }, { status: 400 });
+    }
+
+    if (action === 'secure') {
+      return NextResponse.json({
+        secured: true,
+        ownershipSecured: true,
+        mintOptional: true,
+        source: purchase.source,
+        estate: purchase.estate,
+        wallet: purchase.wallet,
+        paymentTxHash: purchase.paymentTxHash || null,
+        message: 'Purchase verified. This Digital Estate is locked to your Voxel Vault account and bound wallet. Minting is optional and can be completed later.',
+      });
+    }
+
+    if (action !== 'mint') return NextResponse.json({ error: 'Unsupported Digital Estate purchase action.' }, { status: 400 });
+    return await optionalMintResponse({
+      request,
+      user,
+      purchase,
+      requestedWallet: String(body?.wallet || '').trim() || undefined,
+    });
   } catch (error) {
-    console.error('Digital Estate claim verification failed', error);
-    return NextResponse.json({ error: 'Payment could not be verified for minting. No NFT voucher was issued.' }, { status: 500 });
+    console.error('Digital Estate purchase verification failed', error);
+    const message = digitalEstatePaymentErrorMessage(error);
+    const status = message.includes('not confirmed') || message.includes('not paid') ? 409 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/app/api/digital-estates/crypto-config/route.ts
+++ b/app/api/digital-estates/crypto-config/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getAddress } from 'ethers';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { assertDigitalEstatePricing, getDigitalEstate } from '../../../../lib/digital-estates';
-import { digitalEstateMintReady, isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
+import { isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
 import { acquireDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
 import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
 
@@ -32,10 +32,6 @@ export async function POST(request: Request) {
     if (!ADDRESS_RE.test(walletRaw)) return NextResponse.json({ error: 'Connect a valid EVM wallet first.' }, { status: 400 });
     const wallet = getAddress(walletRaw);
 
-    if (!digitalEstateMintReady()) {
-      return NextResponse.json({ error: 'Digital Estate minting is not configured, so USDC transfer is disabled.' }, { status: 503 });
-    }
-
     let minted = false;
     try { minted = await isDigitalEstateMinted(estate.id); }
     catch (error) {
@@ -46,23 +42,12 @@ export async function POST(request: Request) {
 
     const deployment = await getVoxelFlipDeployment();
     const recipientRaw = process.env.DIGITAL_ESTATE_USDC_RECIPIENT?.trim() || deployment.royaltyReceiver;
-    if (!ADDRESS_RE.test(recipientRaw)) {
-      return NextResponse.json({ error: 'The reviewed USDC recipient is not configured. No transfer should be sent.' }, { status: 503 });
-    }
+    if (!ADDRESS_RE.test(recipientRaw)) return NextResponse.json({ error: 'The reviewed USDC recipient is not configured. No transfer should be sent.' }, { status: 503 });
     const recipient = getAddress(recipientRaw);
 
-    const hold = await acquireDigitalEstateReservation({
-      estateId: estate.id,
-      buyerId: user.id,
-      wallet,
-      source: 'base-usdc',
-    });
+    const hold = await acquireDigitalEstateReservation({ estateId: estate.id, buyerId: user.id, wallet, source: 'base-usdc' });
     if (!hold.acquired && !hold.reservedByYou) {
-      return NextResponse.json({
-        error: hold.sold ? 'This Digital Estate has already been purchased.' : 'This Digital Estate is temporarily reserved by another buyer.',
-        sold: hold.sold,
-        reserved: !hold.sold,
-      }, { status: 409 });
+      return NextResponse.json({ error: hold.sold ? 'This Digital Estate has already been purchased.' : 'This Digital Estate is temporarily reserved by another buyer.', sold: hold.sold, reserved: !hold.sold }, { status: 409 });
     }
     if (!hold.acquired && hold.reservation?.source !== 'base-usdc') {
       return NextResponse.json({ error: 'Your existing reservation is using another payment rail. Finish or let that checkout expire first.' }, { status: 409 });
@@ -84,7 +69,8 @@ export async function POST(request: Request) {
       amountUsdcUnits: amountUsdcUnits.toString(),
       amountUsdCents: estate.purchasePriceCents,
       amountUsd: estate.purchasePriceCents / 100,
-      warning: 'This is a real USDC transfer for a digital-only NFT estate. It does not purchase physical real estate, a deed, rent rights, or an investment interest.',
+      mintOptional: true,
+      warning: 'This is a real USDC transfer for a digital-only NFT estate. The purchase secures the estate first. Minting to Base is optional and can be done later.',
     });
   } catch (error) {
     console.error('Digital Estate USDC preflight failed', error);

--- a/app/api/digital-estates/mine/route.ts
+++ b/app/api/digital-estates/mine/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
+import { DIGITAL_ESTATES } from '../../../../lib/digital-estates';
+import { isDigitalEstateMinted } from '../../../../lib/digital-estate-mint';
+import { readDigitalEstateReservation } from '../../../../lib/digital-estate-reservations';
+
+export const runtime = 'nodejs';
+
+async function authenticatedUser(request: Request) {
+  const auth = request.headers.get('authorization');
+  const token = auth?.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token) return null;
+  const supabase = getSupabaseAdmin();
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+  return error ? null : user;
+}
+
+export async function GET(request: Request) {
+  try {
+    const user = await authenticatedUser(request);
+    if (!user) return NextResponse.json({ error: 'Sign in to view your Digital Estates.' }, { status: 401 });
+
+    const owned = [];
+    for (const estate of DIGITAL_ESTATES) {
+      const reservation = await readDigitalEstateReservation(estate.id);
+      if (!reservation || reservation.buyerId !== user.id || !['paid', 'paid-usdc', 'minted'].includes(reservation.state)) continue;
+
+      let minted: boolean | null = null;
+      try { minted = await isDigitalEstateMinted(estate.id); }
+      catch (error) { console.warn('Digital Estate onchain status unavailable', estate.id, error); }
+
+      owned.push({
+        estate,
+        state: reservation.state,
+        wallet: reservation.wallet,
+        paymentSource: reservation.source,
+        purchasedAt: reservation.processedAt,
+        minted,
+        ownershipSecured: true,
+        mintOptional: true,
+      });
+    }
+
+    return NextResponse.json({ owned, count: owned.length });
+  } catch (error) {
+    console.error('Digital Estate ownership lookup failed', error);
+    return NextResponse.json({ error: 'Digital Estate ownership could not be loaded.' }, { status: 500 });
+  }
+}

--- a/app/vault/estates/mine/page.js
+++ b/app/vault/estates/mine/page.js
@@ -1,0 +1,140 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { getAddress } from 'ethers';
+import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
+import { discoverMetaMaskProvider, getMetaMaskDeepLink } from '../../../../lib/wallet-connect';
+import { mintVoxelFlip } from '../../../../lib/voxelflip';
+import { formatUsdCents } from '../../../../lib/digital-estates';
+
+function short(value) {
+  const text = String(value || '');
+  return text ? `${text.slice(0, 7)}…${text.slice(-5)}` : '—';
+}
+function errorText(error) {
+  return String(error?.shortMessage || error?.reason || error?.message || error || 'Action failed.');
+}
+
+export default function MyDigitalEstatesPage() {
+  const [session, setSession] = useState(null);
+  const [items, setItems] = useState([]);
+  const [status, setStatus] = useState('Loading your secured Digital Estates…');
+  const [busy, setBusy] = useState('');
+  const clientRef = useRef(null);
+
+  async function loadOwned(accessToken) {
+    if (!accessToken) return;
+    const response = await fetch('/api/digital-estates/mine', { cache: 'no-store', headers: { Authorization: `Bearer ${accessToken}` } });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(data?.error || 'Could not load your Digital Estates.');
+    setItems(Array.isArray(data.owned) ? data.owned : []);
+    setStatus(data.count ? `${data.count} secured Digital Estate${data.count === 1 ? '' : 's'} in your Vault.` : 'No secured Digital Estates yet.');
+  }
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      const next = data.session || null;
+      setSession(next);
+      if (next?.access_token) await loadOwned(next.access_token);
+      else setStatus('Sign in to see Digital Estates you have purchased.');
+      const auth = client.auth.onAuthStateChange(async (_event, nextSession) => {
+        if (!active) return;
+        setSession(nextSession);
+        if (nextSession?.access_token) await loadOwned(nextSession.access_token);
+        else { setItems([]); setStatus('Sign in to see Digital Estates you have purchased.'); }
+      });
+      subscription = auth.data.subscription;
+    }).catch((error) => setStatus(errorText(error)));
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  async function signIn() {
+    setBusy('signin');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: new URL('/vault/estates/mine', window.location.origin).toString() } });
+      if (error) throw error;
+    } catch (error) { setStatus(errorText(error)); setBusy(''); }
+  }
+
+  async function mintLater(item) {
+    if (!session?.access_token) { await signIn(); return; }
+    setBusy(item.estate.id);
+    try {
+      const injected = await discoverMetaMaskProvider();
+      if (!injected) { window.location.href = getMetaMaskDeepLink(window.location.href); return; }
+      const accounts = await injected.request({ method: 'eth_requestAccounts' });
+      if (!accounts?.[0]) throw new Error('Wallet connection was cancelled.');
+      const wallet = getAddress(accounts[0]);
+      if (wallet.toLowerCase() !== String(item.wallet || '').toLowerCase()) throw new Error(`Connect the wallet bound at purchase: ${short(item.wallet)}.`);
+
+      setStatus(`Preparing optional Base mint for ${item.estate.name}… Your purchase is already secured.`);
+      const response = await fetch('/api/digital-estates/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ source: 'owned', action: 'mint', estateId: item.estate.id, wallet }),
+      });
+      const claim = await response.json().catch(() => ({}));
+      if (!response.ok || !claim?.ready) throw new Error(claim?.error || 'Optional mint could not be prepared.');
+
+      setStatus('Ownership is already secured. MetaMask will now open only the optional NFT mint transaction.');
+      const minted = await mintVoxelFlip({ metadataUrl: claim.metadataUrl, voucherId: claim.voucherId, signature: claim.signature });
+      window.localStorage.setItem(`vv-digital-estate-mint:${item.estate.id}`, JSON.stringify(minted));
+      window.dispatchEvent(new CustomEvent('voxel-vault:transaction-confirmed', { detail: minted }));
+      setStatus(`${item.estate.name} is now onchain in ${short(wallet)}. Minting added public blockchain provenance; it did not create physical-property rights or guarantee higher market value.`);
+      await loadOwned(session.access_token);
+    } catch (error) { setStatus(errorText(error)); }
+    finally { setBusy(''); }
+  }
+
+  return (
+    <main className="page">
+      <header>
+        <div><Link href="/vault/estates">← DIGITAL ESTATES</Link><span>MY DIGITAL ESTATES</span></div>
+        <Link className="test" href="/vault/test-land">SAFE TESTNET LAND ↗</Link>
+      </header>
+      <section className="hero">
+        <div className="eyebrow"><i /> PURCHASE FIRST · MINT WHEN YOU WANT</div>
+        <h1>Your properties.<br/><em>Minting is optional.</em></h1>
+        <p>Payment secures a Digital Estate to your Voxel Vault account and purchase-bound wallet first. Nobody else can buy that secured estate. Minting later adds onchain provenance and wallet visibility, but it is not required to retain the purchase.</p>
+      </section>
+
+      <div className="status">{status}</div>
+      {!session ? <button className="signin" onClick={signIn} disabled={Boolean(busy)}>SIGN IN TO MY VAULT</button> : null}
+
+      <section className="grid">
+        {items.map((item) => <article key={item.estate.id}>
+          <div className="visual" style={{'--accent': item.estate.accent}}>
+            <div className="land"/><div className="house"><b/><b/><b/></div><span>{item.minted === true ? 'ONCHAIN' : 'SECURED'}</span>
+          </div>
+          <div className="body">
+            <small>{item.estate.marketLabel}</small>
+            <h2>{item.estate.name}</h2>
+            <div className="price">{formatUsdCents(item.estate.purchasePriceCents)}</div>
+            <dl>
+              <div><dt>STATUS</dt><dd>{item.minted === true ? 'Owned · Minted' : item.minted === false ? 'Owned · Not minted' : 'Owned · Chain status unavailable'}</dd></div>
+              <div><dt>BOUND WALLET</dt><dd>{short(item.wallet)}</dd></div>
+              <div><dt>PAYMENT</dt><dd>{item.paymentSource === 'base-usdc' ? 'Base USDC' : 'Secure checkout'}</dd></div>
+            </dl>
+            {item.minted === true
+              ? <div className="minted">✓ ONCHAIN PROVENANCE ACTIVE</div>
+              : <button className="mint" onClick={() => mintLater(item)} disabled={Boolean(busy)}>{busy === item.estate.id ? 'PREPARING…' : 'MINT TO BASE · OPTIONAL'}</button>}
+            <p className="note">Your purchase stays secured whether you mint now, later, or never.</p>
+          </div>
+        </article>)}
+      </section>
+
+      <div className="truth"><strong>DIGITAL-ONLY ASSET</strong> No physical parcel, deed, title, tenancy, rent entitlement, mortgage, security, appraisal, or legal claim to real-world property. Minting can add provenance and portability; it does not guarantee appreciation.</div>
+      <style jsx>{`
+        :global(body){margin:0;background:#06070a;color:#f5f6f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:22px clamp(18px,4vw,60px) 90px;background:radial-gradient(circle at 72% 10%,rgba(115,93,255,.15),transparent 28%),#06070a}header{display:flex;justify-content:space-between;align-items:center;gap:16px}header div{display:flex;gap:18px;align-items:center}header a{color:#7f8797;text-decoration:none;font-size:9px;font-weight:900;letter-spacing:.12em}header span{font-size:9px;font-weight:950;letter-spacing:.16em}.test{border:1px solid rgba(255,255,255,.1);padding:10px 12px;border-radius:12px}.hero{max-width:900px;margin:90px 0 42px}.eyebrow{font-size:9px;letter-spacing:.17em;color:#8d96a8;font-weight:900}.eyebrow i{display:inline-block;width:7px;height:7px;border-radius:50%;background:#79efbc;margin-right:8px;box-shadow:0 0 18px #79efbc}.hero h1{font-size:clamp(52px,8vw,105px);letter-spacing:-.065em;line-height:.88;margin:17px 0 22px}.hero h1 em{font-style:normal;color:#767e90}.hero p{max-width:720px;color:#8a93a5;font-size:13px;line-height:1.75}.status{max-width:850px;padding:14px 16px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);border-radius:14px;color:#9ba4b5;font-size:11px;margin-bottom:18px}.signin,.mint{border:0;border-radius:13px;background:#fff;color:#07080b;padding:14px 16px;font-size:9px;font-weight:950;letter-spacing:.1em}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:14px;margin-top:28px}.grid article{border:1px solid rgba(255,255,255,.09);border-radius:24px;overflow:hidden;background:linear-gradient(145deg,rgba(255,255,255,.05),rgba(255,255,255,.015))}.visual{height:190px;position:relative;overflow:hidden;background:radial-gradient(circle at 55% 35%,color-mix(in srgb,var(--accent) 32%, transparent),transparent 36%),linear-gradient(#11151c,#080a0e)}.land{position:absolute;left:10%;right:10%;bottom:18%;height:25%;background:#202b25;transform:perspective(300px) rotateX(58deg);border-radius:10px}.house{position:absolute;left:24%;right:24%;bottom:29%;height:39%;background:#d9d4ca;border-radius:3px;box-shadow:0 20px 45px rgba(0,0,0,.4)}.house:before{content:'';position:absolute;left:-8%;right:-8%;height:12%;top:-7%;background:#343842}.house b{position:absolute;background:var(--accent);opacity:.8;bottom:16%;width:18%;height:35%}.house b:nth-child(1){left:12%}.house b:nth-child(2){left:41%}.house b:nth-child(3){right:12%}.visual span{position:absolute;top:14px;left:14px;font-size:8px;font-weight:950;letter-spacing:.12em;background:rgba(4,7,9,.7);border:1px solid rgba(255,255,255,.1);padding:7px 9px;border-radius:999px}.body{padding:20px}.body small{color:#788194;font-size:8px;letter-spacing:.13em;font-weight:900}.body h2{font-size:24px;letter-spacing:-.04em;margin:6px 0}.price{font-size:28px;font-weight:900;letter-spacing:-.04em;margin-bottom:16px}dl{display:grid;gap:8px;margin:0 0 16px}dl div{display:flex;justify-content:space-between;gap:12px;border-top:1px solid rgba(255,255,255,.06);padding-top:8px}dt{font-size:7px;color:#687183;font-weight:900;letter-spacing:.12em}dd{margin:0;font-size:9px;color:#a3aaba;text-align:right}.mint{width:100%;background:#6656df;color:#fff}.minted{padding:13px;border-radius:12px;background:rgba(121,239,188,.08);border:1px solid rgba(121,239,188,.18);color:#79efbc;text-align:center;font-size:8px;font-weight:950;letter-spacing:.1em}.note{font-size:8px;color:#666f80;line-height:1.5;margin:10px 0 0}.truth{margin-top:35px;max-width:950px;color:#697284;font-size:9px;line-height:1.6;border-top:1px solid rgba(255,255,255,.07);padding-top:20px}.truth strong{display:block;color:#9aa3b4;letter-spacing:.14em;font-size:8px;margin-bottom:5px}@media(max-width:620px){.page{padding:18px 14px 80px}.hero{margin-top:58px}header span{display:none}.hero h1{font-size:54px}.grid{grid-template-columns:1fr}}
+      `}</style>
+    </main>
+  );
+}

--- a/app/vault/estates/page.js
+++ b/app/vault/estates/page.js
@@ -6,7 +6,6 @@ import { BrowserProvider, Contract, formatUnits, getAddress } from 'ethers';
 import { DIGITAL_ESTATE_DISCLOSURE, DIGITAL_ESTATES, formatUsdCents, getDigitalEstate } from '../../../lib/digital-estates';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
 import { discoverMetaMaskProvider, getMetaMaskDeepLink } from '../../../lib/wallet-connect';
-import { mintVoxelFlip } from '../../../lib/voxelflip';
 
 const BASE_CHAIN_ID = '0x2105';
 const BASE_RPC = 'https://mainnet.base.org';
@@ -20,11 +19,9 @@ function short(value) {
   const text = String(value || '');
   return text ? `${text.slice(0, 7)}…${text.slice(-5)}` : '—';
 }
-
 function errorText(error) {
   return String(error?.shortMessage || error?.reason || error?.message || error || 'Action failed.');
 }
-
 function googleReturnUrl(estateId) {
   const url = new URL('/vault/estates', window.location.origin);
   url.searchParams.set('estate', estateId);
@@ -40,16 +37,7 @@ async function ensureBase(provider) {
   } catch (error) {
     if (error?.code === 4001) throw new Error('Base network switch was cancelled.');
     if (error?.code !== 4902) throw error;
-    await provider.request({
-      method: 'wallet_addEthereumChain',
-      params: [{
-        chainId: BASE_CHAIN_ID,
-        chainName: 'Base',
-        nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-        rpcUrls: [BASE_RPC],
-        blockExplorerUrls: [BASE_EXPLORER],
-      }],
-    });
+    await provider.request({ method: 'wallet_addEthereumChain', params: [{ chainId: BASE_CHAIN_ID, chainName: 'Base', nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 }, rpcUrls: [BASE_RPC], blockExplorerUrls: [BASE_EXPLORER] }] });
   }
   chainId = String(await provider.request({ method: 'eth_chainId' }) || '').toLowerCase();
   if (chainId !== BASE_CHAIN_ID) throw new Error('Switch MetaMask to Base before continuing.');
@@ -57,484 +45,189 @@ async function ensureBase(provider) {
 
 function EstateScene({ estate }) {
   const mountRef = useRef(null);
-
   useEffect(() => {
     let disposed = false;
     let cleanup = () => {};
-
     import('three').then((THREE) => {
       if (disposed || !mountRef.current) return;
       const mount = mountRef.current;
       const width = Math.max(320, mount.clientWidth || 320);
-      const height = Math.max(420, mount.clientHeight || 520);
+      const height = Math.max(390, mount.clientHeight || 520);
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.7));
       renderer.setSize(width, height);
       renderer.outputColorSpace = THREE.SRGBColorSpace;
-      renderer.shadowMap.enabled = false;
       mount.innerHTML = '';
       mount.appendChild(renderer.domElement);
 
       const scene = new THREE.Scene();
-      scene.fog = new THREE.Fog(0x07080d, 20, 42);
+      scene.fog = new THREE.Fog(0x07080c, 18, 38);
       const camera = new THREE.PerspectiveCamera(38, width / height, 0.1, 100);
       const world = new THREE.Group();
       scene.add(world);
-
-      const hemi = new THREE.HemisphereLight(0xe8edff, 0x171b24, 1.9);
-      scene.add(hemi);
-      const key = new THREE.DirectionalLight(0xffffff, 3.2);
-      key.position.set(9, 14, 11);
+      scene.add(new THREE.HemisphereLight(0xf2f5ff, 0x11151c, 2.1));
+      const key = new THREE.DirectionalLight(0xffffff, 3.1);
+      key.position.set(10, 14, 9);
       scene.add(key);
-      const accent = new THREE.PointLight(new THREE.Color(estate.accent), 28, 32);
-      accent.position.set(-8, 6, -6);
+      const accent = new THREE.PointLight(new THREE.Color(estate.accent), 34, 32);
+      accent.position.set(-7, 5, 7);
       scene.add(accent);
 
-      const disposable = [];
-      function material(options) {
-        const m = new THREE.MeshStandardMaterial(options);
-        disposable.push(m);
-        return m;
+      const geometries = [];
+      const materials = [];
+      function mat(color, options = {}) {
+        const material = new THREE.MeshStandardMaterial({ color, roughness: options.roughness ?? .62, metalness: options.metalness ?? .08, transparent: Boolean(options.transparent), opacity: options.opacity ?? 1, emissive: options.emissive || 0x000000, emissiveIntensity: options.emissiveIntensity || 0 });
+        materials.push(material);
+        return material;
       }
       function box(w, h, d, color, x, y, z, options = {}) {
         const geometry = new THREE.BoxGeometry(w, h, d);
-        const mesh = new THREE.Mesh(geometry, material({ color, metalness: options.metalness ?? 0.08, roughness: options.roughness ?? 0.62, transparent: Boolean(options.transparent), opacity: options.opacity ?? 1, emissive: options.emissive || 0x000000, emissiveIntensity: options.emissiveIntensity || 0 }));
+        geometries.push(geometry);
+        const mesh = new THREE.Mesh(geometry, mat(color, options));
         mesh.position.set(x, y, z);
         world.add(mesh);
-        disposable.push(geometry);
         return mesh;
       }
-      function cylinder(r, h, color, x, y, z) {
-        const geometry = new THREE.CylinderGeometry(r, r * 1.12, h, 8);
-        const mesh = new THREE.Mesh(geometry, material({ color, roughness: 0.8 }));
-        mesh.position.set(x, y, z);
-        world.add(mesh);
-        disposable.push(geometry);
-        return mesh;
+      function glass(w, h, x, y, z) {
+        return box(w, h, .08, estate.accent, x, y, z, { roughness: .12, metalness: .35, transparent: true, opacity: .58, emissive: estate.accent, emissiveIntensity: .22 });
       }
 
-      box(17, 0.6, 15, estate.terrain, 0, -0.55, 0, { roughness: 0.94 });
-      box(13.6, 0.18, 11.4, 0x121620, 0, -0.17, 0, { roughness: 0.9 });
-
-      const structure = new THREE.Color(estate.structure);
-      const roof = new THREE.Color(estate.roof);
-      const glow = new THREE.Color(estate.accent);
-      const glassMat = material({ color: glow, roughness: 0.12, metalness: 0.35, transparent: true, opacity: 0.58, emissive: glow, emissiveIntensity: 0.23 });
-      const glassGeometries = [];
-      function glass(w, h, d, x, y, z) {
-        const geometry = new THREE.BoxGeometry(w, h, d);
-        const mesh = new THREE.Mesh(geometry, glassMat);
-        mesh.position.set(x, y, z);
-        world.add(mesh);
-        glassGeometries.push(geometry);
-        return mesh;
-      }
+      box(18, .55, 15, estate.terrain, 0, -.6, 0, { roughness: .96 });
+      box(14.2, .18, 11.3, 0x131720, 0, -.22, 0, { roughness: .9 });
+      const structure = estate.structure;
+      const roof = estate.roof;
 
       if (estate.architecture === 'courtyard') {
-        box(5.2, 2.7, 3.3, structure, -3.5, 1.2, -1.8);
-        box(4.2, 2.7, 3.3, structure, 3.9, 1.2, -1.8);
-        box(3.1, 2.7, 4.4, structure, 0.2, 1.2, 2.2);
-        box(5.5, 0.28, 3.6, roof, -3.5, 2.7, -1.8);
-        box(4.5, 0.28, 3.6, roof, 3.9, 2.7, -1.8);
-        glass(2.6, 1.8, 0.08, 0.2, 1.3, 0.0);
-        box(3.7, 0.16, 2.2, 0x26342e, 0.2, -0.02, -0.4);
+        box(5.3, 2.8, 3.4, structure, -3.5, 1.25, -1.6); box(4.5, 2.8, 3.4, structure, 3.8, 1.25, -1.6); box(3.2, 2.8, 4.5, structure, .1, 1.25, 2.1);
+        box(5.7,.28,3.7,roof,-3.5,2.8,-1.6); box(4.9,.28,3.7,roof,3.8,2.8,-1.6); glass(2.7,1.85,.1,1.35,-.18); box(4,.14,2.4,0x29453a,.1,-.08,-.3);
       } else if (estate.architecture === 'glass') {
-        box(10.8, 2.6, 4.2, structure, 0, 1.18, 0);
-        box(12.2, 0.32, 5.4, roof, 0, 2.7, 0);
-        glass(9.2, 1.8, 0.1, 0, 1.25, 2.12);
-        glass(0.1, 1.8, 3.1, 5.42, 1.25, 0);
-        box(5.4, 0.22, 2.5, 0x23505d, 1.7, -0.02, 4.2, { metalness: 0.25, roughness: 0.2 });
+        box(11.2,2.7,4.4,structure,0,1.2,0); box(12.5,.34,5.5,roof,0,2.75,0); glass(9.5,1.85,0,1.3,2.22); box(5.6,.18,2.7,0x25566a,1.7,-.08,4.3,{roughness:.2,metalness:.25});
       } else if (estate.architecture === 'waterfront') {
-        box(8.8, 2.7, 4.8, structure, -1.1, 1.22, 0.4);
-        box(6.2, 2.5, 3.8, structure, 2.2, 3.68, -0.2);
-        box(9.3, 0.3, 5.1, roof, -1.1, 2.72, 0.4);
-        box(6.6, 0.3, 4.2, roof, 2.2, 5.08, -0.2);
-        glass(4.8, 1.85, 0.08, -1.6, 1.3, 2.83);
-        glass(3.9, 1.65, 0.08, 2.2, 3.72, 1.72);
-        box(10.5, 0.2, 2.2, 0x274b5e, 0.3, -0.06, 4.8, { roughness: 0.24 });
-        box(7.2, 0.18, 1.2, 0x5f5146, -0.3, 0.02, 6.5);
+        box(9,2.8,4.9,structure,-1.1,1.25,.4); box(6.4,2.55,3.9,structure,2.1,3.75,-.2); box(9.4,.3,5.2,roof,-1.1,2.82,.4); box(6.8,.3,4.3,roof,2.1,5.17,-.2); glass(4.8,1.9,-1.6,1.35,2.88); glass(4,1.7,2.1,3.78,1.78); box(10.8,.18,2.3,0x26566b,.2,-.08,4.9,{roughness:.2});
       } else if (estate.architecture === 'villa') {
-        box(4.7, 3.0, 5.2, structure, -4.0, 1.35, 0);
-        box(4.7, 3.0, 5.2, structure, 4.0, 1.35, 0);
-        box(4.6, 2.6, 3.8, structure, 0, 3.95, -1.1);
-        box(5.1, 0.34, 5.6, roof, -4.0, 3.0, 0);
-        box(5.1, 0.34, 5.6, roof, 4.0, 3.0, 0);
-        box(5.0, 0.34, 4.2, roof, 0, 5.42, -1.1);
-        glass(3.4, 1.7, 0.08, 0, 3.95, 0.84);
-        box(4.4, 0.2, 3.0, 0x245866, 0, -0.04, 3.6, { roughness: 0.18 });
+        box(4.8,3.1,5.3,structure,-4,1.4,0); box(4.8,3.1,5.3,structure,4,1.4,0); box(4.7,2.7,3.9,structure,0,4,-1); box(5.2,.34,5.7,roof,-4,3.1,0); box(5.2,.34,5.7,roof,4,3.1,0); box(5.1,.34,4.3,roof,0,5.5,-1); glass(3.5,1.75,0,4,.98); box(4.6,.18,3.2,0x255a69,0,-.08,3.7,{roughness:.2});
       } else {
-        box(8.2, 2.5, 4.3, structure, -1.2, 1.15, 0.7);
-        box(7.1, 2.4, 3.8, structure, 1.3, 3.55, -0.2);
-        box(6.0, 2.2, 3.2, structure, -0.9, 5.82, -0.7);
-        box(8.7, 0.3, 4.7, roof, -1.2, 2.58, 0.7);
-        box(7.6, 0.3, 4.2, roof, 1.3, 4.92, -0.2);
-        box(6.4, 0.3, 3.6, roof, -0.9, 7.1, -0.7);
-        glass(4.8, 1.55, 0.08, -1.2, 1.2, 2.88);
-        glass(4.3, 1.45, 0.08, 1.3, 3.58, 1.74);
-        glass(3.8, 1.35, 0.08, -0.9, 5.85, 0.94);
-        box(5.2, 0.16, 2.2, 0x263b38, -0.9, 7.35, -0.7);
+        box(8.4,2.6,4.4,structure,-1.2,1.2,.7); box(7.2,2.5,3.9,structure,1.3,3.65,-.2); box(6.1,2.3,3.3,structure,-.9,5.95,-.7); box(8.8,.3,4.8,roof,-1.2,2.68,.7); box(7.7,.3,4.3,roof,1.3,5.03,-.2); box(6.5,.3,3.7,roof,-.9,7.25,-.7); glass(4.9,1.6,-1.2,1.25,2.93); glass(4.4,1.5,1.3,3.68,1.78); glass(3.9,1.4,-.9,5.98,.98);
       }
 
-      for (let i = 0; i < 9; i += 1) {
-        const side = i % 2 === 0 ? -1 : 1;
-        const x = side * (6.3 + (i % 3) * 0.55);
-        const z = -5 + (i * 1.33) % 10;
-        cylinder(0.18, 1.4 + (i % 2) * 0.5, 0x6f5947, x, 0.55, z);
-        const crownGeometry = new THREE.SphereGeometry(0.7 + (i % 3) * 0.08, 8, 6);
-        const crown = new THREE.Mesh(crownGeometry, material({ color: 0x31543c, roughness: 0.95 }));
-        crown.position.set(x, 1.5 + (i % 2) * 0.45, z);
-        world.add(crown);
-        disposable.push(crownGeometry);
+      for (let i = 0; i < 8; i += 1) {
+        const x = (i % 2 ? 1 : -1) * (6.2 + (i % 3) * .55);
+        const z = -4.8 + (i * 1.47) % 9.7;
+        box(.25,1.25,.25,0x6b5848,x,.45,z);
+        const g = new THREE.SphereGeometry(.65 + (i % 3) * .08, 8, 6); geometries.push(g);
+        const crown = new THREE.Mesh(g, mat(0x31543c,{roughness:.95})); crown.position.set(x,1.35,z); world.add(crown);
       }
+      const ringG = new THREE.RingGeometry(7,7.12,64); geometries.push(ringG);
+      const ring = new THREE.Mesh(ringG, mat(estate.accent,{emissive:estate.accent,emissiveIntensity:.5,transparent:true,opacity:.5})); ring.rotation.x=-Math.PI/2; ring.position.y=-.24; world.add(ring);
 
-      const ringGeometry = new THREE.RingGeometry(6.9, 7.05, 64);
-      const ring = new THREE.Mesh(ringGeometry, material({ color: glow, emissive: glow, emissiveIntensity: 0.45, side: THREE.DoubleSide, transparent: true, opacity: 0.5 }));
-      ring.rotation.x = -Math.PI / 2;
-      ring.position.y = -0.22;
-      world.add(ring);
-      disposable.push(ringGeometry);
-
-      let azimuth = 0.7;
-      let elevation = 0.52;
-      let radius = estate.architecture === 'sky-villa' ? 24 : 21;
-      let dragging = false;
-      let lastX = 0;
-      let lastY = 0;
-      function updateCamera() {
-        const cosE = Math.cos(elevation);
-        camera.position.set(Math.sin(azimuth) * cosE * radius, Math.sin(elevation) * radius, Math.cos(azimuth) * cosE * radius);
-        camera.lookAt(0, estate.architecture === 'sky-villa' ? 2.0 : 1.3, 0);
-      }
-      updateCamera();
-      function down(event) { dragging = true; lastX = event.clientX; lastY = event.clientY; renderer.domElement.setPointerCapture?.(event.pointerId); }
-      function move(event) {
-        if (!dragging) return;
-        const dx = event.clientX - lastX;
-        const dy = event.clientY - lastY;
-        lastX = event.clientX;
-        lastY = event.clientY;
-        azimuth -= dx * 0.008;
-        elevation = Math.max(0.22, Math.min(1.02, elevation + dy * 0.005));
-        updateCamera();
-      }
-      function up() { dragging = false; }
-      function wheel(event) { radius = Math.max(15, Math.min(29, radius + Math.sign(event.deltaY) * 1.2)); updateCamera(); }
-      renderer.domElement.addEventListener('pointerdown', down);
-      renderer.domElement.addEventListener('pointermove', move);
-      renderer.domElement.addEventListener('pointerup', up);
-      renderer.domElement.addEventListener('wheel', wheel, { passive: true });
-
-      let frame;
-      let t = 0;
-      function animate() {
-        frame = requestAnimationFrame(animate);
-        t += 0.01;
-        accent.intensity = 25 + Math.sin(t) * 4;
-        ring.material.opacity = 0.42 + Math.sin(t * 0.7) * 0.08;
-        renderer.render(scene, camera);
-      }
-      animate();
-
-      function resize() {
-        if (!mountRef.current) return;
-        const w = Math.max(320, mountRef.current.clientWidth || 320);
-        const h = Math.max(420, mountRef.current.clientHeight || 520);
-        renderer.setSize(w, h);
-        camera.aspect = w / h;
-        camera.updateProjectionMatrix();
-      }
-      window.addEventListener('resize', resize);
-
-      cleanup = () => {
-        cancelAnimationFrame(frame);
-        window.removeEventListener('resize', resize);
-        renderer.domElement.removeEventListener('pointerdown', down);
-        renderer.domElement.removeEventListener('pointermove', move);
-        renderer.domElement.removeEventListener('pointerup', up);
-        renderer.domElement.removeEventListener('wheel', wheel);
-        glassGeometries.forEach((geometry) => geometry.dispose());
-        disposable.forEach((item) => item?.dispose?.());
-        renderer.dispose();
-        if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement);
-      };
+      let azimuth=.72, elevation=.5, radius=estate.architecture==='sky-villa'?24:21, dragging=false, lx=0, ly=0;
+      const updateCamera=()=>{const c=Math.cos(elevation);camera.position.set(Math.sin(azimuth)*c*radius,Math.sin(elevation)*radius,Math.cos(azimuth)*c*radius);camera.lookAt(0,estate.architecture==='sky-villa'?2:1.35,0)}; updateCamera();
+      const down=e=>{dragging=true;lx=e.clientX;ly=e.clientY;renderer.domElement.setPointerCapture?.(e.pointerId)};
+      const move=e=>{if(!dragging)return;azimuth-=(e.clientX-lx)*.008;elevation=Math.max(.22,Math.min(1.02,elevation+(e.clientY-ly)*.005));lx=e.clientX;ly=e.clientY;updateCamera()};
+      const up=()=>{dragging=false};
+      const wheel=e=>{radius=Math.max(15,Math.min(29,radius+Math.sign(e.deltaY)*1.15));updateCamera()};
+      renderer.domElement.addEventListener('pointerdown',down); renderer.domElement.addEventListener('pointermove',move); renderer.domElement.addEventListener('pointerup',up); renderer.domElement.addEventListener('wheel',wheel,{passive:true});
+      let frame, t=0;
+      const animate=()=>{frame=requestAnimationFrame(animate);t+=.01;accent.intensity=30+Math.sin(t)*5;ring.material.opacity=.42+Math.sin(t*.7)*.08;renderer.render(scene,camera)}; animate();
+      const resize=()=>{if(!mountRef.current)return;const w=Math.max(320,mountRef.current.clientWidth||320),h=Math.max(390,mountRef.current.clientHeight||520);renderer.setSize(w,h);camera.aspect=w/h;camera.updateProjectionMatrix()}; window.addEventListener('resize',resize);
+      cleanup=()=>{cancelAnimationFrame(frame);window.removeEventListener('resize',resize);renderer.domElement.removeEventListener('pointerdown',down);renderer.domElement.removeEventListener('pointermove',move);renderer.domElement.removeEventListener('pointerup',up);renderer.domElement.removeEventListener('wheel',wheel);geometries.forEach(g=>g.dispose());materials.forEach(m=>m.dispose());renderer.dispose();mount.innerHTML=''};
     });
-
-    return () => { disposed = true; cleanup(); };
-  }, [estate]);
-
-  return <div className="estateScene" ref={mountRef} aria-label={`Interactive 3D model of ${estate.name}`} />;
+    return()=>{disposed=true;cleanup()};
+  },[estate]);
+  return <div className="scene" ref={mountRef}/>;
 }
 
 export default function DigitalEstatesPage() {
-  const [selectedId, setSelectedId] = useState(DIGITAL_ESTATES[2].id);
-  const [session, setSession] = useState(null);
-  const [authState, setAuthState] = useState('loading');
-  const [wallet, setWallet] = useState('');
-  const [provider, setProvider] = useState(null);
-  const [busy, setBusy] = useState('');
-  const [status, setStatus] = useState('Explore the collection. Sign in and connect a wallet only when you are ready to reserve an estate.');
-  const [mintResult, setMintResult] = useState(null);
-  const clientRef = useRef(null);
+  const [selectedId,setSelectedId]=useState(DIGITAL_ESTATES[0].id);
+  const estate=useMemo(()=>getDigitalEstate(selectedId)||DIGITAL_ESTATES[0],[selectedId]);
+  const [session,setSession]=useState(null);
+  const [wallet,setWallet]=useState('');
+  const [status,setStatus]=useState('Explore a property. Real payment buttons are clearly labeled; use Testnet Land to test without real money.');
+  const [busy,setBusy]=useState('');
+  const [secured,setSecured]=useState(null);
+  const [recoveryTx,setRecoveryTx]=useState('');
+  const clientRef=useRef(null);
 
-  const estate = useMemo(() => getDigitalEstate(selectedId) || DIGITAL_ESTATES[0], [selectedId]);
-  const price = formatUsdCents(estate.purchasePriceCents);
-  const recoveryTx = typeof window !== 'undefined' ? window.localStorage.getItem(`vv-digital-estate-usdc:${estate.id}`) || '' : '';
+  useEffect(()=>{
+    const params=new URLSearchParams(window.location.search);
+    const requested=getDigitalEstate(params.get('estate'));
+    if(requested)setSelectedId(requested.id);
+    if(params.get('checkout')==='cancelled')setStatus('Checkout cancelled. No purchase was completed.');
+    let active=true,subscription=null;
+    getSupabaseBrowserAsync().then(async client=>{
+      if(!active)return;clientRef.current=client;const{data}=await client.auth.getSession();setSession(data.session||null);
+      const auth=client.auth.onAuthStateChange((_event,next)=>active&&setSession(next));subscription=auth.data.subscription;
+      if(params.get('auth')==='google'){params.delete('auth');window.history.replaceState({},'',`${window.location.pathname}?${params.toString()}`)}
+    }).catch(error=>setStatus(errorText(error)));
+    return()=>{active=false;subscription?.unsubscribe?.()};
+  },[]);
+  useEffect(()=>{try{setRecoveryTx(window.localStorage.getItem(`vv-digital-estate-usdc:${estate.id}`)||'')}catch{setRecoveryTx('')}},[estate.id]);
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const requested = getDigitalEstate(params.get('estate'));
-    if (requested) setSelectedId(requested.id);
-    if (params.get('checkout') === 'cancelled') setStatus('Checkout was cancelled. No ownership changed. Your temporary reservation will expire automatically.');
+  async function signIn(){setBusy('signin');try{const client=clientRef.current||await getSupabaseBrowserAsync();clientRef.current=client;const{error}=await client.auth.signInWithOAuth({provider:'google',options:{redirectTo:googleReturnUrl(estate.id)}});if(error)throw error}catch(error){setStatus(errorText(error));setBusy('')}}
+  async function connectWallet(){const injected=await discoverMetaMaskProvider();if(!injected){window.location.href=getMetaMaskDeepLink(window.location.href);return null}const accounts=await injected.request({method:'eth_requestAccounts'});if(!accounts?.[0])throw new Error('Wallet connection was cancelled.');const address=getAddress(accounts[0]);setWallet(address);return{provider:injected,wallet:address}}
 
-    let active = true;
-    let subscription = null;
-    getSupabaseBrowserAsync().then(async (client) => {
-      if (!active) return;
-      clientRef.current = client;
-      const { data, error } = await client.auth.getSession();
-      if (error) {
-        setAuthState('error');
-        setStatus(error.message);
-      } else {
-        setSession(data.session);
-        setAuthState(data.session?.user ? 'signed-in' : 'signed-out');
-      }
-      const auth = client.auth.onAuthStateChange((_event, next) => {
-        if (!active) return;
-        setSession(next);
-        setAuthState(next?.user ? 'signed-in' : 'signed-out');
-      });
-      subscription = auth.data.subscription;
-      if (params.get('auth') === 'google') {
-        params.delete('auth');
-        window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
-      }
-    }).catch((error) => {
-      if (!active) return;
-      setAuthState('error');
-      setStatus(errorText(error));
-    });
-    return () => { active = false; subscription?.unsubscribe?.(); };
-  }, []);
-
-  function selectEstate(id) {
-    setSelectedId(id);
-    setMintResult(null);
-    const url = new URL(window.location.href);
-    url.searchParams.set('estate', id);
-    url.searchParams.delete('checkout');
-    window.history.replaceState({}, '', url.toString());
-    setStatus('Estate selected. Rotate the 3D model, review the price and rights disclosure, then choose a payment rail.');
+  async function paySecurely(){
+    if(!session?.access_token){await signIn();return}
+    setBusy('stripe');setSecured(null);
+    try{
+      let activeWallet=wallet;if(!activeWallet){const connected=await connectWallet();if(!connected)return;activeWallet=connected.wallet}
+      setStatus(`Creating secure checkout for ${estate.name}. This is a REAL ${formatUsdCents(estate.purchasePriceCents)} digital-asset payment.`);
+      const response=await fetch('/api/digital-estates/checkout',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${session.access_token}`},body:JSON.stringify({estateId:estate.id,wallet:activeWallet})});
+      const data=await response.json().catch(()=>({}));if(!response.ok||!data?.url)throw new Error(data?.error||'Checkout could not be created.');window.location.href=data.url;
+    }catch(error){setStatus(errorText(error));setBusy('')} 
   }
 
-  async function signIn() {
-    setBusy('signin');
-    try {
-      const client = clientRef.current || await getSupabaseBrowserAsync();
-      clientRef.current = client;
-      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: googleReturnUrl(estate.id) } });
-      if (error) throw error;
-    } catch (error) {
-      setBusy('');
-      setStatus(errorText(error));
-    }
+  async function secureUsdcPayment(txHash,activeWallet){
+    setStatus('USDC transfer confirmed. Independently verifying the exact Base payment and securing ownership — no NFT mint will run.');
+    const response=await fetch('/api/digital-estates/claim',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${session.access_token}`},body:JSON.stringify({source:'base-usdc',action:'secure',estateId:estate.id,wallet:activeWallet,txHash})});
+    const data=await response.json().catch(()=>({}));if(!response.ok||!data?.ownershipSecured)throw new Error(data?.error||'USDC payment could not be verified.');
+    setSecured(data);try{window.localStorage.removeItem(`vv-digital-estate-usdc:${estate.id}`)}catch{}setRecoveryTx('');
+    setStatus(`${estate.name} is PURCHASED & SECURED to ${short(activeWallet)}. Minting is optional. Nobody else can buy this unique estate.`);
   }
 
-  async function connectWallet({ requireBase = false } = {}) {
-    setBusy('wallet');
-    try {
-      const injected = provider || await discoverMetaMaskProvider();
-      if (!injected) {
-        window.location.href = getMetaMaskDeepLink(window.location.href);
-        return null;
-      }
-      const accounts = await injected.request({ method: 'eth_requestAccounts' });
-      if (!accounts?.[0]) throw new Error('Wallet connection was cancelled.');
-      if (requireBase) await ensureBase(injected);
-      const address = getAddress(accounts[0]);
-      setProvider(injected);
-      setWallet(address);
-      setStatus(`${short(address)} connected${requireBase ? ' on Base' : ''}. No payment has been sent.`);
-      return { provider: injected, wallet: address };
-    } catch (error) {
-      setStatus(errorText(error));
-      return null;
-    } finally {
-      setBusy('');
-    }
+  async function payUsdc(){
+    if(!session?.access_token){await signIn();return}
+    setBusy('usdc');setSecured(null);
+    try{
+      const connected=await connectWallet();if(!connected)return;await ensureBase(connected.provider);
+      const response=await fetch('/api/digital-estates/crypto-config',{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${session.access_token}`},body:JSON.stringify({estateId:estate.id,wallet:connected.wallet})});
+      const config=await response.json().catch(()=>({}));if(!response.ok||!config?.ready)throw new Error(config?.error||'USDC purchase could not be prepared.');
+      const browser=new BrowserProvider(connected.provider);const signer=await browser.getSigner(connected.wallet);const usdc=new Contract(config.usdcAddress,USDC_ABI,signer);const amount=BigInt(config.amountUsdcUnits);const balance=await usdc.balanceOf(connected.wallet);
+      if(balance<amount)throw new Error(`This real purchase requires ${formatUnits(amount,6)} USDC. Wallet balance is ${formatUnits(balance,6)} USDC.`);
+      setStatus(`REAL PAYMENT: MetaMask will request exactly ${formatUnits(amount,6)} USDC on Base. Buying secures the estate first; minting will NOT happen automatically.`);
+      const tx=await usdc.transfer(getAddress(config.recipient),amount);try{window.localStorage.setItem(`vv-digital-estate-usdc:${estate.id}`,tx.hash)}catch{}setRecoveryTx(tx.hash);setStatus(`USDC submitted ${short(tx.hash)}. Waiting for Base confirmation…`);
+      const receipt=await tx.wait();if(!receipt||Number(receipt.status)!==1)throw new Error('The USDC transfer did not succeed.');await secureUsdcPayment(tx.hash,connected.wallet);
+    }catch(error){setStatus(errorText(error))}finally{setBusy('')}
   }
 
-  async function startHostedCheckout() {
-    if (!session?.access_token) { await signIn(); return; }
-    let activeWallet = wallet;
-    if (!activeWallet) {
-      const connected = await connectWallet();
-      activeWallet = connected?.wallet || '';
-      if (!activeWallet) return;
-    }
-    setBusy('checkout');
-    setStatus(`Reserving ${estate.name} and asking the payment provider for eligible payment methods…`);
-    try {
-      const response = await fetch('/api/digital-estates/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ estateId: estate.id, wallet: activeWallet }),
-      });
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.url) throw new Error(data?.error || 'Checkout could not be created.');
-      window.location.href = data.url;
-    } catch (error) {
-      setStatus(errorText(error));
-      setBusy('');
-    }
+  async function recoverUsdc(){
+    if(!recoveryTx)return;if(!session?.access_token){await signIn();return}setBusy('recover');
+    try{const connected=await connectWallet();if(!connected)return;await secureUsdcPayment(recoveryTx,connected.wallet)}catch(error){setStatus(errorText(error))}finally{setBusy('')}
   }
 
-  async function claimAndMintUsdc(txHash, activeWallet, injected) {
-    setStatus('USDC transfer confirmed. Voxel Vault is independently verifying the exact Base transaction before issuing the NFT voucher…');
-    const response = await fetch('/api/digital-estates/claim', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-      body: JSON.stringify({ source: 'base-usdc', estateId: estate.id, wallet: activeWallet, txHash }),
-    });
-    const claim = await response.json().catch(() => ({}));
-    if (!response.ok || !claim?.ready) throw new Error(claim?.error || 'USDC payment could not be verified for minting.');
-
-    setStatus('Payment verified. MetaMask will open a second transaction to mint the unique estate NFT on Base. Review the gas before approving.');
-    setProvider(injected);
-    setWallet(activeWallet);
-    const minted = await mintVoxelFlip({ metadataUrl: claim.metadataUrl, voucherId: claim.voucherId, signature: claim.signature });
-    setMintResult(minted);
-    window.localStorage.removeItem(`vv-digital-estate-usdc:${estate.id}`);
-    window.localStorage.setItem(`vv-digital-estate-mint:${estate.id}`, JSON.stringify(minted));
-    window.dispatchEvent(new CustomEvent('voxel-vault:transaction-confirmed', { detail: minted }));
-    setStatus(`${estate.name} is minted to ${short(activeWallet)} on Base. It is a digital-only NFT estate; no physical property rights were created.`);
-  }
-
-  async function payUsdc() {
-    if (!session?.access_token) { await signIn(); return; }
-    const connected = await connectWallet({ requireBase: true });
-    if (!connected) return;
-    const injected = connected.provider;
-    const activeWallet = connected.wallet;
-    setBusy('usdc');
-    try {
-      const preflightResponse = await fetch('/api/digital-estates/crypto-config', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ estateId: estate.id, wallet: activeWallet }),
-      });
-      const config = await preflightResponse.json().catch(() => ({}));
-      if (!preflightResponse.ok || !config?.ready) throw new Error(config?.error || 'USDC payment is not ready.');
-      if (config.wallet !== activeWallet || config.chainId !== 8453) throw new Error('USDC preflight returned an unexpected wallet or network.');
-
-      const browserProvider = new BrowserProvider(injected);
-      const signer = await browserProvider.getSigner(activeWallet);
-      const usdc = new Contract(getAddress(config.usdcAddress), USDC_ABI, signer);
-      const balance = await usdc.balanceOf(activeWallet);
-      const amount = BigInt(config.amountUsdcUnits);
-      if (balance < amount) throw new Error(`This wallet has ${Number(formatUnits(balance, 6)).toLocaleString('en-US', { maximumFractionDigits: 2 })} USDC, but ${Number(formatUnits(amount, 6)).toLocaleString('en-US', { maximumFractionDigits: 2 })} USDC is required.`);
-
-      setStatus(`MetaMask will show a REAL ${Number(config.amountUsd).toLocaleString('en-US')} USDC payment on Base to ${short(config.recipient)}. This buys only the digital NFT estate.`);
-      const tx = await usdc.transfer(getAddress(config.recipient), amount);
-      window.localStorage.setItem(`vv-digital-estate-usdc:${estate.id}`, tx.hash);
-      setStatus(`USDC payment submitted: ${short(tx.hash)}. Waiting for Base confirmation…`);
-      const receipt = await tx.wait();
-      if (!receipt || Number(receipt.status) !== 1) throw new Error('The USDC transfer did not succeed.');
-      await claimAndMintUsdc(tx.hash, activeWallet, injected);
-    } catch (error) {
-      setStatus(errorText(error));
-    } finally {
-      setBusy('');
-    }
-  }
-
-  async function recoverUsdc() {
-    if (!recoveryTx) return;
-    if (!session?.access_token) { await signIn(); return; }
-    const connected = await connectWallet({ requireBase: true });
-    if (!connected) return;
-    setBusy('recover');
-    try { await claimAndMintUsdc(recoveryTx, connected.wallet, connected.provider); }
-    catch (error) { setStatus(errorText(error)); }
-    finally { setBusy(''); }
-  }
-
-  return (
-    <main className="page">
-      <header className="topbar">
-        <Link href="/vault" className="brand">VOXEL VAULT</Link>
-        <div className="mode"><span /> DIGITAL ESTATES</div>
-        <div className="topActions">
-          {wallet ? <button className="ghost" onClick={() => connectWallet()}>{short(wallet)}</button> : <button className="ghost" onClick={() => connectWallet()} disabled={Boolean(busy)}>CONNECT WALLET</button>}
-          {authState === 'signed-in' ? <span className="signed">SIGNED IN</span> : <button className="ghost" onClick={signIn} disabled={Boolean(busy)}>SIGN IN</button>}
-        </div>
-      </header>
-
-      <section className="hero">
-        <div className="sceneWrap">
-          <EstateScene estate={estate} />
-          <div className="sceneBadge">DRAG TO ORBIT · SCROLL TO ZOOM</div>
-          <div className="chainBadge">UNIQUE NFT · BASE</div>
-        </div>
-
-        <aside className="details">
-          <div className="eyebrow">{estate.locationLabel}</div>
-          <h1>{estate.name}</h1>
-          <p className="summary">{estate.summary}</p>
-          <div className="specs">
-            <div><strong>{estate.beds}</strong><span>BEDS</span></div>
-            <div><strong>{estate.baths}</strong><span>BATHS</span></div>
-            <div><strong>{estate.sqft.toLocaleString()}</strong><span>SQ FT</span></div>
-            <div><strong>{estate.lotSqft.toLocaleString()}</strong><span>LOT SQ FT</span></div>
-          </div>
-
-          <div className="pricePanel">
-            <div><span>REAL-WORLD REFERENCE</span><strong>{price}</strong></div>
-            <div className="divider" />
-            <div><span>DIGITAL ESTATE LIST PRICE</span><strong>{price}</strong></div>
-            <small>Same nominal price by design. The reference is a creative model-pricing reference, not a physical-property appraisal.</small>
-          </div>
-
-          <div className="payGrid">
-            <button className="primary" onClick={startHostedCheckout} disabled={Boolean(busy)}>
-              <span>{busy === 'checkout' ? 'OPENING CHECKOUT…' : 'PAY SECURELY'}</span>
-              <small>Card · Apple Pay · Google Pay · Link · bank/wallet methods when eligible</small>
-            </button>
-            <button className="crypto" onClick={payUsdc} disabled={Boolean(busy)}>
-              <span>{busy === 'usdc' ? 'VERIFYING BASE…' : 'PAY USDC ON BASE'}</span>
-              <small>Direct wallet payment · exact digital list price</small>
-            </button>
-          </div>
-          {recoveryTx ? <button className="recover" onClick={recoverUsdc} disabled={Boolean(busy)}>RECOVER CONFIRMED USDC PAYMENT · {short(recoveryTx)}</button> : null}
-
-          <div className="status">{status}</div>
-          {mintResult?.hash ? <a className="minted" href={mintResult.explorerUrl} target="_blank" rel="noreferrer">VIEW MINT ON BASE ↗</a> : null}
-          <div className="disclosure"><strong>DIGITAL-ONLY ASSET</strong>{DIGITAL_ESTATE_DISCLOSURE}</div>
-        </aside>
-      </section>
-
-      <section className="collection">
-        <div className="sectionTitle"><div><small>THE FIRST DISTRICT</small><h2>Choose your estate.</h2></div><span>{DIGITAL_ESTATES.length} UNIQUE MODELS</span></div>
-        <div className="cards">
-          {DIGITAL_ESTATES.map((item) => (
-            <button key={item.id} className={`card ${item.id === estate.id ? 'active' : ''}`} onClick={() => selectEstate(item.id)}>
-              <div className="mini" style={{ '--accent': item.accent, '--terrain': item.terrain, '--structure': item.structure }}>
-                <div className="miniHouse"><i /><i /><i /></div>
-              </div>
-              <div className="cardCopy"><small>{item.locationLabel}</small><strong>{item.name}</strong><span>{item.beds} bd · {item.baths} ba · {item.sqft.toLocaleString()} sq ft</span><b>{formatUsdCents(item.purchasePriceCents)}</b></div>
-            </button>
-          ))}
-        </div>
-      </section>
-
-      <section className="truth">
-        <div><small>WHAT YOU BUY</small><h3>A unique blockchain estate.</h3><p>After verified payment, Voxel Vault issues a one-use mint voucher bound to your wallet. You approve the Base transaction and the NFT enters your wallet.</p></div>
-        <div><small>WHAT YOU DO NOT BUY</small><h3>No deed hidden in the fine print.</h3><p>No physical parcel, title, tenancy, rental income, security, appraisal, mortgage, or legal claim on a real building is included in this digital phase.</p></div>
-      </section>
-
-      <style jsx>{`
-        :global(body){margin:0;background:#05060a;color:#f5f7fb;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;background:radial-gradient(circle at 12% 12%,rgba(103,87,223,.12),transparent 28%),radial-gradient(circle at 88% 30%,rgba(70,220,180,.06),transparent 24%),#05060a}.topbar{min-height:72px;padding:0 4vw;border-bottom:1px solid rgba(255,255,255,.07);display:flex;align-items:center;justify-content:space-between;gap:18px;position:relative;z-index:4;background:rgba(5,6,10,.72);backdrop-filter:blur(18px)}.brand{color:white;text-decoration:none;font-size:13px;font-weight:950;letter-spacing:.15em}.mode{font-size:10px;letter-spacing:.2em;color:#929aab;font-weight:900;display:flex;align-items:center;gap:9px}.mode span{width:7px;height:7px;border-radius:50%;background:#76efbc;box-shadow:0 0 18px #76efbc}.topActions{display:flex;align-items:center;gap:8px}.ghost{border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.035);color:white;border-radius:999px;padding:10px 14px;font-size:9px;font-weight:900;letter-spacing:.08em}.signed{font-size:9px;font-weight:900;color:#76efbc;letter-spacing:.1em}.hero{max-width:1480px;margin:0 auto;display:grid;grid-template-columns:minmax(0,1.45fr) minmax(360px,.72fr);min-height:720px}.sceneWrap{min-height:720px;position:relative;overflow:hidden;border-right:1px solid rgba(255,255,255,.07);background:radial-gradient(circle at 50% 38%,rgba(130,142,190,.10),transparent 40%)}.estateScene{position:absolute;inset:0;touch-action:none}.sceneBadge,.chainBadge{position:absolute;bottom:22px;font-size:8px;font-weight:900;letter-spacing:.17em;color:#727b8e;border:1px solid rgba(255,255,255,.08);background:rgba(5,6,10,.68);backdrop-filter:blur(12px);border-radius:999px;padding:9px 12px}.sceneBadge{left:24px}.chainBadge{right:24px;color:#aab5ff}.details{padding:64px 44px 40px;display:flex;flex-direction:column;justify-content:center}.eyebrow{font-size:9px;font-weight:900;letter-spacing:.2em;text-transform:uppercase;color:#838ca0}.details h1{font-size:clamp(44px,4.2vw,72px);letter-spacing:-.065em;line-height:.9;margin:14px 0 18px;max-width:570px}.summary{color:#8e96a8;font-size:14px;line-height:1.75;margin:0 0 26px;max-width:560px}.specs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-bottom:22px}.specs div{padding:14px 8px;border:1px solid rgba(255,255,255,.07);border-radius:14px;background:rgba(255,255,255,.025);text-align:center}.specs strong{display:block;font-size:16px}.specs span{display:block;font-size:7px;letter-spacing:.12em;color:#6f7889;margin-top:4px}.pricePanel{border:1px solid rgba(255,255,255,.09);border-radius:20px;background:linear-gradient(135deg,rgba(255,255,255,.05),rgba(255,255,255,.018));padding:18px;margin-bottom:16px}.pricePanel>div:not(.divider){display:flex;align-items:center;justify-content:space-between;gap:16px}.pricePanel span{font-size:8px;font-weight:900;letter-spacing:.14em;color:#7f8797}.pricePanel strong{font-size:22px;letter-spacing:-.04em}.divider{height:1px;background:rgba(255,255,255,.07);margin:11px 0}.pricePanel small{display:block;margin-top:13px;color:#676f80;line-height:1.45;font-size:9px}.payGrid{display:grid;grid-template-columns:1fr 1fr;gap:8px}.primary,.crypto{border:0;border-radius:16px;min-height:78px;padding:14px 16px;text-align:left;cursor:pointer}.primary{background:white;color:#07080c}.crypto{background:#6355df;color:white}.primary span,.crypto span{display:block;font-size:11px;font-weight:950;letter-spacing:.07em}.primary small,.crypto small{display:block;font-size:8px;line-height:1.4;margin-top:7px;opacity:.62}.primary:disabled,.crypto:disabled,.ghost:disabled{opacity:.45;cursor:wait}.recover{margin-top:8px;width:100%;border:1px solid rgba(118,239,188,.25);background:rgba(118,239,188,.06);color:#9af3ce;border-radius:12px;padding:11px;font-size:8px;font-weight:900;letter-spacing:.07em}.status{margin-top:12px;padding:12px 14px;border-radius:13px;background:rgba(255,255,255,.028);border:1px solid rgba(255,255,255,.065);font-size:10px;line-height:1.55;color:#9098a8;min-height:30px}.minted{display:block;margin-top:8px;text-decoration:none;color:#9af3ce;font-size:9px;font-weight:900;letter-spacing:.08em}.disclosure{margin-top:14px;color:#626b7b;font-size:9px;line-height:1.5}.disclosure strong{display:block;color:#a0a8b8;font-size:8px;letter-spacing:.14em;margin-bottom:4px}.collection{max-width:1480px;margin:0 auto;padding:74px 4vw 85px;border-top:1px solid rgba(255,255,255,.07)}.sectionTitle{display:flex;justify-content:space-between;align-items:end;gap:20px;margin-bottom:24px}.sectionTitle small{font-size:9px;letter-spacing:.2em;color:#727b8d;font-weight:900}.sectionTitle h2{font-size:42px;letter-spacing:-.05em;margin:8px 0 0}.sectionTitle>span{font-size:8px;letter-spacing:.16em;color:#667083}.cards{display:grid;grid-template-columns:repeat(5,minmax(190px,1fr));gap:10px;overflow:auto;padding-bottom:8px}.card{min-width:220px;border:1px solid rgba(255,255,255,.075);background:rgba(255,255,255,.02);border-radius:19px;padding:0;overflow:hidden;color:white;text-align:left;cursor:pointer;transition:.2s transform,.2s border-color}.card:hover,.card.active{transform:translateY(-3px);border-color:rgba(190,184,255,.44)}.mini{height:150px;position:relative;overflow:hidden;background:linear-gradient(#10131d 0 58%,var(--terrain) 58% 100%)}.mini:after{content:"";position:absolute;width:80px;height:80px;border-radius:50%;background:var(--accent);opacity:.12;filter:blur(14px);right:16px;top:20px}.miniHouse{position:absolute;left:50%;bottom:22px;width:118px;height:65px;transform:translateX(-50%);background:var(--structure);clip-path:polygon(0 28%,72% 0,100% 25%,100% 100%,0 100%);box-shadow:0 18px 40px rgba(0,0,0,.4)}.miniHouse i{position:absolute;width:20px;height:25px;background:var(--accent);bottom:9px;opacity:.65}.miniHouse i:nth-child(1){left:20px}.miniHouse i:nth-child(2){left:49px}.miniHouse i:nth-child(3){left:78px}.cardCopy{padding:16px}.cardCopy small{font-size:7px;text-transform:uppercase;letter-spacing:.14em;color:#6f7788}.cardCopy strong{display:block;margin:7px 0 6px;font-size:15px}.cardCopy span{display:block;color:#7b8495;font-size:9px}.cardCopy b{display:block;margin-top:13px;font-size:17px}.truth{max-width:1480px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;border-top:1px solid rgba(255,255,255,.07)}.truth>div{padding:65px 6vw 75px}.truth>div+div{border-left:1px solid rgba(255,255,255,.07)}.truth small{font-size:8px;letter-spacing:.18em;color:#737c8e;font-weight:900}.truth h3{font-size:32px;letter-spacing:-.04em;margin:11px 0}.truth p{color:#7e8799;line-height:1.7;max-width:560px;font-size:13px}@media(max-width:980px){.hero{grid-template-columns:1fr}.sceneWrap{min-height:520px;border-right:0;border-bottom:1px solid rgba(255,255,255,.07)}.details{padding:38px 22px 46px}.cards{grid-template-columns:repeat(5,250px)}.truth{grid-template-columns:1fr}.truth>div+div{border-left:0;border-top:1px solid rgba(255,255,255,.07)}}@media(max-width:620px){.topbar{padding:0 16px;min-height:62px}.mode{display:none}.topActions .signed{display:none}.ghost{padding:9px 10px}.sceneWrap{min-height:450px}.details h1{font-size:48px}.specs{grid-template-columns:repeat(2,1fr)}.payGrid{grid-template-columns:1fr}.collection{padding:55px 16px}.sectionTitle h2{font-size:34px}.sectionTitle>span{display:none}.truth>div{padding:50px 22px}.sceneBadge{left:14px}.chainBadge{right:14px}.pricePanel>div:not(.divider){align-items:flex-end}.pricePanel strong{font-size:19px}}
-      `}</style>
-    </main>
-  );
+  return <main className="page">
+    <header><Link href="/vault">VOXEL VAULT</Link><nav><Link href="/vault/estates/mine">MY ESTATES</Link><Link className="safe" href="/vault/test-land">SAFE TESTNET LAND</Link></nav></header>
+    <section className="layout">
+      <div className="viewer"><EstateScene estate={estate}/><div className="viewerTag"><span>LIVE 3D DIGITAL ESTATE</span><b>DRAG TO ORBIT · SCROLL TO ZOOM</b></div></div>
+      <aside>
+        <div className="eyebrow"><i/> UNIQUE DIGITAL PROPERTY · {estate.locationLabel}</div>
+        <h1>{estate.name}</h1><p className="summary">{estate.summary}</p>
+        <div className="specs"><div><b>{estate.beds}</b><span>BEDS</span></div><div><b>{estate.baths}</b><span>BATHS</span></div><div><b>{estate.sqft.toLocaleString()}</b><span>SQ FT</span></div><div><b>{estate.floors}</b><span>FLOORS</span></div></div>
+        <div className="prices"><div><span>REAL-WORLD REFERENCE</span><strong>{formatUsdCents(estate.referenceValueCents)}</strong></div><div><span>DIGITAL ESTATE LIST PRICE</span><strong>{formatUsdCents(estate.purchasePriceCents)}</strong></div><small>Same nominal price by design. Reference value is creative model pricing, not an appraisal.</small></div>
+        <div className="ownership"><b>1 · BUY</b><span>Payment secures this unique estate to your account + bound wallet.</span><b>2 · MINT LATER (OPTIONAL)</b><span>Add Base provenance and wallet visibility whenever you want.</span></div>
+        <div className="status">{status}</div>
+        {!session?<button onClick={signIn} disabled={Boolean(busy)} className="primary">SIGN IN TO BUY</button>:null}
+        {session?<><button onClick={paySecurely} disabled={Boolean(busy)} className="primary">{busy==='stripe'?'OPENING CHECKOUT…':`REAL PAYMENT · PAY SECURELY`}</button><button onClick={payUsdc} disabled={Boolean(busy)} className="secondary">{busy==='usdc'?'VERIFYING WALLET…':'REAL PAYMENT · PAY USDC ON BASE'}</button></>:null}
+        {recoveryTx&&session?<button onClick={recoverUsdc} disabled={Boolean(busy)} className="recover">RECOVER EXISTING USDC PURCHASE · NO NEW TRANSFER</button>:null}
+        {secured?<Link className="owned" href="/vault/estates/mine">✓ PURCHASED & SECURED · OPEN MY ESTATES</Link>:null}
+        <Link className="testButton" href="/vault/test-land">TRY BLOCKCHAIN SAFELY · BASE SEPOLIA TESTNET →</Link>
+        <p className="warning"><strong>REAL PAYMENT WARNING:</strong> The two payment buttons above can initiate real-money transactions at the displayed Digital Estate price when providers are live. Use Testnet Land to experiment without real money.</p>
+      </aside>
+    </section>
+    <section className="rail">{DIGITAL_ESTATES.map(item=><button key={item.id} onClick={()=>{setSelectedId(item.id);setSecured(null);setStatus('Explore this property. Real payment buttons are labeled; Testnet Land uses no real purchase money.')}} className={item.id===estate.id?'active':''}><div className="thumb" style={{background:`radial-gradient(circle at 60% 35%,${item.accent}55,transparent 30%),linear-gradient(145deg,${item.terrain},#090b0f)`}}><span>{item.architecture.toUpperCase()}</span></div><strong>{item.name}</strong><small>{formatUsdCents(item.purchasePriceCents)}</small></button>)}</section>
+    <footer><strong>DIGITAL ESTATES</strong><p>{DIGITAL_ESTATE_DISCLOSURE} Purchase ownership is secured before minting. Minting is optional and does not guarantee appreciation.</p></footer>
+    <style jsx>{`
+      :global(body){margin:0;background:#050609;color:#f5f6f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,3vw,42px) 80px;background:radial-gradient(circle at 74% 8%,rgba(101,85,223,.13),transparent 26%),#050609}header{height:46px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid rgba(255,255,255,.06)}header>a{color:#fff;text-decoration:none;font-size:11px;font-weight:950;letter-spacing:.16em}nav{display:flex;gap:8px}nav a{color:#8e96a7;text-decoration:none;font-size:8px;letter-spacing:.11em;font-weight:900;padding:9px 11px;border:1px solid rgba(255,255,255,.08);border-radius:12px}.safe{color:#79efbc!important;border-color:rgba(121,239,188,.2)!important}.layout{display:grid;grid-template-columns:minmax(0,1.25fr) minmax(340px,.75fr);gap:18px;margin-top:18px}.viewer{position:relative;min-height:660px;border-radius:30px;overflow:hidden;border:1px solid rgba(255,255,255,.08);background:linear-gradient(145deg,#0c0e14,#08090d)}.scene{position:absolute;inset:0}.viewerTag{position:absolute;left:18px;right:18px;bottom:16px;display:flex;justify-content:space-between;gap:12px;pointer-events:none}.viewerTag span,.viewerTag b{padding:8px 10px;border-radius:999px;background:rgba(5,7,10,.72);border:1px solid rgba(255,255,255,.09);font-size:7px;letter-spacing:.12em}.viewerTag span{color:#9ff0d4}.viewerTag b{color:#767f91}aside{border:1px solid rgba(255,255,255,.08);border-radius:30px;padding:28px;background:linear-gradient(150deg,rgba(255,255,255,.05),rgba(255,255,255,.015));align-self:start}.eyebrow{font-size:8px;color:#858ea0;letter-spacing:.13em;font-weight:900}.eyebrow i{display:inline-block;width:6px;height:6px;border-radius:50%;background:#79efbc;margin-right:8px;box-shadow:0 0 15px #79efbc}h1{font-size:clamp(44px,5vw,72px);line-height:.9;letter-spacing:-.065em;margin:18px 0}.summary{color:#8b94a5;line-height:1.65;font-size:12px}.specs{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:20px 0}.specs div{padding:12px 8px;border:1px solid rgba(255,255,255,.07);border-radius:12px}.specs b{display:block;font-size:14px}.specs span{display:block;margin-top:4px;font-size:6px;color:#697284;letter-spacing:.1em;font-weight:900}.prices{padding:18px;border-radius:18px;background:#0b0d12;border:1px solid rgba(255,255,255,.08)}.prices>div{display:flex;justify-content:space-between;gap:12px;align-items:end;padding:8px 0;border-bottom:1px solid rgba(255,255,255,.05)}.prices span{font-size:7px;color:#70798a;font-weight:900;letter-spacing:.11em}.prices strong{font-size:20px;letter-spacing:-.03em}.prices small{display:block;margin-top:10px;color:#626b7c;font-size:8px;line-height:1.5}.ownership{display:grid;grid-template-columns:auto 1fr;gap:7px 10px;margin:16px 0;padding:14px;border:1px solid rgba(121,239,188,.12);border-radius:14px;background:rgba(121,239,188,.025)}.ownership b{font-size:7px;color:#9ee8cd;letter-spacing:.1em}.ownership span{font-size:8px;color:#7a8394}.status{font-size:9px;line-height:1.55;color:#9aa3b3;background:rgba(255,255,255,.025);border:1px solid rgba(255,255,255,.07);border-radius:13px;padding:12px;margin:12px 0}.primary,.secondary,.recover,.testButton,.owned{box-sizing:border-box;width:100%;border:0;border-radius:13px;padding:14px 13px;margin-top:7px;font-size:8px;font-weight:950;letter-spacing:.09em;text-align:center;text-decoration:none;display:block}.primary{background:#fff;color:#06070a}.secondary{background:#6656df;color:#fff}.recover{background:transparent;color:#f2c77c;border:1px solid rgba(242,199,124,.22)}.testButton{background:rgba(121,239,188,.08);border:1px solid rgba(121,239,188,.18);color:#79efbc}.owned{background:rgba(121,239,188,.1);border:1px solid rgba(121,239,188,.2);color:#8cf2cf}.warning{font-size:8px;line-height:1.55;color:#6f7787;margin:12px 2px}.warning strong{color:#e5b66a}.rail{display:flex;gap:10px;overflow-x:auto;margin-top:18px;padding-bottom:8px}.rail>button{flex:0 0 210px;text-align:left;background:transparent;color:#fff;border:1px solid rgba(255,255,255,.07);border-radius:18px;padding:8px;opacity:.64}.rail>button.active{opacity:1;border-color:rgba(255,255,255,.2);background:rgba(255,255,255,.025)}.thumb{height:105px;border-radius:12px;display:flex;align-items:flex-end;padding:9px;box-sizing:border-box}.thumb span{font-size:6px;font-weight:950;letter-spacing:.1em;background:rgba(0,0,0,.5);padding:5px 7px;border-radius:999px}.rail strong{display:block;font-size:12px;margin:9px 5px 2px}.rail small{display:block;font-size:9px;color:#8d96a8;margin:0 5px 5px}footer{max-width:900px;margin-top:30px;border-top:1px solid rgba(255,255,255,.06);padding-top:18px}footer strong{font-size:8px;letter-spacing:.14em}footer p{color:#687183;font-size:8px;line-height:1.6}@media(max-width:900px){.layout{grid-template-columns:1fr}.viewer{min-height:480px}aside{padding:22px}.specs{grid-template-columns:repeat(2,1fr)}}@media(max-width:520px){.page{padding:12px 10px 70px}.viewer{min-height:420px;border-radius:22px}aside{border-radius:22px;padding:18px}.viewerTag b{display:none}h1{font-size:48px}.rail>button{flex-basis:175px}}
+    `}</style>
+  </main>
 }

--- a/app/vault/estates/success/page.js
+++ b/app/vault/estates/success/page.js
@@ -30,16 +30,16 @@ export default function DigitalEstateSuccessPage() {
   const [busy, setBusy] = useState('');
   const [message, setMessage] = useState('Confirming your Voxel Vault account…');
   const [estate, setEstate] = useState(null);
+  const [secured, setSecured] = useState(false);
   const [mint, setMint] = useState(null);
   const clientRef = useRef(null);
+  const secureAttempt = useRef('');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const id = params.get('session_id') || '';
     setSessionId(id);
-    if (!id.startsWith('cs_')) {
-      setMessage('This page is missing a valid Checkout Session. Return to Digital Estates and open the paid checkout return link.');
-    }
+    if (!id.startsWith('cs_')) setMessage('This page is missing a valid Checkout Session. Return to Digital Estates and use the checkout return link.');
 
     let active = true;
     let subscription = null;
@@ -53,7 +53,7 @@ export default function DigitalEstateSuccessPage() {
       } else {
         setAccountSession(data.session);
         setAuthState(data.session?.user ? 'signed-in' : 'signed-out');
-        setMessage(data.session?.user ? 'Payment returned to Voxel Vault. Connect the wallet you bound before checkout to verify and mint.' : 'Sign in with the same Voxel Vault account used for checkout.');
+        setMessage(data.session?.user ? 'Payment returned to Voxel Vault. Securing the estate to your account now…' : 'Sign in with the same Voxel Vault account used for checkout.');
       }
       const auth = client.auth.onAuthStateChange((_event, next) => {
         if (!active) return;
@@ -72,6 +72,31 @@ export default function DigitalEstateSuccessPage() {
     return () => { active = false; subscription?.unsubscribe?.(); };
   }, []);
 
+  useEffect(() => {
+    if (!accountSession?.access_token || !sessionId.startsWith('cs_') || secured) return;
+    const key = `${accountSession.user?.id || 'user'}:${sessionId}`;
+    if (secureAttempt.current === key) return;
+    secureAttempt.current = key;
+
+    setBusy('secure');
+    setMessage('Re-reading the paid Checkout Session from Stripe and locking this Digital Estate to your Voxel Vault account…');
+    fetch('/api/digital-estates/claim', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountSession.access_token}` },
+      body: JSON.stringify({ source: 'stripe', action: 'secure', sessionId }),
+    }).then(async (response) => {
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ownershipSecured) throw new Error(data?.error || 'The purchase could not be secured.');
+      setEstate(data.estate);
+      setWallet(data.wallet || '');
+      setSecured(true);
+      setMessage(`${data.estate.name} is PURCHASED and SECURED. Nobody else can buy it. Minting is optional — do it now or whenever you want from My Digital Estates.`);
+    }).catch((error) => {
+      secureAttempt.current = '';
+      setMessage(errorText(error));
+    }).finally(() => setBusy(''));
+  }, [accountSession, sessionId, secured]);
+
   async function signIn() {
     if (!sessionId) return;
     setBusy('signin');
@@ -86,37 +111,32 @@ export default function DigitalEstateSuccessPage() {
     }
   }
 
-  async function verifyAndMint() {
-    if (!accountSession?.access_token) { await signIn(); return; }
-    if (!sessionId.startsWith('cs_')) return;
-    setBusy('claim');
+  async function mintNow() {
+    if (!secured || !estate || !accountSession?.access_token) return;
+    setBusy('mint');
     try {
       const injected = await discoverMetaMaskProvider();
-      if (!injected) {
-        window.location.href = getMetaMaskDeepLink(window.location.href);
-        return;
-      }
+      if (!injected) { window.location.href = getMetaMaskDeepLink(window.location.href); return; }
       const accounts = await injected.request({ method: 'eth_requestAccounts' });
       if (!accounts?.[0]) throw new Error('Wallet connection was cancelled.');
       const address = getAddress(accounts[0]);
-      setWallet(address);
-      setMessage('Re-reading the paid Checkout Session from Stripe and matching it to your account, estate, amount, and wallet…');
+      if (address.toLowerCase() !== String(wallet || '').toLowerCase()) throw new Error(`Connect the wallet bound at purchase: ${short(wallet)}.`);
 
+      setMessage('Your purchase is already secured. Preparing the optional onchain mint voucher…');
       const response = await fetch('/api/digital-estates/claim', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accountSession.access_token}` },
-        body: JSON.stringify({ source: 'stripe', sessionId, wallet: address }),
+        body: JSON.stringify({ source: 'owned', action: 'mint', estateId: estate.id, wallet: address }),
       });
       const claim = await response.json().catch(() => ({}));
-      if (!response.ok || !claim?.ready) throw new Error(claim?.error || 'The paid estate could not be verified for minting.');
-      setEstate(claim.estate);
+      if (!response.ok || !claim?.ready) throw new Error(claim?.error || 'Optional mint could not be prepared.');
 
-      setMessage('Payment verified. MetaMask will now open one Base transaction for the unique estate NFT mint. Review the network and gas before approving.');
+      setMessage('Purchase remains secured either way. MetaMask will now open the optional Base NFT mint transaction.');
       const minted = await mintVoxelFlip({ metadataUrl: claim.metadataUrl, voucherId: claim.voucherId, signature: claim.signature });
       setMint(minted);
-      window.localStorage.setItem(`vv-digital-estate-mint:${claim.estate.id}`, JSON.stringify(minted));
+      window.localStorage.setItem(`vv-digital-estate-mint:${estate.id}`, JSON.stringify(minted));
       window.dispatchEvent(new CustomEvent('voxel-vault:transaction-confirmed', { detail: minted }));
-      setMessage(`${claim.estate.name} is now minted to ${short(address)} on Base. The asset is digital-only; no deed or physical-property rights were created.`);
+      setMessage(`${estate.name} is now minted to ${short(address)} on Base. Minting added public blockchain provenance and wallet visibility; it did not create physical-property rights or guarantee appreciation.`);
     } catch (error) {
       setMessage(errorText(error));
     } finally {
@@ -128,26 +148,27 @@ export default function DigitalEstateSuccessPage() {
     <main className="page">
       <section className="card">
         <Link href="/vault/estates" className="back">← DIGITAL ESTATES</Link>
-        <div className="badge"><span /> VERIFIED PURCHASE CLAIM</div>
-        <h1>{mint ? 'Estate secured.' : 'Finish your estate.'}</h1>
-        <p className="lead">Your payment and your NFT mint are intentionally separate. Voxel Vault re-verifies the payment server-side before it will create the one-use onchain voucher.</p>
+        <div className={`badge ${secured ? 'good' : ''}`}><span /> {secured ? 'PURCHASE OWNERSHIP SECURED' : 'VERIFYING PURCHASE'}</div>
+        <h1>{mint ? 'Onchain.' : secured ? 'It’s yours.' : 'Securing estate.'}</h1>
+        <p className="lead">Buying and minting are separate. A verified payment secures the unique Digital Estate first. Minting is an optional later step that adds blockchain provenance and puts the asset in your wallet.</p>
 
         {estate ? <div className="estate">
           <div><small>DIGITAL ESTATE</small><strong>{estate.name}</strong></div>
-          <div><small>PAID LIST PRICE</small><strong>{formatUsdCents(estate.purchasePriceCents)}</strong></div>
+          <div><small>SECURED PRICE</small><strong>{formatUsdCents(estate.purchasePriceCents)}</strong></div>
           <div><small>BOUND WALLET</small><strong>{short(wallet)}</strong></div>
         </div> : null}
 
         <div className="message">{message}</div>
-        {authState === 'signed-out' ? <button className="primary" onClick={signIn} disabled={Boolean(busy)}>SIGN IN TO CONTINUE</button> : null}
-        {authState === 'signed-in' && !mint ? <button className="primary" onClick={verifyAndMint} disabled={Boolean(busy) || !sessionId.startsWith('cs_')}>{busy === 'claim' ? 'VERIFYING PAYMENT…' : 'VERIFY PAYMENT + MINT ON BASE'}</button> : null}
+        {authState === 'signed-out' ? <button className="primary" onClick={signIn} disabled={Boolean(busy)}>SIGN IN TO SECURE PURCHASE</button> : null}
+        {secured && !mint ? <button className="primary mint" onClick={mintNow} disabled={Boolean(busy)}>{busy === 'mint' ? 'PREPARING OPTIONAL MINT…' : 'MINT TO BASE NOW · OPTIONAL'}</button> : null}
+        {secured && !mint ? <Link className="secondary" href="/vault/estates/mine">DO THIS LATER · OPEN MY ESTATES</Link> : null}
         {mint?.explorerUrl ? <a className="primary link" href={mint.explorerUrl} target="_blank" rel="noreferrer">VIEW BASE TRANSACTION ↗</a> : null}
-        {mint ? <Link className="secondary" href="/vault">OPEN MY 3D VAULT</Link> : null}
+        {mint ? <Link className="secondary" href="/vault/estates/mine">OPEN MY DIGITAL ESTATES</Link> : null}
 
-        <div className="truth"><strong>DIGITAL-ONLY OWNERSHIP</strong>This NFT does not include physical land, a deed, rent, tenancy, a security, an appraisal, or an investment interest. The real-world reference price is creative model pricing only.</div>
+        <div className="truth"><strong>DIGITAL-ONLY OWNERSHIP</strong>Your Voxel Vault purchase record is the platform ownership lock for this digital asset. Minting adds onchain provenance and wallet visibility. Neither the purchase nor the NFT includes physical land, a deed, rent, tenancy, a security, an appraisal, or an investment interest.</div>
       </section>
       <style jsx>{`
-        :global(body){margin:0;background:#05060a;color:#f7f8fb;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;display:grid;place-items:center;padding:28px;background:radial-gradient(circle at 50% 15%,rgba(101,85,223,.2),transparent 35%),#05060a}.card{width:min(720px,100%);box-sizing:border-box;border:1px solid rgba(255,255,255,.1);border-radius:32px;padding:44px;background:linear-gradient(145deg,rgba(255,255,255,.065),rgba(255,255,255,.018));box-shadow:0 35px 100px rgba(0,0,0,.38)}.back{color:#858da0;text-decoration:none;font-size:9px;letter-spacing:.14em;font-weight:900}.badge{margin-top:56px;color:#8f98aa;font-size:9px;letter-spacing:.18em;font-weight:900;display:flex;align-items:center;gap:9px}.badge span{width:7px;height:7px;border-radius:50%;background:#79efbc;box-shadow:0 0 18px #79efbc}.card h1{font-size:clamp(50px,8vw,78px);line-height:.9;letter-spacing:-.065em;margin:16px 0 22px}.lead{font-size:14px;line-height:1.7;color:#8d96a8;max-width:590px}.estate{display:grid;grid-template-columns:1.4fr 1fr 1fr;gap:8px;margin:28px 0}.estate>div{border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);border-radius:14px;padding:14px}.estate small{display:block;font-size:7px;letter-spacing:.13em;color:#687184;font-weight:900}.estate strong{display:block;margin-top:6px;font-size:12px}.message{margin:18px 0;padding:15px 16px;border-radius:15px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.07);color:#949cad;font-size:11px;line-height:1.6}.primary,.secondary{width:100%;box-sizing:border-box;display:block;border:0;border-radius:15px;padding:16px 18px;text-align:center;text-decoration:none;font-size:10px;font-weight:950;letter-spacing:.08em;margin-top:8px}.primary{background:white;color:#07080c}.primary:disabled{opacity:.4}.primary.link{background:#6656df;color:white}.secondary{border:1px solid rgba(255,255,255,.11);color:white;background:transparent}.truth{margin-top:24px;padding-top:20px;border-top:1px solid rgba(255,255,255,.07);color:#687183;font-size:9px;line-height:1.55}.truth strong{display:block;color:#9ca4b4;font-size:8px;letter-spacing:.14em;margin-bottom:5px}@media(max-width:620px){.page{padding:14px}.card{padding:28px 20px;border-radius:24px}.badge{margin-top:42px}.estate{grid-template-columns:1fr}.card h1{font-size:52px}}
+        :global(body){margin:0;background:#05060a;color:#f7f8fb;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;display:grid;place-items:center;padding:28px;background:radial-gradient(circle at 50% 15%,rgba(101,85,223,.2),transparent 35%),#05060a}.card{width:min(720px,100%);box-sizing:border-box;border:1px solid rgba(255,255,255,.1);border-radius:32px;padding:44px;background:linear-gradient(145deg,rgba(255,255,255,.065),rgba(255,255,255,.018));box-shadow:0 35px 100px rgba(0,0,0,.38)}.back{color:#858da0;text-decoration:none;font-size:9px;letter-spacing:.14em;font-weight:900}.badge{margin-top:56px;color:#8f98aa;font-size:9px;letter-spacing:.18em;font-weight:900;display:flex;align-items:center;gap:9px}.badge span{width:7px;height:7px;border-radius:50%;background:#f4c46b;box-shadow:0 0 18px #f4c46b}.badge.good{color:#9de7ca}.badge.good span{background:#79efbc;box-shadow:0 0 18px #79efbc}.card h1{font-size:clamp(50px,8vw,78px);line-height:.9;letter-spacing:-.065em;margin:16px 0 22px}.lead{font-size:14px;line-height:1.7;color:#8d96a8;max-width:590px}.estate{display:grid;grid-template-columns:1.4fr 1fr 1fr;gap:8px;margin:28px 0}.estate>div{border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.025);border-radius:14px;padding:14px}.estate small{display:block;font-size:7px;letter-spacing:.13em;color:#687184;font-weight:900}.estate strong{display:block;margin-top:6px;font-size:12px}.message{margin:18px 0;padding:15px 16px;border-radius:15px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.07);color:#949cad;font-size:11px;line-height:1.6}.primary,.secondary{width:100%;box-sizing:border-box;display:block;border:0;border-radius:15px;padding:16px 18px;text-align:center;text-decoration:none;font-size:10px;font-weight:950;letter-spacing:.08em;margin-top:8px}.primary{background:white;color:#07080c}.primary:disabled{opacity:.4}.primary.mint{background:#6656df;color:white}.primary.link{background:#6656df;color:white}.secondary{border:1px solid rgba(255,255,255,.11);color:white;background:transparent}.truth{margin-top:24px;padding-top:20px;border-top:1px solid rgba(255,255,255,.07);color:#687183;font-size:9px;line-height:1.55}.truth strong{display:block;color:#9ca4b4;font-size:8px;letter-spacing:.14em;margin-bottom:5px}@media(max-width:620px){.page{padding:14px}.card{padding:28px 20px;border-radius:24px}.badge{margin-top:42px}.estate{grid-template-columns:1fr}.card h1{font-size:52px}}
       `}</style>
     </main>
   );

--- a/lib/digital-estate-purchases.ts
+++ b/lib/digital-estate-purchases.ts
@@ -1,0 +1,190 @@
+import Stripe from 'stripe';
+import { getAddress, Interface, JsonRpcProvider } from 'ethers';
+import { getSupabaseAdmin } from './supabase-admin';
+import { assertDigitalEstatePricing, getDigitalEstate } from './digital-estates';
+import { readDigitalEstateReservation, updateDigitalEstateReservation } from './digital-estate-reservations';
+import { getVoxelFlipDeployment } from './voxelflip-deployment';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const TX_RE = /^0x[a-fA-F0-9]{64}$/;
+const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDC_PAYMENT_PROVIDER = 'digital-estate-usdc-payment';
+const USDC_INTERFACE = new Interface(['event Transfer(address indexed from,address indexed to,uint256 value)']);
+
+function paymentEventType({ estateId, buyerId, wallet, amountUnits }: { estateId: string; buyerId: string; wallet: string; amountUnits: string }) {
+  return JSON.stringify({ kind: 'digital-estate-usdc', estateId, buyerId, wallet: wallet.toLowerCase(), amountUnits });
+}
+
+async function recordOrVerifyUsdcPayment({ txHash, estateId, buyerId, wallet, amountUnits }: { txHash: string; estateId: string; buyerId: string; wallet: string; amountUnits: string }) {
+  const supabase = getSupabaseAdmin();
+  const expectedType = paymentEventType({ estateId, buyerId, wallet, amountUnits });
+  const { error } = await supabase.from('commerce_webhook_events').insert({
+    provider: USDC_PAYMENT_PROVIDER,
+    event_id: txHash.toLowerCase(),
+    event_type: expectedType,
+    processed_at: new Date().toISOString(),
+  });
+  if (!error) return;
+  if (error.code !== '23505') throw error;
+
+  const { data: existing, error: lookupError } = await supabase
+    .from('commerce_webhook_events')
+    .select('event_type')
+    .eq('provider', USDC_PAYMENT_PROVIDER)
+    .eq('event_id', txHash.toLowerCase())
+    .single();
+  if (lookupError || !existing) throw lookupError || new Error('USDC payment idempotency record could not be verified.');
+  if (String(existing.event_type) !== expectedType) throw new Error('This USDC transaction was already used for another purchase.');
+}
+
+export async function secureStripeDigitalEstatePurchase({ session, expectedBuyerId }: { session: Stripe.Checkout.Session; expectedBuyerId?: string }) {
+  if (session.payment_status !== 'paid') throw new Error('DIGITAL_ESTATE_PAYMENT_NOT_PAID');
+  if (session.metadata?.kind !== 'digital_estate') throw new Error('DIGITAL_ESTATE_METADATA_INVALID');
+
+  const buyerId = String(session.metadata?.buyer_id || '');
+  if (!buyerId || (expectedBuyerId && buyerId !== expectedBuyerId)) throw new Error('DIGITAL_ESTATE_BUYER_MISMATCH');
+
+  const estate = assertDigitalEstatePricing(getDigitalEstate(session.metadata?.estate_id));
+  const walletRaw = String(session.metadata?.wallet || '');
+  if (!ADDRESS_RE.test(walletRaw)) throw new Error('DIGITAL_ESTATE_WALLET_INVALID');
+  const wallet = getAddress(walletRaw);
+
+  if (session.currency !== 'usd' || Number(session.amount_total) !== estate.purchasePriceCents) {
+    throw new Error('DIGITAL_ESTATE_AMOUNT_MISMATCH');
+  }
+  if (String(session.metadata?.purchase_price_cents || '') !== String(estate.purchasePriceCents)
+    || String(session.metadata?.reference_value_cents || '') !== String(estate.referenceValueCents)) {
+    throw new Error('DIGITAL_ESTATE_CATALOG_MISMATCH');
+  }
+
+  const reservation = await readDigitalEstateReservation(estate.id);
+  if (!reservation || reservation.buyerId !== buyerId || reservation.wallet !== wallet.toLowerCase()) {
+    throw new Error('DIGITAL_ESTATE_RESERVATION_MISMATCH');
+  }
+  if (reservation.source !== 'stripe') throw new Error('DIGITAL_ESTATE_PAYMENT_SOURCE_MISMATCH');
+  if (reservation.sourceId && reservation.sourceId !== session.id) throw new Error('DIGITAL_ESTATE_SESSION_MISMATCH');
+  if (!['reserved', 'checkout', 'paid', 'minted'].includes(reservation.state)) throw new Error('DIGITAL_ESTATE_RESERVATION_STATE_INVALID');
+
+  if (reservation.state !== 'paid' && reservation.state !== 'minted') {
+    await updateDigitalEstateReservation({
+      estateId: estate.id,
+      buyerId,
+      wallet,
+      state: 'paid',
+      source: 'stripe',
+      sourceId: session.id,
+    });
+  }
+
+  return { estate, buyerId, wallet, source: 'stripe' as const, sourceId: session.id };
+}
+
+export async function secureBaseUsdcDigitalEstatePurchase({ estateId, buyerId, wallet: walletRaw, txHash }: { estateId: string; buyerId: string; wallet: string; txHash: string }) {
+  const estate = assertDigitalEstatePricing(getDigitalEstate(estateId));
+  if (!ADDRESS_RE.test(walletRaw) || !TX_RE.test(txHash)) throw new Error('DIGITAL_ESTATE_USDC_INPUT_INVALID');
+  const wallet = getAddress(walletRaw);
+
+  const reservation = await readDigitalEstateReservation(estate.id);
+  if (!reservation || reservation.buyerId !== buyerId || reservation.wallet !== wallet.toLowerCase() || reservation.source !== 'base-usdc') {
+    throw new Error('DIGITAL_ESTATE_RESERVATION_MISMATCH');
+  }
+  if (reservation.state === 'paid-usdc' && reservation.sourceId && reservation.sourceId.toLowerCase() !== txHash.toLowerCase()) {
+    throw new Error('DIGITAL_ESTATE_USDC_TX_MISMATCH');
+  }
+  if (!['reserved', 'paid-usdc', 'minted'].includes(reservation.state)) throw new Error('DIGITAL_ESTATE_RESERVATION_STATE_INVALID');
+
+  const deployment = await getVoxelFlipDeployment();
+  const recipientRaw = process.env.DIGITAL_ESTATE_USDC_RECIPIENT?.trim() || deployment.royaltyReceiver;
+  if (!ADDRESS_RE.test(recipientRaw)) throw new Error('DIGITAL_ESTATE_USDC_RECIPIENT_INVALID');
+  const recipient = getAddress(recipientRaw);
+  const rpc = process.env.BASE_RPC_URL?.trim() || 'https://mainnet.base.org';
+  const provider = new JsonRpcProvider(rpc, 8453, { staticNetwork: true });
+
+  try {
+    const [transaction, receipt] = await Promise.all([
+      provider.getTransaction(txHash),
+      provider.getTransactionReceipt(txHash),
+    ]);
+    if (!transaction || !receipt || Number(receipt.status) !== 1) throw new Error('DIGITAL_ESTATE_USDC_NOT_CONFIRMED');
+    if (getAddress(transaction.from) !== wallet || !transaction.to || getAddress(transaction.to) !== getAddress(BASE_USDC)) {
+      throw new Error('DIGITAL_ESTATE_USDC_TRANSACTION_MISMATCH');
+    }
+
+    const block = await provider.getBlock(receipt.blockNumber);
+    if (!block) throw new Error('DIGITAL_ESTATE_USDC_BLOCK_UNAVAILABLE');
+    if (reservation.state === 'reserved') {
+      const reservedAtSeconds = Math.floor(Date.parse(reservation.processedAt) / 1000);
+      if (!Number.isFinite(reservedAtSeconds) || block.timestamp < reservedAtSeconds - 120 || block.timestamp > reservedAtSeconds + 45 * 60) {
+        throw new Error('DIGITAL_ESTATE_USDC_OUTSIDE_RESERVATION');
+      }
+    }
+
+    const expectedUnits = BigInt(estate.purchasePriceCents) * BigInt(10_000);
+    let exactTransfer = false;
+    for (const log of receipt.logs) {
+      if (getAddress(log.address) !== getAddress(BASE_USDC)) continue;
+      try {
+        const parsed = USDC_INTERFACE.parseLog({ topics: log.topics as string[], data: log.data });
+        if (!parsed || parsed.name !== 'Transfer') continue;
+        const from = getAddress(String(parsed.args[0]));
+        const to = getAddress(String(parsed.args[1]));
+        const value = BigInt(parsed.args[2].toString());
+        if (from === wallet && to === recipient && value === expectedUnits) {
+          exactTransfer = true;
+          break;
+        }
+      } catch {}
+    }
+    if (!exactTransfer) throw new Error('DIGITAL_ESTATE_USDC_EXACT_TRANSFER_MISSING');
+
+    await recordOrVerifyUsdcPayment({
+      txHash,
+      estateId: estate.id,
+      buyerId,
+      wallet,
+      amountUnits: expectedUnits.toString(),
+    });
+
+    if (reservation.state !== 'paid-usdc' && reservation.state !== 'minted') {
+      await updateDigitalEstateReservation({
+        estateId: estate.id,
+        buyerId,
+        wallet,
+        state: 'paid-usdc',
+        source: 'base-usdc',
+        sourceId: txHash.toLowerCase(),
+      });
+    }
+
+    return { estate, buyerId, wallet, source: 'base-usdc' as const, sourceId: txHash.toLowerCase(), paymentTxHash: txHash };
+  } finally {
+    provider.destroy();
+  }
+}
+
+export function digitalEstatePaymentErrorMessage(error: unknown) {
+  const code = error instanceof Error ? error.message : String(error || '');
+  const messages: Record<string, string> = {
+    DIGITAL_ESTATE_PAYMENT_NOT_PAID: 'Payment is not confirmed yet.',
+    DIGITAL_ESTATE_METADATA_INVALID: 'This payment is not a Digital Estate purchase.',
+    DIGITAL_ESTATE_BUYER_MISMATCH: 'This payment belongs to another Voxel Vault account.',
+    DIGITAL_ESTATE_WALLET_INVALID: 'The purchase is missing its bound wallet.',
+    DIGITAL_ESTATE_AMOUNT_MISMATCH: 'The paid amount does not match the server-authoritative estate price.',
+    DIGITAL_ESTATE_CATALOG_MISMATCH: 'The payment no longer matches the reviewed estate catalog.',
+    DIGITAL_ESTATE_RESERVATION_MISMATCH: 'The estate reservation could not be matched to this purchase.',
+    DIGITAL_ESTATE_PAYMENT_SOURCE_MISMATCH: 'This estate is reserved on another payment rail.',
+    DIGITAL_ESTATE_SESSION_MISMATCH: 'A different checkout session owns this reservation.',
+    DIGITAL_ESTATE_RESERVATION_STATE_INVALID: 'The estate reservation is in an invalid state.',
+    DIGITAL_ESTATE_USDC_INPUT_INVALID: 'A valid Base USDC transaction and wallet are required.',
+    DIGITAL_ESTATE_USDC_TX_MISMATCH: 'This estate was already secured by a different USDC transaction.',
+    DIGITAL_ESTATE_USDC_RECIPIENT_INVALID: 'The reviewed USDC recipient is unavailable.',
+    DIGITAL_ESTATE_USDC_NOT_CONFIRMED: 'The Base USDC transaction is not confirmed successfully.',
+    DIGITAL_ESTATE_USDC_TRANSACTION_MISMATCH: 'The USDC transaction sender or token contract does not match this purchase.',
+    DIGITAL_ESTATE_USDC_BLOCK_UNAVAILABLE: 'The USDC payment block could not be verified.',
+    DIGITAL_ESTATE_USDC_OUTSIDE_RESERVATION: 'This USDC transfer falls outside the active estate reservation window.',
+    DIGITAL_ESTATE_USDC_EXACT_TRANSFER_MISSING: 'No exact USDC transfer to the reviewed recipient was found.',
+  };
+  return messages[code] || 'Digital Estate payment could not be verified.';
+}
+
+export const DIGITAL_ESTATE_BASE_USDC = BASE_USDC;

--- a/scripts/test-digital-estates.mjs
+++ b/scripts/test-digital-estates.mjs
@@ -4,7 +4,7 @@ import { DIGITAL_ESTATES, STRIPE_MAX_USD_CENTS } from '../lib/digital-estates.js
 
 assert.ok(DIGITAL_ESTATES.length >= 5, 'Digital Estates should launch with a meaningful first district.');
 assert.equal(new Set(DIGITAL_ESTATES.map((estate) => estate.id)).size, DIGITAL_ESTATES.length, 'Estate IDs must be unique.');
-assert.equal(new Set(DIGITAL_ESTATES.map((estate) => estate.purchasePriceCents)).size, DIGITAL_ESTATES.length, 'Estate prices should be unique so direct USDC verification cannot ambiguously match two listings.');
+assert.equal(new Set(DIGITAL_ESTATES.map((estate) => estate.purchasePriceCents)).size, DIGITAL_ESTATES.length, 'Estate prices should remain distinct.');
 for (const estate of DIGITAL_ESTATES) {
   assert.equal(estate.purchasePriceCents, estate.referenceValueCents, `${estate.id} must keep matching digital/reference pricing in this phase.`);
   assert.ok(Number.isInteger(estate.purchasePriceCents) && estate.purchasePriceCents > 0, `${estate.id} must have a valid server price.`);
@@ -17,62 +17,80 @@ assert.match(checkout, /unit_amount: estate\.purchasePriceCents/, 'Checkout amou
 assert.doesNotMatch(checkout, /body\?\.(price|amount|purchasePrice)/, 'Browser-supplied prices must never drive checkout.');
 assert.match(checkout, /isDigitalEstateMinted\(estate\.id\)/, 'Checkout must verify onchain inventory before payment.');
 assert.match(checkout, /acquireDigitalEstateReservation/, 'Checkout must acquire a unique reservation before payment.');
-assert.match(checkout, /previous\.payment_status === 'paid'/, 'An existing Stripe hold must be reconciled against Stripe paid state.');
+assert.match(checkout, /previous\.payment_status === 'paid'/, 'An existing Stripe hold must reconcile against Stripe paid state.');
 assert.match(checkout, /previous\.status === 'expired'/, 'Expired Stripe holds must be releasable.');
-assert.doesNotMatch(checkout, /payment_method_types\s*:/, 'Hosted Checkout should use dynamic eligible payment methods rather than a hard-coded card-only list.');
-assert.match(checkout, /digital_only_no_real_property_rights/, 'Checkout metadata must preserve the digital-only rights boundary.');
+assert.doesNotMatch(checkout, /payment_method_types\s*:/, 'Hosted Checkout should use dynamic eligible payment methods.');
+assert.match(checkout, /digital_only_no_real_property_rights/, 'Checkout metadata must preserve the rights boundary.');
+assert.match(checkout, /minting: 'optional_after_purchase'/, 'Checkout must record that minting is optional.');
+assert.doesNotMatch(checkout, /digitalEstateMintReady/, 'Optional mint readiness must never block buying.');
 
 const reservation = fs.readFileSync(new URL('../lib/digital-estate-reservations.ts', import.meta.url), 'utf8');
-assert.match(reservation, /provider.*digital-estate-reservation|PROVIDER = 'digital-estate-reservation'/s, 'Reservations must use a dedicated provider namespace.');
+assert.match(reservation, /PROVIDER = 'digital-estate-reservation'/, 'Reservations must use a dedicated provider namespace.');
+assert.match(reservation, /\['paid', 'paid-usdc', 'minted'\]/, 'Paid purchase states must remain permanent ownership locks.');
 assert.match(reservation, /if \(reservation\.state === 'checkout'\) return false;/, 'Stripe checkout holds must be resolved from Stripe rather than a local timer.');
-assert.match(reservation, /primary key|commerce_webhook_events|event_id/, 'Reservations must use the existing unique commerce event key.');
 assert.match(reservation, /Digital estate reservation changed concurrently/, 'Concurrent reservation writes must fail closed.');
 
+const purchase = fs.readFileSync(new URL('../lib/digital-estate-purchases.ts', import.meta.url), 'utf8');
+assert.match(purchase, /session\.payment_status !== 'paid'/, 'Stripe purchase security must require Stripe paid state.');
+assert.match(purchase, /Number\(session\.amount_total\) !== estate\.purchasePriceCents/, 'Stripe purchase security must verify exact amount.');
+assert.match(purchase, /expectedBuyerId && buyerId !== expectedBuyerId/, 'Stripe purchase security must remain account-bound.');
+assert.match(purchase, /0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/, 'Base USDC verification must pin Circle native USDC.');
+assert.match(purchase, /getAddress\(transaction\.from\) !== wallet/, 'USDC verification must verify sender.');
+assert.match(purchase, /getAddress\(transaction\.to\) !== getAddress\(BASE_USDC\)/, 'USDC verification must verify token contract.');
+assert.match(purchase, /from === wallet && to === recipient && value === expectedUnits/, 'USDC verification must verify exact sender, recipient and amount.');
+assert.match(purchase, /digital-estate-usdc-payment/, 'USDC transaction hashes must be one-time idempotency keys.');
+assert.match(purchase, /state: 'paid'/, 'Verified Stripe payment must lock ownership before minting.');
+assert.match(purchase, /state: 'paid-usdc'/, 'Verified USDC payment must lock ownership before minting.');
+assert.doesNotMatch(purchase, /buildDigitalEstateVoucher|signMessage/, 'Payment security helper must not mint or issue mint vouchers.');
+
 const mint = fs.readFileSync(new URL('../lib/digital-estate-mint.ts', import.meta.url), 'utf8');
-assert.match(mint, /voxel-vault:digital-estate:\$\{String\(estateId/, 'Voucher ID must be deterministic from the estate identity.');
-assert.doesNotMatch(mint, /sessionId|txHash/, 'The unique estate voucher ID must not depend on a payment session or transaction hash.');
-assert.match(mint, /usedVouchers/, 'Onchain inventory must be read from the VoxelFlip voucher registry.');
-assert.match(mint, /signMessage/, 'Paid claims must use the existing VoxelFlip signed-voucher mint path.');
+assert.match(mint, /voxel-vault:digital-estate:\$\{String\(estateId/, 'Voucher ID must be deterministic from estate identity.');
+assert.doesNotMatch(mint, /sessionId|txHash/, 'Estate voucher ID must not depend on payment identifiers.');
+assert.match(mint, /usedVouchers/, 'Onchain uniqueness must read VoxelFlip voucher state.');
+assert.match(mint, /signMessage/, 'Optional minting must use the reviewed signed-voucher path.');
 
 const claim = fs.readFileSync(new URL('../app/api/digital-estates/claim/route.ts', import.meta.url), 'utf8');
-assert.match(claim, /session\.payment_status !== 'paid'/, 'Stripe claims must fail until Stripe reports paid.');
-assert.match(claim, /Number\(session\.amount_total\) !== estate\.purchasePriceCents/, 'Stripe claims must verify the exact paid amount.');
-assert.match(claim, /session\.metadata\?\.buyer_id !== user\.id/, 'Stripe claims must remain account-bound.');
-assert.match(claim, /0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913/, 'Base USDC verification must pin Circle native USDC.');
-assert.match(claim, /getAddress\(transaction\.from\) !== wallet/, 'USDC claims must verify the transaction sender.');
-assert.match(claim, /getAddress\(transaction\.to\) !== getAddress\(BASE_USDC\)/, 'USDC claims must verify the token contract.');
-assert.match(claim, /from === wallet && to === recipient && value === expectedUnits/, 'USDC claims must verify exact sender, recipient and amount.');
-assert.match(claim, /digital-estate-usdc-payment/, 'USDC transaction hashes must be one-time idempotency keys.');
-assert.match(claim, /block\.timestamp < reservedAtSeconds - 120/, 'Old unrelated USDC transfers must not satisfy a new reservation.');
-assert.match(claim, /buildDigitalEstateVoucher/, 'Only verified payment should reach voucher issuance.');
-assert.match(claim, /requestedWallet && \(!ADDRESS_RE\.test\(requestedWallet\)/, 'Stripe claim must reject malformed or different browser wallets cleanly.');
+assert.match(claim, /action === 'secure'/, 'Claim API must expose purchase security separately from minting.');
+assert.match(claim, /ownershipSecured: true/, 'Secure and mint responses must preserve purchase ownership state.');
+assert.match(claim, /source === 'owned'/, 'A secured owner must be able to return later for optional minting.');
+assert.match(claim, /\['paid', 'paid-usdc', 'minted'\]/, 'Later minting must require a permanent paid ownership state.');
+assert.match(claim, /digitalEstateMintReady\(\)/, 'Mint readiness must be checked only for optional mint preparation.');
+assert.match(claim, /buildDigitalEstateVoucher/, 'Optional mint action must issue the reviewed voucher only after ownership checks.');
 
 const crypto = fs.readFileSync(new URL('../app/api/digital-estates/crypto-config/route.ts', import.meta.url), 'utf8');
-assert.match(crypto, /digitalEstateMintReady/, 'USDC transfer must preflight mint readiness.');
-assert.match(crypto, /isDigitalEstateMinted/, 'USDC transfer must preflight onchain availability.');
-assert.match(crypto, /acquireDigitalEstateReservation/, 'USDC transfer must reserve inventory before showing transfer details.');
+assert.doesNotMatch(crypto, /digitalEstateMintReady/, 'Optional mint readiness must not block a USDC purchase.');
+assert.match(crypto, /isDigitalEstateMinted/, 'USDC purchase must preflight onchain uniqueness.');
+assert.match(crypto, /acquireDigitalEstateReservation/, 'USDC purchase must reserve inventory before showing transfer details.');
 assert.match(crypto, /BigInt\(estate\.purchasePriceCents\) \* BigInt\(10_000\)/, 'USD cents must convert exactly to 6-decimal USDC units.');
-assert.match(crypto, /DIGITAL_ESTATE_USDC_RECIPIENT/, 'USDC payout recipient must support explicit server configuration.');
+assert.match(crypto, /mintOptional: true/, 'USDC preflight must describe minting as optional.');
 
 const metadata = fs.readFileSync(new URL('../app/api/digital-estates/metadata/route.ts', import.meta.url), 'utf8');
 assert.match(metadata, /Real Property Rights.*None/s, 'NFT metadata must state that real-property rights are absent.');
-assert.match(metadata, /reference_value_is_appraisal: false/, 'Metadata must never present the creative reference as an appraisal.');
-assert.match(metadata, /purchase_price_matches_reference_value/, 'Metadata should disclose the intentional matching-price design.');
+assert.match(metadata, /reference_value_is_appraisal: false/, 'Metadata must never present reference pricing as an appraisal.');
 
 const page = fs.readFileSync(new URL('../app/vault/estates/page.js', import.meta.url), 'utf8');
 assert.match(page, /REAL-WORLD REFERENCE/);
 assert.match(page, /DIGITAL ESTATE LIST PRICE/);
-assert.match(page, /Same nominal price by design/);
-assert.match(page, /PAY SECURELY/);
-assert.match(page, /PAY USDC ON BASE/);
-assert.match(page, /usdc\.transfer\(getAddress\(config\.recipient\), amount\)/, 'USDC transfer must use server-preflight recipient and amount.');
-assert.match(page, /claimAndMintUsdc/, 'USDC payment must pass through server verification before minting.');
-assert.match(page, /mintVoxelFlip/, 'A verified purchase must mint through the reviewed VoxelFlip client path.');
-assert.match(page, /No physical parcel, title, tenancy, rental income, security, appraisal, mortgage, or legal claim/i, 'The showroom must make the digital-only boundary unmistakable.');
+assert.match(page, /REAL PAYMENT · PAY SECURELY/);
+assert.match(page, /REAL PAYMENT · PAY USDC ON BASE/);
+assert.match(page, /action:'secure'/, 'USDC payment must stop at secured ownership.');
+assert.match(page, /PURCHASED & SECURED/, 'Showroom must visibly distinguish purchase from minting.');
+assert.match(page, /SAFE TESTNET LAND/, 'Showroom must provide a no-real-purchase testing path.');
+assert.doesNotMatch(page, /mintVoxelFlip/, 'The purchase showroom must never auto-mint after payment.');
 
 const success = fs.readFileSync(new URL('../app/vault/estates/success/page.js', import.meta.url), 'utf8');
-assert.match(success, /source: 'stripe'/, 'Hosted payment return must claim specifically from Stripe.');
-assert.match(success, /VERIFY PAYMENT \+ MINT ON BASE/, 'Buyer must explicitly finish the onchain mint after payment verification.');
-assert.match(success, /mintVoxelFlip/, 'Paid hosted checkout must feed the same reviewed voucher mint path.');
+assert.match(success, /source: 'stripe', action: 'secure'/, 'Hosted checkout return must secure purchase before minting.');
+assert.match(success, /source: 'owned', action: 'mint'/, 'Optional mint must operate from the already-secured ownership record.');
+assert.match(success, /MINT TO BASE NOW · OPTIONAL/, 'Minting must be clearly optional.');
+assert.match(success, /DO THIS LATER · OPEN MY ESTATES/, 'Buyer must be able to leave without minting.');
+assert.match(success, /mintVoxelFlip/, 'The optional button must still use the reviewed VoxelFlip mint client.');
 
-console.log(`Digital Estates safety checks passed for ${DIGITAL_ESTATES.length} unique listings.`);
+const mineApi = fs.readFileSync(new URL('../app/api/digital-estates/mine/route.ts', import.meta.url), 'utf8');
+assert.match(mineApi, /\['paid', 'paid-usdc', 'minted'\]/, 'My Estates API must expose only secured purchases.');
+assert.match(mineApi, /reservation\.buyerId !== user\.id/, 'My Estates API must remain user-bound.');
+const minePage = fs.readFileSync(new URL('../app/vault/estates/mine/page.js', import.meta.url), 'utf8');
+assert.match(minePage, /Owned · Not minted/, 'Purchased unminted estates must remain visible.');
+assert.match(minePage, /MINT TO BASE · OPTIONAL/, 'My Estates must offer optional later minting.');
+assert.match(minePage, /does not guarantee appreciation/i, 'Minting must not be represented as guaranteed value creation.');
+
+console.log(`Digital Estates purchase-first safety checks passed for ${DIGITAL_ESTATES.length} unique listings.`);


### PR DESCRIPTION
Separates Digital Estate purchase security from optional NFT minting.

New ownership model:
- verified payment permanently secures a unique estate to the Voxel Vault account + purchase-bound wallet first
- paid/paid-usdc remain permanent sold states whether or not the buyer mints
- minting is optional and can be completed later from My Digital Estates
- optional mint adds onchain provenance/wallet visibility but is not represented as guaranteed value appreciation

Payment safety:
- Stripe checkout no longer depends on mint-signer availability
- Base USDC preflight no longer depends on mint-signer availability
- server-authoritative pricing, unique reservation, Stripe paid-state reconciliation, Base USDC exact-transfer verification and one-time transaction idempotency remain intact
- showroom does not call mintVoxelFlip after payment

Owner UX:
- Stripe success page automatically verifies and secures purchase first
- buyer can choose MINT TO BASE NOW or DO THIS LATER
- /vault/estates/mine lists purchased-but-unminted and minted estates
- later mint is account + purchase-wallet bound and uses the permanent secured ownership record
- showroom clearly labels real payment buttons and links to Base Sepolia Test Land for safe no-real-purchase testing

Regression tests explicitly fail if payment and minting become coupled again.

Draft until exact-head CI and Vercel preview are green.