### PR TITLE
Add fail-closed live real estate securities investing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,9 @@ VOXEL_VAULT_ADMIN_EMAILS=
 VOXEL_VAULT_ADMIN_USER_IDS=
 
 # Real-property regulated-launch evidence gates.
-# These values are never sufficient to enable money movement by themselves: the code-level
-# implementation-ready constants remain false until the actual provider integrations exist.
+# These values are never sufficient to enable a Voxel Vault-issued property offering by themselves.
+# Direct fractional-property issuance still remains locked until the exact issuer/intermediary/title
+# integrations and authority evidence are verified.
 REAL_ESTATE_REGISTERED_INTERMEDIARY_ACTIVE=false
 REAL_ESTATE_OFFERING_AUTHORIZED=false
 REAL_ESTATE_SECURITIES_COUNSEL_APPROVED=false
@@ -94,7 +95,6 @@ REAL_ESTATE_LIVE_INVESTING_ENABLED=false
 REAL_ESTATE_LIVE_AUTO_REINVESTMENT_ENABLED=false
 
 # Acquisition-engine tokenized-real-estate provider gates.
-# V1 remains research-only even if these are all true because live trading is also code-locked.
 REAL_ESTATE_SECURITIES_PROVIDER_CONTRACTED=false
 REAL_ESTATE_SECURITIES_PROVIDER_API_VERIFIED=false
 REAL_ESTATE_SECURITIES_KYC_ELIGIBILITY_VERIFIED=false
@@ -107,7 +107,7 @@ REAL_ESTATE_TOKENIZED_TRADING_ENABLED=false
 DINARI_ENVIRONMENT=sandbox
 DINARI_API_KEY_ID=
 DINARI_API_SECRET_KEY=
-# The private /admin/digital-reits wizard can create these. Copy only the resulting non-secret IDs here afterward.
+# The private /admin/digital-reits wizard can create sandbox IDs. Production IDs must come from the approved live provider onboarding.
 DINARI_ENTITY_ID=
 DINARI_ACCOUNT_ID=
 DINARI_REAL_ESTATE_SYMBOLS=VNQ,SCHH,XLRE,REET,O,PLD,AMT,WELL
@@ -115,7 +115,22 @@ DINARI_REAL_ESTATE_SYMBOLS=VNQ,SCHH,XLRE,REET,O,PLD,AMT,WELL
 DINARI_SANDBOX_FAUCET_ENABLED=false
 # Allows only capped Dinari SANDBOX orders (currently max $25). No real money can execute.
 DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=false
-# This flag cannot unlock production trading by itself. Production is also code-locked.
+
+# LIVE DINARI GATES - leave every value below false/blank until Dinari/compliance has actually approved it.
+# Live trading is owner-only in V1 and capped in code at $700 per market buy.
+# Environment flags alone are insufficient: every trade also re-checks the provider's live Entity KYC,
+# active US Account, Dinari-managed wallet, AML flag, allowed real-estate catalog and fresh SIP/NBBO quote.
+DINARI_LIVE_PARTNER_APPROVED=false
+DINARI_LIVE_MANAGED_ORDERS_APPROVED=false
+DINARI_US_DISCLOSURES_APPROVED=false
+DINARI_US_NBBO_APPROVED=false
+# Version/URL for the exact compliance-approved U.S. disclosure screen shown before trading.
+DINARI_US_DISCLOSURE_VERSION=
+DINARI_US_DISCLOSURE_PAGE_URL=
+# Server-only HMAC key for short-lived pre-trade confirmation tokens. Minimum 32 characters.
+# Generate privately in your deployment secret manager. Never put the real value in GitHub or chat.
+DINARI_LIVE_CONFIRMATION_SECRET=
+# Final deliberate switch. This still cannot trade unless every gate above and the live provider checks pass.
 DINARI_PRODUCTION_TRADING_ENABLED=false
 
 # Selected regulated-provider integration. Populate only after a signed/approved integration.

