### PR TITLE
Fail closed on unjoined Erie building polygons

### DIFF
--- a/app/real-estate/property/erie-618-main/page.js
+++ b/app/real-estate/property/erie-618-main/page.js
@@ -23,11 +23,11 @@ function EvidenceMap({ parcelGeometry, buildingGeometry }) {
   const parcelRings = collectRings(parcelGeometry);
   const buildingRings = collectRings(buildingGeometry);
   const points = [...parcelRings, ...buildingRings].flat();
-  if (!points.length) return <div className={styles.error}>No source geometry is available. The page will not substitute a generic model.</div>;
+  if (!points.length) return <div className={styles.error}>No accepted source geometry is available. The page will not substitute a generic model.</div>;
 
   const lons = points.map((pair) => Number(pair?.[0])).filter(Number.isFinite);
   const lats = points.map((pair) => Number(pair?.[1])).filter(Number.isFinite);
-  if (!lons.length || !lats.length) return <div className={styles.error}>Source geometry could not be rendered.</div>;
+  if (!lons.length || !lats.length) return <div className={styles.error}>Accepted source geometry could not be rendered.</div>;
 
   const minLon = Math.min(...lons);
   const maxLon = Math.max(...lons);
@@ -50,14 +50,21 @@ function EvidenceMap({ parcelGeometry, buildingGeometry }) {
 
   return (
     <>
-      <svg className={styles.mapSvg} viewBox={`0 0 ${canvasW} ${canvasH}`} role="img" aria-label="Official Erie County parcel polygon and building footprint evidence">
+      <svg
+        className={styles.mapSvg}
+        viewBox={`0 0 ${canvasW} ${canvasH}`}
+        role="img"
+        aria-label={buildingRings.length
+          ? 'Official Erie County parcel polygon with accepted parcel-linked building footprint evidence'
+          : 'Official Erie County parcel polygon; no parcel-specific building footprint is currently accepted'}
+      >
         <rect width={canvasW} height={canvasH} rx="24" fill="#f5f3ee" />
         {parcelRings.map((ring, index) => <path key={`parcel-${index}`} d={pathFor(ring)} fill="rgba(17,17,17,.08)" stroke="#111" strokeWidth="4" />)}
         {buildingRings.map((ring, index) => <path key={`building-${index}`} d={pathFor(ring)} fill="rgba(141,139,131,.66)" stroke="#5f5d57" strokeWidth="3" />)}
       </svg>
       <div className={styles.legend}>
         <span><i className={styles.parcelSwatch} />Official parcel polygon</span>
-        <span><i className={styles.buildingSwatch} />Official building footprint</span>
+        {buildingRings.length ? <span><i className={styles.buildingSwatch} />Accepted parcel-linked building footprint</span> : null}
       </div>
     </>
   );
@@ -91,6 +98,8 @@ export default async function FirstRealErieParcelPage() {
   const twin = evidence?.twin;
   const record = evidence?.countyRecord;
   const labels = evidence?.truthLabels;
+  const buildingAccepted = Boolean(twin?.structure?.buildingGeometry && record?.buildingFootprintCount > 0);
+  const buildingCandidateCount = Number(record?.buildingCandidateCount || 0);
   const lidarCovered = lidarEvidence?.coverageStatus === 'covered';
   const lidarTileNames = lidarEvidence?.tiles?.map((tile) => tile.filename).filter(Boolean) || [];
 
@@ -106,7 +115,7 @@ export default async function FirstRealErieParcelPage() {
           <article className={styles.heroCard}>
             <p className={styles.eyebrow}>FIRST REAL PARCEL · ERIE COUNTY, NEW YORK</p>
             <h1>618 Main Street.<br /><em>Evidence before ownership.</em></h1>
-            <p className={styles.lead}>This page does not use the generic house model. It loads the exact County SBL from Erie County GIS at request time, renders only the parcel and building geometry the county returns, and separately checks New York State&apos;s authoritative LiDAR tile index.</p>
+            <p className={styles.lead}>This page loads the exact County SBL from Erie County GIS and accepts only evidence that can be tied defensibly to this parcel. The parcel polygon is source-backed. The County&apos;s spatially intersecting building polygon is currently rejected from the twin because it is not joined to 618 Main&apos;s exact PIN/SBL. New York State LiDAR coverage is tracked separately.</p>
           </article>
           <aside className={styles.statusCard}>
             <div>
@@ -116,6 +125,7 @@ export default async function FirstRealErieParcelPage() {
             <div className={styles.statusList}>
               <span>COUNTY SBL · {FIRST_REAL_ERIE_PARCEL.countySbl}</span>
               <span>PIN · {FIRST_REAL_ERIE_PARCEL.pin}</span>
+              <span>BUILDING · {buildingAccepted ? 'PARCEL-LINKED' : 'FOOTPRINT UNVERIFIED'}</span>
               <span>LIDAR · {lidarCovered ? 'COVERAGE FOUND' : lidarError ? 'SOURCE UNAVAILABLE' : 'NO COVERAGE FOUND'}</span>
               <span>RIGHTS · REFERENCE ONLY</span>
             </div>
@@ -130,19 +140,21 @@ export default async function FirstRealErieParcelPage() {
           <>
             <section className={styles.truthGrid} aria-label="Spatial truth status">
               <article><small>GEOGRAPHY</small><strong>{labels?.geography}</strong><span>Exact parcel ID, coordinates, polygon and source lineage must all pass.</span></article>
-              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>{lidarCovered ? 'County footprint and NYS LiDAR coverage are present; building height is not measured yet.' : 'County footprint is present; measured building height is still absent.'}</span></article>
-              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification stays false until a defensible roof-minus-ground height is derived.</span></article>
+              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>{buildingAccepted ? 'A parcel-linked footprint is accepted, but measured height is still required.' : 'No parcel-specific building footprint is accepted. A broad spatial candidate is retained only for diagnosis, not rendered as the building.'}</span></article>
+              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification requires both defensible parcel-specific building geometry and measured height.</span></article>
               <article><small>OWNERSHIP</small><strong>{labels?.ownership}</strong><span>County GIS and LiDAR do not establish deed, title, LLC membership or investment rights.</span></article>
             </section>
 
             <section className={styles.twoCol}>
               <article className={styles.panel}>
                 <div className={styles.panelHeader}>
-                  <div><p className={styles.eyebrow}>SOURCE GEOMETRY</p><h2>{record?.parcelAddress || twin?.label}</h2></div>
+                  <div><p className={styles.eyebrow}>ACCEPTED SOURCE GEOMETRY</p><h2>{record?.parcelAddress || twin?.label}</h2></div>
                   <span className={styles.pill}>REFERENCE ONLY</span>
                 </div>
                 <EvidenceMap parcelGeometry={twin?.location?.parcelGeometry} buildingGeometry={twin?.structure?.buildingGeometry} />
-                <p className={styles.note}>The drawing is generated from the returned county GeoJSON. It is a GIS reference, not a legal survey or conveyance boundary. No fake 3D extrusion is rendered while measured height remains absent.</p>
+                <p className={styles.note}>{buildingAccepted
+                  ? 'The drawing contains the source-backed parcel and an exact parcel-linked building footprint. It is still a GIS reference, not a legal survey or conveyance boundary.'
+                  : 'Only the exact source-backed parcel polygon is rendered. The County building layer returned a broader spatial candidate without the parcel identifier, so Voxel Vault refuses to draw it as 618 Main. No generic house or fake 3D extrusion is substituted.'}</p>
               </article>
 
               <article className={styles.panel}>
@@ -153,11 +165,13 @@ export default async function FirstRealErieParcelPage() {
                   <div><span>PIN</span><strong>{record?.pin || '—'}</strong></div>
                   <div><span>Municipality</span><strong>{record?.municipality || '—'}</strong></div>
                   <div><span>Reference point</span><strong>{Number(twin?.location?.latitude).toFixed(6)}, {Number(twin?.location?.longitude).toFixed(6)}</strong></div>
-                  <div><span>Building footprints</span><strong>{record?.buildingFootprintCount ?? '—'}</strong></div>
+                  <div><span>Accepted building footprints</span><strong>{record?.buildingFootprintCount ?? '—'}</strong></div>
+                  <div><span>Unverified spatial candidates</span><strong>{record?.buildingCandidateCount ?? '—'}</strong></div>
+                  <div><span>Building match</span><strong>{record?.buildingMatchStrategy || '—'}</strong></div>
                   <div><span>NYS LiDAR coverage</span><strong>{lidarCovered ? 'FOUND' : lidarError ? 'UNAVAILABLE' : 'NOT FOUND'}</strong></div>
                   <div><span>LAS tiles</span><strong>{lidarEvidence?.tiles?.length ?? '—'}</strong></div>
-                  <div><span>Year built</span><strong>{record?.yearBuilt || '—'}</strong></div>
-                  <div><span>Living area</span><strong>{record?.livingAreaSqFt ? `${record.livingAreaSqFt.toLocaleString()} sq ft` : '—'}</strong></div>
+                  <div><span>Year built reference</span><strong>{record?.yearBuilt || '—'}</strong></div>
+                  <div><span>Living area reference</span><strong>{record?.livingAreaSqFt ? `${record.livingAreaSqFt.toLocaleString()} sq ft` : '—'}</strong></div>
                   <div><span>County assessment</span><strong>{money(record?.totalAssessedValueUsd)}</strong></div>
                   <div><span>Height state</span><strong>{twin?.verification?.heightStatus || 'missing'}</strong></div>
                 </div>
@@ -172,24 +186,25 @@ export default async function FirstRealErieParcelPage() {
               </div>
               <div className={styles.sourceGrid}>
                 <div><strong>Parcel identity + polygon</strong><span>{twin?.location?.source?.authority} · record {twin?.location?.source?.recordId}</span></div>
-                <div><strong>Building footprint</strong><span>{twin?.structure?.source?.authority} · record {twin?.structure?.source?.recordId}</span></div>
+                <div><strong>Parcel-specific building footprint</strong><span>{buildingAccepted ? `${twin?.structure?.source?.authority} · record ${twin?.structure?.source?.recordId}` : `Not accepted · ${buildingCandidateCount} spatial candidate${buildingCandidateCount === 1 ? '' : 's'} retained only for diagnosis`}</span></div>
                 <div><strong>NYS LiDAR coverage</strong><span>{lidarCovered ? `${lidarEvidence?.source?.authority} · ${lidarTileNames.join(', ') || `${lidarEvidence?.tiles?.length || 0} tile(s)`}` : lidarError || 'No intersecting source tile was returned.'}</span></div>
                 <div><strong>Measured height</strong><span>{twin?.structure?.heightUnavailableReason}</span></div>
                 <div><strong>Legal rights</strong><span>Ownership remains unverified and the rights type remains REFERENCE ONLY.</span></div>
               </div>
               <div className={styles.links}>
                 <a href={evidence?.provenance?.parcelLayer} target="_blank" rel="noreferrer">Erie parcel layer ↗</a>
-                <a href={evidence?.provenance?.buildingLayer} target="_blank" rel="noreferrer">Erie building layer ↗</a>
+                <a href={evidence?.provenance?.buildingLayer} target="_blank" rel="noreferrer">Erie building source ↗</a>
                 <a href={NYS_ERIE_LIDAR_INDEX_LAYER} target="_blank" rel="noreferrer">NYS LiDAR index ↗</a>
                 <a href={FIRST_REAL_ERIE_PARCEL.identifierSourceUrl} target="_blank" rel="noreferrer">Buffalo identifier source ↗</a>
               </div>
               <p className={styles.note}>Identifier reconciliation: Erie County GIS returns SBL {FIRST_REAL_ERIE_PARCEL.countySbl}; the City schedule stores the same parcel as raw SBL {FIRST_REAL_ERIE_PARCEL.cityScheduleRawSbl}. Both use PIN {FIRST_REAL_ERIE_PARCEL.pin}. The County-formatted SBL is the runtime geometry lookup key.</p>
-              <p className={styles.note}>LiDAR tile discovery proves authoritative point-cloud coverage only. Voxel Vault will not mark height as measured until roof samples inside the official footprint are compared with a defensible ground reference and the method, source tile and uncertainty are retained.</p>
+              <p className={styles.note}>A spatial intersection is not enough to identify a building. The current County candidate is preserved in provenance for investigation but is excluded from the property twin until a parcel-specific geometry relationship can be defended.</p>
+              <p className={styles.note}>LiDAR tile discovery proves authoritative point-cloud coverage only. Voxel Vault will not mark height as measured until accepted building geometry exists and a reproducible roof-versus-ground method passes its quality and uncertainty gates.</p>
             </section>
           </>
         )}
 
-        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography may verify, LiDAR coverage may verify, physical truth remains partial until measured height exists, ownership remains unverified.</footer>
+        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography verified when source checks pass · parcel-specific physical geometry currently unverified · LiDAR coverage separate · ownership unverified.</footer>
       </div>
     </main>
   );

--- a/lib/real-estate/erie-county-gis.js
+++ b/lib/real-estate/erie-county-gis.js
@@ -248,30 +248,32 @@ export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
   }
 
   const buildingAttributeQuery = queryUrl(ERIE_COUNTY_BUILDING_LAYER, canonicalField, canonicalValue, BUILDING_FIELDS);
-  let buildingQuery = buildingAttributeQuery;
-  let buildingMatchStrategy = `${canonicalField.toLowerCase()}-attribute`;
-  let buildingData = await fetchGeoJson(buildingAttributeQuery, fetchImpl);
-  let buildingFeatures = featuresFrom(buildingData);
+  const buildingAttributeData = await fetchGeoJson(buildingAttributeQuery, fetchImpl);
+  const directBuildingFeatures = featuresFrom(buildingAttributeData);
 
-  // Some records in the BUILDING layer do not carry the same joined parcel identifier even
-  // though their official footprint intersects the official parcel polygon. In that case,
-  // use an ArcGIS polygon-intersection query against the already-resolved parcel geometry.
-  // This stays source-to-source and never falls back to a guessed address or generic model.
+  // Only a BUILDING record joined to the exact county-returned PIN/SBL is accepted as this
+  // parcel's source-backed building geometry. A polygon that merely intersects the parcel is
+  // retained as a diagnostic candidate, never promoted into the property twin. This prevents
+  // block-scale or connected-building polygons from masquerading as a parcel-specific footprint.
   let buildingSpatialQuery = '';
-  if (!buildingFeatures.length) {
+  let spatialBuildingCandidates = [];
+  let buildingMatchStrategy = `${canonicalField.toLowerCase()}-attribute`;
+  if (!directBuildingFeatures.length) {
     buildingSpatialQuery = spatialBuildingQueryUrl(ERIE_COUNTY_BUILDING_LAYER, parcel?.geometry, BUILDING_FIELDS);
     if (buildingSpatialQuery) {
-      buildingData = await fetchGeoJson(buildingSpatialQuery, fetchImpl);
-      buildingFeatures = featuresFrom(buildingData);
-      buildingQuery = buildingSpatialQuery;
-      buildingMatchStrategy = 'parcel-polygon-intersection';
+      const candidateData = await fetchGeoJson(buildingSpatialQuery, fetchImpl);
+      spatialBuildingCandidates = featuresFrom(candidateData);
     }
+    buildingMatchStrategy = spatialBuildingCandidates.length
+      ? 'spatial-candidates-unverified'
+      : 'no-building-match';
   }
 
-  const buildingGeometry = combinePolygonFeatures(buildingFeatures);
+  const acceptedBuildingFeatures = directBuildingFeatures;
+  const buildingGeometry = combinePolygonFeatures(acceptedBuildingFeatures);
   const referencePoint = geometryReferencePoint(parcel?.geometry);
 
-  const buildingEditTimes = buildingFeatures
+  const buildingEditTimes = acceptedBuildingFeatures
     .map((feature) => isoFromArcGisDate(valueFrom(feature?.properties || {}, 'EDITEDDATE', 'DATE_')))
     .filter(Boolean)
     .sort();
@@ -301,15 +303,13 @@ export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
     },
     structure: {
       buildingGeometry,
-      // The county layer exposes footprint and joined property attributes, but no verified
-      // building height. Leaving height null intentionally prevents physical verification.
       heightMeters: null,
       floors: null,
       grossAreaSqFt: numberOrNull(attributes.SFLA),
       yearBuilt: numberOrNull(attributes.YEARBLT),
       source: buildingGeometry ? {
         authority: 'Erie County Office of GIS — BUILDING layer',
-        recordId: buildingFeatures.map((feature) => sourceRecordId(feature?.properties || {})).join(','),
+        recordId: acceptedBuildingFeatures.map((feature) => sourceRecordId(feature?.properties || {})).join(','),
         observedAt: latestBuildingEdit || observedAt,
         sourceUrl: ERIE_COUNTY_BUILDING_LAYER,
       } : {},
@@ -345,7 +345,8 @@ export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
       deedBookReference: clean(attributes.BOOK),
       deedPageReference: clean(attributes.PAGE),
       activeFlag: clean(attributes.ACTIVE),
-      buildingFootprintCount: buildingFeatures.length,
+      buildingFootprintCount: acceptedBuildingFeatures.length,
+      buildingCandidateCount: spatialBuildingCandidates.length,
       buildingMatchStrategy,
     },
     provenance: {
@@ -354,10 +355,11 @@ export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
       buildingLayer: ERIE_COUNTY_BUILDING_LAYER,
       mappingDisclaimer: ERIE_COUNTY_MAPPING_DISCLAIMER,
       parcelQuery,
-      buildingQuery,
+      buildingQuery: directBuildingFeatures.length ? buildingAttributeQuery : '',
       buildingAttributeQuery,
       buildingSpatialQuery,
       buildingMatchStrategy,
+      spatialCandidateRecordIds: spatialBuildingCandidates.map((feature) => sourceRecordId(feature?.properties || {})),
     },
     legalEffects: {
       isLegalSurvey: false,
@@ -372,10 +374,14 @@ export async function fetchErieCountySpatialIntake(input = {}, options = {}) {
       'Displayed coordinates and parcel polygons do not establish legal parcel corners or conveyance boundaries.',
       'Assessed values are not treated as market valuations or guaranteed investment values.',
       'Deed book/page fields are reference leads only; title ownership and encumbrances require authoritative closing/title evidence.',
-      buildingMatchStrategy === 'parcel-polygon-intersection'
-        ? 'The BUILDING footprint was matched by spatial intersection with the official parcel polygon because its joined parcel identifier did not produce a direct match.'
-        : 'The BUILDING footprint was matched by the county-returned parcel identifier.',
-      'Building footprint data does not include a verified height, so full physical 3D verification remains incomplete.',
+      directBuildingFeatures.length
+        ? 'The BUILDING footprint was matched by the county-returned parcel identifier.'
+        : spatialBuildingCandidates.length
+          ? 'The BUILDING layer returned one or more polygons that spatially intersect this parcel, but they were not joined to the exact parcel identifier. They are retained only as unverified candidates and are not used as this parcel\'s building geometry.'
+          : 'No BUILDING geometry matched the exact parcel identifier, so physical building geometry remains unavailable.',
+      buildingGeometry
+        ? 'Building footprint data does not include a verified height, so full physical 3D verification remains incomplete.'
+        : 'No parcel-specific building footprint is accepted, so physical verification remains incomplete.',
     ],
   };
 }

--- a/scripts/test-erie-county-spatial-intake.mjs
+++ b/scripts/test-erie-county-spatial-intake.mjs
@@ -28,78 +28,85 @@ const buildingGeometry = {
   ]],
 };
 
+const broadSpatialCandidate = {
+  type: 'Polygon',
+  coordinates: [[
+    [-78.8830, 42.8830],
+    [-78.8750, 42.8830],
+    [-78.8750, 42.8900],
+    [-78.8830, 42.8900],
+    [-78.8830, 42.8830],
+  ]],
+};
+
+function parcelFeature() {
+  return {
+    type: 'Feature',
+    geometry: parcelGeometry,
+    properties: {
+      OBJECTID: 1001,
+      GlobalID: 'parcel-guid',
+      SWIS: '140200',
+      PIN: '140200-101-01-001.000',
+      SBL: '101.01-1-1',
+      ADDNAME: '10 TEST STREET',
+      ADDRESS: '10 TEST STREET',
+      LOCALZIP: '14202',
+      CITYTOWN: 'BUFFALO',
+      FRONT: 40,
+      DEPTH: 110,
+      ASSESSACRE: 0.1,
+      CALCACRES: 0.101,
+      CLASS: '210',
+      PROP_TYPE: 'Residential',
+      PROP_DESC: 'One family residence',
+      DEEDATE: '2024-01-15',
+      BOOK: '9999',
+      PAGE: '123',
+      ACTIVE: 'A',
+      TOTAV: 150000,
+      LANDAV: 18000,
+      YEARBLT: 1920,
+      SFLA: 1650,
+      OWNER1: 'SHOULD NOT LEAK',
+      OWNER2: 'ALSO SHOULD NOT LEAK',
+      MAILADDR: 'PRIVATE MAILING ADDRESS',
+    },
+  };
+}
+
+function jsonResponse(features) {
+  return {
+    ok: true,
+    status: 200,
+    async json() {
+      return { type: 'FeatureCollection', features };
+    },
+  };
+}
+
 const calls = [];
 const mockFetch = async (url) => {
   calls.push(String(url));
   if (String(url).startsWith(`${ERIE_COUNTY_PARCEL_LAYER}/query`)) {
-    return {
-      ok: true,
-      status: 200,
-      async json() {
-        return {
-          type: 'FeatureCollection',
-          features: [{
-            type: 'Feature',
-            geometry: parcelGeometry,
-            properties: {
-              OBJECTID: 1001,
-              GlobalID: 'parcel-guid',
-              SWIS: '140200',
-              PIN: '140200-101-01-001.000',
-              SBL: '101.01-1-1',
-              ADDNAME: '10 TEST STREET',
-              ADDRESS: '10 TEST STREET',
-              LOCALZIP: '14202',
-              CITYTOWN: 'BUFFALO',
-              FRONT: 40,
-              DEPTH: 110,
-              ASSESSACRE: 0.1,
-              CALCACRES: 0.101,
-              CLASS: '210',
-              PROP_TYPE: 'Residential',
-              PROP_DESC: 'One family residence',
-              DEEDATE: '2024-01-15',
-              BOOK: '9999',
-              PAGE: '123',
-              ACTIVE: 'A',
-              TOTAV: 150000,
-              LANDAV: 18000,
-              YEARBLT: 1920,
-              SFLA: 1650,
-              OWNER1: 'SHOULD NOT LEAK',
-              OWNER2: 'ALSO SHOULD NOT LEAK',
-              MAILADDR: 'PRIVATE MAILING ADDRESS',
-            },
-          }],
-        };
-      },
-    };
+    return jsonResponse([parcelFeature()]);
   }
 
   if (String(url).startsWith(`${ERIE_COUNTY_BUILDING_LAYER}/query`)) {
-    return {
-      ok: true,
-      status: 200,
-      async json() {
-        return {
-          type: 'FeatureCollection',
-          features: [{
-            type: 'Feature',
-            geometry: buildingGeometry,
-            properties: {
-              OBJECTID_12: 501,
-              PIN: '140200-101-01-001.000',
-              SBL: '101.01-1-1',
-              ADDRESS: '10 TEST STREET',
-              YEARBLT: 1920,
-              SFLA: 1650,
-              EDITEDDATE: Date.parse('2026-05-01T12:00:00Z'),
-              erie_DWQMADMIN_Building_AREA: 1200,
-            },
-          }],
-        };
+    return jsonResponse([{
+      type: 'Feature',
+      geometry: buildingGeometry,
+      properties: {
+        OBJECTID_12: 501,
+        PIN: '140200-101-01-001.000',
+        SBL: '101.01-1-1',
+        ADDRESS: '10 TEST STREET',
+        YEARBLT: 1920,
+        SFLA: 1650,
+        EDITEDDATE: Date.parse('2026-05-01T12:00:00Z'),
+        erie_DWQMADMIN_Building_AREA: 1200,
       },
-    };
+    }]);
   }
 
   throw new Error(`Unexpected outbound URL in test: ${url}`);
@@ -126,7 +133,7 @@ const result = await fetchErieCountySpatialIntake(
   { fetchImpl: mockFetch, observedAt: '2026-08-28T12:30:00Z' }
 );
 
-assert.equal(calls.length, 2, 'intake should make exactly one parcel query and one building query');
+assert.equal(calls.length, 2, 'direct parcel-linked intake should make one parcel query and one building query');
 assert.ok(calls[0].startsWith(`${ERIE_COUNTY_PARCEL_LAYER}/query?`), 'parcel query must use the allowlisted official parcel layer');
 assert.ok(calls[1].startsWith(`${ERIE_COUNTY_BUILDING_LAYER}/query?`), 'building query must use the allowlisted official building layer');
 
@@ -146,12 +153,14 @@ assert.equal(result.countyRecord.landAssessedValueUsd, 18000);
 assert.equal(result.countyRecord.yearBuilt, 1920);
 assert.equal(result.countyRecord.livingAreaSqFt, 1650);
 assert.equal(result.countyRecord.buildingFootprintCount, 1);
+assert.equal(result.countyRecord.buildingCandidateCount, 0);
+assert.equal(result.countyRecord.buildingMatchStrategy, 'pin-attribute');
 assert.equal(result.twin.location.parcelGeometry.type, 'Polygon');
 assert.equal(result.twin.structure.buildingGeometry.type, 'Polygon');
 assert.equal(result.twin.structure.heightMeters, null, 'height must remain unknown rather than inferred');
 assert.equal(result.twin.rights.type, 'reference_only');
 assert.equal(result.twin.verification.geography, 'verified', 'source-backed county parcel geometry may pass the platform geographic truth layer');
-assert.equal(result.twin.verification.physical, 'partial', 'county footprint without authoritative height must not pass physical 3D verification');
+assert.equal(result.twin.verification.physical, 'partial', 'direct parcel-linked footprint without authoritative height must not pass physical 3D verification');
 assert.equal(result.twin.verification.rights, 'unverified');
 assert.equal(result.twin.verification.fullyVerified, false);
 
@@ -166,4 +175,54 @@ assert.equal(serialized.includes('PRIVATE MAILING ADDRESS'), false, 'county owne
 assert.equal(parcelQuery.searchParams.get('outFields').includes('OWNER1'), false, 'owner identity fields should not even be requested from the county layer');
 assert.equal(parcelQuery.searchParams.get('outFields').includes('MAIL'), false, 'mailing fields should not be requested from the county layer');
 
-console.log('Erie County spatial intake safety checks passed: official allowlisted GIS layers only, exact parcel-key validation, source-backed geography, partial physical truth without invented height, reference-only rights, no owner mailing data, and no legal/title effect.');
+const fallbackCalls = [];
+const fallbackFetch = async (url) => {
+  fallbackCalls.push(String(url));
+  if (String(url).startsWith(`${ERIE_COUNTY_PARCEL_LAYER}/query`)) {
+    return jsonResponse([parcelFeature()]);
+  }
+  if (String(url).startsWith(`${ERIE_COUNTY_BUILDING_LAYER}/query`)) {
+    const parsed = new URL(String(url));
+    if (!parsed.searchParams.get('geometry')) return jsonResponse([]);
+    return jsonResponse([{
+      type: 'Feature',
+      geometry: broadSpatialCandidate,
+      properties: {
+        OBJECTID: 9999,
+        PIN: null,
+        SBL: null,
+        ADDRESS: null,
+        ADDNAME: null,
+      },
+    }]);
+  }
+  throw new Error(`Unexpected outbound URL in fallback test: ${url}`);
+};
+
+const fallbackResult = await fetchErieCountySpatialIntake(
+  { sbl: '101.01-1-1' },
+  { fetchImpl: fallbackFetch, observedAt: '2026-08-28T12:31:00Z' }
+);
+
+assert.equal(fallbackCalls.length, 3, 'missing direct BUILDING join should perform parcel, exact building, then diagnostic spatial-candidate query');
+const fallbackAttributeQuery = new URL(fallbackCalls[1]);
+const fallbackSpatialQuery = new URL(fallbackCalls[2]);
+assert.equal(fallbackAttributeQuery.searchParams.get('where'), "PIN='140200-101-01-001.000'");
+assert.equal(fallbackAttributeQuery.searchParams.has('geometry'), false, 'exact BUILDING lookup must not be a spatial guess');
+assert.equal(fallbackSpatialQuery.searchParams.get('spatialRel'), 'esriSpatialRelIntersects');
+assert.ok(fallbackSpatialQuery.searchParams.get('geometry'), 'diagnostic spatial query must use the already-resolved parcel polygon');
+
+assert.equal(fallbackResult.countyRecord.buildingFootprintCount, 0, 'spatial-only candidate must never count as an accepted parcel building footprint');
+assert.equal(fallbackResult.countyRecord.buildingCandidateCount, 1, 'spatial-only candidate may be retained for diagnosis');
+assert.equal(fallbackResult.countyRecord.buildingMatchStrategy, 'spatial-candidates-unverified');
+assert.equal(fallbackResult.twin.structure.buildingGeometry, null, 'spatial-only candidate must not enter the property twin');
+assert.equal(fallbackResult.twin.structure.source.authority, '', 'rejected candidate must not supply authoritative structure lineage');
+assert.equal(fallbackResult.twin.structure.source.recordId, '');
+assert.equal(fallbackResult.twin.verification.geography, 'verified');
+assert.equal(fallbackResult.twin.verification.physical, 'unverified', 'physical truth must fail closed without a parcel-linked building footprint');
+assert.equal(fallbackResult.twin.verification.verifiedSpatialTwin, false);
+assert.equal(fallbackResult.twin.verification.fullyVerified, false);
+assert.equal(fallbackResult.provenance.spatialCandidateRecordIds.length, 1, 'candidate record ID should be retained for diagnosis');
+assert.match(fallbackResult.sourceLimitations.join(' '), /retained only as unverified candidates and are not used/i);
+
+console.log('Erie County spatial intake safety checks passed: exact parcel-linked BUILDING geometry may be partial physical evidence; spatial-intersection-only polygons fail closed as diagnostic candidates, with reference-only rights, no owner mailing data, and no legal/title effect.');

--- a/scripts/test-first-real-erie-parcel-live.mjs
+++ b/scripts/test-first-real-erie-parcel-live.mjs
@@ -72,34 +72,39 @@ assert.match(countyRecord.municipality || '', /Buffalo/i, 'county result must id
 
 assert.ok(twin.location.parcelGeometry, 'official parcel polygon must be present');
 assert.ok(['Polygon', 'MultiPolygon'].includes(twin.location.parcelGeometry.type), 'parcel geometry must be polygonal');
-assert.ok(twin.structure.buildingGeometry, 'official building footprint must be present for the first parcel');
-assert.ok(['Polygon', 'MultiPolygon'].includes(twin.structure.buildingGeometry.type), 'building footprint must be polygonal');
-assert.ok(countyRecord.buildingFootprintCount > 0, 'at least one building footprint must match the parcel');
+assert.equal(twin.structure.buildingGeometry, null, '618 Main must not accept a spatial-intersection-only block polygon as its building footprint');
+assert.equal(countyRecord.buildingFootprintCount, 0, 'no parcel-linked BUILDING footprint is currently accepted for 618 Main');
+assert.ok(countyRecord.buildingCandidateCount > 0, 'the broad County spatial candidate should remain visible for diagnosis without being accepted');
+assert.equal(countyRecord.buildingMatchStrategy, 'spatial-candidates-unverified');
 
-assert.equal(twin.verification.geography, PROPERTY_TRUTH_STATES.VERIFIED, 'the live county record must pass geographic truth');
-assert.equal(twin.verification.physical, PROPERTY_TRUTH_STATES.PARTIAL, 'physical truth must remain partial until measured height exists');
-assert.equal(twin.verification.heightStatus, 'explicitly_unavailable', 'height absence must be explicit rather than silent');
+assert.equal(twin.verification.geography, PROPERTY_TRUTH_STATES.VERIFIED, 'the live county parcel record must still pass geographic truth');
+assert.equal(twin.verification.physical, PROPERTY_TRUTH_STATES.UNVERIFIED, 'physical truth must fail closed without parcel-specific building geometry');
+assert.equal(twin.verification.heightStatus, 'explicitly_unavailable', 'height absence must remain explicit rather than silent');
 assert.equal(twin.structure.heightMeters, null, 'no height may be invented');
-assert.match(twin.structure.heightUnavailableReason, /no authoritative measured building height/i);
-assert.equal(twin.verification.verifiedSpatialTwin, false, 'no full spatial verification without measured height');
+assert.match(twin.structure.heightUnavailableReason, /no source-backed building footprint/i);
+assert.equal(twin.verification.verifiedSpatialTwin, false, 'no spatial verification without accepted building geometry and measured height');
 
 assert.equal(twin.rights.type, PROPERTY_RIGHT_TYPES.REFERENCE_ONLY, 'county GIS must never create ownership rights');
 assert.equal(twin.verification.rights, PROPERTY_TRUTH_STATES.UNVERIFIED);
 assert.equal(twin.verification.verifiedOwnership, false);
 assert.equal(twin.verification.fullyVerified, false);
 assert.equal(truthLabels.geography, 'GEO VERIFIED');
-assert.match(truthLabels.physical, /PHYSICAL PARTIAL/);
+assert.equal(truthLabels.physical, 'PHYSICAL UNVERIFIED');
 assert.equal(truthLabels.ownership, 'OWNERSHIP NOT VERIFIED');
 assertSpatialInvariants(twin);
 
 assert.match(twin.location.source.authority, /Erie County/i, 'parcel lineage must name Erie County');
-assert.match(twin.structure.source.authority, /Erie County/i, 'building lineage must name Erie County');
 assert.ok(twin.location.source.recordId, 'parcel lineage record ID must be populated');
-assert.ok(twin.structure.source.recordId, 'building lineage record ID must be populated');
 assert.ok(twin.location.source.observedAt, 'parcel observation time must be populated');
-assert.ok(twin.structure.source.observedAt, 'building observation time must be populated');
+assert.equal(twin.structure.source.authority, '', 'rejected block-scale candidate must not become structure lineage');
+assert.equal(twin.structure.source.recordId, '');
+assert.equal(twin.structure.source.sourceUrl, '');
 assert.ok(provenance?.parcelLayer, 'official parcel layer URL must be retained');
-assert.ok(provenance?.buildingLayer, 'official building layer URL must be retained');
+assert.ok(provenance?.buildingLayer, 'official building layer URL must be retained as a diagnostic source');
+assert.ok(provenance?.buildingAttributeQuery, 'exact building lookup must be retained');
+assert.ok(provenance?.buildingSpatialQuery, 'diagnostic spatial-candidate query must be retained');
+assert.ok(Array.isArray(provenance?.spatialCandidateRecordIds) && provenance.spatialCandidateRecordIds.length > 0, 'rejected candidate IDs must remain available for diagnosis');
+assert.match(result.sourceLimitations.join(' '), /retained only as unverified candidates and are not used/i);
 
 const lidar = await loadLidarWithRetry({
   latitude: twin.location.latitude,
@@ -124,8 +129,8 @@ assert.ok(lidar.tiles.length > 0, 'at least one authoritative LAS tile must cove
 assert.ok(lidar.tiles.some((tile) => tile.filename), 'covered LAS evidence must include an official filename');
 assert.ok(lidar.tiles.some((tile) => tile.directDownloadUrl || tile.ftpPath), 'covered LAS evidence must retain a downloadable source reference');
 assert.equal(lidar.heightMeters, null, 'LiDAR coverage alone must not be promoted into a measured building height');
-assert.equal(lidar.measurementStatus, 'coverage_only', 'LiDAR must remain coverage-only until point-cloud measurement runs');
-assert.equal(lidar.measurementMethod, null, 'no measurement method may be claimed before LAS processing');
+assert.equal(lidar.measurementStatus, 'coverage_only', 'LiDAR must remain coverage-only until a defensible parcel building geometry exists and point-cloud measurement runs');
+assert.equal(lidar.measurementMethod, null, 'no measurement method may be claimed before accepted geometry and LAS processing');
 assert.equal(lidar.legalEffects.establishesBuildingHeight, false, 'tile discovery alone must not establish building height');
 assert.equal(lidar.legalEffects.establishesDeedOwnership, false, 'LiDAR can never establish deed ownership');
 assert.equal(lidar.source.sourceUrl, lidar.resolvedLayer.layerUrl, 'LiDAR lineage must retain the dynamically resolved official NYS layer');
@@ -139,14 +144,16 @@ console.log(JSON.stringify({
   pin: countyRecord.pin,
   address: countyRecord.parcelAddress,
   municipality: countyRecord.municipality,
-  buildingFootprintCount: countyRecord.buildingFootprintCount,
+  acceptedBuildingFootprintCount: countyRecord.buildingFootprintCount,
+  unverifiedBuildingCandidateCount: countyRecord.buildingCandidateCount,
+  buildingMatchStrategy: countyRecord.buildingMatchStrategy,
   geography: twin.verification.geography,
   physical: twin.verification.physical,
   heightStatus: twin.verification.heightStatus,
   verifiedSpatialTwin: twin.verification.verifiedSpatialTwin,
   ownership: twin.verification.verifiedOwnership,
   parcelSource: twin.location.source,
-  buildingSource: twin.structure.source,
+  rejectedBuildingCandidateRecordIds: provenance.spatialCandidateRecordIds,
   lidar: {
     collection: lidar.collection,
     resolvedLayer: lidar.resolvedLayer,


### PR DESCRIPTION
## Why this correction is needed
The 618 Main forcing-function exposed that Erie County's BUILDING spatial fallback can return a connected/block-scale polygon that intersects the parcel without carrying the parcel's exact PIN/SBL. For 618 Main, that candidate is roughly 30x the parcel area and is not defensible as a parcel-specific building footprint.

## What changes
- Accept BUILDING geometry only when the County layer returns it through the exact county-returned PIN/SBL join.
- Keep spatial-intersection results only as diagnostic candidates; never put them into `twin.structure.buildingGeometry` or structure provenance.
- Add regression coverage proving a broad spatial candidate fails closed.
- Update the live 618 Main gate to require zero accepted building footprints, retain the diagnostic candidate, keep geography verified, set physical truth to unverified, and keep LiDAR as coverage-only.
- Update the 618 Main UI to render the exact parcel polygon only, label the parcel-specific building footprint unverified, and explain why the spatial candidate is rejected.

## Truth state for 618 Main after this PR
- Geography: VERIFIED
- Exact parcel polygon: SOURCE-BACKED
- Parcel-specific building footprint: UNVERIFIED / NOT ACCEPTED
- NYS LiDAR coverage: SOURCE-BACKED
- Measured height: NOT ACCEPTED
- Physical: UNVERIFIED
- Verified spatial twin: FALSE
- Ownership: NOT VERIFIED / REFERENCE ONLY

This is intentionally a stricter truth state than the prior PHYSICAL PARTIAL result. It corrects the first parcel rather than preserving a visually convenient but over-broad footprint.