### PR TITLE
Add legal readiness workroom

### DIFF
--- a/app/api/property-platform/status/route.ts
+++ b/app/api/property-platform/status/route.ts
@@ -23,6 +23,13 @@ export async function GET() {
     missingGates: launch.missing,
     allExternalGatesSatisfied: launch.allExternalGatesSatisfied,
     reinvestmentMode: launch.reinvestmentMode,
+    legalReadiness: {
+      environmentVariablesAreNotAuthority: launch.environmentVariablesAreNotAuthority,
+      evidenceRequiredBeforeLive: launch.evidenceRequiredBeforeLive,
+      productionDecisionAuthorities: launch.productionDecisionAuthorities,
+      workstreams: launch.legalReadinessWorkstreams,
+      officialReferences: launch.officialRegulatoryReferences,
+    },
     digitalReits: {
       provider: dinari.provider,
       environment: dinari.environment,

--- a/app/real-estate/launch/page.js
+++ b/app/real-estate/launch/page.js
@@ -1,3 +1,5 @@
+import { legalReadinessWorkstreams, officialRegulatoryReferences } from '../../../lib/real-estate/legal-launch';
+
 const gates = [
   ['01', 'Registered intermediary', 'Contract with a FINRA/SEC-registered broker-dealer or funding portal for the chosen offering path.', 'EXTERNAL'],
   ['02', 'Property + issuer', 'One actual property, dedicated issuer/property LLC, title review, insurance and property-management agreements.', 'EXTERNAL'],
@@ -74,6 +76,37 @@ export default function LegalLaunchPage() {
         </article>)}</div>
       </section>
 
+      <section style={{padding:'42px 0'}}>
+        <div style={{maxWidth:820}}>
+          <div style={eyebrow}>FOUNDER + CODEX WORKROOM</div>
+          <h2 style={sectionTitle}>We can build the product. The live offering needs evidence.</h2>
+          <p style={{...muted,marginTop:12}}>This page separates what we can safely build in GitHub from what licensed counsel, title professionals and regulated providers must approve before any investor money, tokenized rights or distributions go live.</p>
+        </div>
+        <div style={workstreamGrid}>{legalReadinessWorkstreams.map(workstream => <article key={workstream.name} style={workstreamCard}>
+          <div style={{fontSize:12,fontWeight:950,letterSpacing:'.11em',color:'#b8ff55'}}>WORKSTREAM</div>
+          <h3 style={{fontSize:24,letterSpacing:'-.04em',margin:'10px 0 6px'}}>{workstream.name}</h3>
+          <p style={{...muted,fontSize:13}}>Accountable: {workstream.accountable}</p>
+          <div style={laneGrid}>
+            <div><b style={laneTitle}>Founder lane</b><p style={laneCopy}>{workstream.founderLane}</p></div>
+            <div><b style={laneTitle}>Codex lane</b><p style={laneCopy}>{workstream.codexLane}</p></div>
+          </div>
+          <div style={evidenceBox}>
+            <b style={laneTitle}>Evidence before live</b>
+            <ul style={list}>{workstream.evidence.map(item => <li key={item}>{item}</li>)}</ul>
+          </div>
+        </article>)}</div>
+      </section>
+
+      <section style={{padding:'24px 0 42px'}}>
+        <div style={eyebrow}>OFFICIAL SOURCE CHECK</div>
+        <h2 style={sectionTitle}>Build around primary sources.</h2>
+        <div style={referenceGrid}>{officialRegulatoryReferences.map(reference => <a key={reference.name} href={reference.url} target="_blank" rel="noreferrer" style={referenceCard}>
+          <small style={small}>{reference.agency}</small>
+          <strong style={{display:'block',fontSize:19,letterSpacing:'-.025em',margin:'7px 0'}}>{reference.name}</strong>
+          <p style={{...muted,fontSize:13}}>{reference.productImpact}</p>
+        </a>)}</div>
+      </section>
+
       <section style={callout}>
         <div>
           <small style={small}>THE FIRST TRUE LIVE MILESTONE</small>
@@ -105,3 +138,12 @@ const card={border:'1px solid rgba(255,255,255,.11)',borderRadius:22,padding:20,
 const muted={color:'#97a293',lineHeight:1.6,margin:0};
 const sectionTitle={fontSize:'clamp(2rem,5vw,3.7rem)',letterSpacing:'-.05em',margin:'7px 0 0'};
 const gate={display:'grid',gridTemplateColumns:'36px minmax(0,1fr) auto',gap:14,alignItems:'center',border:'1px solid rgba(255,255,255,.1)',borderRadius:18,padding:'15px 16px',background:'rgba(255,255,255,.025)'};
+const workstreamGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(290px,1fr))',gap:12,marginTop:20};
+const workstreamCard={border:'1px solid rgba(184,255,85,.16)',borderRadius:22,padding:20,background:'linear-gradient(145deg,rgba(184,255,85,.055),rgba(255,255,255,.025))'};
+const laneGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(190px,1fr))',gap:12,marginTop:16};
+const laneTitle={display:'block',fontSize:11,letterSpacing:'.1em',textTransform:'uppercase',color:'#dce6d7'};
+const laneCopy={margin:'7px 0 0',color:'#9aa695',lineHeight:1.55,fontSize:13};
+const evidenceBox={marginTop:16,padding:14,border:'1px solid rgba(255,255,255,.1)',borderRadius:16,background:'rgba(7,10,8,.45)'};
+const list={margin:'9px 0 0',paddingLeft:18,color:'#aeb9aa',fontSize:13,lineHeight:1.55};
+const referenceGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(230px,1fr))',gap:12,marginTop:18};
+const referenceCard={display:'block',color:'inherit',textDecoration:'none',border:'1px solid rgba(255,255,255,.1)',borderRadius:18,padding:17,background:'rgba(255,255,255,.03)'};

