### PR TITLE
Improve real estate homepage for iPhone

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -34,6 +34,16 @@ export const metadata = {
   },
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#f6f3ec' },
+    { media: '(prefers-color-scheme: dark)', color: '#101a24' },
+  ],
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en">

--- a/app/real-estate/PropertyTwinCanvas.js
+++ b/app/real-estate/PropertyTwinCanvas.js
@@ -15,8 +15,8 @@ export default function PropertyTwinCanvas({ className = '', style }) {
     camera.position.set(10.5, 7.4, 12.5);
     camera.lookAt(0, 1.4, 0);
 
+    const compactMotion = window.matchMedia('(max-width: 680px)');
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -145,8 +145,13 @@ export default function PropertyTwinCanvas({ className = '', style }) {
     const resize = () => {
       width = Math.max(host.clientWidth, 1);
       height = Math.max(host.clientHeight, 1);
+      const isCompact = compactMotion.matches || width < 520;
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isCompact ? 1.35 : 2));
       renderer.setSize(width, height, false);
       camera.aspect = width / height;
+      camera.fov = isCompact ? 43 : 38;
+      camera.position.set(isCompact ? 11.8 : 10.5, isCompact ? 7.2 : 7.4, isCompact ? 14.2 : 12.5);
+      camera.lookAt(0, 1.4, 0);
       camera.updateProjectionMatrix();
     };
     resize();

