### PR TITLE
Require verified authority evidence before legal launch

### DIFF
--- a/app/api/property-platform/status/route.ts
+++ b/app/api/property-platform/status/route.ts
@@ -20,12 +20,22 @@ export async function GET() {
     productionAutoReinvestmentImplementationReady: launch.productionAutoReinvestmentImplementationReady,
     launchPolicyVersion: launch.policyVersion,
     gates: launch.gates,
+    gateAssertions: launch.gateAssertions,
+    missingGateAssertions: launch.missingAssertions,
+    unverifiedGateAssertions: launch.unverifiedAssertions,
     missingGates: launch.missing,
+    allExternalGatesAsserted: launch.allExternalGatesAsserted,
     allExternalGatesSatisfied: launch.allExternalGatesSatisfied,
+    activationBlockers: launch.activationBlockers,
+    readinessSummary: launch.readinessSummary,
     reinvestmentMode: launch.reinvestmentMode,
     legalReadiness: {
       environmentVariablesAreNotAuthority: launch.environmentVariablesAreNotAuthority,
       evidenceRequiredBeforeLive: launch.evidenceRequiredBeforeLive,
+      evidenceVerifierImplementationReady: launch.legalEvidenceVerifierImplementationReady,
+      evidenceRecordFields: launch.legalEvidenceRecordFields,
+      evidenceRequirements: launch.legalEvidenceRequirements,
+      evidenceRegister: launch.legalEvidenceRegister,
       productionDecisionAuthorities: launch.productionDecisionAuthorities,
       regulatedLaunchPacket: launch.regulatedLaunchPacket,
       partnerDiligenceChecklist: launch.partnerDiligenceChecklist,
@@ -62,6 +72,8 @@ export async function GET() {
       cappedSandboxSecurityOrders: true,
       jurisdictionAcquisitionGate: true,
       regulatedLaunchGateEngine: true,
+      authorityEvidenceRegister: true,
+      authorityEvidenceVerification: false,
       crossAssetAdapterModel: true,
       rentReinvestmentSimulation: true,
       liveInvestmentCheckout: false,
@@ -80,6 +92,6 @@ export async function GET() {
     },
     note: launch.liveInvestingEnabled
       ? 'Controlled live mode is active through the approved production integration.'
-      : 'Fail-closed regulated launch build: sandbox tokenized-security testing and mock funding are supported, but no live investor funds, live securities purchase, automated property acquisition or public security-token sale can execute from this code.',
+      : 'Fail-closed regulated launch build: environment settings are unverified assertions, no authority evidence verifier is connected, and no live investor funds, live securities purchase, automated property acquisition or public security-token sale can execute from this code.',
   });
 }

--- a/app/real-estate/launch/page.js
+++ b/app/real-estate/launch/page.js
@@ -1,10 +1,13 @@
 import {
+  evaluateLegalLaunch,
   legalReadinessWorkstreams,
   officialRegulatoryReferences,
   partnerDiligenceChecklist,
   regulatedLaunchPacket,
   reviewReadyWorkItems,
 } from '../../../lib/real-estate/legal-launch';
