### PR TITLE
Add Erie County source-backed property spatial intake

### DIFF
--- a/app/admin/property-spatial-intake/page.js
+++ b/app/admin/property-spatial-intake/page.js
@@ -1,0 +1,296 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import styles from './page.module.css';
+
+const AUTH_TIMEOUT_MS = 10000;
+const API_TIMEOUT_MS = 15000;
+
+function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+async function fetchWithTimeout(input, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, cache: 'no-store', signal: controller.signal });
+  } catch (error) {
+    if (error?.name === 'AbortError') throw new Error('Erie County GIS intake timed out. No property was verified or changed.');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function money(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(number);
+}
+
+function number(value, suffix = '') {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return '—';
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(parsed)}${suffix}`;
+}
+
+function title(value) {
+  const text = String(value || 'unverified').replaceAll('_', ' ');
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function collectRings(geometry) {
+  if (!geometry || !Array.isArray(geometry.coordinates)) return [];
+  if (geometry.type === 'Polygon') return geometry.coordinates.length ? [geometry.coordinates[0]] : [];
+  if (geometry.type === 'MultiPolygon') return geometry.coordinates.map((polygon) => polygon?.[0]).filter(Array.isArray);
+  return [];
+}
+
+function ParcelPreview({ parcelGeometry, buildingGeometry }) {
+  const parcelRings = collectRings(parcelGeometry);
+  const buildingRings = collectRings(buildingGeometry);
+  const points = [...parcelRings, ...buildingRings].flat();
+  if (!points.length) return <div className={styles.emptyPreview}>No source geometry returned.</div>;
+
+  const lons = points.map((pair) => Number(pair?.[0])).filter(Number.isFinite);
+  const lats = points.map((pair) => Number(pair?.[1])).filter(Number.isFinite);
+  if (!lons.length || !lats.length) return <div className={styles.emptyPreview}>Geometry could not be previewed.</div>;
+
+  const minLon = Math.min(...lons);
+  const maxLon = Math.max(...lons);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const width = Math.max(maxLon - minLon, 0.000001);
+  const height = Math.max(maxLat - minLat, 0.000001);
+  const pad = 28;
+  const canvasW = 520;
+  const canvasH = 320;
+  const scale = Math.min((canvasW - pad * 2) / width, (canvasH - pad * 2) / height);
+  const offsetX = (canvasW - width * scale) / 2;
+  const offsetY = (canvasH - height * scale) / 2;
+
+  const pathFor = (ring) => ring.map((pair, index) => {
+    const x = offsetX + (Number(pair[0]) - minLon) * scale;
+    const y = canvasH - (offsetY + (Number(pair[1]) - minLat) * scale);
+    return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+  }).join(' ') + ' Z';
+
+  return (
+    <svg className={styles.mapSvg} viewBox={`0 0 ${canvasW} ${canvasH}`} role="img" aria-label="Source-backed parcel and building footprint preview">
+      <rect className={styles.mapBackdrop} x="0" y="0" width={canvasW} height={canvasH} rx="28" />
+      {parcelRings.map((ring, index) => <path className={styles.parcelShape} d={pathFor(ring)} key={`parcel-${index}`} />)}
+      {buildingRings.map((ring, index) => <path className={styles.buildingShape} d={pathFor(ring)} key={`building-${index}`} />)}
+    </svg>
+  );
+}
+
+export default function PropertySpatialIntakePage() {
+  const [token, setToken] = useState('');
+  const [authState, setAuthState] = useState('loading');
+  const [mode, setMode] = useState('sbl');
+  const [parcelKey, setParcelKey] = useState('');
+  const [data, setData] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    let subscription;
+    (async () => {
+      try {
+        const client = await withTimeout(getSupabaseBrowserAsync(), AUTH_TIMEOUT_MS, 'Voxel Vault account setup timed out.');
+        const { data: sessionData } = await withTimeout(client.auth.getSession(), AUTH_TIMEOUT_MS, 'Your owner session check timed out.');
+        const accessToken = sessionData?.session?.access_token || '';
+        if (cancelled) return;
+        if (!accessToken) {
+          setAuthState('signed-out');
+          return;
+        }
+        setToken(accessToken);
+        setAuthState('authenticated');
+        const result = client.auth.onAuthStateChange((_event, session) => {
+          const next = session?.access_token || '';
+          setToken(next);
+          if (!next) {
+            setAuthState('signed-out');
+            setData(null);
+          }
+        });
+        subscription = result?.data?.subscription;
+      } catch (err) {
+        if (!cancelled) {
+          setAuthState('auth-error');
+          setError(err instanceof Error ? err.message : 'Owner authentication could not be loaded.');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      subscription?.unsubscribe?.();
+    };
+  }, []);
+
+  async function loadParcel(event) {
+    event.preventDefault();
+    if (!token) {
+      setError('Owner sign-in is required before loading a parcel.');
+      return;
+    }
+    const key = parcelKey.trim();
+    if (!key) {
+      setError(`Enter an Erie County ${mode.toUpperCase()}.`);
+      return;
+    }
+
+    setBusy(true);
+    setError('');
+    setData(null);
+    try {
+      const params = new URLSearchParams({ [mode]: key });
+      const response = await fetchWithTimeout(`/api/admin/property-platform/erie-county?${params.toString()}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body.ok) throw new Error(body.error || 'The parcel intake could not be loaded.');
+      setData(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'The parcel intake could not be loaded.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const twin = data?.twin;
+  const record = data?.countyRecord;
+  const verification = twin?.verification;
+  const referencePoint = useMemo(() => {
+    const latitude = Number(twin?.location?.latitude);
+    const longitude = Number(twin?.location?.longitude);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return '—';
+    return `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`;
+  }, [twin?.location?.latitude, twin?.location?.longitude]);
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.shell}>
+        <nav className={styles.nav}>
+          <Link className={styles.brand} href="/real-estate"><span>V</span>Voxel Vault</Link>
+          <div className={styles.navLinks}>
+            <Link href="/real-estate">Real estate</Link>
+            <Link href="/admin/digital-reits/live">Live securities</Link>
+          </div>
+        </nav>
+
+        <section className={styles.hero}>
+          <div>
+            <p className={styles.eyebrow}>OWNER SPATIAL INTAKE · ERIE COUNTY, NY</p>
+            <h1>Turn one real parcel into a <em>source-backed Spatial Vault.</em></h1>
+            <p className={styles.lead}>Enter an exact county PIN or SBL. Voxel Vault pulls official parcel geometry and building footprints, records provenance, and keeps legal ownership separate from the map.</p>
+          </div>
+          <div className={styles.heroBadge}>
+            <strong>Reference-first</strong>
+            <span>GIS ≠ deed</span>
+            <span>GIS ≠ legal survey</span>
+            <span>Assessment ≠ market value</span>
+          </div>
+        </section>
+
+        <section className={styles.panel}>
+          <form className={styles.form} onSubmit={loadParcel}>
+            <div className={styles.segmented} aria-label="Parcel identifier type">
+              <button type="button" className={mode === 'sbl' ? styles.activeSegment : ''} onClick={() => { setMode('sbl'); setData(null); }}>SBL</button>
+              <button type="button" className={mode === 'pin' ? styles.activeSegment : ''} onClick={() => { setMode('pin'); setData(null); }}>PIN</button>
+            </div>
+            <label className={styles.field}>
+              <span>Erie County {mode.toUpperCase()}</span>
+              <input value={parcelKey} onChange={(event) => setParcelKey(event.target.value)} placeholder={mode === 'sbl' ? 'Example format: 101.01-1-1' : 'Enter exact county PIN'} autoCapitalize="characters" autoCorrect="off" spellCheck="false" />
+            </label>
+            <button className={styles.primaryButton} disabled={busy || authState !== 'authenticated'} type="submit">
+              {busy ? 'Loading official record…' : 'Load real parcel'}
+            </button>
+          </form>
+
+          <div className={styles.authLine}>
+            <span className={authState === 'authenticated' ? styles.goodDot : styles.neutralDot} />
+            {authState === 'loading' && 'Checking owner session…'}
+            {authState === 'authenticated' && 'Owner session ready · intake stays private/no-store'}
+            {authState === 'signed-out' && 'Sign in with the authorized Voxel Vault owner account first.'}
+            {authState === 'auth-error' && 'Owner authentication needs attention.'}
+          </div>
+          {error && <div className={styles.error}>{error}</div>}
+        </section>
+
+        {data && (
+          <>
+            <section className={styles.truthGrid}>
+              <article><small>GEOGRAPHY</small><strong>{title(verification?.geography)}</strong><span>County parcel ID + polygon + reference coordinates + provenance</span></article>
+              <article><small>PHYSICAL 3D</small><strong>{title(verification?.physical)}</strong><span>Footprint loaded; trusted building height still required</span></article>
+              <article><small>RIGHTS</small><strong>Reference only</strong><span>No deed, title or security interest created by this intake</span></article>
+              <article><small>FULLY VERIFIED</small><strong>{verification?.fullyVerified ? 'Yes' : 'No'}</strong><span>Spatial truth and legal/economic ownership must both pass</span></article>
+            </section>
+
+            <section className={styles.twoColumn}>
+              <article className={styles.mapCard}>
+                <div className={styles.cardHeader}>
+                  <div><p className={styles.eyebrow}>COUNTY GEOMETRY</p><h2>{record?.parcelAddress || twin?.label || 'Erie County parcel'}</h2></div>
+                  <span className={styles.referencePill}>REFERENCE ONLY</span>
+                </div>
+                <ParcelPreview parcelGeometry={twin?.location?.parcelGeometry} buildingGeometry={twin?.structure?.buildingGeometry} />
+                <div className={styles.legend}><span><i className={styles.parcelSwatch} />Parcel polygon</span><span><i className={styles.buildingSwatch} />Building footprint</span></div>
+                <p className={styles.mapNote}>Visual preview uses the county-provided GIS geometry. It is not a legal survey or conveyance boundary.</p>
+              </article>
+
+              <article className={styles.detailsCard}>
+                <p className={styles.eyebrow}>REAL RECORD SNAPSHOT</p>
+                <div className={styles.detailRows}>
+                  <div><span>SBL</span><strong>{record?.sbl || '—'}</strong></div>
+                  <div><span>PIN</span><strong>{record?.pin || '—'}</strong></div>
+                  <div><span>Municipality</span><strong>{record?.municipality || '—'}</strong></div>
+                  <div><span>Reference point</span><strong>{referencePoint}</strong></div>
+                  <div><span>Calculated acres</span><strong>{number(record?.calculatedAcres)}</strong></div>
+                  <div><span>Frontage / depth</span><strong>{number(record?.frontageFt, ' ft')} / {number(record?.depthFt, ' ft')}</strong></div>
+                  <div><span>Year built</span><strong>{record?.yearBuilt || '—'}</strong></div>
+                  <div><span>Living area</span><strong>{number(record?.livingAreaSqFt, ' sq ft')}</strong></div>
+                  <div><span>Building footprints</span><strong>{record?.buildingFootprintCount ?? '—'}</strong></div>
+                </div>
+              </article>
+            </section>
+
+            <section className={styles.financeCard}>
+              <div><p className={styles.eyebrow}>FINANCIAL REFERENCE</p><h2>County assessment stays separate from investment value.</h2></div>
+              <div className={styles.financeNumbers}>
+                <div><small>Total assessed value</small><strong>{money(record?.totalAssessedValueUsd)}</strong></div>
+                <div><small>Land assessed value</small><strong>{money(record?.landAssessedValueUsd)}</strong></div>
+              </div>
+              <p>These are county assessment fields, not a Voxel Vault market valuation, appraisal, sale price, guaranteed value, or promise that the property will appreciate.</p>
+            </section>
+
+            <section className={styles.sourceCard}>
+              <div><p className={styles.eyebrow}>PROVENANCE + NEXT GATES</p><h2>What is real now—and what still has to be proven.</h2></div>
+              <div className={styles.sourceGrid}>
+                <div><strong>Spatial source loaded</strong><span>Erie County parcel polygon, PIN/SBL and tax-record attributes are source-backed.</span></div>
+                <div><strong>Physical height missing</strong><span>We do not invent a building height. A trusted LiDAR/DSM or other authoritative height source comes next.</span></div>
+                <div><strong>Title still separate</strong><span>Book/page references are only leads. Title ownership and liens require title/closing evidence.</span></div>
+                <div><strong>Financial rights still separate</strong><span>No fractional security, LLC membership, deed interest or blockchain ownership is created here.</span></div>
+              </div>
+              <div className={styles.sourceLinks}>
+                <a href={data?.provenance?.parcelLayer} target="_blank" rel="noreferrer">Official parcel layer ↗</a>
+                <a href={data?.provenance?.buildingLayer} target="_blank" rel="noreferrer">Official building layer ↗</a>
+                <a href={data?.provenance?.mappingDisclaimer} target="_blank" rel="noreferrer">County mapping disclaimer ↗</a>
+              </div>
+            </section>
+          </>
+        )}
+
+        <footer className={styles.footer}>Voxel Vault · owner-only spatial intake · no deed/title/blockchain rights are changed by loading a county GIS record.</footer>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/property-spatial-intake/page.module.css
+++ b/app/admin/property-spatial-intake/page.module.css
@@ -1,0 +1,521 @@
+.page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 4%, rgba(126, 249, 205, 0.18), transparent 28%),
+    radial-gradient(circle at 88% 12%, rgba(139, 168, 255, 0.18), transparent 28%),
+    #f4f6f8;
+  color: #111418;
+  padding: 22px;
+}
+
+.shell {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 4px 24px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.brand span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  background: #111418;
+  color: white;
+}
+
+.navLinks {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.navLinks a,
+.sourceLinks a {
+  color: inherit;
+  text-decoration: none;
+  border: 1px solid rgba(17, 20, 24, 0.1);
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 999px;
+  padding: 9px 13px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 26px;
+  align-items: end;
+  padding: 42px;
+  border: 1px solid rgba(17, 20, 24, 0.08);
+  border-radius: 34px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 24px 80px rgba(28, 35, 43, 0.08);
+  backdrop-filter: blur(22px);
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: #65707c;
+}
+
+.hero h1 {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(42px, 6vw, 76px);
+  line-height: 0.95;
+  letter-spacing: -0.065em;
+}
+
+.hero h1 em {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-weight: 500;
+}
+
+.lead {
+  max-width: 760px;
+  margin: 22px 0 0;
+  font-size: 18px;
+  line-height: 1.6;
+  color: #505862;
+}
+
+.heroBadge {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+  background: #111418;
+  color: #f8fafb;
+  border-radius: 24px;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.heroBadge strong {
+  font-size: 18px;
+}
+
+.heroBadge span {
+  color: #b9c2ca;
+  font-size: 13px;
+}
+
+.panel,
+.mapCard,
+.detailsCard,
+.financeCard,
+.sourceCard {
+  margin-top: 18px;
+  border: 1px solid rgba(17, 20, 24, 0.08);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 18px 60px rgba(28, 35, 43, 0.05);
+}
+
+.panel {
+  padding: 22px;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: auto minmax(260px, 1fr) auto;
+  gap: 14px;
+  align-items: end;
+}
+
+.segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 16px;
+  background: #edf0f3;
+}
+
+.segmented button {
+  border: 0;
+  padding: 13px 18px;
+  border-radius: 12px;
+  background: transparent;
+  color: #66707a;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.segmented .activeSegment {
+  background: white;
+  color: #111418;
+  box-shadow: 0 3px 14px rgba(20, 24, 29, 0.09);
+}
+
+.field {
+  display: grid;
+  gap: 7px;
+}
+
+.field span {
+  font-size: 12px;
+  font-weight: 800;
+  color: #5b6570;
+}
+
+.field input {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  border: 1px solid #d9dee4;
+  border-radius: 15px;
+  padding: 14px 15px;
+  background: white;
+  color: #111418;
+  font: inherit;
+  outline: none;
+}
+
+.field input:focus {
+  border-color: #8ba8ff;
+  box-shadow: 0 0 0 4px rgba(139, 168, 255, 0.13);
+}
+
+.primaryButton {
+  border: 0;
+  border-radius: 15px;
+  padding: 15px 20px;
+  background: #111418;
+  color: white;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.primaryButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.authLine {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  color: #65707c;
+  font-size: 12px;
+}
+
+.goodDot,
+.neutralDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #25a66a;
+}
+
+.neutralDot {
+  background: #98a2ad;
+}
+
+.error {
+  margin-top: 14px;
+  border-radius: 14px;
+  background: #fff0f0;
+  border: 1px solid #ffd0d0;
+  color: #9b2c2c;
+  padding: 12px 14px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.truthGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.truthGrid article {
+  min-height: 135px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: space-between;
+  padding: 20px;
+  background: #111418;
+  color: white;
+  border-radius: 24px;
+}
+
+.truthGrid small {
+  color: #97a4af;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.truthGrid strong {
+  font-size: 24px;
+  letter-spacing: -0.04em;
+}
+
+.truthGrid span {
+  color: #b8c1c9;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.twoColumn {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(310px, 0.7fr);
+  gap: 18px;
+}
+
+.mapCard,
+.detailsCard,
+.financeCard,
+.sourceCard {
+  padding: 26px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: start;
+}
+
+.cardHeader h2,
+.financeCard h2,
+.sourceCard h2 {
+  margin: 0;
+  font-size: clamp(25px, 4vw, 38px);
+  letter-spacing: -0.045em;
+}
+
+.referencePill {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #edf0f3;
+  padding: 9px 12px;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+}
+
+.mapSvg {
+  display: block;
+  width: 100%;
+  margin-top: 22px;
+}
+
+.mapBackdrop {
+  fill: #f0f3f5;
+}
+
+.parcelShape {
+  fill: rgba(67, 112, 255, 0.12);
+  stroke: #315ae8;
+  stroke-width: 3;
+  vector-effect: non-scaling-stroke;
+}
+
+.buildingShape {
+  fill: rgba(26, 161, 101, 0.35);
+  stroke: #128155;
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.emptyPreview {
+  display: grid;
+  place-items: center;
+  min-height: 280px;
+  margin-top: 20px;
+  border-radius: 24px;
+  background: #f0f3f5;
+  color: #69737d;
+}
+
+.legend {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  color: #5d6670;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.legend i {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+}
+
+.parcelSwatch {
+  border: 2px solid #315ae8;
+  background: rgba(67, 112, 255, 0.12);
+}
+
+.buildingSwatch {
+  border: 2px solid #128155;
+  background: rgba(26, 161, 101, 0.35);
+}
+
+.mapNote,
+.financeCard > p {
+  color: #66707a;
+  line-height: 1.55;
+  font-size: 13px;
+}
+
+.detailsCard > .eyebrow {
+  margin-bottom: 16px;
+}
+
+.detailRows {
+  display: grid;
+}
+
+.detailRows div {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 12px 0;
+  border-bottom: 1px solid #edf0f2;
+}
+
+.detailRows div:last-child {
+  border-bottom: 0;
+}
+
+.detailRows span {
+  color: #707a84;
+  font-size: 12px;
+}
+
+.detailRows strong {
+  text-align: right;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.financeCard {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 22px 36px;
+  align-items: end;
+}
+
+.financeNumbers {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.financeNumbers div {
+  padding: 16px;
+  border-radius: 18px;
+  background: #f1f4f6;
+}
+
+.financeNumbers small {
+  display: block;
+  margin-bottom: 7px;
+  color: #68727c;
+  font-weight: 800;
+}
+
+.financeNumbers strong {
+  font-size: 24px;
+  letter-spacing: -0.04em;
+}
+
+.financeCard > p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.sourceGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.sourceGrid div {
+  padding: 18px;
+  border-radius: 18px;
+  background: #f1f4f6;
+}
+
+.sourceGrid strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.sourceGrid span {
+  color: #66717b;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.sourceLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.footer {
+  padding: 28px 6px 48px;
+  color: #737d87;
+  font-size: 12px;
+  text-align: center;
+}
+
+@media (max-width: 860px) {
+  .page { padding: 12px; }
+  .hero { grid-template-columns: 1fr; padding: 28px 22px; border-radius: 28px; }
+  .heroBadge { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .heroBadge strong { grid-column: 1 / -1; }
+  .form { grid-template-columns: 1fr; }
+  .truthGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .twoColumn { grid-template-columns: 1fr; }
+  .financeCard { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 560px) {
+  .nav { align-items: flex-start; }
+  .navLinks { justify-content: flex-end; }
+  .navLinks a { padding: 7px 9px; font-size: 11px; }
+  .hero h1 { font-size: 46px; }
+  .heroBadge { grid-template-columns: 1fr; }
+  .truthGrid { grid-template-columns: 1fr; }
+  .sourceGrid { grid-template-columns: 1fr; }
+  .financeNumbers { grid-template-columns: 1fr; }
+  .cardHeader { flex-direction: column; }
+}

--- a/app/api/admin/property-platform/erie-county/route.ts
+++ b/app/api/admin/property-platform/erie-county/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../lib/admin-auth';
+import { fetchErieCountySpatialIntake } from '../../../../../lib/real-estate/erie-county-gis.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: unknown, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'no-store, private' },
+  });
+}
+
+function statusFor(error: unknown) {
+  const code = String((error as { code?: string })?.code || '');
+  if (code === 'INVALID_PARCEL_KEY') return 400;
+  if (code === 'PARCEL_NOT_FOUND') return 404;
+  if (code === 'AMBIGUOUS_PARCEL') return 409;
+  if (code === 'GIS_UNAVAILABLE') return 502;
+  return 500;
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if ('error' in auth) {
+    return response({
+      ok: false,
+      error: auth.error,
+      setupRequired: Boolean(auth.setupRequired),
+    }, auth.status);
+  }
+
+  const url = new URL(request.url);
+  const pin = String(url.searchParams.get('pin') || '').trim();
+  const sbl = String(url.searchParams.get('sbl') || '').trim();
+
+  try {
+    const intake = await fetchErieCountySpatialIntake({ pin, sbl });
+    return response({
+      ...intake,
+      authorized: true,
+      intakeMode: 'owner-only-reference-intake',
+      controls: {
+        canChangeDeed: false,
+        canEstablishTitle: false,
+        canCreatePropertyRights: false,
+        canMintOwnershipInterest: false,
+        humanTitleReviewRequired: true,
+        separateLegalRightsEvidenceRequired: true,
+      },
+      nextStep: 'Review the source-backed spatial record, then add a separate trusted building-height source and separate title/legal-rights evidence before any ownership status can advance beyond REFERENCE ONLY.',
+    });
+  } catch (error) {
+    const status = statusFor(error);
+    return response({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Erie County spatial intake failed.',
+      code: String((error as { code?: string })?.code || 'UNKNOWN_ERROR'),
+      legalEffects: {
+        establishesDeedOwnership: false,
+        establishesTitleStatus: false,
+        createsBlockchainRights: false,
+      },
+    }, status);
+  }
+}

--- a/app/api/property-platform/status/route.ts
+++ b/app/api/property-platform/status/route.ts
@@ -73,6 +73,19 @@ export async function GET() {
         rightsType: 'future deed/entity-linked property rights after title and legal closing',
       },
     },
+    spatialPropertyIntake: {
+      erieCountyNy: {
+        implementationReady: true,
+        access: 'owner-only',
+        sourceType: 'official county parcel and building GIS reference',
+        accepts: ['PIN', 'SBL'],
+        ownerIdentityFieldsReturned: false,
+        legalSurvey: false,
+        establishesTitle: false,
+        establishesOwnershipRights: false,
+        physicalHeightSourceConnected: false,
+      },
+    },
     digitalReits: {
       provider: dinari.provider,
       environment: dinari.environment,
@@ -87,6 +100,8 @@ export async function GET() {
     capabilities: {
       threeDimensionalPropertyTwin: true,
       verifiedSpatialTruthModel: true,
+      authoritativeCountyGisReferenceIntake: true,
+      ownerOnlyParcelLookup: true,
       geographicParcelVerificationGate: true,
       physicalBuildingVerificationGate: true,
       explicitPropertyRightsClassification: true,
@@ -126,12 +141,14 @@ export async function GET() {
       digitalReitStatus: '/api/digital-reits',
       digitalReitSandboxFunding: '/api/digital-reits/sandbox-fund',
       ownerLiveDigitalReitConsole: '/admin/digital-reits/live',
+      ownerErieCountySpatialIntake: '/admin/property-spatial-intake',
+      ownerErieCountySpatialIntakeApi: '/api/admin/property-platform/erie-county',
       propertyVault: '/real-estate/property/[propertyId]',
     },
     note: liveSecuritiesProviderActivated
       ? 'The approved owner-only real-estate securities rail is activated. This does not activate direct deed-linked property investing.'
       : directPropertyInvestingActivated
         ? 'A controlled direct-property launch is active under its separate approved legal/provider gates.'
-        : 'Fail-closed regulated launch build: the real-estate securities execution implementation exists, but provider activation remains separate from direct property ownership. Direct deed-linked investing, automated property acquisition, public pooled investing and mainnet property-token issuance remain disabled until their own verified launch gates pass.',
+        : 'Fail-closed regulated launch build: source-backed spatial parcel intake and the real-estate securities execution implementation exist, but neither county GIS data nor provider readiness creates direct property ownership. Direct deed-linked investing, automated property acquisition, public pooled investing and mainnet property-token issuance remain disabled until their own verified launch gates pass.',
   });
 }

--- a/lib/real-estate/erie-county-gis.js
+++ b/lib/real-estate/erie-county-gis.js
@@ -1,0 +1,324 @@
+import {
+  PROPERTY_RIGHT_TYPES,
+  normalizePropertyTwin,
+} from './property-twin.js';
+
+export const ERIE_COUNTY_PARCEL_LAYER = 'https://gis.erie.gov/server/rest/services/OGIS/Parcels/MapServer/0';
+export const ERIE_COUNTY_BUILDING_LAYER = 'https://gis.erie.gov/server/rest/services/DSM/DSM_Basemap_2025/MapServer/120';
+export const ERIE_COUNTY_MAPPING_DISCLAIMER = 'https://gis.erie.gov/public/HTML5/ErieCountyNY/';
+
+const PARCEL_FIELDS = [
+  'OBJECTID',
+  'GlobalID',
+  'SWIS',
+  'PIN',
+  'SBL',
+  'ADDNAME',
+  'ADDRESS',
+  'LOCALZIP',
+  'CITYTOWN',
+  'FRONT',
+  'DEPTH',
+  'ASSESSACRE',
+  'CALCACRES',
+  'CLASS',
+  'PROP_TYPE',
+  'PROP_DESC',
+  'DEEDATE',
+  'BOOK',
+  'PAGE',
+  'ACTIVE',
+  'TOTAV',
+  'LANDAV',
+  'YEARBLT',
+  'SFLA',
+];
+
+const BUILDING_FIELDS = [
+  'OBJECTID_12',
+  'OBJECTID',
+  'GlobalID',
+  'PIN',
+  'SBL',
+  'ADDNAME',
+  'ADDRESS',
+  'YEARBLT',
+  'SFLA',
+  'DATE_',
+  'EDITEDDATE',
+  'erie_DWQMADMIN_Building_AREA',
+];
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function numberOrNull(value) {
+  if (value === null || value === undefined || clean(value) === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function valueFrom(attributes, ...keys) {
+  for (const key of keys) {
+    if (attributes && attributes[key] !== undefined && attributes[key] !== null) return attributes[key];
+  }
+  return null;
+}
+
+function exactParcelKey(value, label) {
+  const normalized = clean(value).toUpperCase().replace(/\s+/g, '');
+  if (!normalized) return '';
+  if (normalized.length < 3 || normalized.length > 32 || !/^[A-Z0-9.-]+$/.test(normalized)) {
+    throw Object.assign(new Error(`${label} may contain only letters, numbers, periods and hyphens.`), { code: 'INVALID_PARCEL_KEY' });
+  }
+  return normalized;
+}
+
+export function normalizeErieParcelLookup(input = {}) {
+  const pin = exactParcelKey(input.pin, 'PIN');
+  const sbl = exactParcelKey(input.sbl, 'SBL');
+  if ((pin && sbl) || (!pin && !sbl)) {
+    throw Object.assign(new Error('Provide exactly one Erie County parcel key: PIN or SBL.'), { code: 'INVALID_PARCEL_KEY' });
+  }
+  return pin ? { field: 'PIN', value: pin, pin, sbl: '' } : { field: 'SBL', value: sbl, pin: '', sbl };
+}
+
+function queryUrl(layer, field, value, outFields) {
+  const url = new URL(`${layer}/query`);
+  url.searchParams.set('f', 'geojson');
+  url.searchParams.set('where', `${field}='${value}'`);
+  url.searchParams.set('outFields', outFields.join(','));
+  url.searchParams.set('returnGeometry', 'true');
+  url.searchParams.set('outSR', '4326');
+  url.searchParams.set('resultRecordCount', '25');
+  return url.toString();
+}
+
+async function fetchGeoJson(url, fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: { Accept: 'application/geo+json, application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10000),
+    });
+  } catch (error) {
+    throw Object.assign(new Error(`Erie County GIS request failed: ${error instanceof Error ? error.message : 'network error'}`), { code: 'GIS_UNAVAILABLE' });
+  }
+
+  if (!response?.ok) {
+    throw Object.assign(new Error(`Erie County GIS returned HTTP ${response?.status || 'error'}.`), { code: 'GIS_UNAVAILABLE' });
+  }
+
+  const data = await response.json().catch(() => null);
+  if (!data || typeof data !== 'object') {
+    throw Object.assign(new Error('Erie County GIS returned an unreadable response.'), { code: 'GIS_UNAVAILABLE' });
+  }
+  if (data.error) {
+    throw Object.assign(new Error(`Erie County GIS query error: ${clean(data.error.message) || 'unknown ArcGIS error'}`), { code: 'GIS_UNAVAILABLE' });
+  }
+  return data;
+}
+
+function featuresFrom(data) {
+  return Array.isArray(data?.features) ? data.features : [];
+}
+
+function polygonCoordinates(geometry) {
+  if (!geometry || typeof geometry !== 'object') return [];
+  if (geometry.type === 'Polygon' && Array.isArray(geometry.coordinates)) return [geometry.coordinates];
+  if (geometry.type === 'MultiPolygon' && Array.isArray(geometry.coordinates)) return geometry.coordinates;
+  return [];
+}
+
+function combinePolygonFeatures(features) {
+  const polygons = features.flatMap((feature) => polygonCoordinates(feature?.geometry));
+  if (!polygons.length) return null;
+  return polygons.length === 1
+    ? { type: 'Polygon', coordinates: polygons[0] }
+    : { type: 'MultiPolygon', coordinates: polygons };
+}
+
+function collectCoordinatePairs(value, output = []) {
+  if (!Array.isArray(value)) return output;
+  if (value.length >= 2 && Number.isFinite(Number(value[0])) && Number.isFinite(Number(value[1]))) {
+    output.push([Number(value[0]), Number(value[1])]);
+    return output;
+  }
+  for (const child of value) collectCoordinatePairs(child, output);
+  return output;
+}
+
+export function geometryReferencePoint(geometry) {
+  const pairs = collectCoordinatePairs(geometry?.coordinates);
+  if (!pairs.length) return { latitude: null, longitude: null };
+  let minLon = Infinity;
+  let maxLon = -Infinity;
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  for (const [lon, lat] of pairs) {
+    minLon = Math.min(minLon, lon);
+    maxLon = Math.max(maxLon, lon);
+    minLat = Math.min(minLat, lat);
+    maxLat = Math.max(maxLat, lat);
+  }
+  return {
+    latitude: (minLat + maxLat) / 2,
+    longitude: (minLon + maxLon) / 2,
+  };
+}
+
+function sourceRecordId(attributes) {
+  const pin = clean(attributes?.PIN);
+  const sbl = clean(attributes?.SBL);
+  const objectId = clean(valueFrom(attributes, 'OBJECTID', 'OBJECTID_12'));
+  return [pin || sbl || 'parcel', objectId ? `object-${objectId}` : ''].filter(Boolean).join(':');
+}
+
+function isoFromArcGisDate(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return '';
+  try {
+    return new Date(number).toISOString();
+  } catch {
+    return '';
+  }
+}
+
+export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
+  const lookup = normalizeErieParcelLookup(input);
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw Object.assign(new Error('No fetch implementation is available for Erie County GIS.'), { code: 'GIS_UNAVAILABLE' });
+  }
+
+  const observedAt = options.observedAt || new Date().toISOString();
+  const parcelQuery = queryUrl(ERIE_COUNTY_PARCEL_LAYER, lookup.field, lookup.value, PARCEL_FIELDS);
+  const parcelData = await fetchGeoJson(parcelQuery, fetchImpl);
+  const parcelFeatures = featuresFrom(parcelData);
+  if (!parcelFeatures.length) {
+    throw Object.assign(new Error(`No Erie County parcel matched ${lookup.field} ${lookup.value}.`), { code: 'PARCEL_NOT_FOUND' });
+  }
+  if (parcelFeatures.length !== 1) {
+    throw Object.assign(new Error(`Erie County GIS returned ${parcelFeatures.length} parcel matches; exact identity is ambiguous.`), { code: 'AMBIGUOUS_PARCEL' });
+  }
+
+  const parcel = parcelFeatures[0];
+  const attributes = parcel?.properties || {};
+  const pin = clean(attributes.PIN) || lookup.pin;
+  const sbl = clean(attributes.SBL) || lookup.sbl;
+  const canonicalField = pin ? 'PIN' : 'SBL';
+  const canonicalValue = pin || sbl;
+
+  if (!canonicalValue) {
+    throw Object.assign(new Error('Matched Erie County parcel did not include a PIN or SBL.'), { code: 'GIS_UNAVAILABLE' });
+  }
+
+  const buildingQuery = queryUrl(ERIE_COUNTY_BUILDING_LAYER, canonicalField, canonicalValue, BUILDING_FIELDS);
+  const buildingData = await fetchGeoJson(buildingQuery, fetchImpl);
+  const buildingFeatures = featuresFrom(buildingData);
+  const buildingGeometry = combinePolygonFeatures(buildingFeatures);
+  const referencePoint = geometryReferencePoint(parcel?.geometry);
+
+  const buildingEditTimes = buildingFeatures
+    .map((feature) => isoFromArcGisDate(valueFrom(feature?.properties || {}, 'EDITEDDATE', 'DATE_')))
+    .filter(Boolean)
+    .sort();
+  const latestBuildingEdit = buildingEditTimes.at(-1) || '';
+
+  const twin = normalizePropertyTwin({
+    propertyId: `ERIE:${pin || sbl}`,
+    label: clean(attributes.ADDNAME) || clean(attributes.ADDRESS) || `Erie County parcel ${sbl || pin}`,
+    addressLabel: [clean(attributes.ADDRESS) || clean(attributes.ADDNAME), clean(attributes.CITYTOWN), 'NY', clean(attributes.LOCALZIP)].filter(Boolean).join(' · '),
+    identity: {
+      countryCode: 'US',
+      subdivisionCode: 'NY',
+      countyCode: 'ERIE',
+      parcelId: pin || sbl,
+      fingerprint: '',
+    },
+    location: {
+      latitude: referencePoint.latitude,
+      longitude: referencePoint.longitude,
+      parcelGeometry: parcel?.geometry || null,
+      source: {
+        authority: 'Erie County Office of GIS / Real Property Tax Services',
+        recordId: sourceRecordId(attributes),
+        observedAt,
+        sourceUrl: ERIE_COUNTY_PARCEL_LAYER,
+      },
+    },
+    structure: {
+      buildingGeometry,
+      // The county layer exposes footprint, year built and area, but no verified building
+      // height. Leaving height null intentionally prevents a full physical-verification claim.
+      heightMeters: null,
+      floors: null,
+      grossAreaSqFt: numberOrNull(attributes.SFLA),
+      yearBuilt: numberOrNull(attributes.YEARBLT),
+      source: buildingGeometry ? {
+        authority: 'Erie County Office of GIS — BUILDING layer',
+        recordId: buildingFeatures.map((feature) => sourceRecordId(feature?.properties || {})).join(','),
+        observedAt: latestBuildingEdit || observedAt,
+        sourceUrl: ERIE_COUNTY_BUILDING_LAYER,
+      } : {},
+    },
+    rights: {
+      type: PROPERTY_RIGHT_TYPES.REFERENCE_ONLY,
+    },
+  });
+
+  return {
+    ok: true,
+    lookup,
+    twin,
+    countyRecord: {
+      pin,
+      sbl,
+      swis: clean(attributes.SWIS),
+      parcelAddress: clean(attributes.ADDRESS) || clean(attributes.ADDNAME),
+      municipality: clean(attributes.CITYTOWN),
+      zip: clean(attributes.LOCALZIP),
+      propertyClass: clean(attributes.CLASS),
+      propertyType: clean(attributes.PROP_TYPE),
+      propertyDescription: clean(attributes.PROP_DESC),
+      frontageFt: numberOrNull(attributes.FRONT),
+      depthFt: numberOrNull(attributes.DEPTH),
+      assessedAcres: numberOrNull(attributes.ASSESSACRE),
+      calculatedAcres: numberOrNull(attributes.CALCACRES),
+      totalAssessedValueUsd: numberOrNull(attributes.TOTAV),
+      landAssessedValueUsd: numberOrNull(attributes.LANDAV),
+      yearBuilt: numberOrNull(attributes.YEARBLT),
+      livingAreaSqFt: numberOrNull(attributes.SFLA),
+      deedDateReference: clean(attributes.DEEDATE),
+      deedBookReference: clean(attributes.BOOK),
+      deedPageReference: clean(attributes.PAGE),
+      activeFlag: clean(attributes.ACTIVE),
+      buildingFootprintCount: buildingFeatures.length,
+    },
+    provenance: {
+      observedAt,
+      parcelLayer: ERIE_COUNTY_PARCEL_LAYER,
+      buildingLayer: ERIE_COUNTY_BUILDING_LAYER,
+      mappingDisclaimer: ERIE_COUNTY_MAPPING_DISCLAIMER,
+      parcelQuery,
+      buildingQuery,
+    },
+    legalEffects: {
+      isLegalSurvey: false,
+      establishesParcelBoundary: false,
+      establishesDeedOwnership: false,
+      establishesTitleStatus: false,
+      establishesFractionalSecurityRights: false,
+      createsBlockchainRights: false,
+    },
+    sourceLimitations: [
+      'Erie County GIS is used as a source-backed spatial and tax-record reference, not as a legal survey.',
+      'Displayed coordinates and parcel polygons do not establish legal parcel corners or conveyance boundaries.',
+      'Assessed values are not treated as market valuations or guaranteed investment values.',
+      'Deed book/page fields are reference leads only; title ownership and encumbrances require authoritative closing/title evidence.',
+      'Building footprint data does not include a verified height, so full physical 3D verification remains incomplete.',
+    ],
+  };
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:liquidity-engine": "node scripts/test-liquidity-engine-safety.mjs",
     "test:multipair": "node scripts/test-multipair-profit-engine.mjs",
     "test:ai-licensing": "node scripts/test-ai-licensing.mjs",
-    "test:property-platform": "node scripts/test-property-platform-safety.mjs",
+    "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:global-rent": "node scripts/test-global-rent-engine.mjs",
     "test:fractional-compound": "node scripts/test-fractional-compound-engine.mjs",

--- a/scripts/test-erie-county-spatial-intake.mjs
+++ b/scripts/test-erie-county-spatial-intake.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import {
+  ERIE_COUNTY_BUILDING_LAYER,
+  ERIE_COUNTY_PARCEL_LAYER,
+  fetchErieCountySpatialIntake,
+  normalizeErieParcelLookup,
+} from '../lib/real-estate/erie-county-gis.js';
+
+const parcelGeometry = {
+  type: 'Polygon',
+  coordinates: [[
+    [-78.8800, 42.8850],
+    [-78.8780, 42.8850],
+    [-78.8780, 42.8870],
+    [-78.8800, 42.8870],
+    [-78.8800, 42.8850],
+  ]],
+};
+
+const buildingGeometry = {
+  type: 'Polygon',
+  coordinates: [[
+    [-78.8795, 42.8855],
+    [-78.8787, 42.8855],
+    [-78.8787, 42.8864],
+    [-78.8795, 42.8864],
+    [-78.8795, 42.8855],
+  ]],
+};
+
+const calls = [];
+const mockFetch = async (url) => {
+  calls.push(String(url));
+  if (String(url).startsWith(`${ERIE_COUNTY_PARCEL_LAYER}/query`)) {
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: parcelGeometry,
+            properties: {
+              OBJECTID: 1001,
+              GlobalID: 'parcel-guid',
+              SWIS: '140200',
+              PIN: '140200-101-01-001.000',
+              SBL: '101.01-1-1',
+              ADDNAME: '10 TEST STREET',
+              ADDRESS: '10 TEST STREET',
+              LOCALZIP: '14202',
+              CITYTOWN: 'BUFFALO',
+              FRONT: 40,
+              DEPTH: 110,
+              ASSESSACRE: 0.1,
+              CALCACRES: 0.101,
+              CLASS: '210',
+              PROP_TYPE: 'Residential',
+              PROP_DESC: 'One family residence',
+              DEEDATE: '2024-01-15',
+              BOOK: '9999',
+              PAGE: '123',
+              ACTIVE: 'A',
+              TOTAV: 150000,
+              LANDAV: 18000,
+              YEARBLT: 1920,
+              SFLA: 1650,
+              OWNER1: 'SHOULD NOT LEAK',
+              OWNER2: 'ALSO SHOULD NOT LEAK',
+              MAILADDR: 'PRIVATE MAILING ADDRESS',
+            },
+          }],
+        };
+      },
+    };
+  }
+
+  if (String(url).startsWith(`${ERIE_COUNTY_BUILDING_LAYER}/query`)) {
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: buildingGeometry,
+            properties: {
+              OBJECTID_12: 501,
+              PIN: '140200-101-01-001.000',
+              SBL: '101.01-1-1',
+              ADDRESS: '10 TEST STREET',
+              YEARBLT: 1920,
+              SFLA: 1650,
+              EDITEDDATE: Date.parse('2026-05-01T12:00:00Z'),
+              erie_DWQMADMIN_Building_AREA: 1200,
+            },
+          }],
+        };
+      },
+    };
+  }
+
+  throw new Error(`Unexpected outbound URL in test: ${url}`);
+};
+
+assert.deepEqual(
+  normalizeErieParcelLookup({ sbl: '101.01-1-1' }),
+  { field: 'SBL', value: '101.01-1-1', pin: '', sbl: '101.01-1-1' },
+  'SBL should normalize into an exact controlled lookup'
+);
+assert.throws(
+  () => normalizeErieParcelLookup({ pin: "1' OR '1'='1" }),
+  /only letters, numbers, periods and hyphens/,
+  'SQL-like input must be rejected before an ArcGIS where clause is built'
+);
+assert.throws(
+  () => normalizeErieParcelLookup({ pin: 'A-1', sbl: 'B-2' }),
+  /exactly one Erie County parcel key/,
+  'callers cannot provide competing parcel keys'
+);
+
+const result = await fetchErieCountySpatialIntake(
+  { sbl: '101.01-1-1' },
+  { fetchImpl: mockFetch, observedAt: '2026-08-28T12:30:00Z' }
+);
+
+assert.equal(calls.length, 2, 'intake should make exactly one parcel query and one building query');
+assert.ok(calls[0].startsWith(`${ERIE_COUNTY_PARCEL_LAYER}/query?`), 'parcel query must use the allowlisted official parcel layer');
+assert.ok(calls[1].startsWith(`${ERIE_COUNTY_BUILDING_LAYER}/query?`), 'building query must use the allowlisted official building layer');
+
+const parcelQuery = new URL(calls[0]);
+const buildingQuery = new URL(calls[1]);
+assert.equal(parcelQuery.searchParams.get('where'), "SBL='101.01-1-1'");
+assert.equal(parcelQuery.searchParams.get('outSR'), '4326');
+assert.equal(parcelQuery.searchParams.get('f'), 'geojson');
+assert.equal(buildingQuery.searchParams.get('where'), "PIN='140200-101-01-001.000'", 'building lookup should prefer the county-returned canonical PIN');
+assert.equal(buildingQuery.searchParams.get('outSR'), '4326');
+
+assert.equal(result.ok, true);
+assert.equal(result.countyRecord.sbl, '101.01-1-1');
+assert.equal(result.countyRecord.pin, '140200-101-01-001.000');
+assert.equal(result.countyRecord.totalAssessedValueUsd, 150000);
+assert.equal(result.countyRecord.landAssessedValueUsd, 18000);
+assert.equal(result.countyRecord.yearBuilt, 1920);
+assert.equal(result.countyRecord.livingAreaSqFt, 1650);
+assert.equal(result.countyRecord.buildingFootprintCount, 1);
+assert.equal(result.twin.location.parcelGeometry.type, 'Polygon');
+assert.equal(result.twin.structure.buildingGeometry.type, 'Polygon');
+assert.equal(result.twin.structure.heightMeters, null, 'height must remain unknown rather than inferred');
+assert.equal(result.twin.rights.type, 'reference_only');
+assert.equal(result.twin.verification.geography, 'verified', 'source-backed county parcel geometry may pass the platform geographic truth layer');
+assert.equal(result.twin.verification.physical, 'partial', 'county footprint without authoritative height must not pass physical 3D verification');
+assert.equal(result.twin.verification.rights, 'unverified');
+assert.equal(result.twin.verification.fullyVerified, false);
+
+assert.ok(Object.values(result.legalEffects).every((value) => value === false), 'GIS intake must create no legal/title/blockchain rights');
+assert.match(result.sourceLimitations.join(' '), /not as a legal survey/i);
+assert.match(result.sourceLimitations.join(' '), /not treated as market valuations/i);
+assert.match(result.sourceLimitations.join(' '), /title ownership and encumbrances require authoritative closing\/title evidence/i);
+
+const serialized = JSON.stringify(result);
+assert.equal(serialized.includes('SHOULD NOT LEAK'), false, 'county owner names must not be returned by the intake adapter');
+assert.equal(serialized.includes('PRIVATE MAILING ADDRESS'), false, 'county owner mailing details must not be returned by the intake adapter');
+assert.equal(parcelQuery.searchParams.get('outFields').includes('OWNER1'), false, 'owner identity fields should not even be requested from the county layer');
+assert.equal(parcelQuery.searchParams.get('outFields').includes('MAIL'), false, 'mailing fields should not be requested from the county layer');
+
+console.log('Erie County spatial intake safety checks passed: official allowlisted GIS layers only, exact parcel-key validation, source-backed geography, partial physical truth without invented height, reference-only rights, no owner mailing data, and no legal/title effect.');