--- a/docs/LEGAL_LAUNCH_PLAN.md
+++ b/docs/LEGAL_LAUNCH_PLAN.md
@@ -6,6 +6,31 @@ Turn the current real-property/tokenization prototype into a U.S. investment pro
 
 This document is an engineering/compliance implementation plan, not legal advice. Final offering structure, documents, marketing and launch approval must come from licensed securities and real-estate/title counsel plus the selected registered intermediary.
 
+## Official legal-readiness sources
+
+Use primary sources for the first pass and have counsel update the final legal matrix before launch:
+
+- [SEC Regulation Crowdfunding](https://www.sec.gov/resources-small-businesses/exempt-offerings/regulation-crowdfunding) - online Reg CF securities offerings require an SEC-registered intermediary, investor limits, issuer disclosure and filings.
+- [SEC Regulation Crowdfunding guidance for issuers](https://www.sec.gov/resources-small-businesses/small-business-compliance-guides/regulation-crowdfunding-guidance-issuers) - issuer eligibility, filing, disclosure, advertising and bad-actor requirements need review before any raise.
+- [FINRA Funding Portals](https://www.finra.org/registration-exams-ce/funding-portals) - funding portal members are regulated by FINRA and are not interchangeable with an ordinary website checkout.
+- [SEC digital asset investment-contract framework](https://www.sec.gov/files/dlt-framework.pdf) - tokenized rights tied to profit expectations require securities analysis.
+- [FinCEN convertible virtual currency guidance](https://www.fincen.gov/system/files/2019-05/FinCEN%20CVC%20Guidance%20FINAL.pdf) - fiat, stablecoin, wallet, custody and transfer flows need Bank Secrecy Act / money-services analysis.
+- [New York DFS Virtual Currency Business Activity](https://www.dfs.ny.gov/apps_and_licensing/virtual_currency_businesses) - New York-facing virtual-currency activity may need licensing or an approved exemption path.
+- [IRS digital assets](https://www.irs.gov/filing/digital-assets) - digital-asset and distribution records need tax-reporting design before production.
+
+## Shared Founder + Codex workroom
+
+This is the working split. Codex can make the product safer, clearer and review-ready; licensed professionals and regulated providers still control the legal green lights.
+
+| Workstream | Founder lane | Codex lane | Evidence before live |
+| --- | --- | --- | --- |
+| Offering path | Choose the first property/offering goal, collect business facts and approve only counsel-reviewed marketing. | Keep investing disabled, document gates, expose provider status and prevent any client-side payment from creating ownership. | Counsel memo, intermediary acceptance, approved Form C or selected filing path, marketing review record. |
+| Property and issuer | Identify one real property, collect parcel/title/entity documents and confirm the operator/property manager. | Store only public hashes/references on-chain and keep private title, lease, tenant and identity documents out of public metadata. | Title commitment/search, issuer/property LLC records, insurance confirmation, property-management agreement. |
+| Investor onboarding | Select the provider workflow and avoid accepting money outside the approved subscription path. | Bind wallet/account state only to provider-confirmed identity, eligibility and subscription status. | KYC/AML/sanctions configuration, investor-limit or accreditation workflow, subscription document flow, jurisdiction rules. |
+| Funds, custody and settlement | Select where investor funds legally sit before closing and who controls refunds/cancellations. | Require provider-authoritative settled funds and closing allocations before minting or recording investment units. | Escrow agreement, custody/on-ramp review, settlement reconciliation, refund/cancellation procedure. |
+| Token recordkeeping | Approve exactly what the token represents and whether transfers are allowed. | Keep tokens permissioned, capped and separated from the non-economic Property Passport. | Executed rights map, transfer restriction rules, cap-table reconciliation plan, audit-reviewed contracts. |
+| Rent distributions | Confirm rent, expenses, reserves and distributable net income before any investor statement. | Distribute only from approved net-income statements and record-date/cap-table snapshots. | Operating account records, expense/reserve policy, approved accounting statement, tax-reporting workflow. |
+
 ## Recommended first launch path: retail Regulation Crowdfunding through a registered intermediary
 
 For the first property, the default product path is:

--- a/lib/real-estate/legal-launch.js
+++ b/lib/real-estate/legal-launch.js
@@ -24,6 +24,104 @@ export const launchGateDefinitions = [
   ['providerIntegrationVerified', 'REAL_ESTATE_PROVIDER_INTEGRATION_VERIFIED'],
 ];
 
+export const officialRegulatoryReferences = [
+  {
+    agency: 'SEC',
+    name: 'Regulation Crowdfunding',
+    url: 'https://www.sec.gov/resources-small-businesses/exempt-offerings/regulation-crowdfunding',
+    productImpact: 'Retail-accessible securities offerings require issuer disclosures, investor limits and an SEC-registered intermediary.',
+  },
+  {
+    agency: 'SEC',
+    name: 'Reg CF issuer guidance',
+    url: 'https://www.sec.gov/resources-small-businesses/small-business-compliance-guides/regulation-crowdfunding-guidance-issuers',
+    productImpact: 'Offering documents, marketing, filing obligations and bad-actor checks need counsel/intermediary review before any capital raise.',
+  },
+  {
+    agency: 'FINRA',
+    name: 'Funding portal registration',
+    url: 'https://www.finra.org/registration-exams-ce/funding-portals',
+    productImpact: 'A funding portal must be SEC-registered and a FINRA member; Voxel Vault should integrate a qualified intermediary rather than act as one.',
+  },
+  {
+    agency: 'SEC',
+    name: 'Digital asset investment-contract framework',
+    url: 'https://www.sec.gov/files/dlt-framework.pdf',
+    productImpact: 'A token tied to expected profit from real-estate operations can implicate securities analysis even when it uses blockchain rails.',
+  },
+  {
+    agency: 'FinCEN',
+    name: 'Convertible virtual currency guidance',
+    url: 'https://www.fincen.gov/system/files/2019-05/FinCEN%20CVC%20Guidance%20FINAL.pdf',
+    productImpact: 'Fiat, stablecoin, wallet, custody and transfer flows need MSB/BSA review before production money movement.',
+  },
+  {
+    agency: 'NY DFS',
+    name: 'Virtual Currency Business Activity',
+    url: 'https://www.dfs.ny.gov/apps_and_licensing/virtual_currency_businesses',
+    productImpact: 'New York-facing virtual-currency activity can require separate state licensing or an approved exemption path.',
+  },
+  {
+    agency: 'IRS',
+    name: 'Digital assets',
+    url: 'https://www.irs.gov/filing/digital-assets',
+    productImpact: 'Tax reporting, investor statements and digital-asset records must be designed before distributions or transfers are enabled.',
+  },
+];
+
+export const productionDecisionAuthorities = [
+  'Licensed securities counsel',
+  'Property/title counsel and title company',
+  'SEC/FINRA-registered intermediary or otherwise approved regulated partner',
+  'KYC/AML, custody, payment/escrow and tax-reporting providers',
+  'Independent smart-contract/security reviewer',
+];
+
+export const legalReadinessWorkstreams = [
+  {
+    name: 'Offering path',
+    accountable: 'Securities counsel + registered intermediary',
+    founderLane: 'Choose the first property/offering goal, collect business facts and approve only counsel-reviewed marketing.',
+    codexLane: 'Keep investing disabled, document gates, expose provider status and prevent any client-side payment from creating ownership.',
+    evidence: ['Counsel memo', 'Intermediary acceptance', 'Approved Form C or selected offering filing path', 'Marketing review record'],
+  },
+  {
+    name: 'Property and issuer',
+    accountable: 'Property/title counsel + title company',
+    founderLane: 'Identify one real property, collect parcel/title/entity documents and confirm the operator/property manager.',
+    codexLane: 'Store only public hashes/references on-chain and keep private title, lease, tenant and identity documents out of public metadata.',
+    evidence: ['Title commitment/search', 'Issuer or property LLC records', 'Insurance confirmation', 'Property-management agreement'],
+  },
+  {
+    name: 'Investor onboarding',
+    accountable: 'Registered intermediary + KYC/AML provider',
+    founderLane: 'Select the provider workflow and avoid accepting money outside the approved subscription path.',
+    codexLane: 'Bind wallet/account state only to provider-confirmed identity, eligibility and subscription status.',
+    evidence: ['KYC/AML/sanctions configuration', 'Investor-limit or accreditation workflow', 'Subscription document flow', 'Jurisdiction rules'],
+  },
+  {
+    name: 'Funds, custody and settlement',
+    accountable: 'Escrow/payment/custody provider + intermediary',
+    founderLane: 'Select where investor funds legally sit before closing and who controls refunds/cancellations.',
+    codexLane: 'Require provider-authoritative settled funds and closing allocations before minting or recording investment units.',
+    evidence: ['Escrow agreement', 'Custody/on-ramp review', 'Settlement reconciliation', 'Refund/cancellation procedure'],
+  },
+  {
+    name: 'Token recordkeeping',
+    accountable: 'Securities counsel + transfer/cap-table provider',
+    founderLane: 'Approve exactly what the token represents and whether transfers are allowed.',
+    codexLane: 'Keep tokens permissioned, capped and separated from the non-economic Property Passport.',
+    evidence: ['Executed operating/subscription rights map', 'Transfer restriction rules', 'Cap-table reconciliation plan', 'Audit-reviewed contracts'],
+  },
+  {
+    name: 'Rent distributions',
+    accountable: 'Property manager + accounting/tax provider',
+    founderLane: 'Confirm rent, expenses, reserves and distributable net income before any investor statement.',
+    codexLane: 'Distribute only from approved net-income statements and record-date/cap-table snapshots.',
+    evidence: ['Property operating account records', 'Expense/reserve policy', 'Approved accounting statement', 'Tax-reporting workflow'],
+  },
+];
+
 export function evaluateLegalLaunch(env = {}) {
   const gates = Object.fromEntries(
     launchGateDefinitions.map(([name, envKey]) => [name, env[envKey] === 'true'])
@@ -55,6 +153,11 @@ export function evaluateLegalLaunch(env = {}) {
     explicitAutoReinvestmentFlag,
     productionInvestmentImplementationReady: LIVE_INVESTMENT_IMPLEMENTATION_READY,
     productionAutoReinvestmentImplementationReady: LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY,
+    environmentVariablesAreNotAuthority: true,
+    evidenceRequiredBeforeLive: true,
+    productionDecisionAuthorities,
+    officialRegulatoryReferences,
+    legalReadinessWorkstreams,
     liveInvestingEnabled,
     liveAutomaticReinvestmentEnabled,
     reinvestmentMode: liveAutomaticReinvestmentEnabled ? 'provider-approved-instruction' : 'confirm-each-or-cash',

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import assert from 'node:assert/strict';
 
 function read(path) {
   return fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
@@ -20,6 +21,14 @@ const home = read('app/real-estate/page.js');
 const vault = read('app/real-estate/property/[propertyId]/page.js');
 const invest = read('app/real-estate/invest/page.js');
 const wallet = read('app/real-estate/invest/AutoCompoundWallet.js');
+const legalPlan = read('docs/LEGAL_LAUNCH_PLAN.md');
+
+function loadLaunchPolicyForTest(source) {
+  const executable = source
+    .replace(/export const /g, 'const ')
+    .replace(/export function /g, 'function ');
+  return Function(`${executable}\nreturn { evaluateLegalLaunch, launchGateDefinitions, officialRegulatoryReferences, legalReadinessWorkstreams };`)();
+}
 
 requireText(launch, 'LIVE_INVESTMENT_IMPLEMENTATION_READY = false', 'legal launch engine');
 requireText(launch, 'LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY = false', 'legal launch engine');
@@ -28,10 +37,16 @@ requireText(launch, 'REAL_ESTATE_OFFERING_AUTHORIZED', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_ESCROW_SETTLEMENT_CONFIGURED', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_PROVIDER_INTEGRATION_VERIFIED', 'legal launch engine');
 requireText(launch, 'Regulation Crowdfunding through a registered intermediary', 'legal launch engine');
+requireText(launch, 'officialRegulatoryReferences', 'legal launch engine');
+requireText(launch, 'productionDecisionAuthorities', 'legal launch engine');
+requireText(launch, 'New York-facing virtual-currency activity', 'legal launch engine');
+requireText(launch, 'environmentVariablesAreNotAuthority: true', 'legal launch engine');
 requireText(status, 'liveInvestmentCheckout: false', 'property status route');
 requireText(status, 'liveAutomaticReinvestment: false', 'property status route');
 requireText(status, 'mainnetPropertyTokenDeployment: false', 'property status route');
 requireText(status, 'evaluateLegalLaunch(process.env)', 'property status route');
+requireText(status, 'legalReadiness', 'property status route');
+requireText(status, 'officialReferences', 'property status route');
 requireText(deploy, 'network.chainId !== 84532n', 'property deploy script');
 requireText(deploy, 'Base Sepolia only', 'property deploy script');
 requireText(deploy, 'PROPERTY_PASSPORT_ADDRESS', 'property deploy script');
@@ -60,5 +75,33 @@ requireText(wallet, 'Confirm each', 'auto-compound wallet');
 requireText(launchPage, 'Regulation Crowdfunding + registered partner', 'legal launch page');
 requireText(launchPage, 'REAL-MONEY EXECUTION · LOCKED', 'legal launch page');
 requireText(launchPage, 'One real property. One real closing. One reconciled rent distribution.', 'legal launch page');
+requireText(launchPage, 'FOUNDER + CODEX WORKROOM', 'legal launch page');
+requireText(launchPage, 'Build around primary sources.', 'legal launch page');
+requireText(legalPlan, 'Shared Founder + Codex workroom', 'legal launch plan');
+requireText(legalPlan, 'SEC Regulation Crowdfunding', 'legal launch plan');
+requireText(legalPlan, 'New York DFS Virtual Currency Business Activity', 'legal launch plan');
+
+const {
+  evaluateLegalLaunch,
+  launchGateDefinitions,
+  officialRegulatoryReferences,
+  legalReadinessWorkstreams,
+} = loadLaunchPolicyForTest(launch);
+
+const allExternalGatesTrueEnv = Object.fromEntries(
+  launchGateDefinitions.map(([, envKey]) => [envKey, 'true'])
+);
+allExternalGatesTrueEnv.REAL_ESTATE_LIVE_INVESTING_ENABLED = 'true';
+allExternalGatesTrueEnv.REAL_ESTATE_LIVE_AUTO_REINVESTMENT_ENABLED = 'true';
+
+const evaluatedLaunch = evaluateLegalLaunch(allExternalGatesTrueEnv);
+assert.equal(evaluatedLaunch.allExternalGatesSatisfied, true, 'test env should satisfy every external gate');
+assert.equal(evaluatedLaunch.liveInvestingEnabled, false, 'implementation constant must keep live investing fail-closed');
+assert.equal(evaluatedLaunch.liveAutomaticReinvestmentEnabled, false, 'implementation constant must keep auto-reinvestment fail-closed');
+assert.equal(evaluatedLaunch.environmentVariablesAreNotAuthority, true, 'env vars are evidence inputs, not legal authority');
+assert.equal(evaluatedLaunch.officialRegulatoryReferences, officialRegulatoryReferences, 'policy should return the shared official references');
+assert.equal(evaluatedLaunch.legalReadinessWorkstreams, legalReadinessWorkstreams, 'policy should return the shared workstreams');
+assert.ok(officialRegulatoryReferences.length >= 6, 'official regulatory references should stay visible');
+assert.ok(legalReadinessWorkstreams.length >= 6, 'shared workstreams should stay visible');
 
 console.log('Property-platform safety checks passed: regulated launch gates are explicit, the verified Property Passport cannot be used as a transferable deed proxy, live investing and auto-reinvestment remain fail-closed, distribution claims remain permissioned, and property deployment is Base Sepolia-only.');


### PR DESCRIPTION
## Summary
- add shared legal-readiness policy data for official sources, production decision authorities, and founder/Codex workstreams
- expose legalReadiness in the property-platform status API
- add a Founder + Codex workroom and official-source section to the real-estate launch page
- expand the property-platform safety test so legal authority stays fail-closed and evidence-based

## Legal posture
This PR does not make Voxel Vault legally live. It makes the implementation more review-ready while preserving the fail-closed stance for live investing, auto-reinvestment, and regulated real-property/token flows until licensed counsel and regulated providers approve the production path.

## Verification
- npm run test:property-platform
- npm run build
- git diff --check