+
+const launchReadiness = evaluateLegalLaunch();
 
 const gates = [
   ['01', 'Registered intermediary', 'Contract with a FINRA/SEC-registered broker-dealer or funding portal for the chosen offering path.', 'EXTERNAL'],
@@ -20,7 +23,7 @@ const gates = [
 ];
 
 const paths = [
-  { name: 'Reg CF · FIRST RETAIL PATH', audience: 'Accredited + non-accredited investors', limit: 'Up to $5M / 12 months per eligible issuer', note: 'Use one registered broker-dealer or funding portal for each offering. Best fit for proving the first small-property retail offering.' },
+  { name: 'Reg CF · COUNSEL REVIEW CANDIDATE', audience: 'Accredited + non-accredited investors', limit: 'Up to $5M / 12 months per eligible issuer', note: 'A working candidate for counsel and intermediary review. It is not selected or approved until those authorities confirm it for the actual issuer and property.' },
   { name: 'Reg D 506(c)', audience: 'Accredited investors only', limit: 'Private-offering exemption', note: 'Useful later for accredited capital. Accredited status requires reasonable verification; a checkbox alone is not enough.' },
   { name: 'Reg A Tier 2', audience: 'Retail + accredited', limit: 'Potential scale path', note: 'Heavier qualification/reporting project. Treat as phase two after one property and its operating/distribution loop are proven.' },
 ];
@@ -36,7 +39,7 @@ export default function LegalLaunchPage() {
       <nav style={nav}>
         <a href="/" style={brand}>V · Voxel Vault</a>
         <div style={{display:'flex',gap:9,flexWrap:'wrap',alignItems:'center'}}>
-          <span style={pill}><span style={dot}/>LEGAL LAUNCH BUILD</span>
+          <span style={pill}><span style={dot}/>LEGAL REVIEW BUILD</span>
           <a href="/real-estate/invest" style={link}>$1,000 wallet</a>
           <a href="/real-estate/onboard" style={link}>Property intake</a>
         </div>
@@ -47,14 +50,14 @@ export default function LegalLaunchPage() {
         <h1 style={hero}>Make it<br/><span style={{color:'#b8ff55'}}>legally launchable.</span></h1>
         <p style={lead}>Voxel Vault should own the spatial product experience—not pretend to be an unlicensed broker, exchange or custodian. The first live property is designed to launch through a registered securities intermediary while Voxel Vault supplies the 3D wallet, property verification layer, permissioned blockchain contracts and reconciled distribution experience.</p>
         <div style={{display:'flex',gap:10,flexWrap:'wrap',marginTop:22}}>
-          <a href="#gates" style={{...button,background:'#b8ff55',color:'#0a0e0a'}}>VIEW LAUNCH GATES</a>
+          <a href="#evidence" style={{...button,background:'#b8ff55',color:'#0a0e0a'}}>VIEW EVIDENCE REGISTER</a>
           <a href="/real-estate/onboard" style={{...button,border:'1px solid #354234',color:'#f6f8f2'}}>START PROPERTY #0001</a>
         </div>
       </section>
 
       <section style={callout}>
         <div>
-          <small style={small}>RECOMMENDED FIRST OFFERING PATH</small>
+          <small style={small}>FIRST PATH FOR COUNSEL TO EVALUATE</small>
           <strong style={{display:'block',fontSize:'clamp(2rem,5vw,4rem)',letterSpacing:'-.055em',marginTop:6}}>Regulation Crowdfunding + registered partner</strong>
         </div>
         <p style={{margin:0,color:'#acb7a8',lineHeight:1.65,maxWidth:480}}>Designed for a retail-accessible first property. Voxel Vault does not unlock live checkout until the actual issuer, intermediary, offering, title, investor-compliance and settlement integrations exist.</p>
@@ -78,8 +81,35 @@ export default function LegalLaunchPage() {
         <div style={{display:'grid',gap:10,marginTop:20}}>{gates.map(([n,title,copy,status]) => <article key={n} style={gate}>
           <span style={{fontWeight:950,color:'#b8ff55'}}>{n}</span>
           <div><strong style={{fontSize:18}}>{title}</strong><p style={{...muted,marginTop:5}}>{copy}</p></div>
-          <span style={{...pill,justifySelf:'end',color:status.startsWith('BUILT')?'#b8ff55':'#cad2c7'}}>{status}</span>
+          <span style={{...pill,justifySelf:'start',gridColumn:'2',color:status.startsWith('BUILT')?'#b8ff55':'#cad2c7'}}>{status}</span>
         </article>)}</div>
+      </section>
+
+      <section id="evidence" style={{padding:'24px 0 42px'}}>
+        <div style={eyebrow}>AUTHORITY EVIDENCE REGISTER</div>
+        <h2 style={sectionTitle}>No legal approval is assumed.</h2>
+        <div style={evidenceSummary}>
+          <div>
+            <small style={small}>CURRENT VERIFIED GATES</small>
+            <strong style={{display:'block',fontSize:34,marginTop:5}}>{launchReadiness.readinessSummary.verifiedGateCount} / {launchReadiness.readinessSummary.requiredGateCount}</strong>
+          </div>
+          <div style={statusStrip}>
+            <span style={{...pill,color:'#ffca7a',borderColor:'#5d4930'}}>LEGAL STATUS · NOT CLEARED</span>
+            <span style={{...pill,color:'#cad2c7'}}>EVIDENCE VERIFIER · NOT CONNECTED</span>
+          </div>
+          <p style={{...muted,maxWidth:720,gridColumn:'1 / -1'}}>Environment variables are recorded only as unverified assertions. A gate stays blocked until the named licensed professional or regulated provider supplies scoped evidence in controlled storage and that evidence is independently verified.</p>
+        </div>
+        <div style={evidenceGrid}>{launchReadiness.legalEvidenceRegister.map(item => <details key={item.gate} style={evidenceCard}>
+          <summary style={evidenceTitle}>
+            <span>{item.label}</span>
+            <span style={{...pill,color:'#ffca7a',borderColor:'#5d4930'}}>NOT VERIFIED</span>
+          </summary>
+          <div style={{padding:'0 14px 15px'}}>
+            <p style={{...muted,fontSize:13}}><b>Authority:</b> {item.authority}</p>
+            <b style={{...laneTitle,marginTop:14}}>Required controlled evidence</b>
+            <ul style={list}>{item.requiredEvidence.map(evidence => <li key={evidence}>{evidence}</li>)}</ul>
+          </div>
+        </details>)}</div>
       </section>
 
       <section style={{padding:'42px 0'}}>
@@ -179,7 +209,7 @@ const pill={display:'inline-flex',alignItems:'center',border:'1px solid #34402f'
 const dot={display:'inline-block',width:7,height:7,borderRadius:'50%',background:'#ffb552',marginRight:7};
 const link={color:'#c8d0c3',textDecoration:'none',fontSize:13,fontWeight:800};
 const eyebrow={fontSize:12,fontWeight:900,letterSpacing:'.15em',color:'#b8ff55'};
-const hero={fontSize:'clamp(3.8rem,10vw,8.5rem)',lineHeight:.84,letterSpacing:'-.075em',margin:'15px 0 26px'};
+const hero={fontSize:'clamp(3rem,10vw,8.5rem)',lineHeight:.9,letterSpacing:0,margin:'15px 0 26px'};
 const lead={fontSize:'clamp(1.05rem,2vw,1.28rem)',lineHeight:1.65,color:'#b8c1b4',maxWidth:860};
 const button={display:'inline-block',borderRadius:14,padding:'13px 17px',textDecoration:'none',fontWeight:950,fontSize:13,letterSpacing:'.03em'};
 const callout={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))',gap:24,alignItems:'center',border:'1px solid #2a3528',borderRadius:26,padding:'clamp(20px,4vw,30px)',background:'rgba(184,255,85,.045)'};
@@ -188,7 +218,7 @@ const pathGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(250px
 const card={border:'1px solid rgba(255,255,255,.11)',borderRadius:22,padding:20,background:'rgba(255,255,255,.04)'};
 const muted={color:'#97a293',lineHeight:1.6,margin:0};
 const sectionTitle={fontSize:'clamp(2rem,5vw,3.7rem)',letterSpacing:'-.05em',margin:'7px 0 0'};
-const gate={display:'grid',gridTemplateColumns:'36px minmax(0,1fr) auto',gap:14,alignItems:'center',border:'1px solid rgba(255,255,255,.1)',borderRadius:18,padding:'15px 16px',background:'rgba(255,255,255,.025)'};
+const gate={display:'grid',gridTemplateColumns:'36px minmax(0,1fr)',gap:14,alignItems:'center',border:'1px solid rgba(255,255,255,.1)',borderRadius:18,padding:'15px 16px',background:'rgba(255,255,255,.025)'};
 const workstreamGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(290px,1fr))',gap:12,marginTop:20};
 const workstreamCard={border:'1px solid rgba(184,255,85,.16)',borderRadius:22,padding:20,background:'linear-gradient(145deg,rgba(184,255,85,.055),rgba(255,255,255,.025))'};
 const laneGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(190px,1fr))',gap:12,marginTop:16};
@@ -206,3 +236,7 @@ const issueGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(250p
 const issueCard={display:'block',color:'inherit',textDecoration:'none',border:'1px solid rgba(184,255,85,.14)',borderRadius:18,padding:17,background:'rgba(255,255,255,.03)'};
 const referenceGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(230px,1fr))',gap:12,marginTop:18};
 const referenceCard={display:'block',color:'inherit',textDecoration:'none',border:'1px solid rgba(255,255,255,.1)',borderRadius:18,padding:17,background:'rgba(255,255,255,.03)'};
+const evidenceSummary={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(240px,1fr))',gap:18,alignItems:'center',border:'1px solid #5d4930',borderRadius:8,padding:'clamp(16px,3vw,22px)',background:'rgba(255,181,82,.055)',marginTop:18};
+const evidenceGrid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))',gap:10,marginTop:12};
+const evidenceCard={border:'1px solid rgba(255,255,255,.12)',borderRadius:8,background:'rgba(255,255,255,.025)',overflow:'hidden'};
+const evidenceTitle={display:'flex',justifyContent:'space-between',alignItems:'center',flexWrap:'wrap',gap:12,padding:14,cursor:'pointer',fontSize:15,fontWeight:850};

--- a/docs/LEGAL_APPROVAL_EVIDENCE_SPEC.md
+++ b/docs/LEGAL_APPROVAL_EVIDENCE_SPEC.md
@@ -1,0 +1,115 @@
+# Voxel Vault Legal Approval Evidence Specification
+
+## Purpose
+
+This specification defines the records Voxel Vault needs before a real-estate investment gate can be treated as satisfied. It is an engineering control, not a legal opinion, registration, filing or authorization.
+
+No repository commit, founder decision, admin toggle, screenshot or environment variable can make an offering legal. The decision must come from the licensed professional or regulated provider responsible for that gate, and the supporting record must be retained in controlled storage.
+
+## Current implementation state
+
+- Legal clearance claimed: `false`
+- Authority evidence verifier implemented: `false`
+- Live investor money movement: `blocked`
+- Live economic-interest issuance: `blocked`
+- Automatic reinvestment: `blocked`
+
+Environment variables are accepted only as operational assertions. Until the verifier is connected, every assertion remains `asserted-unverified` and every launch gate remains unsatisfied.
+
+## Public-safe record shape
+
+Private evidence stays in the controlled legal data room. A future verifier may expose only a public-safe record such as:
+
+```json
+{
+  "gateId": "registeredIntermediaryAgreementActive",
+  "decision": "approved",
+  "authorityRole": "registered-intermediary",
+  "reviewedAt": "YYYY-MM-DD",
+  "nextReviewAt": "YYYY-MM-DD",
+  "scope": "offering-id + issuer-id + property-id",
+  "jurisdictions": ["US", "US-NY"],
+  "controlledRecordId": "opaque-private-record-id",
+  "documentSha256": "64-lowercase-hex-characters",
+  "registryReference": "official-public-registry-reference",
+  "revokedAt": null
+}
+```
+
+The public record must not contain legal advice, signatures, identity documents, tax IDs, bank details, tenant data, private keys or unredacted title/closing files.
+
+## Acceptance rules
+
+A gate may become authority-evidence verified only when all applicable rules pass:
+
+1. The decision is `approved` by the authority assigned to that exact gate.
+2. The approval scope matches the actual issuer, offering, property, product flow and jurisdictions.
+3. The controlled record exists and its approved version matches the stored SHA-256 digest.
+4. The approval is not expired, superseded, rejected, revoked or limited in a way the product violates.
+5. Any required intermediary or provider registration is checked against an official source.
+6. A second controlled verification record shows who checked the evidence and when.
+7. The production integration passes provider-authoritative end-to-end testing and reconciliation.
+8. A reviewed release explicitly enables only the approved scope after the code, security and contract gates pass.
+
+An environment assertion can help operators notice expected configuration. It cannot satisfy any acceptance rule above.
+
+## Required gates and authorities
+
+| Gate | Deciding authority | Minimum controlled evidence |
+| --- | --- | --- |
+| Registered intermediary agreement | SEC/FINRA-registered intermediary + securities counsel | Official registration, executed agreement, written services scope. |
+| Offering authorization | Securities counsel + registered intermediary | Approved exemption path, filing record, disclosures and communications controls. |
+| Securities structure | Licensed securities counsel | Written structure, token-rights and investor-flow approval. |
+| Property and title | Property/title counsel + title company | Title, liens, parcel and property/entity linkage review. |
+| Issuer entity | Issuer counsel + property/title counsel | Good standing, operating authority, capitalization and property-control evidence. |
+| Investor eligibility | Intermediary + approved compliance provider | KYC/AML, sanctions, jurisdiction and investor-limit/accreditation workflow. |
+| Escrow and settlement | Intermediary + escrow/payment provider | Executed arrangement, closing/refund rules and authoritative settlement states. |
+| Custody and wallet rails | Counsel + approved custody/wallet provider | Custody model, wallet binding, account control and recovery rules. |
+| Recordkeeping and transfers | Counsel + authoritative recordkeeper | Securityholder authority, transfer rules and cap-table/on-chain reconciliation. |
+| Property accounting | Property manager + accounting reviewer | Operating accounts, expenses, reserves and distribution-statement process. |
+| Tax reporting | Qualified tax counsel/accounting provider | Issuer treatment, investor reports and digital-asset records. |
+| Smart contracts | Independent contract/security reviewer | Final-scope audit, resolved findings and production bytecode review. |
+| Privacy and security | Privacy counsel + security reviewer | Data flow, retention, access control and approved notices. |
+| Terms and disclosures | Securities/privacy counsel + intermediary | Approved terms, risk disclosures, marketing and investor communications. |
+| Incident response | Provider owners + counsel + security reviewer | Pause authority, incident runbook and investor notification/support process. |
+| Provider integration | Intermediary + each production provider | End-to-end sandbox evidence, signed event proof, reconciliation and production acceptance. |
+
+## Evidence lifecycle
+
+```text
+missing
+  -> submitted to authority
+  -> authority decision recorded
+  -> independently verified
+  -> active for exact approved scope
+  -> expired, superseded or revoked
+```
+
+Any expiry, revocation, scope mismatch, missing provider event or failed reconciliation moves the affected capability back to blocked.
+
+## Production activation boundary
+
+The future activation decision must require all of the following at the same time:
+
+```text
+all authority evidence active for the exact scope
+AND evidence verifier implementation reviewed
+AND provider integration verified
+AND production code implementation reviewed
+AND security and contract release checks passed
+AND explicit release approval present
+= controlled live capability for that approved scope only
+```
+
+The current repository deliberately cannot satisfy this formula. Implementing the verifier must be a separate reviewed change after counsel and providers define their authoritative records and interfaces.
+
+## Reviewer handoff
+
+Reviewers should start with:
+
+1. [Regulated Launch Packet](./REGULATED_LAUNCH_PACKET.md)
+2. [Legal Review Data Room](./LEGAL_REVIEW_DATA_ROOM.md)
+3. This evidence specification
+4. The actual private issuer, property, provider and offering records
+
+Review decisions should be returned as scoped records, not as informal approval messages.

--- a/docs/LEGAL_LAUNCH_PLAN.md
+++ b/docs/LEGAL_LAUNCH_PLAN.md
@@ -24,6 +24,7 @@ Use these working documents before any live investment build:
 
 - [Regulated Launch Packet](./REGULATED_LAUNCH_PACKET.md) - product posture, partner diligence questions, launch locks and first outreach note.
 - [Legal Review Data Room](./LEGAL_REVIEW_DATA_ROOM.md) - evidence categories, gate mapping and public/private handling rules.
+- [Legal Approval Evidence Specification](./LEGAL_APPROVAL_EVIDENCE_SPEC.md) - public-safe record shape, acceptance rules, authority mapping and activation boundary.
 
 ## Shared Founder + Codex workroom
 
@@ -204,9 +205,10 @@ A live investment checkout is blocked unless all required gates are true in an a
 - smart contracts independently audited;
 - incident response/pause procedures approved;
 - privacy/security review completed;
+- public terms, risk disclosures and investor communications approved;
 - production provider integration verified end-to-end.
 
-Environment variables alone must never satisfy this list.
+Environment variables alone must never satisfy this list. They are operational assertions only; every gate stays unsatisfied until scoped authority evidence is independently verified under the [Legal Approval Evidence Specification](./LEGAL_APPROVAL_EVIDENCE_SPEC.md).
 
 ## First real property milestone
 

--- a/docs/LEGAL_REVIEW_DATA_ROOM.md
+++ b/docs/LEGAL_REVIEW_DATA_ROOM.md
@@ -6,6 +6,8 @@ Do not commit private legal, identity, banking, tenant, title, wallet-key, tax o
 
 This checklist defines the evidence categories that must exist in controlled storage before Voxel Vault can move from `regulated-launch-build` to any live investment workflow. Public code may store document names, review states, non-sensitive hashes and provider references only.
 
+The public-safe record contract and evidence acceptance rules are defined in [Legal Approval Evidence Specification](./LEGAL_APPROVAL_EVIDENCE_SPEC.md).
+
 ## Minimum data-room folders
 
 | Folder | Contents | Public repo treatment |
@@ -51,6 +53,7 @@ Each gate needs:
 | `taxReportingConfigured` | Investor statements and required tax reporting workflow. |
 | `smartContractsAudited` | Independent contract review and deployment approval. |
 | `privacySecurityApproved` | Privacy, access-control and security review. |
+| `publicTermsDisclosuresApproved` | Counsel/intermediary-approved terms, risk disclosures and public communications. |
 | `incidentResponseApproved` | Pause authority, incident runbook and support escalation path. |
 | `providerIntegrationVerified` | End-to-end sandbox proof using provider-authoritative states. |
 
@@ -61,7 +64,8 @@ private evidence document
     -> controlled storage
     -> reviewer approval record
     -> public-safe hash/reference
-    -> launch gate can become externally satisfied
+    -> scope, authority, expiry and registry checks pass
+    -> launch gate can become authority-evidence verified
     -> code still remains fail-closed until production implementation constants are reviewed
 ```
 
@@ -73,4 +77,3 @@ private evidence document
 - Tenant names, tenant financials or tenant communications.
 - Private legal advice unless counsel approves disclosure.
 - Unapproved marketing or investor solicitation copy.
-

--- a/docs/REGULATED_LAUNCH_PACKET.md
+++ b/docs/REGULATED_LAUNCH_PACKET.md
@@ -48,6 +48,8 @@ The following remain blocked until the required authorities approve them:
 
 Environment variables, admin toggles, screenshots or founder approval do not satisfy legal authority by themselves.
 
+Voxel Vault records those settings only as unverified assertions. The required authority records, acceptance rules and fail-closed activation boundary are defined in [Legal Approval Evidence Specification](./LEGAL_APPROVAL_EVIDENCE_SPEC.md).
+
 ## Partner diligence questions
 
 | Area | Question | Needed evidence |
@@ -93,4 +95,3 @@ Dominic
 - [#342 Funds, escrow, custody + settlement](https://github.com/hartensteindominic/Voxel-Vault/issues/342)
 - [#343 Token recordkeeping + transfer controls](https://github.com/hartensteindominic/Voxel-Vault/issues/343)
 - [#344 Rent distributions + reinvestment rules](https://github.com/hartensteindominic/Voxel-Vault/issues/344)
-

--- a/lib/real-estate/legal-launch.js
+++ b/lib/real-estate/legal-launch.js
@@ -1,28 +1,144 @@
-export const LEGAL_LAUNCH_POLICY_VERSION = '2026-08-regulated-intermediary-v1';
+export const LEGAL_LAUNCH_POLICY_VERSION = '2026-08-authority-evidence-v2';
 
 // These constants can only change in a reviewed release after the corresponding
 // production integrations actually exist. Environment variables are evidence
 // inputs, never authority to make the implementation live by themselves.
 export const LIVE_INVESTMENT_IMPLEMENTATION_READY = false;
 export const LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY = false;
+export const LEGAL_EVIDENCE_VERIFIER_IMPLEMENTATION_READY = false;
 
-export const launchGateDefinitions = [
-  ['registeredIntermediaryAgreementActive', 'REAL_ESTATE_REGISTERED_INTERMEDIARY_ACTIVE'],
-  ['offeringAuthorizationApproved', 'REAL_ESTATE_OFFERING_AUTHORIZED'],
-  ['securitiesCounselApproved', 'REAL_ESTATE_SECURITIES_COUNSEL_APPROVED'],
-  ['titleCounselApproved', 'REAL_ESTATE_TITLE_COUNSEL_APPROVED'],
-  ['issuerPropertyEntityVerified', 'REAL_ESTATE_ISSUER_ENTITY_VERIFIED'],
-  ['kycAmlInvestorEligibilityConfigured', 'REAL_ESTATE_KYC_AML_CONFIGURED'],
-  ['escrowSettlementConfigured', 'REAL_ESTATE_ESCROW_SETTLEMENT_CONFIGURED'],
-  ['custodyRailsConfigured', 'REAL_ESTATE_CUSTODY_RAILS_CONFIGURED'],
-  ['capTableTransferControlsConfigured', 'REAL_ESTATE_CAP_TABLE_TRANSFER_CONFIGURED'],
-  ['propertyAccountingConfigured', 'REAL_ESTATE_PROPERTY_ACCOUNTING_CONFIGURED'],
-  ['taxReportingConfigured', 'REAL_ESTATE_TAX_REPORTING_CONFIGURED'],
-  ['smartContractsAudited', 'REAL_ESTATE_CONTRACTS_AUDITED'],
-  ['privacySecurityApproved', 'REAL_ESTATE_PRIVACY_SECURITY_APPROVED'],
-  ['incidentResponseApproved', 'REAL_ESTATE_INCIDENT_RESPONSE_APPROVED'],
-  ['providerIntegrationVerified', 'REAL_ESTATE_PROVIDER_INTEGRATION_VERIFIED'],
+export const legalEvidenceRecordFields = [
+  'gateId',
+  'decision',
+  'authorityRole',
+  'reviewedAt',
+  'nextReviewAt',
+  'scope',
+  'jurisdictions',
+  'controlledRecordId',
+  'documentSha256',
+  'registryReference',
+  'revokedAt',
 ];
+
+export const legalEvidenceRequirements = [
+  {
+    gate: 'registeredIntermediaryAgreementActive',
+    label: 'Registered intermediary agreement',
+    assertionEnvKey: 'REAL_ESTATE_REGISTERED_INTERMEDIARY_ACTIVE',
+    authority: 'SEC/FINRA-registered intermediary + securities counsel',
+    requiredEvidence: ['Official registration record', 'Executed agreement', 'Written regulated-services scope'],
+  },
+  {
+    gate: 'offeringAuthorizationApproved',
+    label: 'Offering authorization',
+    assertionEnvKey: 'REAL_ESTATE_OFFERING_AUTHORIZED',
+    authority: 'Securities counsel + registered intermediary',
+    requiredEvidence: ['Approved exemption path', 'Required filing record', 'Approved disclosures and marketing controls'],
+  },
+  {
+    gate: 'securitiesCounselApproved',
+    label: 'Securities counsel approval',
+    assertionEnvKey: 'REAL_ESTATE_SECURITIES_COUNSEL_APPROVED',
+    authority: 'Licensed securities counsel',
+    requiredEvidence: ['Written structure approval', 'Token-rights analysis', 'Investor-flow and communications approval'],
+  },
+  {
+    gate: 'titleCounselApproved',
+    label: 'Property and title approval',
+    assertionEnvKey: 'REAL_ESTATE_TITLE_COUNSEL_APPROVED',
+    authority: 'Property/title counsel + title company',
+    requiredEvidence: ['Title review', 'Lien and parcel review', 'Approved property/entity linkage'],
+  },
+  {
+    gate: 'issuerPropertyEntityVerified',
+    label: 'Issuer and property entity',
+    assertionEnvKey: 'REAL_ESTATE_ISSUER_ENTITY_VERIFIED',
+    authority: 'Issuer counsel + property/title counsel',
+    requiredEvidence: ['Entity good-standing record', 'Operating agreement and authority', 'Capitalization and property-control evidence'],
+  },
+  {
+    gate: 'kycAmlInvestorEligibilityConfigured',
+    label: 'Investor identity and eligibility',
+    assertionEnvKey: 'REAL_ESTATE_KYC_AML_CONFIGURED',
+    authority: 'Registered intermediary + approved identity/compliance provider',
+    requiredEvidence: ['KYC/AML and sanctions workflow', 'Investor-limit or accreditation workflow', 'Jurisdiction eligibility rules'],
+  },
+  {
+    gate: 'escrowSettlementConfigured',
+    label: 'Escrow and settlement',
+    assertionEnvKey: 'REAL_ESTATE_ESCROW_SETTLEMENT_CONFIGURED',
+    authority: 'Registered intermediary + escrow/payment provider',
+    requiredEvidence: ['Executed escrow arrangement', 'Closing and refund rules', 'Provider-authoritative settlement states'],
+  },
+  {
+    gate: 'custodyRailsConfigured',
+    label: 'Custody and wallet rails',
+    assertionEnvKey: 'REAL_ESTATE_CUSTODY_RAILS_CONFIGURED',
+    authority: 'Counsel + approved custody/wallet provider',
+    requiredEvidence: ['Approved custody model', 'Wallet-account binding rules', 'Key recovery and account-control procedures'],
+  },
+  {
+    gate: 'capTableTransferControlsConfigured',
+    label: 'Recordkeeping and transfer controls',
+    assertionEnvKey: 'REAL_ESTATE_CAP_TABLE_TRANSFER_CONFIGURED',
+    authority: 'Counsel + authoritative recordkeeper/transfer provider',
+    requiredEvidence: ['Securityholder record authority', 'Transfer restrictions', 'Cap-table and on-chain reconciliation procedure'],
+  },
+  {
+    gate: 'propertyAccountingConfigured',
+    label: 'Property accounting',
+    assertionEnvKey: 'REAL_ESTATE_PROPERTY_ACCOUNTING_CONFIGURED',
+    authority: 'Property manager + approved accounting reviewer',
+    requiredEvidence: ['Operating-account controls', 'Rent, expense and reserve policy', 'Distribution statement approval process'],
+  },
+  {
+    gate: 'taxReportingConfigured',
+    label: 'Tax reporting',
+    assertionEnvKey: 'REAL_ESTATE_TAX_REPORTING_CONFIGURED',
+    authority: 'Qualified tax counsel/accounting provider',
+    requiredEvidence: ['Issuer tax treatment', 'Investor reporting workflow', 'Digital-asset recordkeeping procedure'],
+  },
+  {
+    gate: 'smartContractsAudited',
+    label: 'Smart-contract audit',
+    assertionEnvKey: 'REAL_ESTATE_CONTRACTS_AUDITED',
+    authority: 'Independent smart-contract/security reviewer',
+    requiredEvidence: ['Final deployment-scope audit', 'Resolved findings', 'Reviewed production bytecode and authority controls'],
+  },
+  {
+    gate: 'privacySecurityApproved',
+    label: 'Privacy and security approval',
+    assertionEnvKey: 'REAL_ESTATE_PRIVACY_SECURITY_APPROVED',
+    authority: 'Privacy counsel + independent security reviewer',
+    requiredEvidence: ['Data-flow and retention review', 'Access-control review', 'Approved privacy and security notices'],
+  },
+  {
+    gate: 'publicTermsDisclosuresApproved',
+    label: 'Terms, disclosures and communications',
+    assertionEnvKey: 'REAL_ESTATE_PUBLIC_TERMS_DISCLOSURES_APPROVED',
+    authority: 'Securities/privacy counsel + registered intermediary',
+    requiredEvidence: ['Approved public terms', 'Approved risk disclosures', 'Approved marketing and investor communications'],
+  },
+  {
+    gate: 'incidentResponseApproved',
+    label: 'Incident and pause response',
+    assertionEnvKey: 'REAL_ESTATE_INCIDENT_RESPONSE_APPROVED',
+    authority: 'Provider owners + counsel + security reviewer',
+    requiredEvidence: ['Pause authority map', 'Incident runbook', 'Investor support and notification procedure'],
+  },
+  {
+    gate: 'providerIntegrationVerified',
+    label: 'Provider integration verification',
+    assertionEnvKey: 'REAL_ESTATE_PROVIDER_INTEGRATION_VERIFIED',
+    authority: 'Registered intermediary + each production provider',
+    requiredEvidence: ['End-to-end sandbox evidence', 'Signed webhook/reconciliation proof', 'Provider production acceptance'],
+  },
+];
+
+export const launchGateDefinitions = legalEvidenceRequirements.map(
+  ({ gate, assertionEnvKey }) => [gate, assertionEnvKey]
+);
 
 export const officialRegulatoryReferences = [
   {
@@ -92,6 +208,7 @@ export const regulatedLaunchPacket = {
     { name: 'Legal launch plan', path: 'docs/LEGAL_LAUNCH_PLAN.md' },
     { name: 'Regulated launch packet', path: 'docs/REGULATED_LAUNCH_PACKET.md' },
     { name: 'Legal review data room', path: 'docs/LEGAL_REVIEW_DATA_ROOM.md' },
+    { name: 'Legal approval evidence specification', path: 'docs/LEGAL_APPROVAL_EVIDENCE_SPEC.md' },
   ],
   founderCanDoNow: [
     'Pick one first-property thesis and budget range.',
@@ -106,6 +223,7 @@ export const regulatedLaunchPacket = {
     'Build sandbox-only provider adapters until a real provider contract exists.',
     'Separate non-economic Property Passport data from economic property-interest units.',
     'Preserve audit logs, reconciliation records and provider-authoritative state transitions.',
+    'Treat environment flags as unverified assertions until authority evidence is independently verified.',
   ],
   prohibitedUntilApproved: [
     'Accept investor funds directly into Voxel Vault-controlled accounts.',
@@ -113,6 +231,7 @@ export const regulatedLaunchPacket = {
     'Show pending payment as ownership.',
     'Offer automatic reinvestment without counsel/intermediary approval.',
     'Enable unrestricted peer-to-peer trading of property-interest tokens.',
+    'Use a founder toggle, admin setting or environment variable as legal approval.',
   ],
 };
 
@@ -270,10 +389,38 @@ export const legalReadinessWorkstreams = [
 ];
 
 export function evaluateLegalLaunch(env = {}) {
-  const gates = Object.fromEntries(
+  const gateAssertions = Object.fromEntries(
     launchGateDefinitions.map(([name, envKey]) => [name, env[envKey] === 'true'])
   );
-  const missing = Object.entries(gates).filter(([, passed]) => !passed).map(([name]) => name);
+  const legalEvidenceRegister = legalEvidenceRequirements.map((requirement) => {
+    const asserted = gateAssertions[requirement.gate];
+
+    return {
+      gate: requirement.gate,
+      label: requirement.label,
+      authority: requirement.authority,
+      assertionStatus: asserted ? 'asserted-unverified' : 'not-asserted',
+      authorityEvidenceStatus: 'not-connected',
+      launchSatisfied: false,
+      requiredEvidence: requirement.requiredEvidence,
+      reason: asserted
+        ? 'An environment assertion exists, but no controlled authority evidence has been independently verified.'
+        : 'No controlled authority evidence has been independently verified.',
+    };
+  });
+  const gates = Object.fromEntries(
+    legalEvidenceRegister.map(({ gate, launchSatisfied }) => [gate, launchSatisfied])
+  );
+  const missingAssertions = Object.entries(gateAssertions)
+    .filter(([, asserted]) => !asserted)
+    .map(([name]) => name);
+  const unverifiedAssertions = Object.entries(gateAssertions)
+    .filter(([, asserted]) => asserted)
+    .map(([name]) => name);
+  const missing = legalEvidenceRegister
+    .filter(({ launchSatisfied }) => !launchSatisfied)
+    .map(({ gate }) => gate);
+  const allExternalGatesAsserted = missingAssertions.length === 0;
   const allExternalGatesSatisfied = missing.length === 0;
   const explicitLiveFlag = env.REAL_ESTATE_LIVE_INVESTING_ENABLED === 'true';
   const explicitAutoReinvestmentFlag = env.REAL_ESTATE_LIVE_AUTO_REINVESTMENT_ENABLED === 'true';
@@ -290,18 +437,42 @@ export function evaluateLegalLaunch(env = {}) {
     LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY
   );
 
+  const activationBlockers = [
+    !LEGAL_EVIDENCE_VERIFIER_IMPLEMENTATION_READY && 'legal-evidence-verifier-not-implemented',
+    !allExternalGatesSatisfied && 'authority-evidence-not-verified',
+    !LIVE_INVESTMENT_IMPLEMENTATION_READY && 'live-investment-integration-not-reviewed',
+  ].filter(Boolean);
+
   return {
     policyVersion: LEGAL_LAUNCH_POLICY_VERSION,
     targetOfferingPath: 'Regulation Crowdfunding through a registered intermediary',
     gates,
+    gateAssertions,
+    missingAssertions,
+    unverifiedAssertions,
     missing,
+    allExternalGatesAsserted,
     allExternalGatesSatisfied,
     explicitLiveFlag,
     explicitAutoReinvestmentFlag,
     productionInvestmentImplementationReady: LIVE_INVESTMENT_IMPLEMENTATION_READY,
     productionAutoReinvestmentImplementationReady: LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY,
+    legalEvidenceVerifierImplementationReady: LEGAL_EVIDENCE_VERIFIER_IMPLEMENTATION_READY,
     environmentVariablesAreNotAuthority: true,
     evidenceRequiredBeforeLive: true,
+    legalEvidenceRecordFields,
+    legalEvidenceRequirements,
+    legalEvidenceRegister,
+    activationBlockers,
+    readinessSummary: {
+      stage: 'external-legal-approval-needed',
+      legalClearanceClaimed: false,
+      verifiedGateCount: legalEvidenceRegister.filter(({ launchSatisfied }) => launchSatisfied).length,
+      requiredGateCount: legalEvidenceRegister.length,
+      canAcceptInvestorFunds: false,
+      canIssueEconomicInterests: false,
+      nextActor: 'Founder + licensed counsel + registered intermediary',
+    },
     productionDecisionAuthorities,
     officialRegulatoryReferences,
     regulatedLaunchPacket,

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -24,20 +24,23 @@ const wallet = read('app/real-estate/invest/AutoCompoundWallet.js');
 const legalPlan = read('docs/LEGAL_LAUNCH_PLAN.md');
 const launchPacket = read('docs/REGULATED_LAUNCH_PACKET.md');
 const dataRoom = read('docs/LEGAL_REVIEW_DATA_ROOM.md');
+const evidenceSpec = read('docs/LEGAL_APPROVAL_EVIDENCE_SPEC.md');
 
 function loadLaunchPolicyForTest(source) {
   const executable = source
     .replace(/export const /g, 'const ')
     .replace(/export function /g, 'function ');
-  return Function(`${executable}\nreturn { evaluateLegalLaunch, launchGateDefinitions, officialRegulatoryReferences, legalReadinessWorkstreams, regulatedLaunchPacket, partnerDiligenceChecklist, reviewReadyWorkItems };`)();
+  return Function(`${executable}\nreturn { evaluateLegalLaunch, launchGateDefinitions, legalEvidenceRecordFields, legalEvidenceRequirements, officialRegulatoryReferences, legalReadinessWorkstreams, regulatedLaunchPacket, partnerDiligenceChecklist, reviewReadyWorkItems };`)();
 }
 
 requireText(launch, 'LIVE_INVESTMENT_IMPLEMENTATION_READY = false', 'legal launch engine');
 requireText(launch, 'LIVE_AUTO_REINVESTMENT_IMPLEMENTATION_READY = false', 'legal launch engine');
+requireText(launch, 'LEGAL_EVIDENCE_VERIFIER_IMPLEMENTATION_READY = false', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_REGISTERED_INTERMEDIARY_ACTIVE', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_OFFERING_AUTHORIZED', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_ESCROW_SETTLEMENT_CONFIGURED', 'legal launch engine');
 requireText(launch, 'REAL_ESTATE_PROVIDER_INTEGRATION_VERIFIED', 'legal launch engine');
+requireText(launch, 'REAL_ESTATE_PUBLIC_TERMS_DISCLOSURES_APPROVED', 'legal launch engine');
 requireText(launch, 'Regulation Crowdfunding through a registered intermediary', 'legal launch engine');
 requireText(launch, 'officialRegulatoryReferences', 'legal launch engine');
 requireText(launch, 'productionDecisionAuthorities', 'legal launch engine');
@@ -49,6 +52,8 @@ requireText(launch, 'founder-provider-review-needed', 'legal launch engine');
 requireText(launch, 'Accept investor funds directly into Voxel Vault-controlled accounts.', 'legal launch engine');
 requireText(launch, 'New York-facing virtual-currency activity', 'legal launch engine');
 requireText(launch, 'environmentVariablesAreNotAuthority: true', 'legal launch engine');
+requireText(launch, 'asserted-unverified', 'legal launch engine');
+requireText(launch, 'authority-evidence-not-verified', 'legal launch engine');
 requireText(status, 'liveInvestmentCheckout: false', 'property status route');
 requireText(status, 'liveAutomaticReinvestment: false', 'property status route');
 requireText(status, 'mainnetPropertyTokenDeployment: false', 'property status route');
@@ -58,6 +63,11 @@ requireText(status, 'officialReferences', 'property status route');
 requireText(status, 'regulatedLaunchPacket', 'property status route');
 requireText(status, 'partnerDiligenceChecklist', 'property status route');
 requireText(status, 'reviewReadyWorkItems', 'property status route');
+requireText(status, 'gateAssertions', 'property status route');
+requireText(status, 'allExternalGatesAsserted', 'property status route');
+requireText(status, 'evidenceVerifierImplementationReady', 'property status route');
+requireText(status, 'evidenceRegister', 'property status route');
+requireText(status, 'authorityEvidenceVerification: false', 'property status route');
 requireText(deploy, 'network.chainId !== 84532n', 'property deploy script');
 requireText(deploy, 'Base Sepolia only', 'property deploy script');
 requireText(deploy, 'PROPERTY_PASSPORT_ADDRESS', 'property deploy script');
@@ -89,11 +99,15 @@ requireText(launchPage, 'One real property. One real closing. One reconciled ren
 requireText(launchPage, 'FOUNDER + CODEX WORKROOM', 'legal launch page');
 requireText(launchPage, 'REGULATED LAUNCH PACKET', 'legal launch page');
 requireText(launchPage, 'REVIEW-READY GITHUB QUEUE', 'legal launch page');
+requireText(launchPage, 'AUTHORITY EVIDENCE REGISTER', 'legal launch page');
+requireText(launchPage, 'LEGAL STATUS · NOT CLEARED', 'legal launch page');
+requireText(launchPage, 'EVIDENCE VERIFIER · NOT CONNECTED', 'legal launch page');
 requireText(launchPage, 'MONEY MOVEMENT ·', 'legal launch page');
 requireText(launchPage, 'Build around primary sources.', 'legal launch page');
 requireText(legalPlan, 'Shared Founder + Codex workroom', 'legal launch plan');
 requireText(legalPlan, 'Regulated Launch Packet', 'legal launch plan');
 requireText(legalPlan, 'Legal Review Data Room', 'legal launch plan');
+requireText(legalPlan, 'Legal Approval Evidence Specification', 'legal launch plan');
 requireText(legalPlan, 'SEC Regulation Crowdfunding', 'legal launch plan');
 requireText(legalPlan, 'New York DFS Virtual Currency Business Activity', 'legal launch plan');
 requireText(launchPacket, 'Voxel Vault is not currently:', 'regulated launch packet');
@@ -103,10 +117,17 @@ requireText(launchPacket, 'Environment variables, admin toggles, screenshots or 
 requireText(dataRoom, 'Do not commit private legal, identity, banking, tenant, title, wallet-key, tax or property documents', 'legal review data room');
 requireText(dataRoom, 'Launch gate mapping', 'legal review data room');
 requireText(dataRoom, 'Public-safe implementation pattern', 'legal review data room');
+requireText(dataRoom, 'publicTermsDisclosuresApproved', 'legal review data room');
+requireText(evidenceSpec, 'No repository commit, founder decision, admin toggle, screenshot or environment variable can make an offering legal.', 'legal approval evidence spec');
+requireText(evidenceSpec, 'asserted-unverified', 'legal approval evidence spec');
+requireText(evidenceSpec, 'Production activation boundary', 'legal approval evidence spec');
+requireText(evidenceSpec, 'The current repository deliberately cannot satisfy this formula.', 'legal approval evidence spec');
 
 const {
   evaluateLegalLaunch,
   launchGateDefinitions,
+  legalEvidenceRecordFields,
+  legalEvidenceRequirements,
   officialRegulatoryReferences,
   legalReadinessWorkstreams,
   regulatedLaunchPacket,
@@ -121,10 +142,24 @@ allExternalGatesTrueEnv.REAL_ESTATE_LIVE_INVESTING_ENABLED = 'true';
 allExternalGatesTrueEnv.REAL_ESTATE_LIVE_AUTO_REINVESTMENT_ENABLED = 'true';
 
 const evaluatedLaunch = evaluateLegalLaunch(allExternalGatesTrueEnv);
-assert.equal(evaluatedLaunch.allExternalGatesSatisfied, true, 'test env should satisfy every external gate');
+assert.equal(evaluatedLaunch.allExternalGatesAsserted, true, 'test env should assert every external gate');
+assert.equal(evaluatedLaunch.allExternalGatesSatisfied, false, 'environment assertions must not satisfy authority evidence gates');
 assert.equal(evaluatedLaunch.liveInvestingEnabled, false, 'implementation constant must keep live investing fail-closed');
 assert.equal(evaluatedLaunch.liveAutomaticReinvestmentEnabled, false, 'implementation constant must keep auto-reinvestment fail-closed');
 assert.equal(evaluatedLaunch.environmentVariablesAreNotAuthority, true, 'env vars are evidence inputs, not legal authority');
+assert.equal(evaluatedLaunch.legalEvidenceVerifierImplementationReady, false, 'authority evidence verifier must remain code-locked');
+assert.equal(evaluatedLaunch.unverifiedAssertions.length, launchGateDefinitions.length, 'every true env flag should remain an unverified assertion');
+assert.ok(Object.values(evaluatedLaunch.gates).every((passed) => passed === false), 'no environment assertion may satisfy a launch gate');
+assert.ok(evaluatedLaunch.legalEvidenceRegister.every((record) => record.launchSatisfied === false), 'evidence register must remain unsatisfied without a verifier');
+assert.ok(evaluatedLaunch.legalEvidenceRegister.every((record) => record.authorityEvidenceStatus === 'not-connected'), 'authority evidence must report the disconnected verifier');
+assert.ok(evaluatedLaunch.activationBlockers.includes('legal-evidence-verifier-not-implemented'), 'activation blockers should expose missing evidence verifier');
+assert.ok(evaluatedLaunch.activationBlockers.includes('authority-evidence-not-verified'), 'activation blockers should expose unverified authority evidence');
+assert.equal(evaluatedLaunch.readinessSummary.legalClearanceClaimed, false, 'status must never claim legal clearance');
+assert.equal(evaluatedLaunch.readinessSummary.verifiedGateCount, 0, 'no authority gates should be reported verified');
+assert.equal(evaluatedLaunch.readinessSummary.canAcceptInvestorFunds, false, 'investor funds must remain blocked');
+assert.equal(evaluatedLaunch.readinessSummary.canIssueEconomicInterests, false, 'economic-interest issuance must remain blocked');
+assert.equal(evaluatedLaunch.legalEvidenceRecordFields, legalEvidenceRecordFields, 'policy should return shared evidence record fields');
+assert.equal(evaluatedLaunch.legalEvidenceRequirements, legalEvidenceRequirements, 'policy should return shared evidence requirements');
 assert.equal(evaluatedLaunch.officialRegulatoryReferences, officialRegulatoryReferences, 'policy should return the shared official references');
 assert.equal(evaluatedLaunch.legalReadinessWorkstreams, legalReadinessWorkstreams, 'policy should return the shared workstreams');
 assert.equal(evaluatedLaunch.regulatedLaunchPacket, regulatedLaunchPacket, 'policy should return the regulated launch packet');
@@ -134,8 +169,10 @@ assert.ok(officialRegulatoryReferences.length >= 6, 'official regulatory referen
 assert.ok(legalReadinessWorkstreams.length >= 6, 'shared workstreams should stay visible');
 assert.ok(partnerDiligenceChecklist.length >= 6, 'partner diligence checklist should stay visible');
 assert.ok(reviewReadyWorkItems.length >= 6, 'GitHub work queue should stay visible');
+assert.ok(legalEvidenceRecordFields.includes('documentSha256'), 'evidence records should require a public-safe document digest');
+assert.ok(legalEvidenceRequirements.length >= 16, 'every regulated workstream should have an authority evidence gate');
 assert.equal(regulatedLaunchPacket.liveMoneyMovement, 'blocked', 'money movement must remain blocked');
 assert.equal(regulatedLaunchPacket.liveOwnershipMinting, 'blocked', 'ownership minting must remain blocked');
 assert.ok(regulatedLaunchPacket.reviewDocuments.some((doc) => doc.path === 'docs/REGULATED_LAUNCH_PACKET.md'), 'launch packet doc should be listed for review');
 
-console.log('Property-platform safety checks passed: regulated launch gates are explicit, the verified Property Passport cannot be used as a transferable deed proxy, live investing and auto-reinvestment remain fail-closed, distribution claims remain permissioned, and property deployment is Base Sepolia-only.');
+console.log('Property-platform safety checks passed: environment assertions cannot satisfy authority-evidence gates, legal clearance is never claimed, the Property Passport cannot act as a transferable deed proxy, live investing and auto-reinvestment remain fail-closed, and property deployment is Base Sepolia-only.');


### PR DESCRIPTION
## Summary
- replace boolean legal-gate satisfaction with a 16-gate authority evidence register
- expose assertions, verification blockers, and the 0/16 legal-clearance state through the status API and iPhone-friendly launch page
- add a public-safe evidence specification for counsel, intermediary, title, identity, escrow, custody, accounting, tax, security, terms, and provider approvals
- prove that setting every environment flag to true still cannot enable investing, economic-interest issuance, or automatic reinvestment

## Product posture
This does not claim that Voxel Vault is legally approved. It makes the app more legitimate by reporting the exact external approvals still missing and by refusing to treat founder/admin/environment settings as legal authority.

## Verification
- `npm run test:release`
- `git diff --check`
- direct all-flags-true evaluation: 16 asserted, 0 satisfied, live investing false, auto-reinvestment false