--- a/app/real-estate/page.js
+++ b/app/real-estate/page.js
@@ -63,7 +63,7 @@ export default function RealEstatePlatformPage() {
         </nav>
 
         <section className={styles.hero}>
-          <div>
+          <div className={styles.heroIntro}>
             <p className={styles.eyebrow}>Real property × legal ownership × spatial 3D</p>
             <h1>Real estate,<br /><em>made spatial.</em></h1>
             <p className={styles.lead}>
@@ -177,8 +177,8 @@ export default function RealEstatePlatformPage() {
 
           <div className={styles.propertyGrid}>
             {properties.map((property) => (
-              <a key={property.id} href={`/real-estate/property/${property.routeId}`} style={{color:'inherit',textDecoration:'none'}} aria-label={`Open ${property.location} property vault`}>
-                <article className={styles.propertyCard} style={{height:'100%'}}>
+              <a key={property.id} href={`/real-estate/property/${property.routeId}`} className={styles.propertyLink} aria-label={`Open ${property.location} property vault`}>
+                <article className={styles.propertyCard}>
                   <div className={styles.propertyArt} data-tone={property.tone}>
                     <span className={styles.artGlyph}>{property.glyph}</span>
                   </div>
@@ -191,7 +191,7 @@ export default function RealEstatePlatformPage() {
                       <div className={styles.propertyStat}><small>Gross rent</small><b>{property.rent}</b></div>
                       <div className={styles.propertyStat}><small>Token units</small><b>{property.units}</b></div>
                     </div>
-                    <div style={{marginTop:16,fontSize:13,fontWeight:900,letterSpacing:'.04em'}}>OPEN PROPERTY VAULT →</div>
+                    <div className={styles.propertyOpen}>OPEN PROPERTY VAULT →</div>
                   </div>
                 </article>
               </a>
@@ -245,6 +245,13 @@ export default function RealEstatePlatformPage() {
           <div>Demo only · not an investment offer · not legal, tax, title or investment advice · live investment flows disabled by design.</div>
         </footer>
       </div>
+
+      <nav className={styles.mobileTabBar} aria-label="Mobile quick navigation">
+        <a href="/real-estate/acquire"><span>01</span><b>Find</b></a>
+        <a href="/real-estate/invest"><span>$</span><b>Invest</b></a>
+        <a href="#portfolio"><span>3D</span><b>Vault</b></a>
+        <a href="/studio"><span>V</span><b>Studio</b></a>
+      </nav>
     </main>
   );
 }

--- a/app/real-estate/real-estate.module.css
+++ b/app/real-estate/real-estate.module.css
@@ -14,6 +14,8 @@
   color: var(--ink);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", sans-serif;
   overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+  padding-bottom: max(0px, env(safe-area-inset-bottom));
 }
 
 .shell {
@@ -101,6 +103,10 @@
   align-items: center;
 }
 
+.heroIntro {
+  min-width: 0;
+}
+
 .eyebrow {
   margin: 0 0 13px;
   font-size: 0.77rem;
@@ -153,6 +159,8 @@
   text-decoration: none;
   font-weight: 950;
   letter-spacing: -0.02em;
+  line-height: 1.1;
+  touch-action: manipulation;
 }
 
 .primaryButton {
@@ -417,9 +425,17 @@
   gap: 14px;
 }
 
+.propertyLink {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  height: 100%;
+}
+
 .propertyCard {
   border-radius: 27px;
   overflow: hidden;
+  height: 100%;
 }
 
 .propertyArt {
@@ -497,6 +513,13 @@
   display: block;
   margin-top: 4px;
   font-size: 0.92rem;
+}
+
+.propertyOpen {
+  margin-top: 16px;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
 }
 
 .moneyGrid {
@@ -610,6 +633,10 @@
   line-height: 1.55;
 }
 
+.mobileTabBar {
+  display: none;
+}
+
 .intakeHero {
   padding: 56px 0 28px;
   max-width: 870px;
@@ -667,53 +694,280 @@
 }
 
 @media (max-width: 680px) {
+  .page {
+    padding-bottom: calc(86px + env(safe-area-inset-bottom));
+  }
   .shell {
-    width: min(100% - 22px, 1180px);
+    width: min(1180px, calc(100% - 22px));
   }
   .nav {
-    min-height: 68px;
+    min-height: 64px;
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    margin: 0 -11px;
+    padding: env(safe-area-inset-top) 11px 0;
+    background: rgba(246, 243, 236, 0.82);
+    border-bottom: 1px solid rgba(19, 32, 44, 0.08);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
   }
   .brand {
     font-size: 1.08rem;
+  }
+  .brandMark {
+    width: 31px;
+    height: 31px;
+    border-radius: 10px;
+  }
+  .navActions {
+    flex: 0 0 auto;
+  }
+  .statusPill {
+    padding: 8px 10px;
+    font-size: 0.62rem;
+    letter-spacing: 0.07em;
+  }
+  .statusDot {
+    width: 7px;
+    height: 7px;
+    box-shadow: 0 0 0 3px rgba(184, 255, 94, 0.13);
   }
   .ghostPill {
     display: none;
   }
   .hero {
-    gap: 26px;
+    gap: 20px;
+    padding: 18px 0 24px;
+  }
+  .heroIntro {
+    display: flex;
+    flex-direction: column;
   }
   .hero h1 {
-    font-size: clamp(3.25rem, 18vw, 5.7rem);
+    font-size: clamp(3rem, 16vw, 4.9rem);
+    line-height: 0.88;
+    letter-spacing: -0.072em;
+  }
+  .lead {
+    margin-top: 18px;
+    font-size: 1rem;
+    line-height: 1.55;
+  }
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 9px;
+  }
+  .primaryButton,
+  .secondaryButton {
+    min-height: 48px;
+    width: 100%;
+    padding: 0 12px;
+    border-radius: 13px;
+    text-align: center;
+    white-space: normal;
+    font-size: 0.86rem;
+  }
+  .primaryButton {
+    grid-column: 1 / -1;
+  }
+  .heroNote {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+    margin-top: 14px;
+  }
+  .heroNote span {
+    padding: 9px 10px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.58);
+    border: 1px solid rgba(19, 32, 44, 0.08);
   }
   .heroVisual {
-    min-height: 440px;
-    border-radius: 27px;
+    order: -1;
+    min-height: clamp(330px, 86svw, 430px);
+    border-radius: 24px;
+    box-shadow: 0 24px 54px rgba(33, 44, 55, 0.22);
+  }
+  .twinCanvas {
+    touch-action: pan-y pinch-zoom;
   }
   .visualTop,
   .visualBottom {
-    left: 14px;
-    right: 14px;
+    left: 13px;
+    right: 13px;
   }
-  .metricGrid,
+  .visualTop {
+    top: 13px;
+  }
+  .visualBottom {
+    bottom: 14px;
+  }
+  .darkPill,
+  .demoPill {
+    padding: 8px 9px;
+    font-size: 0.58rem;
+  }
+  .propertyCaption strong {
+    font-size: clamp(1.28rem, 8vw, 1.9rem);
+  }
+  .dragHint {
+    display: none;
+  }
+  .metricGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    padding-bottom: 32px;
+  }
+  .metricCard {
+    border-radius: 16px;
+    padding: 14px;
+  }
+  .metricLabel {
+    font-size: 0.58rem;
+  }
+  .metricValue {
+    font-size: clamp(1.25rem, 8vw, 1.85rem);
+  }
+  .metricSub {
+    font-size: 0.72rem;
+  }
   .stackGrid,
   .intakeGrid {
     grid-template-columns: 1fr;
   }
   .section {
-    padding: 48px 0;
+    padding: 42px 0;
+  }
+  .sectionDark {
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+    padding: 54px calc(50vw - 50% + 11px);
   }
   .sectionHeader {
     display: block;
   }
+  .sectionHeader h2,
+  .intakeHero h1 {
+    font-size: clamp(2.05rem, 11vw, 3.3rem);
+    line-height: 1.02;
+  }
   .sectionHeader p {
     margin-top: 13px;
   }
+  .stackCard {
+    border-radius: 18px;
+    padding: 18px;
+  }
+  .propertyArt {
+    min-height: 178px;
+  }
+  .propertyBody {
+    padding: 16px;
+  }
+  .propertyBody h3 {
+    font-size: 1.18rem;
+  }
   .propertyStats {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+  }
+  .propertyStat {
+    border-radius: 12px;
+    padding: 9px 7px;
+  }
+  .propertyStat small {
+    font-size: 0.55rem;
+  }
+  .propertyStat b {
+    font-size: 0.78rem;
+    word-break: break-word;
+  }
+  .propertyOpen {
+    font-size: 0.76rem;
+  }
+  .waterfallCard,
+  .gateCard {
+    border-radius: 20px;
+    padding: 20px;
+  }
+  .moneyLine strong {
+    flex: 0 0 auto;
   }
   .legacyCard,
   .footer {
     align-items: flex-start;
     flex-direction: column;
+  }
+  .legacyCard {
+    border-radius: 19px;
+    padding: 20px;
+  }
+  .legacyCard .secondaryButton {
+    width: 100%;
+  }
+  .footer {
+    padding-bottom: 18px;
+  }
+  .mobileTabBar {
+    position: fixed;
+    z-index: 40;
+    left: 10px;
+    right: 10px;
+    bottom: max(10px, env(safe-area-inset-bottom));
+    height: 66px;
+    padding: 7px;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 5px;
+    border: 1px solid rgba(255, 255, 255, 0.46);
+    border-radius: 22px;
+    background: rgba(16, 26, 36, 0.88);
+    box-shadow: 0 20px 58px rgba(16, 26, 36, 0.34);
+    backdrop-filter: blur(22px);
+    -webkit-backdrop-filter: blur(22px);
+  }
+  .mobileTabBar a {
+    min-width: 0;
+    min-height: 52px;
+    display: grid;
+    place-items: center;
+    align-content: center;
+    gap: 3px;
+    border-radius: 16px;
+    color: rgba(248, 250, 252, 0.74);
+    text-decoration: none;
+    font-size: 0.63rem;
+    font-weight: 850;
+  }
+  .mobileTabBar a:first-child {
+    background: rgba(184, 255, 94, 0.15);
+    color: #fff;
+  }
+  .mobileTabBar span {
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--accent);
+    font-size: 0.66rem;
+    line-height: 1;
+  }
+  .mobileTabBar b {
+    font-size: 0.62rem;
+    letter-spacing: 0.02em;
+  }
+}
+
+@media (max-width: 380px) {
+  .hero h1 {
+    font-size: 2.82rem;
+  }
+  .primaryButton,
+  .secondaryButton {
+    font-size: 0.8rem;
   }
 }