### PR DESCRIPTION
## What this adds

- Adds an owner-only Erie County, NY parcel intake flow using exact PIN or SBL identifiers.
- Pulls source-backed county parcel polygons and building footprints from official Erie County GIS services.
- Feeds the result through Voxel Vault's spatial truth model while keeping legal/economic rights `REFERENCE ONLY`.
- Adds a private owner console at `/admin/property-spatial-intake` with parcel/footprint preview, county assessment fields, provenance links, and separate geography / physical / rights truth states.
- Adds a private no-store API at `/api/admin/property-platform/erie-county` protected by the existing Voxel Vault admin allowlist.
- Adds regression tests with mocked GIS responses so CI never depends on the live county service.
- Updates the platform status endpoint to expose the owner spatial-intake capability separately from direct-property investing.

## Safety and truth boundaries

- County GIS is treated as a source-backed spatial/tax-record reference, not a legal survey or conveyance boundary.
- The adapter does not request or return owner identity or mailing-address fields.
- County assessed value is not treated as market value, appraisal value, guaranteed value, or expected appreciation.
- Building footprint is accepted, but building height is deliberately left unknown; full physical 3D verification therefore remains incomplete.
- Loading a parcel creates no deed ownership, title status, fractional security rights, LLC membership rights, or blockchain ownership rights.
- Direct-property investing, automated acquisition, pooled public investing and mainnet property-token issuance remain fail-closed.

## Next milestone

Use one real Erie County PIN/SBL in the owner console, then add a trusted height/elevation source and a completely separate title/legal-rights evidence workflow before any property can advance beyond `REFERENCE ONLY`.