--- a/app/admin/digital-reits/live/page.js
+++ b/app/admin/digital-reits/live/page.js
@@ -1,0 +1,358 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
+
+const AUTH_TIMEOUT_MS = 10000;
+const API_TIMEOUT_MS = 12000;
+const QUOTE_REFRESH_MS = 12000;
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+async function fetchWithTimeout(input, init = {}, timeoutMs = API_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal, cache: 'no-store' });
+  } catch (error) {
+    if (error?.name === 'AbortError') throw new Error('Live provider request timed out. No order was assumed to be placed.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readJson(response) {
+  return response.json().catch(() => ({}));
+}
+
+function usd(value) {
+  const number = Number(value || 0);
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(Number.isFinite(number) ? number : 0);
+}
+
+function short(value) {
+  const text = String(value || '');
+  return text.length > 18 ? `${text.slice(0, 8)}…${text.slice(-6)}` : text || '—';
+}
+
+export default function LiveDigitalRealEstatePage() {
+  const [token, setToken] = useState('');
+  const [authState, setAuthState] = useState('loading');
+  const [state, setState] = useState(null);
+  const [amount, setAmount] = useState('25');
+  const [selectedAsset, setSelectedAsset] = useState(null);
+  const [confirmation, setConfirmation] = useState(null);
+  const [disclosuresAccepted, setDisclosuresAccepted] = useState(false);
+  const [busy, setBusy] = useState('');
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+
+  const live = state?.live || {};
+  const maxOrder = Number(live.orderMaxUsd || 700);
+  const totalCash = useMemo(() => (state?.cash || []).reduce((sum, item) => sum + Number(item.amount || 0), 0), [state?.cash]);
+  const portfolioBySymbol = useMemo(() => new Map((state?.portfolio || []).map((item) => [item.symbol, item])), [state?.portfolio]);
+
+  const load = useCallback(async (accessToken) => {
+    if (!accessToken) return;
+    setBusy('load');
+    setError('');
+    try {
+      const response = await fetchWithTimeout('/api/admin/digital-reits/live', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const data = await readJson(response);
+      if (!response.ok || !data.ok) throw new Error(data.error || 'Live real-estate status could not be loaded.');
+      setState(data);
+      setAuthState('authorized');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Live real-estate status could not be loaded.');
+    } finally {
+      setBusy('');
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let subscription;
+    (async () => {
+      try {
+        const client = await withTimeout(getSupabaseBrowserAsync(), AUTH_TIMEOUT_MS, 'Voxel Vault account setup timed out.');
+        const { data } = await withTimeout(client.auth.getSession(), AUTH_TIMEOUT_MS, 'Your Google session check timed out.');
+        const accessToken = data?.session?.access_token || '';
+        if (cancelled) return;
+        if (!accessToken) {
+          setAuthState('signed-out');
+          return;
+        }
+        setToken(accessToken);
+        setAuthState('authenticated');
+        await load(accessToken);
+        const result = client.auth.onAuthStateChange((_event, session) => {
+          const next = session?.access_token || '';
+          setToken(next);
+          if (!next) {
+            setAuthState('signed-out');
+            setState(null);
+          }
+        });
+        subscription = result?.data?.subscription;
+      } catch (err) {
+        if (!cancelled) {
+          setAuthState('auth-error');
+          setError(err instanceof Error ? err.message : 'Owner authentication could not be loaded.');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      subscription?.unsubscribe?.();
+    };
+  }, [load]);
+
+  const requestQuote = useCallback(async (asset, { quiet = false } = {}) => {
+    if (!token || !asset || busy === 'buy') return;
+    const numericAmount = Number(amount);
+    if (!Number.isFinite(numericAmount) || numericAmount < 1 || numericAmount > maxOrder) {
+      setError(`Enter a live investment amount between $1 and $${maxOrder}.`);
+      return;
+    }
+    if (!quiet) {
+      setBusy('quote');
+      setNotice('');
+    }
+    setError('');
+    try {
+      const response = await fetchWithTimeout('/api/admin/digital-reits/live-quote', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ stockId: asset.id, paymentAmount: numericAmount }),
+      });
+      const data = await readJson(response);
+      if (!response.ok || !data.ok) throw new Error(data.error || 'Live NBBO confirmation could not be created.');
+      setSelectedAsset(asset);
+      setConfirmation(data.confirmation);
+      if (!quiet) setDisclosuresAccepted(false);
+    } catch (err) {
+      setConfirmation(null);
+      setError(err instanceof Error ? err.message : 'Live NBBO confirmation could not be created.');
+    } finally {
+      if (!quiet) setBusy('');
+    }
+  }, [amount, busy, maxOrder, token]);
+
+  useEffect(() => {
+    if (!confirmation || !selectedAsset || busy === 'buy' || !live.executable) return undefined;
+    const timer = window.setInterval(() => {
+      requestQuote(selectedAsset, { quiet: true });
+    }, QUOTE_REFRESH_MS);
+    return () => window.clearInterval(timer);
+  }, [confirmation, selectedAsset, busy, live.executable, requestQuote]);
+
+  async function placeLiveBuy() {
+    if (!token || !confirmation || !disclosuresAccepted || busy) return;
+    const accepted = window.confirm(
+      `REAL MONEY ORDER\n\nPlace a ${usd(confirmation.paymentAmount)} market buy of ${confirmation.quote?.symbol || selectedAsset?.symbol || 'this security'} through the configured live Dinari account?\n\nMarket price can move before execution. This is not a purchase of a deed to a specific house.`
+    );
+    if (!accepted) return;
+
+    setBusy('buy');
+    setError('');
+    setNotice('');
+    try {
+      const response = await fetchWithTimeout('/api/admin/digital-reits/live-buy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ confirmationToken: confirmation.confirmationToken }),
+      });
+      const data = await readJson(response);
+      if (!response.ok || !data.ok) throw new Error(data.error || 'Live order was not accepted.');
+      const orderId = data.order?.id || data.order?.order_request_id || data.order?.order_id || 'provider order created';
+      setNotice(`LIVE order request accepted by Dinari: ${orderId}. Voxel Vault will only show the position after the provider portfolio reports it.`);
+      setConfirmation(null);
+      setSelectedAsset(null);
+      setDisclosuresAccepted(false);
+      await load(token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Live order failed. Do not assume an order was placed unless the provider confirms it.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  if (authState === 'loading' || authState === 'authenticated') {
+    return <main style={page}><section style={panel}><div style={eyebrow}>OWNER LIVE REAL ESTATE</div><h1 style={hero}>Checking owner access…</h1></section></main>;
+  }
+
+  if (authState === 'signed-out') {
+    return <main style={page}><section style={panel}><div style={eyebrow}>OWNER ONLY</div><h1 style={hero}>Sign in first.</h1><p style={copy}>Open the Voxel Vault owner/admin flow with the approved Google account, then return to this page.</p><Link href="/admin/digital-reits" style={button}>OPEN OWNER ONBOARDING</Link></section></main>;
+  }
+
+  return (
+    <main style={page}>
+      <div style={shell}>
+        <nav style={nav}>
+          <Link href="/" style={brand}>V · Voxel Vault</Link>
+          <div style={{display:'flex',gap:8,flexWrap:'wrap'}}>
+            <Link href="/admin/digital-reits" style={navLink}>Sandbox / onboarding</Link>
+            <Link href="/real-estate/reits" style={navLink}>Spatial REIT Vault</Link>
+          </div>
+        </nav>
+
+        <section style={{padding:'54px 0 24px'}}>
+          <div style={eyebrow}>OWNER-ONLY · LIVE REAL-ESTATE SECURITIES</div>
+          <h1 style={hero}>Real money.<br/><span style={{color:'#b8ff55'}}>Fail closed.</span></h1>
+          <p style={{...copy,maxWidth:760,fontSize:18}}>This console is the first live-money path for Voxel Vault: provider-backed REIT and real-estate securities through the configured Dinari live account. It does not claim that a dShare is the deed to an individual property.</p>
+        </section>
+
+        {error ? <div style={{...panel,borderColor:'#7b4742',color:'#ffc5bd'}}>{error}</div> : null}
+        {notice ? <div style={{...panel,borderColor:'#496337',color:'#d8f9ae'}}>{notice}</div> : null}
+
+        <section style={grid}>
+          <div style={panel}><div style={label}>ENVIRONMENT</div><strong style={metric}>{String(live.environment || 'unknown').toUpperCase()}</strong><p style={small}>Must be LIVE to trade real money.</p></div>
+          <div style={panel}><div style={label}>EXECUTION</div><strong style={metric}>{live.executable ? 'READY' : 'LOCKED'}</strong><p style={small}>{live.executable ? 'Provider + code gates passed' : 'No real-money order can execute'}</p></div>
+          <div style={panel}><div style={label}>PROVIDER CASH</div><strong style={metric}>{usd(totalCash)}</strong><p style={small}>Provider-reported balances; not a promise of buying power.</p></div>
+          <div style={panel}><div style={label}>PER-ORDER CAP</div><strong style={metric}>{usd(maxOrder)}</strong><p style={small}>Hard V1 maximum.</p></div>
+        </section>
+
+        {!live.executable ? (
+          <section style={{...panel,marginTop:18,borderColor:'#645336'}}>
+            <div style={eyebrow}>LIVE ACTIVATION BLOCKERS</div>
+            <h2 style={sectionTitle}>Nothing spends money until every line is real.</h2>
+            <ul style={{...copy,paddingLeft:20}}>
+              {(live.readinessBlockers || []).map((item) => <li key={item} style={{marginBottom:7}}>{item}</li>)}
+              {(live.providerAccount?.blockers || []).map((item) => <li key={`provider-${item}`} style={{marginBottom:7}}>{item}</li>)}
+              {live.providerAccountError ? <li>{live.providerAccountError}</li> : null}
+            </ul>
+          </section>
+        ) : (
+          <section style={{...panel,marginTop:18,borderColor:'#4b6338'}}>
+            <div style={eyebrow}>PROVIDER VERIFIED</div>
+            <h2 style={sectionTitle}>Live account is eligible for this managed-order path.</h2>
+            <div style={grid}>
+              <div style={mini}><span style={label}>KYC</span><b>{live.providerAccount?.kycStatus || '—'}</b></div>
+              <div style={mini}><span style={label}>US ACCOUNT</span><b>{live.providerAccount?.accountActive ? 'ACTIVE' : '—'}</b></div>
+              <div style={mini}><span style={label}>MANAGED WALLET</span><b>{live.providerAccount?.managedWallet ? 'YES' : 'NO'}</b></div>
+              <div style={mini}><span style={label}>AML FLAG</span><b>{live.providerAccount?.amlFlagged ? 'FLAGGED' : 'CLEAR'}</b></div>
+            </div>
+          </section>
+        )}
+
+        <section style={{marginTop:30}}>
+          <div style={{display:'flex',justifyContent:'space-between',gap:16,alignItems:'end',flexWrap:'wrap'}}>
+            <div>
+              <div style={eyebrow}>PROVIDER-CONFIRMED REAL ESTATE UNIVERSE</div>
+              <h2 style={sectionTitle}>Choose the exposure, then review NBBO.</h2>
+            </div>
+            <label style={{display:'grid',gap:6,minWidth:170}}>
+              <span style={label}>INVESTMENT AMOUNT</span>
+              <input
+                type="number"
+                min="1"
+                max={maxOrder}
+                step="1"
+                value={amount}
+                onChange={(event) => { setAmount(event.target.value); setConfirmation(null); setSelectedAsset(null); }}
+                style={input}
+                aria-label="Live investment amount in US dollars"
+              />
+            </label>
+          </div>
+
+          <div style={{...grid,marginTop:14}}>
+            {(state?.catalog || []).map((asset) => {
+              const holding = portfolioBySymbol.get(asset.symbol);
+              return (
+                <article key={asset.id} style={panel}>
+                  <div style={label}>{asset.rawType || 'TOKENIZED SECURITY'}</div>
+                  <h3 style={{fontSize:32,margin:'7px 0 2px'}}>{asset.symbol}</h3>
+                  <p style={{...copy,minHeight:44}}>{asset.name}</p>
+                  <div style={mini}><span style={label}>PROVIDER POSITION</span><b>{holding ? Number(holding.amount || 0).toFixed(6) : '0.000000'}</b></div>
+                  <button
+                    type="button"
+                    onClick={() => requestQuote(asset)}
+                    disabled={!live.executable || Boolean(busy)}
+                    style={{...button,width:'100%',marginTop:12,opacity:(!live.executable || busy) ? .45 : 1,cursor:(!live.executable || busy) ? 'not-allowed':'pointer'}}
+                  >
+                    {busy === 'quote' && selectedAsset?.id === asset.id ? 'GETTING NBBO…' : `REVIEW ${usd(amount || 0)} LIVE BUY`}
+                  </button>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        {confirmation ? (
+          <section style={{...panel,marginTop:28,borderColor:'#70814a'}}>
+            <div style={eyebrow}>MANDATORY PRE-TRADE CONFIRMATION · AUTO-REFRESHES</div>
+            <div style={{display:'flex',justifyContent:'space-between',gap:16,flexWrap:'wrap',alignItems:'start'}}>
+              <div>
+                <h2 style={{...sectionTitle,marginBottom:4}}>{confirmation.quote.symbol} · {usd(confirmation.paymentAmount)}</h2>
+                <p style={{...small,marginTop:0}}>Quote token expires {new Date(confirmation.expiresAt).toLocaleTimeString()} and is refreshed while this review is open.</p>
+              </div>
+              <span style={pill}>REAL MONEY</span>
+            </div>
+
+            <div style={{...grid,marginTop:15}}>
+              <div style={mini}><span style={label}>BID</span><b>{usd(confirmation.quote.bid)}</b><small>{confirmation.quote.bidSize} shares · {confirmation.quote.bidExchange}</small></div>
+              <div style={mini}><span style={label}>OFFER</span><b>{usd(confirmation.quote.offer)}</b><small>{confirmation.quote.offerSize} shares · {confirmation.quote.offerExchange}</small></div>
+              <div style={mini}><span style={label}>QUOTE TIME</span><b>{new Date(confirmation.quote.timestamp).toLocaleTimeString()}</b><small>Provider SIP/NBBO feed</small></div>
+              <div style={mini}><span style={label}>DISCLOSURES</span><b>{confirmation.disclosureVersion || 'approved version'}</b><small>Must remain approved</small></div>
+            </div>
+
+            <div style={{...panel,marginTop:14,background:'#0a0e0a'}}>
+              <p style={{...copy,marginTop:0}}>A market order can fill at a different price than the displayed offer. This security provides exposure to a real-estate company/fund; it is not a recorded deed or guaranteed increase in value.</p>
+              {confirmation.disclosurePageUrl ? (
+                <a href={confirmation.disclosurePageUrl} target="_blank" rel="noreferrer" style={{...button,display:'inline-block',textDecoration:'none',background:'#1b2419'}}>OPEN APPROVED DISCLOSURES ↗</a>
+              ) : null}
+              <label style={{display:'flex',gap:10,alignItems:'start',marginTop:15,color:'#dce7d7',fontSize:13,lineHeight:1.5}}>
+                <input type="checkbox" checked={disclosuresAccepted} onChange={(event) => setDisclosuresAccepted(event.target.checked)} style={{width:20,height:20,marginTop:1}} />
+                <span>I reviewed the approved disclosures and this current pre-trade quote, and I want to submit this real-money market order.</span>
+              </label>
+            </div>
+
+            <button
+              type="button"
+              onClick={placeLiveBuy}
+              disabled={!disclosuresAccepted || Boolean(busy)}
+              style={{...button,width:'100%',marginTop:14,background:'#b8ff55',color:'#081008',opacity:(!disclosuresAccepted || busy) ? .45 : 1,cursor:(!disclosuresAccepted || busy) ? 'not-allowed':'pointer'}}
+            >
+              {busy === 'buy' ? 'SUBMITTING LIVE ORDER…' : `PLACE LIVE ${usd(confirmation.paymentAmount)} MARKET BUY`}
+            </button>
+          </section>
+        ) : null}
+
+        <section style={{...panel,marginTop:28}}>
+          <div style={eyebrow}>BOUNDARY</div>
+          <p style={{...copy,marginBottom:0}}>This is live investing in provider-backed real-estate securities when the external production gates are genuinely active. Voxel Vault still does not issue fractional interests in an individual house from this screen, pool customer money, auto-reinvest dividends, or bypass the registered provider.</p>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+const page={minHeight:'100vh',background:'#070a08',color:'#f4f7f0',fontFamily:'Inter,ui-sans-serif,system-ui,-apple-system,sans-serif'};
+const shell={maxWidth:1180,margin:'0 auto',padding:'18px clamp(16px,4vw,38px) 60px'};
+const nav={display:'flex',justifyContent:'space-between',alignItems:'center',gap:12,flexWrap:'wrap'};
+const brand={color:'#f4f7f0',textDecoration:'none',fontWeight:950,letterSpacing:'-.04em',fontSize:20};
+const navLink={color:'#bcc7b8',textDecoration:'none',fontSize:12,fontWeight:800,border:'1px solid #2c352b',borderRadius:999,padding:'8px 11px'};
+const hero={fontSize:'clamp(3.3rem,9vw,7rem)',lineHeight:.84,letterSpacing:'-.075em',margin:'13px 0 22px'};
+const sectionTitle={fontSize:'clamp(1.8rem,4.5vw,3.2rem)',lineHeight:.98,letterSpacing:'-.055em',margin:'8px 0 12px'};
+const eyebrow={fontSize:11,fontWeight:950,letterSpacing:'.15em',color:'#b8ff55'};
+const label={fontSize:10,fontWeight:900,letterSpacing:'.12em',color:'#8e9a89'};
+const copy={color:'#aeb9aa',lineHeight:1.6,fontSize:14};
+const small={color:'#82907e',lineHeight:1.5,fontSize:11};
+const grid={display:'grid',gridTemplateColumns:'repeat(auto-fit,minmax(210px,1fr))',gap:12};
+const panel={border:'1px solid #283126',background:'#0d120d',borderRadius:22,padding:20,minWidth:0};
+const mini={border:'1px solid #252e24',borderRadius:14,padding:12,display:'grid',gap:4,minWidth:0,overflowWrap:'anywhere'};
+const metric={display:'block',fontSize:28,letterSpacing:'-.04em',marginTop:7};
+const button={border:0,borderRadius:13,padding:'13px 15px',fontWeight:950,fontSize:12,letterSpacing:'.03em',background:'#20291e',color:'#f4f7f0'};
+const input={border:'1px solid #394235',borderRadius:12,padding:'11px 12px',background:'#0d120d',color:'#f4f7f0',fontSize:16,width:'100%',boxSizing:'border-box'};
+const pill={border:'1px solid #5e713e',borderRadius:999,padding:'8px 11px',fontSize:11,fontWeight:950,letterSpacing:'.09em',color:'#d9ffad',whiteSpace:'nowrap'};

--- a/app/api/admin/digital-reits/live-buy/route.ts
+++ b/app/api/admin/digital-reits/live-buy/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../lib/admin-auth';
+import { createLiveMarketBuy } from '../../../../../lib/real-estate/dinari.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function sameOrigin(request: Request) {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  return origin === new URL(request.url).origin;
+}
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'no-store, private' },
+  });
+}
+
+export async function POST(request: Request) {
+  if (!sameOrigin(request)) {
+    return response({ ok: false, error: 'Live trade request must originate from this Voxel Vault deployment.' }, 403);
+  }
+
+  const auth = await requireVoxelVaultAdmin(request);
+  if ('error' in auth) return response({ ok: false, error: auth.error, setupRequired: Boolean(auth.setupRequired) }, auth.status);
+
+  const body = await request.json().catch(() => ({}));
+  try {
+    const result = await createLiveMarketBuy({
+      userId: auth.user.id,
+      confirmationToken: body?.confirmationToken,
+    }, process.env);
+
+    return response({
+      ok: true,
+      ...result,
+    });
+  } catch (error) {
+    return response({ ok: false, error: error instanceof Error ? error.message : 'Live Dinari market buy failed.' }, 422);
+  }
+}

--- a/app/api/admin/digital-reits/live-quote/route.ts
+++ b/app/api/admin/digital-reits/live-quote/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../lib/admin-auth';
+import { createLivePreTradeConfirmation } from '../../../../../lib/real-estate/dinari.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function sameOrigin(request: Request) {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  return origin === new URL(request.url).origin;
+}
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'no-store, private' },
+  });
+}
+
+export async function POST(request: Request) {
+  if (!sameOrigin(request)) {
+    return response({ ok: false, error: 'Live quote request must originate from this Voxel Vault deployment.' }, 403);
+  }
+
+  const auth = await requireVoxelVaultAdmin(request);
+  if ('error' in auth) return response({ ok: false, error: auth.error, setupRequired: Boolean(auth.setupRequired) }, auth.status);
+
+  const body = await request.json().catch(() => ({}));
+  try {
+    const confirmation = await createLivePreTradeConfirmation({
+      userId: auth.user.id,
+      stockId: body?.stockId,
+      paymentAmount: body?.paymentAmount,
+    }, process.env);
+
+    return response({
+      ok: true,
+      environment: 'live',
+      realMoney: true,
+      confirmation,
+    });
+  } catch (error) {
+    return response({ ok: false, error: error instanceof Error ? error.message : 'Live NBBO confirmation failed.' }, 423);
+  }
+}

--- a/app/api/admin/digital-reits/live/route.ts
+++ b/app/api/admin/digital-reits/live/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../lib/admin-auth';
+import {
+  getDigitalReitSnapshot,
+  getDinariConfig,
+  inspectLiveDinariAccount,
+} from '../../../../../lib/real-estate/dinari.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'no-store, private' },
+  });
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if ('error' in auth) return response({ ok: false, error: auth.error, setupRequired: Boolean(auth.setupRequired) }, auth.status);
+
+  const config = getDinariConfig(process.env);
+  const snapshot = await getDigitalReitSnapshot(process.env);
+  let providerAccount = null;
+  let providerAccountError = '';
+
+  if (config.environment === 'live' && config.credentialsConfigured && config.entityConfigured && config.accountConfigured) {
+    try {
+      providerAccount = await inspectLiveDinariAccount(process.env);
+    } catch (error) {
+      providerAccountError = error instanceof Error ? error.message : 'Live provider account verification failed.';
+    }
+  }
+
+  return response({
+    ok: true,
+    authorized: true,
+    ownerUserId: auth.user.id,
+    live: {
+      environment: config.environment,
+      implementationReady: snapshot.productionTradingImplementationReady,
+      tradingEnabledByConfiguration: config.productionTradingEnabled,
+      orderMaxUsd: snapshot.liveOrderMaxUsd,
+      readinessBlockers: snapshot.productionReadinessBlockers,
+      disclosureVersion: snapshot.disclosureVersion,
+      disclosurePageUrl: snapshot.disclosurePageUrl,
+      providerAccount,
+      providerAccountError,
+      executable: Boolean(config.productionTradingEnabled && providerAccount?.ready),
+    },
+    catalog: snapshot.catalog,
+    portfolio: snapshot.portfolio,
+    cash: snapshot.cash,
+    dividends: snapshot.dividends,
+    errors: snapshot.errors,
+  });
+}

