### PR TITLE
Attach authoritative NYS LiDAR coverage to 618 Main

### DIFF
--- a/app/real-estate/property/erie-618-main/page.js
+++ b/app/real-estate/property/erie-618-main/page.js
@@ -3,6 +3,10 @@ import {
   FIRST_REAL_ERIE_PARCEL,
   fetchFirstRealErieParcel,
 } from '../../../../lib/real-estate/erie-county-evidence.js';
+import {
+  NYS_ERIE_LIDAR_INDEX_LAYER,
+  fetchNysErieLidarCoverage,
+} from '../../../../lib/real-estate/nys-lidar-evidence.js';
 import styles from './page.module.css';
 
 export const dynamic = 'force-dynamic';
@@ -67,9 +71,19 @@ function money(value) {
 
 export default async function FirstRealErieParcelPage() {
   let evidence;
+  let lidarEvidence;
   let error = '';
+  let lidarError = '';
   try {
     evidence = await fetchFirstRealErieParcel();
+    try {
+      lidarEvidence = await fetchNysErieLidarCoverage({
+        latitude: evidence?.twin?.location?.latitude,
+        longitude: evidence?.twin?.location?.longitude,
+      });
+    } catch (err) {
+      lidarError = err instanceof Error ? err.message : 'NYS LiDAR coverage could not be loaded.';
+    }
   } catch (err) {
     error = err instanceof Error ? err.message : 'Erie County evidence could not be loaded.';
   }
@@ -77,6 +91,8 @@ export default async function FirstRealErieParcelPage() {
   const twin = evidence?.twin;
   const record = evidence?.countyRecord;
   const labels = evidence?.truthLabels;
+  const lidarCovered = lidarEvidence?.coverageStatus === 'covered';
+  const lidarTileNames = lidarEvidence?.tiles?.map((tile) => tile.filename).filter(Boolean) || [];
 
   return (
     <main className={styles.page}>
@@ -90,16 +106,17 @@ export default async function FirstRealErieParcelPage() {
           <article className={styles.heroCard}>
             <p className={styles.eyebrow}>FIRST REAL PARCEL · ERIE COUNTY, NEW YORK</p>
             <h1>618 Main Street.<br /><em>Evidence before ownership.</em></h1>
-            <p className={styles.lead}>This page does not use the generic house model. It loads the exact County SBL from Erie County GIS at request time and renders only the parcel and building geometry the county actually returns.</p>
+            <p className={styles.lead}>This page does not use the generic house model. It loads the exact County SBL from Erie County GIS at request time, renders only the parcel and building geometry the county returns, and separately checks New York State&apos;s authoritative LiDAR tile index.</p>
           </article>
           <aside className={styles.statusCard}>
             <div>
               <p className={styles.eyebrow}>FORCING FUNCTION</p>
-              <strong>{error ? 'EVIDENCE UNAVAILABLE' : 'LIVE COUNTY EVIDENCE'}</strong>
+              <strong>{error ? 'EVIDENCE UNAVAILABLE' : 'LIVE SOURCE EVIDENCE'}</strong>
             </div>
             <div className={styles.statusList}>
               <span>COUNTY SBL · {FIRST_REAL_ERIE_PARCEL.countySbl}</span>
               <span>PIN · {FIRST_REAL_ERIE_PARCEL.pin}</span>
+              <span>LIDAR · {lidarCovered ? 'COVERAGE FOUND' : lidarError ? 'SOURCE UNAVAILABLE' : 'NO COVERAGE FOUND'}</span>
               <span>RIGHTS · REFERENCE ONLY</span>
             </div>
           </aside>
@@ -113,9 +130,9 @@ export default async function FirstRealErieParcelPage() {
           <>
             <section className={styles.truthGrid} aria-label="Spatial truth status">
               <article><small>GEOGRAPHY</small><strong>{labels?.geography}</strong><span>Exact parcel ID, coordinates, polygon and source lineage must all pass.</span></article>
-              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>County footprint is present; measured building height is still absent.</span></article>
-              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification stays false until measured height is attached.</span></article>
-              <article><small>OWNERSHIP</small><strong>{labels?.ownership}</strong><span>County GIS does not establish deed, title, LLC membership or investment rights.</span></article>
+              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>{lidarCovered ? 'County footprint and NYS LiDAR coverage are present; building height is not measured yet.' : 'County footprint is present; measured building height is still absent.'}</span></article>
+              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification stays false until a defensible roof-minus-ground height is derived.</span></article>
+              <article><small>OWNERSHIP</small><strong>{labels?.ownership}</strong><span>County GIS and LiDAR do not establish deed, title, LLC membership or investment rights.</span></article>
             </section>
 
             <section className={styles.twoCol}>
@@ -125,7 +142,7 @@ export default async function FirstRealErieParcelPage() {
                   <span className={styles.pill}>REFERENCE ONLY</span>
                 </div>
                 <EvidenceMap parcelGeometry={twin?.location?.parcelGeometry} buildingGeometry={twin?.structure?.buildingGeometry} />
-                <p className={styles.note}>The drawing is generated from the returned county GeoJSON. It is a GIS reference, not a legal survey or conveyance boundary.</p>
+                <p className={styles.note}>The drawing is generated from the returned county GeoJSON. It is a GIS reference, not a legal survey or conveyance boundary. No fake 3D extrusion is rendered while measured height remains absent.</p>
               </article>
 
               <article className={styles.panel}>
@@ -137,11 +154,14 @@ export default async function FirstRealErieParcelPage() {
                   <div><span>Municipality</span><strong>{record?.municipality || '—'}</strong></div>
                   <div><span>Reference point</span><strong>{Number(twin?.location?.latitude).toFixed(6)}, {Number(twin?.location?.longitude).toFixed(6)}</strong></div>
                   <div><span>Building footprints</span><strong>{record?.buildingFootprintCount ?? '—'}</strong></div>
+                  <div><span>NYS LiDAR coverage</span><strong>{lidarCovered ? 'FOUND' : lidarError ? 'UNAVAILABLE' : 'NOT FOUND'}</strong></div>
+                  <div><span>LAS tiles</span><strong>{lidarEvidence?.tiles?.length ?? '—'}</strong></div>
                   <div><span>Year built</span><strong>{record?.yearBuilt || '—'}</strong></div>
                   <div><span>Living area</span><strong>{record?.livingAreaSqFt ? `${record.livingAreaSqFt.toLocaleString()} sq ft` : '—'}</strong></div>
                   <div><span>County assessment</span><strong>{money(record?.totalAssessedValueUsd)}</strong></div>
                   <div><span>Height state</span><strong>{twin?.verification?.heightStatus || 'missing'}</strong></div>
                 </div>
+                {lidarError ? <p className={styles.note}>LiDAR check failed closed for this request: {lidarError}</p> : null}
               </article>
             </section>
 
@@ -153,20 +173,23 @@ export default async function FirstRealErieParcelPage() {
               <div className={styles.sourceGrid}>
                 <div><strong>Parcel identity + polygon</strong><span>{twin?.location?.source?.authority} · record {twin?.location?.source?.recordId}</span></div>
                 <div><strong>Building footprint</strong><span>{twin?.structure?.source?.authority} · record {twin?.structure?.source?.recordId}</span></div>
+                <div><strong>NYS LiDAR coverage</strong><span>{lidarCovered ? `${lidarEvidence?.source?.authority} · ${lidarTileNames.join(', ') || `${lidarEvidence?.tiles?.length || 0} tile(s)`}` : lidarError || 'No intersecting source tile was returned.'}</span></div>
                 <div><strong>Measured height</strong><span>{twin?.structure?.heightUnavailableReason}</span></div>
                 <div><strong>Legal rights</strong><span>Ownership remains unverified and the rights type remains REFERENCE ONLY.</span></div>
               </div>
               <div className={styles.links}>
                 <a href={evidence?.provenance?.parcelLayer} target="_blank" rel="noreferrer">Erie parcel layer ↗</a>
                 <a href={evidence?.provenance?.buildingLayer} target="_blank" rel="noreferrer">Erie building layer ↗</a>
+                <a href={NYS_ERIE_LIDAR_INDEX_LAYER} target="_blank" rel="noreferrer">NYS LiDAR index ↗</a>
                 <a href={FIRST_REAL_ERIE_PARCEL.identifierSourceUrl} target="_blank" rel="noreferrer">Buffalo identifier source ↗</a>
               </div>
               <p className={styles.note}>Identifier reconciliation: Erie County GIS returns SBL {FIRST_REAL_ERIE_PARCEL.countySbl}; the City schedule stores the same parcel as raw SBL {FIRST_REAL_ERIE_PARCEL.cityScheduleRawSbl}. Both use PIN {FIRST_REAL_ERIE_PARCEL.pin}. The County-formatted SBL is the runtime geometry lookup key.</p>
+              <p className={styles.note}>LiDAR tile discovery proves authoritative point-cloud coverage only. Voxel Vault will not mark height as measured until roof samples inside the official footprint are compared with a defensible ground reference and the method, source tile and uncertainty are retained.</p>
             </section>
           </>
         )}
 
-        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography may verify, physical truth remains partial until measured height exists, ownership remains unverified.</footer>
+        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography may verify, LiDAR coverage may verify, physical truth remains partial until measured height exists, ownership remains unverified.</footer>
       </div>
     </main>
   );

--- a/lib/real-estate/nys-lidar-evidence.js
+++ b/lib/real-estate/nys-lidar-evidence.js
@@ -1,5 +1,6 @@
-export const NYS_ERIE_LIDAR_INDEX_LAYER = 'https://elevation.its.ny.gov/arcgis/rest/services/LAS_Indexes/FeatureServer/6';
+export const NYS_LIDAR_INDEX_SERVICE = 'https://elevation.its.ny.gov/arcgis/rest/services/LAS_Indexes/FeatureServer';
 export const NYS_ERIE_LIDAR_COLLECTION = 'NYS - Erie, Genesee, Livingston 2019';
+export const NYS_ERIE_LIDAR_INDEX_LAYER = `${NYS_LIDAR_INDEX_SERVICE}/7`;
 
 function clean(value) {
   return String(value ?? '').trim();
@@ -17,23 +18,6 @@ function finiteCoordinate(value, label, min, max) {
     throw Object.assign(new Error(`${label} must be a finite coordinate between ${min} and ${max}.`), { code: 'INVALID_LIDAR_POINT' });
   }
   return number;
-}
-
-export function buildNysErieLidarCoverageQuery(point = {}) {
-  const latitude = finiteCoordinate(point.latitude, 'Latitude', -90, 90);
-  const longitude = finiteCoordinate(point.longitude, 'Longitude', -180, 180);
-
-  const url = new URL(`${NYS_ERIE_LIDAR_INDEX_LAYER}/query`);
-  url.searchParams.set('f', 'json');
-  url.searchParams.set('where', '1=1');
-  url.searchParams.set('geometry', `${longitude},${latitude}`);
-  url.searchParams.set('geometryType', 'esriGeometryPoint');
-  url.searchParams.set('inSR', '4326');
-  url.searchParams.set('spatialRel', 'esriSpatialRelIntersects');
-  url.searchParams.set('outFields', 'OBJECTID,FILENAME,SIZE_GB,COLLECTION,DIRECT_DL,FTP_PATH');
-  url.searchParams.set('returnGeometry', 'false');
-  url.searchParams.set('resultRecordCount', '10');
-  return url.toString();
 }
 
 async function fetchJson(url, fetchImpl, timeoutMs) {
@@ -62,6 +46,51 @@ async function fetchJson(url, fetchImpl, timeoutMs) {
   return body;
 }
 
+export async function discoverNysErieLidarLayer(fetchImpl = globalThis.fetch, timeoutMs = 10000) {
+  if (typeof fetchImpl !== 'function') {
+    throw Object.assign(new Error('No fetch implementation is available for the NYS LiDAR index.'), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+
+  const serviceUrl = new URL(NYS_LIDAR_INDEX_SERVICE);
+  serviceUrl.searchParams.set('f', 'json');
+  const service = await fetchJson(serviceUrl.toString(), fetchImpl, timeoutMs);
+  const layers = Array.isArray(service.layers) ? service.layers : [];
+  const matches = layers.filter((layer) => clean(layer?.name) === NYS_ERIE_LIDAR_COLLECTION);
+
+  if (matches.length !== 1 || !Number.isInteger(Number(matches[0]?.id))) {
+    throw Object.assign(
+      new Error(`NYS LiDAR index must expose exactly one layer named "${NYS_ERIE_LIDAR_COLLECTION}"; found ${matches.length}.`),
+      { code: 'LIDAR_COLLECTION_NOT_FOUND' },
+    );
+  }
+
+  const layerId = Number(matches[0].id);
+  return {
+    id: layerId,
+    name: clean(matches[0].name),
+    geometryType: clean(matches[0].geometryType),
+    layerUrl: `${NYS_LIDAR_INDEX_SERVICE}/${layerId}`,
+    serviceUrl: NYS_LIDAR_INDEX_SERVICE,
+  };
+}
+
+export function buildNysErieLidarCoverageQuery(point = {}, layerUrl = NYS_ERIE_LIDAR_INDEX_LAYER) {
+  const latitude = finiteCoordinate(point.latitude, 'Latitude', -90, 90);
+  const longitude = finiteCoordinate(point.longitude, 'Longitude', -180, 180);
+
+  const url = new URL(`${layerUrl}/query`);
+  url.searchParams.set('f', 'json');
+  url.searchParams.set('where', '1=1');
+  url.searchParams.set('geometry', `${longitude},${latitude}`);
+  url.searchParams.set('geometryType', 'esriGeometryPoint');
+  url.searchParams.set('inSR', '4326');
+  url.searchParams.set('spatialRel', 'esriSpatialRelIntersects');
+  url.searchParams.set('outFields', 'OBJECTID,FILENAME,SIZE_GB,COLLECTION,DIRECT_DL,FTP_PATH');
+  url.searchParams.set('returnGeometry', 'false');
+  url.searchParams.set('resultRecordCount', '10');
+  return url.toString();
+}
+
 function normalizeTile(feature = {}) {
   const attributes = feature.attributes || feature.properties || {};
   return {
@@ -83,8 +112,18 @@ export async function fetchNysErieLidarCoverage(point = {}, options = {}) {
   const latitude = finiteCoordinate(point.latitude, 'Latitude', -90, 90);
   const longitude = finiteCoordinate(point.longitude, 'Longitude', -180, 180);
   const observedAt = options.observedAt || new Date().toISOString();
-  const queryUrl = buildNysErieLidarCoverageQuery({ latitude, longitude });
-  const body = await fetchJson(queryUrl, fetchImpl, options.timeoutMs || 10000);
+  const timeoutMs = options.timeoutMs || 10000;
+
+  // The state periodically republishes this FeatureServer and layer IDs can shift. Resolve the
+  // authoritative collection by its exact official name on every live evidence read instead of
+  // silently trusting a stale numeric layer ID. This caught the July 2026 move from layer 6 to 7.
+  const resolvedLayer = await discoverNysErieLidarLayer(fetchImpl, timeoutMs);
+  if (resolvedLayer.geometryType && resolvedLayer.geometryType !== 'esriGeometryPolygon') {
+    throw Object.assign(new Error(`NYS LiDAR collection has unexpected geometry type ${resolvedLayer.geometryType}.`), { code: 'LIDAR_COLLECTION_INVALID' });
+  }
+
+  const queryUrl = buildNysErieLidarCoverageQuery({ latitude, longitude }, resolvedLayer.layerUrl);
+  const body = await fetchJson(queryUrl, fetchImpl, timeoutMs);
   const features = Array.isArray(body.features) ? body.features : [];
   const tiles = features.map(normalizeTile).filter((tile) => tile.filename || tile.directDownloadUrl || tile.ftpPath);
 
@@ -93,6 +132,7 @@ export async function fetchNysErieLidarCoverage(point = {}, options = {}) {
     coverageStatus: tiles.length ? 'covered' : 'not_covered',
     point: { latitude, longitude },
     collection: NYS_ERIE_LIDAR_COLLECTION,
+    resolvedLayer,
     tiles,
     // Discovering an authoritative LAS tile is evidence of LiDAR coverage only. It does not
     // become a building-height measurement until point-cloud samples are actually processed
@@ -103,11 +143,14 @@ export async function fetchNysErieLidarCoverage(point = {}, options = {}) {
     source: {
       authority: 'New York State ITS Geospatial Services',
       observedAt,
-      sourceUrl: NYS_ERIE_LIDAR_INDEX_LAYER,
+      sourceUrl: resolvedLayer.layerUrl,
     },
     provenance: {
       queryUrl,
-      layer: NYS_ERIE_LIDAR_INDEX_LAYER,
+      service: NYS_LIDAR_INDEX_SERVICE,
+      resolvedLayerId: resolvedLayer.id,
+      resolvedLayerName: resolvedLayer.name,
+      layer: resolvedLayer.layerUrl,
       collection: NYS_ERIE_LIDAR_COLLECTION,
     },
     legalEffects: {

--- a/lib/real-estate/nys-lidar-evidence.js
+++ b/lib/real-estate/nys-lidar-evidence.js
@@ -1,0 +1,120 @@
+export const NYS_ERIE_LIDAR_INDEX_LAYER = 'https://elevation.its.ny.gov/arcgis/rest/services/LAS_Indexes/FeatureServer/6';
+export const NYS_ERIE_LIDAR_COLLECTION = 'NYS - Erie, Genesee, Livingston 2019';
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function numberOrNull(value) {
+  if (value === null || value === undefined || clean(value) === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function finiteCoordinate(value, label, min, max) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < min || number > max) {
+    throw Object.assign(new Error(`${label} must be a finite coordinate between ${min} and ${max}.`), { code: 'INVALID_LIDAR_POINT' });
+  }
+  return number;
+}
+
+export function buildNysErieLidarCoverageQuery(point = {}) {
+  const latitude = finiteCoordinate(point.latitude, 'Latitude', -90, 90);
+  const longitude = finiteCoordinate(point.longitude, 'Longitude', -180, 180);
+
+  const url = new URL(`${NYS_ERIE_LIDAR_INDEX_LAYER}/query`);
+  url.searchParams.set('f', 'json');
+  url.searchParams.set('where', '1=1');
+  url.searchParams.set('geometry', `${longitude},${latitude}`);
+  url.searchParams.set('geometryType', 'esriGeometryPoint');
+  url.searchParams.set('inSR', '4326');
+  url.searchParams.set('spatialRel', 'esriSpatialRelIntersects');
+  url.searchParams.set('outFields', 'OBJECTID,FILENAME,SIZE_GB,COLLECTION,DIRECT_DL,FTP_PATH');
+  url.searchParams.set('returnGeometry', 'false');
+  url.searchParams.set('resultRecordCount', '10');
+  return url.toString();
+}
+
+async function fetchJson(url, fetchImpl, timeoutMs) {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw Object.assign(new Error(`NYS LiDAR index request failed: ${error instanceof Error ? error.message : 'network error'}`), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+
+  if (!response?.ok) {
+    throw Object.assign(new Error(`NYS LiDAR index returned HTTP ${response?.status || 'error'}.`), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+
+  const body = await response.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    throw Object.assign(new Error('NYS LiDAR index returned an unreadable response.'), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+  if (body.error) {
+    throw Object.assign(new Error(`NYS LiDAR index query error: ${clean(body.error.message) || 'unknown ArcGIS error'}`), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+  return body;
+}
+
+function normalizeTile(feature = {}) {
+  const attributes = feature.attributes || feature.properties || {};
+  return {
+    objectId: clean(attributes.OBJECTID),
+    filename: clean(attributes.FILENAME),
+    sizeGb: numberOrNull(attributes.SIZE_GB),
+    collection: clean(attributes.COLLECTION) || NYS_ERIE_LIDAR_COLLECTION,
+    directDownloadUrl: clean(attributes.DIRECT_DL),
+    ftpPath: clean(attributes.FTP_PATH),
+  };
+}
+
+export async function fetchNysErieLidarCoverage(point = {}, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw Object.assign(new Error('No fetch implementation is available for the NYS LiDAR index.'), { code: 'LIDAR_INDEX_UNAVAILABLE' });
+  }
+
+  const latitude = finiteCoordinate(point.latitude, 'Latitude', -90, 90);
+  const longitude = finiteCoordinate(point.longitude, 'Longitude', -180, 180);
+  const observedAt = options.observedAt || new Date().toISOString();
+  const queryUrl = buildNysErieLidarCoverageQuery({ latitude, longitude });
+  const body = await fetchJson(queryUrl, fetchImpl, options.timeoutMs || 10000);
+  const features = Array.isArray(body.features) ? body.features : [];
+  const tiles = features.map(normalizeTile).filter((tile) => tile.filename || tile.directDownloadUrl || tile.ftpPath);
+
+  return {
+    ok: true,
+    coverageStatus: tiles.length ? 'covered' : 'not_covered',
+    point: { latitude, longitude },
+    collection: NYS_ERIE_LIDAR_COLLECTION,
+    tiles,
+    // Discovering an authoritative LAS tile is evidence of LiDAR coverage only. It does not
+    // become a building-height measurement until point-cloud samples are actually processed
+    // against the official building footprint and a defensible ground reference.
+    heightMeters: null,
+    measurementStatus: tiles.length ? 'coverage_only' : 'no_coverage',
+    measurementMethod: null,
+    source: {
+      authority: 'New York State ITS Geospatial Services',
+      observedAt,
+      sourceUrl: NYS_ERIE_LIDAR_INDEX_LAYER,
+    },
+    provenance: {
+      queryUrl,
+      layer: NYS_ERIE_LIDAR_INDEX_LAYER,
+      collection: NYS_ERIE_LIDAR_COLLECTION,
+    },
+    legalEffects: {
+      establishesParcelBoundary: false,
+      establishesBuildingHeight: false,
+      establishesDeedOwnership: false,
+      createsBlockchainRights: false,
+    },
+  };
+}

--- a/scripts/test-first-real-erie-parcel-live.mjs
+++ b/scripts/test-first-real-erie-parcel-live.mjs
@@ -5,6 +5,11 @@ import {
 } from '../lib/real-estate/erie-county-evidence.js';
 import { ERIE_COUNTY_PARCEL_LAYER } from '../lib/real-estate/erie-county-gis.js';
 import {
+  NYS_ERIE_LIDAR_COLLECTION,
+  NYS_ERIE_LIDAR_INDEX_LAYER,
+  fetchNysErieLidarCoverage,
+} from '../lib/real-estate/nys-lidar-evidence.js';
+import {
   PROPERTY_RIGHT_TYPES,
   PROPERTY_TRUTH_STATES,
   assertSpatialInvariants,
@@ -36,6 +41,19 @@ async function loadWithRetry() {
   if (lastError?.code === 'PARCEL_NOT_FOUND') {
     const diagnostic = await discoverAddressCandidates().catch((error) => ({ diagnosticError: error instanceof Error ? error.message : String(error) }));
     console.error('ERIE_IDENTIFIER_DIAGNOSTIC', JSON.stringify(diagnostic, null, 2));
+  }
+  throw lastError;
+}
+
+async function loadLidarWithRetry(point) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await fetchNysErieLidarCoverage(point);
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) await new Promise((resolve) => setTimeout(resolve, attempt * 1500));
+    }
   }
   throw lastError;
 }
@@ -83,6 +101,24 @@ assert.ok(twin.structure.source.observedAt, 'building observation time must be p
 assert.ok(provenance?.parcelLayer, 'official parcel layer URL must be retained');
 assert.ok(provenance?.buildingLayer, 'official building layer URL must be retained');
 
+const lidar = await loadLidarWithRetry({
+  latitude: twin.location.latitude,
+  longitude: twin.location.longitude,
+});
+
+assert.equal(lidar.ok, true, 'official NYS LiDAR index query must succeed for 618 Main');
+assert.equal(lidar.collection, NYS_ERIE_LIDAR_COLLECTION, 'the first parcel must use the Erie/Genesee/Livingston 2019 collection');
+assert.equal(lidar.coverageStatus, 'covered', 'the 618 Main reference point must intersect at least one official LAS tile');
+assert.ok(lidar.tiles.length > 0, 'at least one authoritative LAS tile must cover the parcel reference point');
+assert.ok(lidar.tiles.some((tile) => tile.filename), 'covered LAS evidence must include an official filename');
+assert.ok(lidar.tiles.some((tile) => tile.directDownloadUrl || tile.ftpPath), 'covered LAS evidence must retain a downloadable source reference');
+assert.equal(lidar.heightMeters, null, 'LiDAR coverage alone must not be promoted into a measured building height');
+assert.equal(lidar.measurementStatus, 'coverage_only', 'LiDAR must remain coverage-only until point-cloud measurement runs');
+assert.equal(lidar.measurementMethod, null, 'no measurement method may be claimed before LAS processing');
+assert.equal(lidar.legalEffects.establishesBuildingHeight, false, 'tile discovery alone must not establish building height');
+assert.equal(lidar.legalEffects.establishesDeedOwnership, false, 'LiDAR can never establish deed ownership');
+assert.equal(lidar.source.sourceUrl, NYS_ERIE_LIDAR_INDEX_LAYER, 'LiDAR lineage must retain the official NYS index layer');
+
 console.log(JSON.stringify({
   forcingFunction: 'first-real-erie-parcel',
   propertyId: twin.propertyId,
@@ -100,4 +136,12 @@ console.log(JSON.stringify({
   ownership: twin.verification.verifiedOwnership,
   parcelSource: twin.location.source,
   buildingSource: twin.structure.source,
+  lidar: {
+    collection: lidar.collection,
+    coverageStatus: lidar.coverageStatus,
+    measurementStatus: lidar.measurementStatus,
+    tileCount: lidar.tiles.length,
+    tiles: lidar.tiles,
+    source: lidar.source,
+  },
 }, null, 2));

--- a/scripts/test-first-real-erie-parcel-live.mjs
+++ b/scripts/test-first-real-erie-parcel-live.mjs
@@ -6,7 +6,7 @@ import {
 import { ERIE_COUNTY_PARCEL_LAYER } from '../lib/real-estate/erie-county-gis.js';
 import {
   NYS_ERIE_LIDAR_COLLECTION,
-  NYS_ERIE_LIDAR_INDEX_LAYER,
+  NYS_LIDAR_INDEX_SERVICE,
   fetchNysErieLidarCoverage,
 } from '../lib/real-estate/nys-lidar-evidence.js';
 import {
@@ -106,8 +106,19 @@ const lidar = await loadLidarWithRetry({
   longitude: twin.location.longitude,
 });
 
+console.log('LIDAR_COVERAGE_DIAGNOSTIC', JSON.stringify({
+  point: lidar.point,
+  collection: lidar.collection,
+  resolvedLayer: lidar.resolvedLayer,
+  coverageStatus: lidar.coverageStatus,
+  tileCount: lidar.tiles.length,
+  queryUrl: lidar.provenance?.queryUrl,
+}, null, 2));
+
 assert.equal(lidar.ok, true, 'official NYS LiDAR index query must succeed for 618 Main');
 assert.equal(lidar.collection, NYS_ERIE_LIDAR_COLLECTION, 'the first parcel must use the Erie/Genesee/Livingston 2019 collection');
+assert.equal(lidar.resolvedLayer?.name, NYS_ERIE_LIDAR_COLLECTION, 'the live source layer must be resolved by exact official collection name');
+assert.ok(String(lidar.resolvedLayer?.layerUrl || '').startsWith(`${NYS_LIDAR_INDEX_SERVICE}/`), 'resolved LiDAR layer must stay inside the official NYS LAS index service');
 assert.equal(lidar.coverageStatus, 'covered', 'the 618 Main reference point must intersect at least one official LAS tile');
 assert.ok(lidar.tiles.length > 0, 'at least one authoritative LAS tile must cover the parcel reference point');
 assert.ok(lidar.tiles.some((tile) => tile.filename), 'covered LAS evidence must include an official filename');
@@ -117,7 +128,7 @@ assert.equal(lidar.measurementStatus, 'coverage_only', 'LiDAR must remain covera
 assert.equal(lidar.measurementMethod, null, 'no measurement method may be claimed before LAS processing');
 assert.equal(lidar.legalEffects.establishesBuildingHeight, false, 'tile discovery alone must not establish building height');
 assert.equal(lidar.legalEffects.establishesDeedOwnership, false, 'LiDAR can never establish deed ownership');
-assert.equal(lidar.source.sourceUrl, NYS_ERIE_LIDAR_INDEX_LAYER, 'LiDAR lineage must retain the official NYS index layer');
+assert.equal(lidar.source.sourceUrl, lidar.resolvedLayer.layerUrl, 'LiDAR lineage must retain the dynamically resolved official NYS layer');
 
 console.log(JSON.stringify({
   forcingFunction: 'first-real-erie-parcel',
@@ -138,6 +149,7 @@ console.log(JSON.stringify({
   buildingSource: twin.structure.source,
   lidar: {
     collection: lidar.collection,
+    resolvedLayer: lidar.resolvedLayer,
     coverageStatus: lidar.coverageStatus,
     measurementStatus: lidar.measurementStatus,
     tileCount: lidar.tiles.length,


### PR DESCRIPTION
## What this changes
- Adds an authoritative NYS ITS LiDAR tile-index adapter for the Erie/Genesee/Livingston 2019 collection.
- Extends the existing 618 Main forcing-function test so CI must prove the parcel reference point intersects at least one real LAS tile with a downloadable source reference.
- Keeps height deliberately null: tile coverage alone is not treated as a measured building height and cannot upgrade physical verification.
- Preserves the existing ownership boundary: LiDAR evidence never establishes deed/title or blockchain rights.

## Why
The next hard gap for the first real parcel is measured physical height. This PR proves the authoritative point-cloud source exists for the exact parcel before implementing any roof-minus-ground measurement pipeline.

## Truth state after this PR
- Geography: VERIFIED
- Building footprint: source-backed
- NYS LiDAR coverage: must pass live CI
- Height: still unmeasured
- Physical: PARTIAL
- Verified spatial twin: FALSE
- Ownership: NOT VERIFIED / REFERENCE ONLY