--- a/scripts/check-mobile-webgl.mjs
+++ b/scripts/check-mobile-webgl.mjs
@@ -3,10 +3,18 @@ import { readFile } from 'node:fs/promises';
 
 const voxel = await readFile(new URL('../app/components/VoxelViewer.js', import.meta.url), 'utf8');
 const art = await readFile(new URL('../app/components/ArtPreview.js', import.meta.url), 'utf8');
+const propertyTwin = await readFile(new URL('../app/real-estate/PropertyTwinCanvas.js', import.meta.url), 'utf8');
+const realEstateCss = await readFile(new URL('../app/real-estate/real-estate.module.css', import.meta.url), 'utf8');
 
 // Passive mobile rendering must not be silently disabled by a workflow mutation.
 // The guard only verifies that the source retains an explicit mobile strategy.
 assert.match(voxel, /ResizeObserver/, 'VoxelViewer must observe its rendered frame');
 assert.match(art, /ResizeObserver/, 'ArtPreview must observe its rendered frame');
+assert.match(propertyTwin, /ResizeObserver/, 'PropertyTwinCanvas must observe its rendered frame');
+assert.match(propertyTwin, /matchMedia\('\(max-width: 680px\)'\)/, 'PropertyTwinCanvas must keep an explicit compact mobile strategy');
+assert.match(propertyTwin, /1\.35/, 'PropertyTwinCanvas must cap compact mobile pixel ratio');
+assert.match(realEstateCss, /mobileTabBar/, 'Real estate homepage must expose mobile quick navigation');
+assert.match(realEstateCss, /safe-area-inset-bottom/, 'Real estate homepage must account for iPhone safe-area insets');
+assert.match(realEstateCss, /calc\(100% - 22px\)/, 'Real estate mobile shell width must use valid CSS math');
 
 console.log('Mobile WebGL source guard passed.');


### PR DESCRIPTION
## Summary
- adds iPhone viewport/safe-area support
- reworks the real-estate homepage mobile layout with first-screen 3D property visibility
- adds a fixed mobile quick nav and denser phone-friendly cards
- caps compact WebGL pixel ratio and expands the mobile guard

## Verification
- npm run test:mobile
- npm run build
- local production route check returned HTTP 200

Note: Playwright visual screenshot QA could not run because the container was missing a browser binary and the Chromium download repeatedly timed out.