--- a/app/api/digital-reits/route.ts
+++ b/app/api/digital-reits/route.ts
@@ -1,17 +1,24 @@
 import { NextResponse } from 'next/server';
-import { getDigitalReitSnapshot } from '../../../lib/real-estate/dinari';
+import { getDinariConfig, getDigitalReitSnapshot } from '../../../lib/real-estate/dinari';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const snapshot = await getDigitalReitSnapshot(process.env);
+  const config = getDinariConfig(process.env);
+  const publicAccountDataAllowed = config.environment !== 'live';
+  const snapshot = await getDigitalReitSnapshot(process.env, {
+    includeAccountData: publicAccountDataAllowed,
+  });
 
   return NextResponse.json({
     ...snapshot,
     apiCredentialsExposed: false,
     liveOrderExecution: false,
-    note: snapshot.credentialsConfigured
-      ? 'Connected to the configured Dinari environment for provider-backed catalog/portfolio data. Production order execution remains code-locked.'
-      : 'Add server-side Dinari sandbox credentials to activate provider-backed catalog/portfolio data. No secrets are sent to the browser.',
+    liveAccountDataPublic: false,
+    note: config.environment === 'live'
+      ? 'Live provider catalog may be shown publicly, but live account cash, holdings, dividends and order execution are owner-authenticated and are not returned by this endpoint.'
+      : snapshot.credentialsConfigured
+        ? 'Connected to the configured Dinari sandbox for provider-backed pilot catalog/portfolio data. Live order execution is not exposed by this public endpoint.'
+        : 'Add server-side Dinari sandbox credentials to activate provider-backed pilot data. No secrets are sent to the browser.',
   });
 }

--- a/app/real-estate/reits/page.js
+++ b/app/real-estate/reits/page.js
@@ -1,7 +1,7 @@
 import styles from '../real-estate.module.css';
 import DigitalReitDashboard from './DigitalReitDashboard';
 import ReitVaultCanvas from './ReitVaultCanvas';
-import { getDigitalReitSnapshot } from '../../../lib/real-estate/dinari';
+import { getDinariConfig, getDigitalReitSnapshot } from '../../../lib/real-estate/dinari';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,8 +11,12 @@ export const metadata = {
 };
 
 export default async function DigitalReitPage() {
-  const snapshot = await getDigitalReitSnapshot(process.env);
-  const status = snapshot.environment === 'live'
+  const config = getDinariConfig(process.env);
+  const liveEnvironment = config.environment === 'live';
+  const snapshot = await getDigitalReitSnapshot(process.env, {
+    includeAccountData: !liveEnvironment,
+  });
+  const status = liveEnvironment
     ? snapshot.productionTradingEnabled
       ? 'LIVE CONFIGURED · OWNER VERIFY'
       : 'LIVE · LOCKED'
@@ -36,18 +40,18 @@ export default async function DigitalReitPage() {
             <p className={styles.eyebrow}>Stage 1 · regulated tokenized real-estate securities</p>
             <h1>Digital REITs,<br /><em>inside the vault.</em></h1>
             <p className={styles.lead}>
-              Voxel Vault combines a spatial portfolio with a provider-backed tokenized-securities layer. The REIT district uses the same Dinari snapshot as the financial dashboard: provider-confirmed assets become buildings, and only positions actually returned by the configured provider account are shown as held.
+              Voxel Vault combines a spatial portfolio with a provider-backed tokenized-securities layer. Provider-confirmed real-estate securities can become buildings in the spatial district, while live account holdings and cash stay private behind the owner-authenticated console.
             </p>
             <div className={styles.actions}>
-              <a className={styles.primaryButton} href="#spatial-vault">Enter My Vault</a>
-              <a className={styles.secondaryButton} href="#vault">Open financial view</a>
+              <a className={styles.primaryButton} href="#spatial-vault">Enter REIT district</a>
+              {!liveEnvironment ? <a className={styles.secondaryButton} href="#vault">Open sandbox financial view</a> : null}
               <a className={styles.secondaryButton} href="/admin/digital-reits/live">Owner live console</a>
               <a className={styles.secondaryButton} href="/real-estate/launch">Direct-property launch gates</a>
             </div>
             <div className={styles.heroNote}>
               <span>Dinari integration.</span>
-              <span>Spatial portfolio.</span>
-              <span>Provider-backed holdings only.</span>
+              <span>Provider-backed assets only.</span>
+              <span>Live holdings stay owner-private.</span>
               <span>{snapshot.productionTradingImplementationReady ? 'Live execution code present; external/provider gates still required.' : 'Production execution code locked.'}</span>
             </div>
           </div>
@@ -56,30 +60,45 @@ export default async function DigitalReitPage() {
         <section id="spatial-vault" className={styles.section} style={{paddingTop:24}}>
           <div style={{display:'flex',justifyContent:'space-between',gap:16,alignItems:'end',flexWrap:'wrap',marginBottom:14}}>
             <div>
-              <p className={styles.eyebrow}>My Vault · spatial portfolio</p>
-              <h2 style={{fontSize:'clamp(2.2rem,5vw,4.4rem)',lineHeight:.92,letterSpacing:'-.065em',margin:'6px 0 0'}}>Your real-estate exposure,<br />built into a 3D district.</h2>
+              <p className={styles.eyebrow}>{liveEnvironment ? 'Provider universe · public spatial view' : 'My Vault · sandbox spatial portfolio'}</p>
+              <h2 style={{fontSize:'clamp(2.2rem,5vw,4.4rem)',lineHeight:.92,letterSpacing:'-.065em',margin:'6px 0 0'}}>Real-estate exposure,<br />built into a 3D district.</h2>
             </div>
             <div style={{maxWidth:430,fontSize:12,lineHeight:1.65,color:'#95a18f'}}>
-              Bright buildings represent provider-reported holdings. Dark buildings are browseable provider-confirmed assets or, before connection, clearly labeled watchlist previews. The 3D view never invents ownership.
+              {liveEnvironment
+                ? 'The public live view shows provider-confirmed eligible assets without exposing the owner account balance or positions. Open the authenticated owner console for live holdings and order review.'
+                : 'Bright buildings represent provider-reported sandbox holdings. Dark buildings are browseable provider-confirmed assets or clearly labeled watchlist previews. The 3D view never invents ownership.'}
             </div>
           </div>
           <ReitVaultCanvas
             assets={snapshot.catalog}
-            positions={snapshot.portfolio}
+            positions={liveEnvironment ? [] : snapshot.portfolio}
             watchlistSymbols={snapshot.symbols}
           />
         </section>
 
-        <section id="vault" className={styles.section} style={{paddingTop:24}}>
-          <DigitalReitDashboard snapshot={snapshot} />
-        </section>
+        {liveEnvironment ? (
+          <section id="vault" className={styles.section} style={{paddingTop:24}}>
+            <div className={styles.gateCard}>
+              <p className={styles.eyebrow}>Live account privacy boundary</p>
+              <h3>Cash, holdings, dividends and real-money controls are private.</h3>
+              <p>The public Digital REIT Vault can show the live provider catalog, but it does not return the configured live account portfolio. Sign in through the owner console to verify KYC/account/wallet readiness, review the current SIP/NBBO quote and deliberately submit an eligible live order.</p>
+              <div className={styles.actions}>
+                <a className={styles.primaryButton} href="/admin/digital-reits/live">Open owner live console</a>
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section id="vault" className={styles.section} style={{paddingTop:24}}>
+            <DigitalReitDashboard snapshot={snapshot} />
+          </section>
+        )}
 
         <section className={styles.section}>
           <div className={styles.stackGrid}>
             {[
               ['Provider catalog', 'Voxel Vault asks the regulated provider which configured real-estate symbols are actually supported instead of inventing listings.'],
-              ['Account holdings', 'The vault reads dShare balances from the configured provider account and keeps provider account IDs and API secrets server-side.'],
-              ['Cash dividends', 'Actual provider dividend-payment records can feed the acquisition-reserve ledger; the UI does not manufacture projected income.'],
+              ['Private live holdings', 'Live portfolio, cash and dividend records remain behind the authenticated owner route instead of being published with the browse experience.'],
+              ['Current pre-trade data', 'The owner live path requires a fresh provider SIP/NBBO confirmation before a real-money market buy can be submitted.'],
               ['Property ladder', 'Digital real-estate exposure remains separate from the future direct-property workflow: diligence → legal entity → closing → recorded deed → Property Passport.'],
             ].map(([title, copy], index) => (
               <article className={styles.stackCard} key={title}>

--- a/app/real-estate/reits/page.js
+++ b/app/real-estate/reits/page.js
@@ -7,11 +7,16 @@ export const dynamic = 'force-dynamic';
 
 export const metadata = {
   title: 'Digital REIT Vault | Voxel Vault',
-  description: 'Spatial provider-backed tokenized real-estate securities, account positions, dividends and sandbox execution inside Voxel Vault.',
+  description: 'Spatial provider-backed tokenized real-estate securities, provider positions, dividends, sandbox testing and an owner-gated live investment path inside Voxel Vault.',
 };
 
 export default async function DigitalReitPage() {
   const snapshot = await getDigitalReitSnapshot(process.env);
+  const status = snapshot.environment === 'live'
+    ? snapshot.productionTradingEnabled
+      ? 'LIVE CONFIGURED · OWNER VERIFY'
+      : 'LIVE · LOCKED'
+    : 'SANDBOX';
 
   return (
     <main className={styles.page}>
@@ -19,7 +24,8 @@ export default async function DigitalReitPage() {
         <nav className={styles.nav}>
           <a className={styles.brand} href="/"><span className={styles.brandMark}>V</span>Voxel Vault</a>
           <div className={styles.navActions}>
-            <span className={styles.statusPill}><span className={styles.statusDot} />DIGITAL REIT VAULT · {snapshot.environment.toUpperCase()}</span>
+            <span className={styles.statusPill}><span className={styles.statusDot} />DIGITAL REIT VAULT · {status}</span>
+            <a className={styles.ghostPill} href="/admin/digital-reits/live">Owner live investing</a>
             <a className={styles.ghostPill} href="/real-estate/acquire">Acquisition engine</a>
             <a className={styles.ghostPill} href="/real-estate/invest">Capital simulator</a>
           </div>
@@ -35,13 +41,14 @@ export default async function DigitalReitPage() {
             <div className={styles.actions}>
               <a className={styles.primaryButton} href="#spatial-vault">Enter My Vault</a>
               <a className={styles.secondaryButton} href="#vault">Open financial view</a>
-              <a className={styles.secondaryButton} href="/real-estate/launch">Production gates</a>
+              <a className={styles.secondaryButton} href="/admin/digital-reits/live">Owner live console</a>
+              <a className={styles.secondaryButton} href="/real-estate/launch">Direct-property launch gates</a>
             </div>
             <div className={styles.heroNote}>
               <span>Dinari integration.</span>
               <span>Spatial portfolio.</span>
               <span>Provider-backed holdings only.</span>
-              <span>Production trading locked.</span>
+              <span>{snapshot.productionTradingImplementationReady ? 'Live execution code present; external/provider gates still required.' : 'Production execution code locked.'}</span>
             </div>
           </div>
         </section>
@@ -73,7 +80,7 @@ export default async function DigitalReitPage() {
               ['Provider catalog', 'Voxel Vault asks the regulated provider which configured real-estate symbols are actually supported instead of inventing listings.'],
               ['Account holdings', 'The vault reads dShare balances from the configured provider account and keeps provider account IDs and API secrets server-side.'],
               ['Cash dividends', 'Actual provider dividend-payment records can feed the acquisition-reserve ledger; the UI does not manufacture projected income.'],
-              ['Property ladder', 'Digital real-estate exposure can remain separate from the future direct-property workflow: diligence → legal entity → closing → recorded deed → Property Passport.'],
+              ['Property ladder', 'Digital real-estate exposure remains separate from the future direct-property workflow: diligence → legal entity → closing → recorded deed → Property Passport.'],
             ].map(([title, copy], index) => (
               <article className={styles.stackCard} key={title}>
                 <span className={styles.stackNumber}>{index + 1}</span>
@@ -86,8 +93,8 @@ export default async function DigitalReitPage() {
         </section>
 
         <footer className={styles.footer}>
-          <div><strong>Voxel Vault Digital REIT Vault</strong><br />Spatial provider-backed tokenized real-estate integration with sandbox-first execution.</div>
-          <div>Not an investment recommendation · availability and eligibility are determined by the regulated provider · production trading is disabled.</div>
+          <div><strong>Voxel Vault Digital REIT Vault</strong><br />Spatial provider-backed real-estate securities with sandbox and owner-gated live execution paths.</div>
+          <div>Not an investment recommendation · provider availability/eligibility controls execution · a REIT/dShare position is not a deed to a particular property.</div>
         </footer>
       </div>
     </main>

--- a/docs/DIGITAL_REITS_DINARI.md
+++ b/docs/DIGITAL_REITS_DINARI.md
@@ -1,159 +1,150 @@
 # Digital REIT Vault — Dinari integration
 
-Voxel Vault's first real tokenized-securities provider adapter targets Dinari's dShares API.
+Voxel Vault's first real-money real-estate investment path uses Dinari's regulated tokenized-securities infrastructure for provider-supported REITs, real-estate ETFs and listed real-estate companies.
+
+This path is **not** a deed to a particular house. Direct fractional interests in a specific property remain a separate title/issuer/securities workflow.
 
 ## What is implemented
 
-- `/real-estate/reits` Digital REIT Vault for the controlled provider pilot.
+### Read and sandbox paths
+
+- `/real-estate/reits` Digital REIT Vault for the controlled provider integration.
 - `/admin/digital-reits` owner-only sandbox onboarding wizard.
-- Owner wizard uses the existing Supabase Google session plus a server-side admin allowlist.
-- Server-side Dinari API authentication; no API credential is returned to the browser.
-- Sandbox customer Entity creation through Dinari's official `/entities/` endpoint.
-- Dinari-managed hosted KYC URL creation through `/entities/{entity_id}/kyc/url`.
-- US KYC status checks before Account creation.
-- Idempotent US sandbox Account creation: an existing active US Account is reused.
-- Server-controlled user/provider identity binding after KYC PASS and provider-confirmed Account creation/reuse.
-- `vault_provider_account_bindings` RLS table: a signed-in user may read their own binding, but browser clients have no insert/update/delete policy.
-- A Dinari provider account can be bound to only one Voxel Vault user per environment.
-- `/api/vault/digital-reits` private authenticated read endpoint that returns holdings only from the verified provider account bound to that signed-in Voxel Vault user.
-- User-bound provider reads forcibly disable sandbox orders, sandbox faucet actions and production trading regardless of environment flags inherited elsewhere.
-- `/vault` uses the user-bound provider endpoint for the personal Digital REIT wing. It never attributes the global pilot Account to an arbitrary signed-in user.
-- Provider-backed stock/ETF catalog filtering for a configurable real-estate watchlist.
-- Provider-backed account portfolio and cash-balance reads.
-- Provider-backed dividend-payment reads using Dinari's required date window.
-- Dividend records are fail-closed to stock IDs returned in the confirmed real-estate catalog.
-- `/api/digital-reits` safe pilot status/snapshot endpoint with no credentials exposed.
-- `/api/digital-reits/sandbox-fund` same-origin, sandbox-only faucet route.
-- `/api/digital-reits/sandbox-buy` same-origin, sandbox-only managed market-buy route.
-- `/api/digital-reits/reconcile` same-origin, sandbox-only position-reconciliation route.
-- The sandbox UI records the provider position before a buy and refuses to call the asset owned until a later Dinari portfolio read reports a positive quantity increase.
-- Official sandbox faucet flow mints 1,000 mockUSD test funds to the configured managed account.
-- Hard $25 sandbox order cap.
-- Production trading, production funding and live onboarding writes remain hard-disabled in code.
+- Server-side Dinari API authentication; no API secret is returned to the browser.
+- Sandbox Entity creation, Dinari-hosted KYC, US Account creation/reuse and provider-account binding.
+- Provider-backed real-estate catalog, portfolio, cash and dividend reads.
+- `/api/digital-reits/sandbox-fund` sandbox-only mock funding.
+- `/api/digital-reits/sandbox-buy` sandbox-only managed market buys capped at $25.
+- Provider reconciliation before an order is ever shown as a held position.
 
-## Dinari environment
+### Live owner path
 
-Official API base URLs:
+- `/admin/digital-reits/live` owner-only live investment console.
+- `/api/admin/digital-reits/live` authenticated provider/readiness status.
+- `/api/admin/digital-reits/live-quote` authenticated U.S. pre-trade SIP/NBBO confirmation.
+- `/api/admin/digital-reits/live-buy` authenticated real-money managed market-buy route.
+- Hard $700 maximum per live market-buy request in V1.
+- Live orders are limited to the configured provider-confirmed real-estate universe.
+- A security must be provider-reported as tradable and fractionable before Voxel Vault will create a live market-buy confirmation.
+- Every live quote and every live buy re-checks the configured Dinari Entity, KYC, US Account and Wallet.
+- KYC must be `PASS`, the account must be active and US-jurisdiction, the wallet must be Dinari-managed for this V1 flow, and the wallet must not be provider-reported as AML flagged.
+- U.S. pre-trade confirmation requests a current provider quote using the SIP feed and configured Entity ID.
+- Voxel Vault requires a usable bid, bid size, bid exchange, offer, offer size, offer exchange and quote timestamp.
+- Stale/malformed quote data fails closed.
+- The owner UI refreshes the quote while the pre-trade review is open.
+- A live confirmation is HMAC-signed server-side, bound to the authenticated Voxel Vault user, provider account hash, stock, amount, quote, disclosure version and short expiry.
+- The resulting Dinari `client_order_id` is derived from the signed confirmation ID, so replaying the same confirmation collides with the same provider-side client order ID instead of silently creating a new intent.
+- The browser must show the approved disclosure link/version and receive an explicit owner acknowledgment before the final real-money submit control is enabled.
+- The final browser confirmation says that the order uses real money, market prices can move, and the security is not the deed to a specific property.
+
+## What “live-ready” means
+
+The live code path exists, but the repository intentionally does **not** contain production credentials or pretend that external approvals are complete.
+
+`DINARI_LIVE_TRADING_IMPLEMENTATION_READY` is `true`, meaning Voxel Vault now contains a production execution implementation. That constant alone cannot trade.
+
+A production trade also requires all of these server-side configuration gates:
+
+```text
+DINARI_ENVIRONMENT=live
+DINARI_API_KEY_ID=<approved live key id>
+DINARI_API_SECRET_KEY=<approved live secret>
+DINARI_ENTITY_ID=<approved live customer/entity id>
+DINARI_ACCOUNT_ID=<approved live US account id>
+DINARI_LIVE_PARTNER_APPROVED=true
+DINARI_LIVE_MANAGED_ORDERS_APPROVED=true
+DINARI_US_DISCLOSURES_APPROVED=true
+DINARI_US_NBBO_APPROVED=true
+DINARI_US_DISCLOSURE_VERSION=<approved disclosure version>
+DINARI_US_DISCLOSURE_PAGE_URL=https://<approved disclosure page>
+DINARI_LIVE_CONFIRMATION_SECRET=<server-only secret, 32+ characters>
+DINARI_PRODUCTION_TRADING_ENABLED=true
+```
+
+Even if every environment value above is set, the live routes still call Dinari and refuse execution unless the provider itself confirms the required KYC/account/wallet state.
+
+Do not set approval flags merely to make the UI green. They represent external facts that need to be true.
+
+## Live launch sequence
+
+1. Complete Dinari partner/production onboarding and obtain the approved live API credentials.
+2. Complete the live Entity/KYC/Account workflow required for the intended U.S. customer/account structure.
+3. Use the approved Dinari-managed wallet flow for this V1 implementation. External-wallet live signing is intentionally not implemented here.
+4. Complete the U.S. disclosure review and deploy the exact approved disclosure page. Record its version in `DINARI_US_DISCLOSURE_VERSION`.
+5. Complete the U.S. SIP/NBBO review and confirm the production API response contains all fields the live confirmation screen requires.
+6. Store live credentials and `DINARI_LIVE_CONFIRMATION_SECRET` only in the deployment secret manager/Vercel server environment. Never put real secrets in GitHub, browser code, screenshots or chat.
+7. Keep `DINARI_PRODUCTION_TRADING_ENABLED=false` while verifying `/admin/digital-reits/live` shows every external/provider gate correctly.
+8. Run the automated Digital REIT tests and production build.
+9. Set `DINARI_PRODUCTION_TRADING_ENABLED=true` only after the live provider, disclosures and NBBO gates are truly approved.
+10. Open `/admin/digital-reits/live` while signed in with the authorized owner Google account.
+11. Start with a small live order, review the current NBBO and disclosure screen, submit deliberately, and verify the resulting provider portfolio before treating the position as owned.
+
+## Dinari environments
 
 - Sandbox: `https://api-enterprise.sandbox.dinari.com/api/v2`
 - Live: `https://api-enterprise.sbt.dinari.com/api/v2`
 
-Voxel Vault defaults to sandbox.
+Voxel Vault defaults to sandbox unless `DINARI_ENVIRONMENT=live` is explicitly configured.
 
-## Immediately after creating a Dinari secret
+## Sandbox setup
 
-Put the **matching Key ID** and the **Secret Key** directly into Vercel Preview environment variables. Never paste the secret into chat, a GitHub issue, source code, a browser input, or a variable prefixed with `NEXT_PUBLIC_`.
+Put the matching sandbox Key ID and Secret Key directly into Vercel Preview environment variables. Never paste the secret into chat, a GitHub issue, source code, a browser input, or a variable prefixed with `NEXT_PUBLIC_`.
 
 ```text
 DINARI_ENVIRONMENT=sandbox
 DINARI_API_KEY_ID=<sandbox key id>
 DINARI_API_SECRET_KEY=<sandbox secret>
-```
-
-Redeploy Preview, sign into Voxel Vault with the authorized Google account, then open `/admin/digital-reits`. The wizard will verify the credentials by asking Dinari for the current organization Entity.
-
-## Required Supabase identity-binding migration
-
-Before My Vault can call a Dinari position **personal to a signed-in user**, apply:
-
-```text
-supabase/migrations/014_provider_account_bindings.sql
-```
-
-The migration creates `public.vault_provider_account_bindings` with these important properties:
-
-- RLS is enabled.
-- Authenticated users may select only their own binding.
-- There is intentionally no authenticated browser insert/update/delete policy.
-- Trusted service-role server code stores the binding after provider verification.
-- `(provider, environment, account_id)` is unique so the same provider account cannot silently be claimed by multiple Voxel Vault users.
-
-Merging the migration file into GitHub does **not** by itself prove the migration has been applied to the active Supabase project. Until the table exists, `/api/vault/digital-reits` returns no personal holdings and reports setup required.
-
-## Private wizard sequence
-
-1. Verify the server-side Dinari credentials.
-2. Create a sandbox customer `INDIVIDUAL` Entity.
-3. Request a Dinari-managed KYC URL with `jurisdiction=US`.
-4. Complete the sensitive identity/KYC flow on Dinari's hosted interface. Voxel Vault does not collect the KYC payload.
-5. Return to `/admin/digital-reits` and refresh status until Dinari reports `PASS`.
-6. Create/reuse an active US sandbox Account. Voxel Vault refuses this step before KYC PASS.
-7. Bind the provider-confirmed active US Account to the currently authenticated Voxel Vault user. The binding endpoint re-reads the account from Dinari; it does not trust a browser-submitted Account ID.
-8. The non-secret Entity ID and Account ID may still be configured in Vercel for the controlled public/pilot Digital REIT dashboard:
-
-```text
-DINARI_ENTITY_ID=<created entity id>
-DINARI_ACCOUNT_ID=<created account id>
+DINARI_ENTITY_ID=<sandbox entity id>
+DINARI_ACCOUNT_ID=<sandbox account id>
 DINARI_REAL_ESTATE_SYMBOLS=VNQ,SCHH,XLRE,REET,O,PLD,AMT,WELL
 DINARI_SANDBOX_FAUCET_ENABLED=false
 DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=false
 DINARI_PRODUCTION_TRADING_ENABLED=false
 ```
 
-9. Verify `/api/digital-reits` and `/real-estate/reits` read the configured pilot provider account with both action flags still false.
-10. Verify `/api/vault/digital-reits` while signed in. It must either return the account bound to that exact user or return an empty/unbound response; it must never inherit the global pilot Account.
-11. Set `DINARI_SANDBOX_FAUCET_ENABLED=true`, redeploy Preview and use **ADD 1,000 TEST FUNDS** only in the controlled sandbox pilot.
-12. Verify the provider cash balance appears.
-13. Set `DINARI_SANDBOX_ORDER_EXECUTION_ENABLED=true`, redeploy Preview and submit one $5 sandbox real-estate-security buy from the controlled sandbox pilot.
-14. Let the Digital REIT Vault reconcile the pre-order quantity against repeated provider portfolio reads. Only a positive provider-reported increase becomes a confirmed holding.
-15. If the position is still settling, use **CHECK PROVIDER AGAIN**.
-16. Return to `/vault#digital-reits` while signed in. The position can enter the spatial personal Vault only if the signed-in identity is bound to that same provider account and the provider reports a positive balance.
-17. Keep production trading disabled.
+The private `/admin/digital-reits` wizard uses the existing Supabase Google session plus server-side owner allowlist to create/recover the sandbox Entity, open Dinari-hosted KYC, create/reuse the US sandbox Account and bind it to the authenticated Voxel Vault user after KYC PASS.
 
-## Pilot account vs personal My Vault account
+## Required Supabase identity-binding migration
 
-These are deliberately different concepts:
-
-- `/api/digital-reits` and `/real-estate/reits` can use `DINARI_ACCOUNT_ID` as the explicitly configured owner/pilot sandbox account for controlled testing.
-- `/api/vault/digital-reits` ignores that global account as an ownership claim. It requires a verified signed-in user, finds that user's server-controlled provider binding, scopes Dinari reads to the bound Account ID, and disables all write flags.
-- `/vault` consumes the user-bound endpoint, so signing in alone is never enough to inherit the pilot holdings.
-
-This distinction prevents a shared test account from accidentally appearing as every user's personal security portfolio.
-
-## Owner authorization
-
-The private wizard accepts the generic owner allowlist:
+Before My Vault can attribute provider holdings to a signed-in user, apply:
 
 ```text
-VOXEL_VAULT_ADMIN_EMAILS=
-VOXEL_VAULT_ADMIN_USER_IDS=
+supabase/migrations/014_provider_account_bindings.sql
 ```
 
-If those are blank, it falls back to the existing `NEURAL_CORE_ADMIN_EMAILS` / `NEURAL_CORE_ADMIN_USER_IDS` allowlist so an already-configured owner account does not need a second identity system.
+The binding table is RLS-protected, browser clients cannot write bindings, and a provider Account ID cannot be silently claimed by multiple Voxel Vault users in the same environment.
+
+The new live V1 execution console is more restrictive: it is owner/admin-only and uses the explicitly configured live account after direct provider verification. It does not open live trading to arbitrary signed-in users.
 
 ## Safety invariants
 
-- `DINARI_LIVE_TRADING_IMPLEMENTATION_READY` is `false`.
-- No environment variable can unlock live trading.
-- The owner onboarding wizard refuses Entity, KYC-session, Account creation and provider-binding writes in `DINARI_ENVIRONMENT=live`.
-- Account creation requires Dinari KYC status `PASS` and `is_kyc_complete=true`.
-- Existing active accounts are reused instead of duplicated.
-- A user/provider binding requires KYC PASS and a provider-confirmed active account.
-- A provider Account ID cannot be assigned to two Voxel Vault users in the same environment.
-- Browser users cannot create, overwrite or delete provider bindings through Supabase RLS.
-- A missing provider-binding migration fails closed: My Vault shows no personal provider holdings.
-- Suspended/revoked bindings do not load holdings.
-- User-bound provider reads always force sandbox order execution, sandbox faucet execution and production trading flags off.
-- Sandbox funding and buying refuse `DINARI_ENVIRONMENT=live`.
-- Sandbox buys are capped at $25 per request.
-- Reconciliation is read-only and sandbox-only.
-- A submitted sandbox order is not treated as ownership; confirmation requires a later provider portfolio amount above the pre-order baseline.
-- The faucet uses mock tokens only; it cannot fund a production account.
-- The browser never receives the API key ID or API secret.
-- The personal binding summary exposes only safe metadata such as the provider, environment, status and Account ID suffix—not the full provider Account or Entity ID.
-- The hosted KYC response exposes only an expiring Dinari URL; Voxel Vault does not request or store SSN/tax-ID/document data in the wizard.
-- Dividend records are not assumed to be real-estate distributions unless their `stock_id` is in the provider-confirmed real-estate catalog.
-- The live property-acquisition engine remains a separate legal/title workflow.
-- Digital REIT/dShare ownership is not represented as ownership of a specific deed.
+- Sandbox funding/buying still refuses `DINARI_ENVIRONMENT=live`.
+- Sandbox buys remain capped at $25.
+- Live buys are capped at $700 per request in code.
+- Live execution requires server-side owner authentication and same-origin requests.
+- Live configuration flags cannot substitute for live provider KYC/account/wallet verification.
+- Live account KYC must be PASS and `is_kyc_complete=true`.
+- The configured account must be active, US-jurisdiction and belong to the configured Entity.
+- The V1 live path requires a Dinari-managed wallet and refuses a provider AML-flagged wallet.
+- Live assets must be returned by the provider in Voxel Vault's configured real-estate universe and must be tradable/fractionable.
+- U.S. live market buys require a fresh SIP/NBBO pre-trade confirmation.
+- Missing/stale NBBO prices, sizes, exchanges or timestamp fail closed.
+- The signed pre-trade token is short-lived and bound to the authenticated user, account, amount, quote and disclosure version.
+- A changed disclosure version invalidates an older confirmation.
+- A submitted order is not treated as ownership. Provider portfolio data remains the source of the held position.
+- The browser never receives the Dinari API key ID, API secret or live-confirmation HMAC secret.
+- Live auto-reinvestment is not enabled in this V1 path.
+- Public pooled investing is not enabled in this V1 path.
+- Digital REIT/dShare ownership is not represented as ownership of a specific recorded deed.
+- The direct-property/fractional-property issuance engine remains a separate legal/title/securities workflow and stays fail-closed until its issuer/intermediary/title evidence is real.
 
 ## Provider references
 
 - Quickstart: https://docs.dinari.com/docs/quickstart
 - Environments: https://docs.dinari.com/reference/environments
-- Funding accounts through wallets / sandbox faucet: https://docs.dinari.com/docs/funding-accounts-through-wallets
-- Cash balances: https://docs.dinari.com/reference/getaccountcash
+- U.S. customers / disclosures / NBBO: https://docs.dinari.com/docs/us
 - Stock data: https://docs.dinari.com/docs/stock-data
 - Placing orders: https://docs.dinari.com/docs/placing-orders
 - KYC: https://docs.dinari.com/docs/managing-kyc
+- Accounts/wallet funding: https://docs.dinari.com/docs/funding-accounts-through-wallets
 - Corporate actions/dividends: https://docs.dinari.com/docs/corporate-action-processing
-- U.S. customers: https://docs.dinari.com/docs/us

--- a/lib/real-estate/dinari.js
+++ b/lib/real-estate/dinari.js
@@ -360,7 +360,7 @@ function normalizeLiveQuote(payload = {}, asset = {}) {
   const bid = Number(payload.bid_price ?? payload.bid ?? 0);
   const offer = Number(payload.ask_price ?? payload.offer_price ?? payload.ask ?? payload.offer ?? 0);
   const bidSize = Number(payload.bid_size ?? payload.bid_volume ?? 0);
-  const offerSize = Number(payload.ask_size ?? payload.offer_size ?? payload.ask_volume ?? 0);
+  const offerSize = Number(payload.ask_size ?? payload.offer_size ?? payload.ask_volume ?? payload.offer_volume ?? 0);
   const bidExchange = clean(payload.bid_exchange || payload.bid_exchange_code || payload.bid_market_center || payload.bid_exchange_name);
   const offerExchange = clean(payload.ask_exchange || payload.offer_exchange || payload.ask_exchange_code || payload.offer_exchange_code || payload.ask_market_center || payload.offer_market_center);
   const timestamp = clean(payload.timestamp || payload.quote_timestamp || payload.generated_at);
@@ -541,7 +541,7 @@ export async function createLiveMarketBuy({ userId, confirmationToken } = {}, en
   };
 }
 
-export async function getDigitalReitSnapshot(env = process.env) {
+export async function getDigitalReitSnapshot(env = process.env, { includeAccountData = true } = {}) {
   const config = getDinariConfig(env);
   const snapshot = {
     provider: config.provider,
@@ -549,6 +549,7 @@ export async function getDigitalReitSnapshot(env = process.env) {
     credentialsConfigured: config.credentialsConfigured,
     accountConfigured: config.accountConfigured,
     entityConfigured: config.entityConfigured,
+    accountDataIncluded: includeAccountData === true,
     sandboxTradingEnabled: config.sandboxTradingEnabled,
     sandboxFaucetEnabled: config.sandboxFaucetEnabled,
     productionTradingEnabled: config.productionTradingEnabled,
@@ -572,6 +573,8 @@ export async function getDigitalReitSnapshot(env = process.env) {
   } catch (error) {
     snapshot.errors.push(`catalog: ${error?.message || 'provider request failed'}`);
   }
+
+  if (includeAccountData !== true) return snapshot;
 
   const results = await Promise.allSettled([
     getDigitalRealEstatePortfolio(env),

--- a/lib/real-estate/dinari.js
+++ b/lib/real-estate/dinari.js
@@ -1,7 +1,16 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
 const SANDBOX_BASE_URL = 'https://api-enterprise.sandbox.dinari.com/api/v2';
 const LIVE_BASE_URL = 'https://api-enterprise.sbt.dinari.com/api/v2';
 
-export const DINARI_LIVE_TRADING_IMPLEMENTATION_READY = false;
+// The live implementation is now present, but activation is still fail-closed. A live
+// trade requires approved production credentials, a provider-verified US account/KYC,
+// a Dinari-managed non-AML-flagged wallet, the approved disclosure/NBBO gates below,
+// an owner-authenticated pre-trade confirmation, and a fresh signed quote token.
+export const DINARI_LIVE_TRADING_IMPLEMENTATION_READY = true;
+export const DINARI_LIVE_ORDER_MAX_USD = 700;
+export const DINARI_LIVE_CONFIRMATION_TTL_MS = 18_000;
+export const DINARI_LIVE_QUOTE_MAX_AGE_MS = 30_000;
 export const DINARI_SANDBOX_ORDER_MAX_USD = 25;
 export const DINARI_SANDBOX_FAUCET_AMOUNT = 1000;
 
@@ -20,10 +29,32 @@ function clean(value) {
   return String(value || '').trim();
 }
 
+function bool(value) {
+  return value === true || clean(value).toLowerCase() === 'true';
+}
+
 function configuredSymbols(env = {}) {
   const raw = clean(env.DINARI_REAL_ESTATE_SYMBOLS);
   if (!raw) return [...DEFAULT_REAL_ESTATE_SYMBOLS];
   return [...new Set(raw.split(',').map((item) => item.trim().toUpperCase()).filter(Boolean))].slice(0, 100);
+}
+
+function liveConfigurationBlockers(config) {
+  const blockers = [];
+  if (config.environment !== 'live') blockers.push('DINARI_ENVIRONMENT must be live.');
+  if (!config.credentialsConfigured) blockers.push('Live Dinari API key ID and secret are required.');
+  if (!config.entityConfigured) blockers.push('DINARI_ENTITY_ID is required for live KYC/NBBO verification.');
+  if (!config.accountConfigured) blockers.push('DINARI_ACCOUNT_ID is required for live trading.');
+  if (!config.livePartnerApproved) blockers.push('DINARI_LIVE_PARTNER_APPROVED=true is required after Dinari production approval.');
+  if (!config.liveManagedOrdersApproved) blockers.push('DINARI_LIVE_MANAGED_ORDERS_APPROVED=true is required for the approved managed-wallet flow.');
+  if (!config.usDisclosuresApproved) blockers.push('DINARI_US_DISCLOSURES_APPROVED=true is required after compliance approves the disclosure screen.');
+  if (!config.disclosureVersion) blockers.push('DINARI_US_DISCLOSURE_VERSION must identify the approved disclosure version.');
+  if (!config.disclosurePageUrl) blockers.push('DINARI_US_DISCLOSURE_PAGE_URL must point to the approved disclosure screen.');
+  if (!config.nbboApproved) blockers.push('DINARI_US_NBBO_APPROVED=true is required after the SIP/NBBO display is approved.');
+  if (!config.confirmationSecretReady) blockers.push('DINARI_LIVE_CONFIRMATION_SECRET must be a server-only secret of at least 32 characters.');
+  if (!config.productionTradingFlag) blockers.push('DINARI_PRODUCTION_TRADING_ENABLED=true is required for deliberate activation.');
+  if (!DINARI_LIVE_TRADING_IMPLEMENTATION_READY) blockers.push('Live trading implementation is code-locked.');
+  return blockers;
 }
 
 export function getDinariConfig(env = {}) {
@@ -33,14 +64,24 @@ export function getDinariConfig(env = {}) {
   const apiSecretKey = clean(env.DINARI_API_SECRET_KEY);
   const accountId = clean(env.DINARI_ACCOUNT_ID);
   const entityId = clean(env.DINARI_ENTITY_ID);
-  const sandboxOrderFlag = env.DINARI_SANDBOX_ORDER_EXECUTION_ENABLED === 'true';
-  const sandboxFaucetFlag = env.DINARI_SANDBOX_FAUCET_ENABLED === 'true';
-  const productionTradingFlag = env.DINARI_PRODUCTION_TRADING_ENABLED === 'true';
+  const sandboxOrderFlag = bool(env.DINARI_SANDBOX_ORDER_EXECUTION_ENABLED);
+  const sandboxFaucetFlag = bool(env.DINARI_SANDBOX_FAUCET_ENABLED);
+  const productionTradingFlag = bool(env.DINARI_PRODUCTION_TRADING_ENABLED);
+  const livePartnerApproved = bool(env.DINARI_LIVE_PARTNER_APPROVED);
+  const liveManagedOrdersApproved = bool(env.DINARI_LIVE_MANAGED_ORDERS_APPROVED);
+  const usDisclosuresApproved = bool(env.DINARI_US_DISCLOSURES_APPROVED);
+  const nbboApproved = bool(env.DINARI_US_NBBO_APPROVED);
+  const disclosureVersion = clean(env.DINARI_US_DISCLOSURE_VERSION);
+  const rawDisclosureUrl = clean(env.DINARI_US_DISCLOSURE_PAGE_URL);
+  const disclosurePageUrl = /^https:\/\//i.test(rawDisclosureUrl) ? rawDisclosureUrl : '';
+  const confirmationSecret = clean(env.DINARI_LIVE_CONFIRMATION_SECRET);
+  const confirmationSecretReady = confirmationSecret.length >= 32;
   const credentialsConfigured = Boolean(apiKeyId && apiSecretKey);
   const accountConfigured = Boolean(accountId);
+  const entityConfigured = Boolean(entityId);
   const symbols = configuredSymbols(env);
 
-  return {
+  const config = {
     provider: 'Dinari',
     environment,
     baseUrl: environment === 'live' ? LIVE_BASE_URL : SANDBOX_BASE_URL,
@@ -50,19 +91,28 @@ export function getDinariConfig(env = {}) {
     entityId,
     credentialsConfigured,
     accountConfigured,
+    entityConfigured,
     symbols,
     sandboxOrderFlag,
     sandboxFaucetFlag,
+    productionTradingFlag,
+    livePartnerApproved,
+    liveManagedOrdersApproved,
+    usDisclosuresApproved,
+    nbboApproved,
+    disclosureVersion,
+    disclosurePageUrl,
+    confirmationSecret,
+    confirmationSecretReady,
     sandboxTradingEnabled: Boolean(environment === 'sandbox' && credentialsConfigured && accountConfigured && sandboxOrderFlag),
     sandboxFaucetEnabled: Boolean(environment === 'sandbox' && credentialsConfigured && accountConfigured && sandboxFaucetFlag),
-    productionTradingEnabled: Boolean(
-      environment === 'live' &&
-      credentialsConfigured &&
-      accountConfigured &&
-      productionTradingFlag &&
-      DINARI_LIVE_TRADING_IMPLEMENTATION_READY
-    ),
+    productionTradingEnabled: false,
+    productionReadinessBlockers: [],
   };
+
+  config.productionReadinessBlockers = liveConfigurationBlockers(config);
+  config.productionTradingEnabled = config.productionReadinessBlockers.length === 0;
+  return config;
 }
 
 function headers(config) {
@@ -128,9 +178,10 @@ function normalizeStock(stock = {}) {
   return {
     id: clean(stock.id || stock.stock_id),
     symbol: clean(stock.symbol).toUpperCase(),
-    name: clean(stock.name || stock.display_name || stock.company_name || stock.symbol),
+    name: clean(stock.display_name || stock.name || stock.company_name || stock.symbol),
     cusip: clean(stock.cusip),
     isFractionable: stock.is_fractionable ?? stock.fractionable ?? null,
+    isTradable: stock.is_tradable ?? stock.tradable ?? null,
     rawType: clean(stock.type || stock.asset_type || stock.security_type),
   };
 }
@@ -223,6 +274,273 @@ export async function getDigitalRealEstateDividends(env = process.env, catalog =
   return normalizeDividendPayments(payload, stockById).filter((payment) => allowedStockIds.has(payment.stockId));
 }
 
+function providerAccount(account = {}) {
+  return {
+    id: clean(account.id),
+    entityId: clean(account.entity_id),
+    isActive: account.is_active === true,
+    jurisdiction: clean(account.jurisdiction).toUpperCase(),
+  };
+}
+
+export async function inspectLiveDinariAccount(env = process.env) {
+  const config = getDinariConfig(env);
+  const blockers = [];
+  if (config.environment !== 'live') blockers.push('Server is not configured for the Dinari live environment.');
+  if (!config.credentialsConfigured) blockers.push('Live Dinari credentials are missing.');
+  if (!config.entityConfigured) blockers.push('Live Dinari Entity ID is missing.');
+  if (!config.accountConfigured) blockers.push('Live Dinari Account ID is missing.');
+
+  const state = {
+    checked: false,
+    ready: false,
+    kycComplete: false,
+    kycStatus: '',
+    accountActive: false,
+    accountJurisdiction: '',
+    managedWallet: false,
+    amlFlagged: null,
+    entitySuffix: config.entityId ? config.entityId.slice(-6) : '',
+    accountSuffix: config.accountId ? config.accountId.slice(-6) : '',
+    blockers,
+  };
+
+  if (blockers.length) return state;
+
+  const [entity, kyc, accountsPayload, wallet] = await Promise.all([
+    dinariRequest(`/entities/${encodeURIComponent(config.entityId)}`, { env }),
+    dinariRequest(`/entities/${encodeURIComponent(config.entityId)}/kyc`, { env }),
+    dinariRequest(`/entities/${encodeURIComponent(config.entityId)}/accounts?limit=100&order=desc`, { env }),
+    dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/wallet`, { env }),
+  ]);
+
+  state.checked = true;
+  state.kycComplete = entity?.is_kyc_complete === true;
+  state.kycStatus = clean(kyc?.status).toUpperCase();
+  const account = resultItems(accountsPayload).map(providerAccount).find((candidate) => candidate.id === config.accountId) || null;
+  state.accountActive = account?.isActive === true;
+  state.accountJurisdiction = account?.jurisdiction || '';
+  state.managedWallet = wallet?.is_managed_wallet === true;
+  state.amlFlagged = wallet?.is_aml_flagged === true;
+
+  if (!state.kycComplete || state.kycStatus !== 'PASS') state.blockers.push(`Provider KYC must be PASS; current status is ${state.kycStatus || 'UNKNOWN'}.`);
+  if (!account) state.blockers.push('Configured live account was not returned under the configured live Entity.');
+  else {
+    if (!state.accountActive) state.blockers.push('Configured live account is not active.');
+    if (state.accountJurisdiction !== 'US') state.blockers.push(`Configured live account jurisdiction must be US; provider returned ${state.accountJurisdiction || 'UNKNOWN'}.`);
+  }
+  if (!state.managedWallet) state.blockers.push('Configured live account does not have a Dinari-managed wallet; this live managed-order path will not sign for an external wallet.');
+  if (state.amlFlagged === true) state.blockers.push('Provider reports the configured wallet as AML flagged.');
+  state.ready = state.blockers.length === 0;
+  return state;
+}
+
+export async function verifyLiveDinariAccount(env = process.env) {
+  const config = getDinariConfig(env);
+  if (!config.productionTradingEnabled) {
+    throw new Error(`Live Dinari trading is locked: ${config.productionReadinessBlockers.join(' ') || 'production activation is incomplete.'}`);
+  }
+  const state = await inspectLiveDinariAccount(env);
+  if (!state.ready) throw new Error(`Live Dinari account verification failed: ${state.blockers.join(' ')}`);
+  return state;
+}
+
+async function resolveLiveRealEstateAsset(stockId, env = process.env) {
+  const id = clean(stockId);
+  if (!id) throw new Error('A Dinari stock_id is required.');
+  const catalog = await listDigitalRealEstateAssets(env);
+  const asset = catalog.find((candidate) => candidate.id === id);
+  if (!asset) throw new Error('That stock is not in the configured provider-confirmed real-estate universe.');
+  if (asset.isTradable === false) throw new Error(`${asset.symbol} is not currently tradable according to the provider.`);
+  if (asset.isFractionable === false) throw new Error(`${asset.symbol} is not fractionable; Voxel Vault live market buys require a fractionable security.`);
+  return asset;
+}
+
+function normalizeLiveQuote(payload = {}, asset = {}) {
+  const bid = Number(payload.bid_price ?? payload.bid ?? 0);
+  const offer = Number(payload.ask_price ?? payload.offer_price ?? payload.ask ?? payload.offer ?? 0);
+  const bidSize = Number(payload.bid_size ?? payload.bid_volume ?? 0);
+  const offerSize = Number(payload.ask_size ?? payload.offer_size ?? payload.ask_volume ?? 0);
+  const bidExchange = clean(payload.bid_exchange || payload.bid_exchange_code || payload.bid_market_center || payload.bid_exchange_name);
+  const offerExchange = clean(payload.ask_exchange || payload.offer_exchange || payload.ask_exchange_code || payload.offer_exchange_code || payload.ask_market_center || payload.offer_market_center);
+  const timestamp = clean(payload.timestamp || payload.quote_timestamp || payload.generated_at);
+  return {
+    stockId: clean(payload.stock_id || asset.id),
+    symbol: clean(payload.symbol || asset.symbol).toUpperCase(),
+    bid,
+    bidSize,
+    bidExchange,
+    offer,
+    offerSize,
+    offerExchange,
+    timestamp,
+  };
+}
+
+function assertFreshUsQuote(quote) {
+  if (!quote.stockId || !quote.symbol) throw new Error('Provider quote is missing stock identity.');
+  if (!Number.isFinite(quote.bid) || quote.bid <= 0 || !Number.isFinite(quote.offer) || quote.offer <= 0) {
+    throw new Error('Provider did not return a usable NBBO bid and offer.');
+  }
+  if (!Number.isFinite(quote.bidSize) || quote.bidSize < 0 || !Number.isFinite(quote.offerSize) || quote.offerSize < 0) {
+    throw new Error('Provider returned invalid NBBO sizes.');
+  }
+  if (!quote.bidExchange || !quote.offerExchange) {
+    throw new Error('Provider quote is missing the bid/offer exchange fields required for the U.S. pre-trade screen.');
+  }
+  const generated = Date.parse(quote.timestamp);
+  if (!Number.isFinite(generated)) throw new Error('Provider quote timestamp is invalid.');
+  const age = Date.now() - generated;
+  if (age < -5_000 || age > DINARI_LIVE_QUOTE_MAX_AGE_MS) {
+    throw new Error('Provider NBBO quote is stale. Refresh the pre-trade confirmation before trading.');
+  }
+}
+
+export async function getLiveRealEstateQuote({ stockId } = {}, env = process.env) {
+  const config = getDinariConfig(env);
+  if (!config.productionTradingEnabled) {
+    throw new Error(`Live quote is locked: ${config.productionReadinessBlockers.join(' ') || 'production activation is incomplete.'}`);
+  }
+  const asset = await resolveLiveRealEstateAsset(stockId, env);
+  const params = new URLSearchParams({ feed: 'sip', entity_id: config.entityId });
+  const payload = await dinariRequest(`/market_data/stocks/${encodeURIComponent(asset.id)}/current_quote?${params.toString()}`, { env });
+  const quote = normalizeLiveQuote(payload, asset);
+  assertFreshUsQuote(quote);
+  return quote;
+}
+
+function normalizeLiveAmount(value) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount < 1 || amount > DINARI_LIVE_ORDER_MAX_USD) {
+    throw new Error(`Live market buy must be between $1 and $${DINARI_LIVE_ORDER_MAX_USD}.`);
+  }
+  return Number(amount.toFixed(2));
+}
+
+function b64url(value) {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function signConfirmation(encodedPayload, secret) {
+  return createHmac('sha256', secret).update(encodedPayload).digest('base64url');
+}
+
+function quoteDigest(quote) {
+  return createHash('sha256').update(JSON.stringify({
+    stockId: quote.stockId,
+    symbol: quote.symbol,
+    bid: quote.bid,
+    bidSize: quote.bidSize,
+    bidExchange: quote.bidExchange,
+    offer: quote.offer,
+    offerSize: quote.offerSize,
+    offerExchange: quote.offerExchange,
+    timestamp: quote.timestamp,
+  })).digest('hex');
+}
+
+export async function createLivePreTradeConfirmation({ userId, stockId, paymentAmount } = {}, env = process.env) {
+  const config = getDinariConfig(env);
+  const uid = clean(userId);
+  if (!uid) throw new Error('An authenticated Voxel Vault user is required.');
+  const amount = normalizeLiveAmount(paymentAmount);
+  await verifyLiveDinariAccount(env);
+  const quote = await getLiveRealEstateQuote({ stockId }, env);
+
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + DINARI_LIVE_CONFIRMATION_TTL_MS;
+  const confirmationId = randomBytes(12).toString('hex');
+  const payload = {
+    v: 1,
+    confirmationId,
+    userId: uid,
+    environment: 'live',
+    accountHash: createHash('sha256').update(config.accountId).digest('hex'),
+    stockId: quote.stockId,
+    symbol: quote.symbol,
+    paymentAmount: amount,
+    quoteTimestamp: quote.timestamp,
+    quoteDigest: quoteDigest(quote),
+    disclosureVersion: config.disclosureVersion,
+    issuedAt,
+    expiresAt,
+  };
+  const encoded = b64url(JSON.stringify(payload));
+  const signature = signConfirmation(encoded, config.confirmationSecret);
+
+  return {
+    confirmationToken: `${encoded}.${signature}`,
+    confirmationId,
+    paymentAmount: amount,
+    quote,
+    disclosureVersion: config.disclosureVersion,
+    disclosurePageUrl: config.disclosurePageUrl,
+    issuedAt: new Date(issuedAt).toISOString(),
+    expiresAt: new Date(expiresAt).toISOString(),
+  };
+}
+
+function verifyLiveConfirmationToken(token, userId, env = process.env) {
+  const config = getDinariConfig(env);
+  const uid = clean(userId);
+  const raw = clean(token);
+  const [encoded, signature, extra] = raw.split('.');
+  if (!encoded || !signature || extra) throw new Error('Live confirmation token is malformed.');
+  if (!config.confirmationSecretReady) throw new Error('Live confirmation signing secret is unavailable.');
+  const expected = signConfirmation(encoded, config.confirmationSecret);
+  const providedBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length || !timingSafeEqual(providedBuffer, expectedBuffer)) {
+    throw new Error('Live confirmation signature is invalid.');
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('Live confirmation payload is invalid.');
+  }
+
+  if (payload?.v !== 1 || payload?.environment !== 'live') throw new Error('Live confirmation version/environment is invalid.');
+  if (!uid || payload.userId !== uid) throw new Error('Live confirmation belongs to a different Voxel Vault user.');
+  if (payload.accountHash !== createHash('sha256').update(config.accountId).digest('hex')) throw new Error('Live confirmation belongs to a different provider account.');
+  if (payload.disclosureVersion !== config.disclosureVersion) throw new Error('Approved disclosure version changed; review a new confirmation.');
+  if (!Number.isFinite(payload.expiresAt) || Date.now() > payload.expiresAt) throw new Error('Live pre-trade confirmation expired. Refresh the NBBO quote.');
+  normalizeLiveAmount(payload.paymentAmount);
+  return payload;
+}
+
+export async function createLiveMarketBuy({ userId, confirmationToken } = {}, env = process.env) {
+  const config = getDinariConfig(env);
+  if (!config.productionTradingEnabled) {
+    throw new Error(`Live trading is locked: ${config.productionReadinessBlockers.join(' ') || 'production activation is incomplete.'}`);
+  }
+  const payload = verifyLiveConfirmationToken(confirmationToken, userId, env);
+  await verifyLiveDinariAccount(env);
+  const asset = await resolveLiveRealEstateAsset(payload.stockId, env);
+  if (asset.symbol !== payload.symbol) throw new Error('Provider symbol changed since confirmation; refresh before trading.');
+
+  const order = await dinariRequest(`/accounts/${encodeURIComponent(config.accountId)}/order_requests/market_buy`, {
+    env,
+    method: 'POST',
+    body: {
+      stock_id: asset.id,
+      payment_amount: Number(payload.paymentAmount.toFixed(2)),
+      client_order_id: `vv-live-${payload.confirmationId}`,
+    },
+  });
+
+  return {
+    order,
+    confirmationId: payload.confirmationId,
+    symbol: payload.symbol,
+    paymentAmount: payload.paymentAmount,
+    quoteTimestamp: payload.quoteTimestamp,
+    realMoney: true,
+    environment: 'live',
+  };
+}
+
 export async function getDigitalReitSnapshot(env = process.env) {
   const config = getDinariConfig(env);
   const snapshot = {
@@ -230,10 +548,15 @@ export async function getDigitalReitSnapshot(env = process.env) {
     environment: config.environment,
     credentialsConfigured: config.credentialsConfigured,
     accountConfigured: config.accountConfigured,
+    entityConfigured: config.entityConfigured,
     sandboxTradingEnabled: config.sandboxTradingEnabled,
     sandboxFaucetEnabled: config.sandboxFaucetEnabled,
     productionTradingEnabled: config.productionTradingEnabled,
     productionTradingImplementationReady: DINARI_LIVE_TRADING_IMPLEMENTATION_READY,
+    productionReadinessBlockers: [...config.productionReadinessBlockers],
+    disclosurePageUrl: config.disclosurePageUrl,
+    disclosureVersion: config.disclosureVersion,
+    liveOrderMaxUsd: DINARI_LIVE_ORDER_MAX_USD,
     symbols: config.symbols,
     catalog: [],
     portfolio: [],

--- a/scripts/test-digital-reits.mjs
+++ b/scripts/test-digital-reits.mjs
@@ -1,33 +1,60 @@
 import assert from 'node:assert/strict';
 import {
+  DINARI_LIVE_ORDER_MAX_USD,
   DINARI_LIVE_TRADING_IMPLEMENTATION_READY,
   DINARI_SANDBOX_FAUCET_AMOUNT,
   DINARI_SANDBOX_ORDER_MAX_USD,
+  createLiveMarketBuy,
+  createLivePreTradeConfirmation,
   createSandboxMarketBuy,
   getDigitalRealEstateCash,
   getDigitalRealEstateDividends,
   getDinariConfig,
+  inspectLiveDinariAccount,
   listDigitalRealEstateAssets,
   mintSandboxFunds,
 } from '../lib/real-estate/dinari.js';
 import { reconcileDigitalReitPosition } from '../lib/real-estate/reconciliation.js';
 
-assert.equal(DINARI_LIVE_TRADING_IMPLEMENTATION_READY, false, 'production trading must remain code-locked');
+assert.equal(DINARI_LIVE_TRADING_IMPLEMENTATION_READY, true, 'live trading implementation should be present');
+assert.equal(DINARI_LIVE_ORDER_MAX_USD, 700, 'live per-order cap changed unexpectedly');
 assert.equal(DINARI_SANDBOX_ORDER_MAX_USD, 25, 'sandbox order cap changed unexpectedly');
 assert.equal(DINARI_SANDBOX_FAUCET_AMOUNT, 1000, 'sandbox faucet amount changed unexpectedly');
 
-const live = getDinariConfig({
+const liveLocked = getDinariConfig({
   DINARI_ENVIRONMENT: 'live',
   DINARI_API_KEY_ID: 'test-key',
   DINARI_API_SECRET_KEY: 'test-secret',
+  DINARI_ENTITY_ID: 'entity-test',
   DINARI_ACCOUNT_ID: 'account-test',
   DINARI_PRODUCTION_TRADING_ENABLED: 'true',
   DINARI_SANDBOX_FAUCET_ENABLED: 'true',
 });
-assert.equal(live.environment, 'live');
-assert.equal(live.productionTradingEnabled, false, 'environment variables must not unlock production trading');
-assert.equal(live.sandboxTradingEnabled, false, 'live environment cannot use sandbox trading path');
-assert.equal(live.sandboxFaucetEnabled, false, 'live environment cannot use sandbox faucet path');
+assert.equal(liveLocked.environment, 'live');
+assert.equal(liveLocked.productionTradingEnabled, false, 'credentials and a single env flag must not unlock production trading');
+assert.ok(liveLocked.productionReadinessBlockers.some((item) => item.includes('DINARI_LIVE_PARTNER_APPROVED')), 'live partner approval gate missing');
+assert.equal(liveLocked.sandboxTradingEnabled, false, 'live environment cannot use sandbox trading path');
+assert.equal(liveLocked.sandboxFaucetEnabled, false, 'live environment cannot use sandbox faucet path');
+
+const liveEnv = {
+  DINARI_ENVIRONMENT: 'live',
+  DINARI_API_KEY_ID: 'test-key',
+  DINARI_API_SECRET_KEY: 'test-secret',
+  DINARI_ENTITY_ID: 'entity-test',
+  DINARI_ACCOUNT_ID: 'account-test',
+  DINARI_REAL_ESTATE_SYMBOLS: 'VNQ,SCHH',
+  DINARI_LIVE_PARTNER_APPROVED: 'true',
+  DINARI_LIVE_MANAGED_ORDERS_APPROVED: 'true',
+  DINARI_US_DISCLOSURES_APPROVED: 'true',
+  DINARI_US_NBBO_APPROVED: 'true',
+  DINARI_US_DISCLOSURE_VERSION: 'test-v1',
+  DINARI_US_DISCLOSURE_PAGE_URL: 'https://example.com/dinari-disclosures',
+  DINARI_LIVE_CONFIRMATION_SECRET: 'test-live-confirmation-secret-that-is-at-least-32-characters',
+  DINARI_PRODUCTION_TRADING_ENABLED: 'true',
+};
+const liveReadyConfig = getDinariConfig(liveEnv);
+assert.equal(liveReadyConfig.productionTradingEnabled, true, 'all explicit production configuration gates should enable the code path');
+assert.deepEqual(liveReadyConfig.productionReadinessBlockers, []);
 
 const sandboxLocked = getDinariConfig({
   DINARI_ENVIRONMENT: 'sandbox',
@@ -69,35 +96,76 @@ const calls = [];
 global.fetch = async (url, options = {}) => {
   const href = String(url);
   calls.push({ url: href, options });
+  const parsed = new URL(href);
+  const path = parsed.pathname;
 
-  if (href.includes('/market_data/stocks/')) {
+  if (path.endsWith('/market_data/stocks/')) {
     return new Response(JSON.stringify({ data: [
-      { id: 'stock-vnq', symbol: 'VNQ', name: 'Example REIT ETF', is_fractionable: true },
-      { id: 'stock-aapl', symbol: 'AAPL', name: 'Not real estate' },
+      { id: 'stock-vnq', symbol: 'VNQ', name: 'Example REIT ETF', is_fractionable: true, is_tradable: true },
+      { id: 'stock-aapl', symbol: 'AAPL', name: 'Not real estate', is_fractionable: true, is_tradable: true },
     ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
-  if (href.endsWith('/accounts/account-test/cash')) {
+  if (path.endsWith('/market_data/stocks/stock-vnq/current_quote')) {
+    return new Response(JSON.stringify({
+      stock_id: 'stock-vnq',
+      symbol: 'VNQ',
+      bid_price: 99.9,
+      bid_size: 10,
+      bid_exchange: 'NYSE',
+      ask_price: 100.1,
+      ask_size: 11,
+      ask_exchange: 'NASDAQ',
+      timestamp: new Date().toISOString(),
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/entities/entity-test') {
+    return new Response(JSON.stringify({ id: 'entity-test', is_kyc_complete: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/entities/entity-test/kyc') {
+    return new Response(JSON.stringify({ id: 'kyc-test', status: 'PASS', jurisdiction: 'US' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/entities/entity-test/accounts') {
+    return new Response(JSON.stringify({ data: [
+      { id: 'account-test', entity_id: 'entity-test', is_active: true, jurisdiction: 'US' },
+    ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/accounts/account-test/wallet') {
+    return new Response(JSON.stringify({
+      address: '0x0000000000000000000000000000000000000001',
+      chain_id: 'eip155:42161',
+      is_managed_wallet: true,
+      is_aml_flagged: false,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/accounts/account-test/portfolio') {
+    return new Response(JSON.stringify({ assets: [
+      { stock_id: 'stock-vnq', symbol: 'VNQ', amount: 1.125, chain_id: 'eip155:42161', token_address: '0xvnq' },
+    ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+  if (path === '/api/v2/accounts/account-test/cash') {
     return new Response(JSON.stringify([
       { symbol: 'mockUSD', amount: 1000, chain_id: 'eip155:42161', token_address: '0xmock' },
     ]), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
-  if (href.includes('/dividend_payments?')) {
+  if (path.endsWith('/dividend_payments')) {
     return new Response(JSON.stringify({ data: [
       { stock_id: 'stock-vnq', amount: 1.25, currency: 'USD', payment_date: '2026-08-01' },
       { stock_id: 'stock-aapl', amount: 9.99, currency: 'USD', payment_date: '2026-08-01' },
     ] }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
-  if (href.endsWith('/accounts/account-test/faucet')) {
+  if (path === '/api/v2/accounts/account-test/faucet') {
     return new Response(null, { status: 204 });
   }
-  if (href.includes('/order_requests/market_buy')) {
-    return new Response(JSON.stringify({ id: 'sandbox-order-1', status: 'PENDING' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  if (path === '/api/v2/accounts/account-test/order_requests/market_buy') {
+    const body = JSON.parse(options.body || '{}');
+    const liveOrder = String(body.client_order_id || '').startsWith('vv-live-');
+    return new Response(JSON.stringify({ id: liveOrder ? 'live-order-1' : 'sandbox-order-1', status: 'PENDING' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   }
   throw new Error(`Unexpected fetch: ${url}`);
 };
 
 try {
-  const env = {
+  const sandboxEnv = {
     DINARI_ENVIRONMENT: 'sandbox',
     DINARI_API_KEY_ID: 'test-key',
     DINARI_API_SECRET_KEY: 'test-secret',
@@ -107,18 +175,19 @@ try {
     DINARI_REAL_ESTATE_SYMBOLS: 'VNQ,SCHH',
   };
 
-  const assets = await listDigitalRealEstateAssets(env);
+  const assets = await listDigitalRealEstateAssets(sandboxEnv);
   assert.equal(assets.length, 1, 'provider assets outside configured real-estate symbols must be filtered out');
   assert.equal(assets[0].symbol, 'VNQ');
+  assert.equal(assets[0].isTradable, true);
   assert.ok(calls[0].url.startsWith('https://api-enterprise.sandbox.dinari.com/api/v2/'), 'sandbox adapter must use sandbox base URL');
   assert.equal(calls[0].options.headers['X-API-Key-Id'], 'test-key', 'provider auth header missing');
 
-  const cash = await getDigitalRealEstateCash(env);
+  const cash = await getDigitalRealEstateCash(sandboxEnv);
   assert.equal(cash.length, 1);
   assert.equal(cash[0].symbol, 'MOCKUSD');
   assert.equal(cash[0].amount, 1000);
 
-  const dividends = await getDigitalRealEstateDividends(env, assets);
+  const dividends = await getDigitalRealEstateDividends(sandboxEnv, assets);
   assert.equal(dividends.length, 1, 'dividends for non-real-estate stocks must be excluded');
   assert.equal(dividends[0].stockId, 'stock-vnq');
   assert.equal(dividends[0].symbol, 'VNQ');
@@ -126,7 +195,7 @@ try {
   assert.ok(dividendCall?.url.includes('start_date='), 'Dinari dividend request must include required start_date');
   assert.ok(dividendCall?.url.includes('end_date='), 'Dinari dividend request must include required end_date');
 
-  const funding = await mintSandboxFunds(env);
+  const funding = await mintSandboxFunds(sandboxEnv);
   assert.equal(funding.realMoney, false);
   assert.equal(funding.amount, 1000);
   const faucetCall = calls.find((call) => call.url.endsWith('/accounts/account-test/faucet'));
@@ -134,34 +203,81 @@ try {
   assert.equal(faucetCall.options.method, 'POST');
   assert.deepEqual(JSON.parse(faucetCall.options.body), { chain_id: 'eip155:42161' });
 
-  const order = await createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 5 }, env);
-  assert.equal(order.id, 'sandbox-order-1');
-  const orderCall = calls.find((call) => call.url.includes('/order_requests/market_buy'));
-  assert.ok(orderCall, 'sandbox market buy endpoint was not called');
-  assert.equal(orderCall.options.method, 'POST');
-  const orderBody = JSON.parse(orderCall.options.body);
-  assert.equal(orderBody.stock_id, 'stock-vnq');
-  assert.equal(orderBody.payment_amount, 5);
+  const sandboxOrder = await createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 5 }, sandboxEnv);
+  assert.equal(sandboxOrder.id, 'sandbox-order-1');
+  const sandboxOrderCall = calls.find((call) => call.url.includes('/order_requests/market_buy') && JSON.parse(call.options.body).client_order_id?.startsWith('voxel-reit-sandbox-'));
+  assert.ok(sandboxOrderCall, 'sandbox market buy endpoint was not called');
+  assert.equal(sandboxOrderCall.options.method, 'POST');
+  const sandboxOrderBody = JSON.parse(sandboxOrderCall.options.body);
+  assert.equal(sandboxOrderBody.stock_id, 'stock-vnq');
+  assert.equal(sandboxOrderBody.payment_amount, 5);
 
   await assert.rejects(
-    () => createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 25.01 }, env),
+    () => createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 25.01 }, sandboxEnv),
     /no more than \$25/,
     'sandbox orders above the cap must fail closed',
   );
 
   await assert.rejects(
-    () => createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 5 }, { ...env, DINARI_ENVIRONMENT: 'live' }),
+    () => createSandboxMarketBuy({ stockId: 'stock-vnq', paymentAmount: 5 }, { ...sandboxEnv, DINARI_ENVIRONMENT: 'live' }),
     /refuses non-sandbox/,
     'sandbox order function must refuse live environment',
   );
 
   await assert.rejects(
-    () => mintSandboxFunds({ ...env, DINARI_ENVIRONMENT: 'live' }),
+    () => mintSandboxFunds({ ...sandboxEnv, DINARI_ENVIRONMENT: 'live' }),
     /refuses non-sandbox/,
     'sandbox faucet must refuse live environment',
+  );
+
+  const providerState = await inspectLiveDinariAccount(liveEnv);
+  assert.equal(providerState.ready, true, 'mocked live provider account should pass KYC/account/wallet verification');
+  assert.equal(providerState.kycStatus, 'PASS');
+  assert.equal(providerState.accountJurisdiction, 'US');
+  assert.equal(providerState.managedWallet, true);
+  assert.equal(providerState.amlFlagged, false);
+
+  const confirmation = await createLivePreTradeConfirmation({
+    userId: 'owner-user',
+    stockId: 'stock-vnq',
+    paymentAmount: 700,
+  }, liveEnv);
+  assert.equal(confirmation.paymentAmount, 700);
+  assert.equal(confirmation.quote.symbol, 'VNQ');
+  assert.equal(confirmation.quote.bid, 99.9);
+  assert.equal(confirmation.quote.offer, 100.1);
+  assert.ok(confirmation.confirmationToken.includes('.'), 'pre-trade confirmation must be signed');
+  const quoteCall = calls.find((call) => call.url.includes('/current_quote?'));
+  assert.ok(quoteCall?.url.includes('feed=sip'), 'live quote must request the SIP feed');
+  assert.ok(quoteCall?.url.includes('entity_id=entity-test'), 'live quote must be scoped to the provider Entity');
+
+  const liveBuy = await createLiveMarketBuy({
+    userId: 'owner-user',
+    confirmationToken: confirmation.confirmationToken,
+  }, liveEnv);
+  assert.equal(liveBuy.realMoney, true);
+  assert.equal(liveBuy.environment, 'live');
+  assert.equal(liveBuy.order.id, 'live-order-1');
+  const liveOrderCall = calls.find((call) => call.url.includes('/order_requests/market_buy') && JSON.parse(call.options.body).client_order_id?.startsWith('vv-live-'));
+  assert.ok(liveOrderCall, 'live market buy endpoint was not called');
+  const liveOrderBody = JSON.parse(liveOrderCall.options.body);
+  assert.equal(liveOrderBody.stock_id, 'stock-vnq');
+  assert.equal(liveOrderBody.payment_amount, 700);
+  assert.ok(/^vv-live-[a-f0-9]{24}$/.test(liveOrderBody.client_order_id), 'live order must use the signed confirmation ID for provider duplicate protection');
+
+  await assert.rejects(
+    () => createLiveMarketBuy({ userId: 'different-user', confirmationToken: confirmation.confirmationToken }, liveEnv),
+    /different Voxel Vault user/,
+    'a live confirmation must never be transferable to another authenticated user',
+  );
+
+  await assert.rejects(
+    () => createLivePreTradeConfirmation({ userId: 'owner-user', stockId: 'stock-vnq', paymentAmount: 700.01 }, liveEnv),
+    /between \$1 and \$700/,
+    'live orders above the owner budget cap must fail closed',
   );
 } finally {
   global.fetch = originalFetch;
 }
 
-console.log('Digital REIT safety checks passed: provider catalog/dividends are real-estate filtered, cash and sandbox faucet flows are modeled, sandbox orders remain capped, provider position increases are reconciled before ownership confirmation, and production trading/funding remain code-locked.');
+console.log('Digital REIT checks passed: sandbox remains isolated/capped, live execution requires explicit production gates plus verified KYC/account/wallet state, the U.S. path requires a fresh SIP/NBBO pre-trade confirmation and approved disclosure version, live orders are owner-authenticated and capped at $700, and provider positions remain the source of ownership confirmation.');


### PR DESCRIPTION
## What this adds

- Owner-only live real-estate securities console at `/admin/digital-reits/live`
- Real-money Dinari managed market-buy path for provider-confirmed real-estate securities
- Hard $700 per-order V1 cap
- Production configuration gates for partner approval, managed orders, U.S. disclosures, SIP/NBBO approval and server-side confirmation signing
- Fresh U.S. SIP/NBBO pre-trade confirmation with required bid/offer price, size, exchange and timestamp fields
- Short-lived HMAC-signed confirmation bound to the authenticated owner, provider account, asset, amount, quote and disclosure version
- Per-trade provider verification of live Entity/KYC, active US Account, Dinari-managed wallet and AML status
- Same-origin + Supabase owner authentication on live quote/buy routes
- Provider duplicate protection through stable `client_order_id` derived from the signed confirmation ID
- Explicit UI disclosure that this is a real-money security order and not a deed to a particular property
- Automated Digital REIT tests for the live gates and $700 cap
- Updated `.env.example`, provider docs and public REIT page

## Deliberate boundaries

This PR does **not** put live secrets in GitHub, enable public pooled investing, auto-reinvest dividends, issue Voxel Vault property securities, or pretend a REIT/dShare is a house deed. Live execution remains fail-closed unless the actual production provider credentials, U.S. KYC/account/wallet state, disclosure/NBBO approvals and final activation flag are present.

Direct fractional ownership of a specific property remains the separate regulated property-offering/title workflow.