### PR TITLE
Add official Buffalo historic identity evidence for 618 Main

### DIFF
--- a/app/real-estate/property/erie-618-main/page.js
+++ b/app/real-estate/property/erie-618-main/page.js
@@ -4,6 +4,10 @@ import {
   fetchFirstRealErieParcel,
 } from '../../../../lib/real-estate/erie-county-evidence.js';
 import {
+  FIRST_REAL_BUFFALO_PRESERVATION_RECORD,
+  validateFirstRealBuffaloPreservationRecord,
+} from '../../../../lib/real-estate/buffalo-preservation-evidence.js';
+import {
   NYS_ERIE_LIDAR_INDEX_LAYER,
   fetchNysErieLidarCoverage,
 } from '../../../../lib/real-estate/nys-lidar-evidence.js';
@@ -77,6 +81,7 @@ function money(value) {
 }
 
 export default async function FirstRealErieParcelPage() {
+  const cityRecord = validateFirstRealBuffaloPreservationRecord(FIRST_REAL_BUFFALO_PRESERVATION_RECORD);
   let evidence;
   let lidarEvidence;
   let error = '';
@@ -102,6 +107,7 @@ export default async function FirstRealErieParcelPage() {
   const buildingCandidateCount = Number(record?.buildingCandidateCount || 0);
   const lidarCovered = lidarEvidence?.coverageStatus === 'covered';
   const lidarTileNames = lidarEvidence?.tiles?.map((tile) => tile.filename).filter(Boolean) || [];
+  const citySblMatches = cityRecord.sbl === record?.sbl;
 
   return (
     <main className={styles.page}>
@@ -115,7 +121,7 @@ export default async function FirstRealErieParcelPage() {
           <article className={styles.heroCard}>
             <p className={styles.eyebrow}>FIRST REAL PARCEL · ERIE COUNTY, NEW YORK</p>
             <h1>618 Main Street.<br /><em>Evidence before ownership.</em></h1>
-            <p className={styles.lead}>This page loads the exact County SBL from Erie County GIS and accepts only evidence that can be tied defensibly to this parcel. The parcel polygon is source-backed. The County&apos;s spatially intersecting building polygon is currently rejected from the twin because it is not joined to 618 Main&apos;s exact PIN/SBL. New York State LiDAR coverage is tracked separately.</p>
+            <p className={styles.lead}>This page anchors the property to the exact Erie County parcel and independently cross-references the City of Buffalo&apos;s published historic inventory. The City identifies SBL {cityRecord.sbl} as {cityRecord.address}, also {cityRecord.alternativeAddress}, the {cityRecord.propertyName}, an office building recorded as built in {cityRecord.yearBuilt}. That historic identity evidence does not substitute for a current parcel-specific footprint or measured height.</p>
           </article>
           <aside className={styles.statusCard}>
             <div>
@@ -125,6 +131,7 @@ export default async function FirstRealErieParcelPage() {
             <div className={styles.statusList}>
               <span>COUNTY SBL · {FIRST_REAL_ERIE_PARCEL.countySbl}</span>
               <span>PIN · {FIRST_REAL_ERIE_PARCEL.pin}</span>
+              <span>CITY RECORD · {citySblMatches ? 'SBL MATCH' : 'MISMATCH'}</span>
               <span>BUILDING · {buildingAccepted ? 'PARCEL-LINKED' : 'FOOTPRINT UNVERIFIED'}</span>
               <span>LIDAR · {lidarCovered ? 'COVERAGE FOUND' : lidarError ? 'SOURCE UNAVAILABLE' : 'NO COVERAGE FOUND'}</span>
               <span>RIGHTS · REFERENCE ONLY</span>
@@ -140,9 +147,9 @@ export default async function FirstRealErieParcelPage() {
           <>
             <section className={styles.truthGrid} aria-label="Spatial truth status">
               <article><small>GEOGRAPHY</small><strong>{labels?.geography}</strong><span>Exact parcel ID, coordinates, polygon and source lineage must all pass.</span></article>
-              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>{buildingAccepted ? 'A parcel-linked footprint is accepted, but measured height is still required.' : 'No parcel-specific building footprint is accepted. A broad spatial candidate is retained only for diagnosis, not rendered as the building.'}</span></article>
-              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification requires both defensible parcel-specific building geometry and measured height.</span></article>
-              <article><small>OWNERSHIP</small><strong>{labels?.ownership}</strong><span>County GIS and LiDAR do not establish deed, title, LLC membership or investment rights.</span></article>
+              <article><small>PHYSICAL</small><strong>{labels?.physical}</strong><span>{buildingAccepted ? 'A parcel-linked footprint is accepted, but measured height is still required.' : 'The City historic identity matches, but no current parcel-specific building footprint is accepted. Broad spatial candidates remain diagnostic only.'}</span></article>
+              <article><small>SPATIAL TWIN</small><strong>{labels?.spatialTwin}</strong><span>Full spatial verification requires defensible parcel-specific building geometry and measured height, not just a historical record.</span></article>
+              <article><small>OWNERSHIP</small><strong>{labels?.ownership}</strong><span>County GIS, City preservation records and LiDAR do not establish deed, title, LLC membership or investment rights.</span></article>
             </section>
 
             <section className={styles.twoCol}>
@@ -154,7 +161,7 @@ export default async function FirstRealErieParcelPage() {
                 <EvidenceMap parcelGeometry={twin?.location?.parcelGeometry} buildingGeometry={twin?.structure?.buildingGeometry} />
                 <p className={styles.note}>{buildingAccepted
                   ? 'The drawing contains the source-backed parcel and an exact parcel-linked building footprint. It is still a GIS reference, not a legal survey or conveyance boundary.'
-                  : 'Only the exact source-backed parcel polygon is rendered. The County building layer returned a broader spatial candidate without the parcel identifier, so Voxel Vault refuses to draw it as 618 Main. No generic house or fake 3D extrusion is substituted.'}</p>
+                  : 'Only the exact source-backed parcel polygon is rendered. The County building layer returned a broader spatial candidate without the parcel identifier, so Voxel Vault refuses to draw it as 618 Main. The City historic inventory confirms building identity, not current geometry. No generic house or fake 3D extrusion is substituted.'}</p>
               </article>
 
               <article className={styles.panel}>
@@ -164,14 +171,20 @@ export default async function FirstRealErieParcelPage() {
                   <div><span>City raw SBL</span><strong>{FIRST_REAL_ERIE_PARCEL.cityScheduleRawSbl}</strong></div>
                   <div><span>PIN</span><strong>{record?.pin || '—'}</strong></div>
                   <div><span>Municipality</span><strong>{record?.municipality || '—'}</strong></div>
+                  <div><span>City historic address</span><strong>{cityRecord.address}</strong></div>
+                  <div><span>Alternative address</span><strong>{cityRecord.alternativeAddress}</strong></div>
+                  <div><span>Historic building name</span><strong>{cityRecord.propertyName}</strong></div>
+                  <div><span>Historic use</span><strong>{cityRecord.propertyDescription}</strong></div>
+                  <div><span>City survey year built</span><strong>{cityRecord.yearBuilt}</strong></div>
+                  <div><span>Architect</span><strong>{cityRecord.architect}</strong></div>
+                  <div><span>Style</span><strong>{cityRecord.style}</strong></div>
+                  <div><span>Historic district</span><strong>{cityRecord.historicDistrictName}</strong></div>
                   <div><span>Reference point</span><strong>{Number(twin?.location?.latitude).toFixed(6)}, {Number(twin?.location?.longitude).toFixed(6)}</strong></div>
                   <div><span>Accepted building footprints</span><strong>{record?.buildingFootprintCount ?? '—'}</strong></div>
                   <div><span>Unverified spatial candidates</span><strong>{record?.buildingCandidateCount ?? '—'}</strong></div>
                   <div><span>Building match</span><strong>{record?.buildingMatchStrategy || '—'}</strong></div>
                   <div><span>NYS LiDAR coverage</span><strong>{lidarCovered ? 'FOUND' : lidarError ? 'UNAVAILABLE' : 'NOT FOUND'}</strong></div>
                   <div><span>LAS tiles</span><strong>{lidarEvidence?.tiles?.length ?? '—'}</strong></div>
-                  <div><span>Year built reference</span><strong>{record?.yearBuilt || '—'}</strong></div>
-                  <div><span>Living area reference</span><strong>{record?.livingAreaSqFt ? `${record.livingAreaSqFt.toLocaleString()} sq ft` : '—'}</strong></div>
                   <div><span>County assessment</span><strong>{money(record?.totalAssessedValueUsd)}</strong></div>
                   <div><span>Height state</span><strong>{twin?.verification?.heightStatus || 'missing'}</strong></div>
                 </div>
@@ -186,6 +199,7 @@ export default async function FirstRealErieParcelPage() {
               </div>
               <div className={styles.sourceGrid}>
                 <div><strong>Parcel identity + polygon</strong><span>{twin?.location?.source?.authority} · record {twin?.location?.source?.recordId}</span></div>
+                <div><strong>Historic building identity</strong><span>{cityRecord.source.authority} · {cityRecord.address} / {cityRecord.alternativeAddress} · {cityRecord.yearBuilt}</span></div>
                 <div><strong>Parcel-specific building footprint</strong><span>{buildingAccepted ? `${twin?.structure?.source?.authority} · record ${twin?.structure?.source?.recordId}` : `Not accepted · ${buildingCandidateCount} spatial candidate${buildingCandidateCount === 1 ? '' : 's'} retained only for diagnosis`}</span></div>
                 <div><strong>NYS LiDAR coverage</strong><span>{lidarCovered ? `${lidarEvidence?.source?.authority} · ${lidarTileNames.join(', ') || `${lidarEvidence?.tiles?.length || 0} tile(s)`}` : lidarError || 'No intersecting source tile was returned.'}</span></div>
                 <div><strong>Measured height</strong><span>{twin?.structure?.heightUnavailableReason}</span></div>
@@ -194,17 +208,19 @@ export default async function FirstRealErieParcelPage() {
               <div className={styles.links}>
                 <a href={evidence?.provenance?.parcelLayer} target="_blank" rel="noreferrer">Erie parcel layer ↗</a>
                 <a href={evidence?.provenance?.buildingLayer} target="_blank" rel="noreferrer">Erie building source ↗</a>
+                <a href={cityRecord.source.sourceUrl} target="_blank" rel="noreferrer">Buffalo preservation survey ↗</a>
                 <a href={NYS_ERIE_LIDAR_INDEX_LAYER} target="_blank" rel="noreferrer">NYS LiDAR index ↗</a>
                 <a href={FIRST_REAL_ERIE_PARCEL.identifierSourceUrl} target="_blank" rel="noreferrer">Buffalo identifier source ↗</a>
               </div>
-              <p className={styles.note}>Identifier reconciliation: Erie County GIS returns SBL {FIRST_REAL_ERIE_PARCEL.countySbl}; the City schedule stores the same parcel as raw SBL {FIRST_REAL_ERIE_PARCEL.cityScheduleRawSbl}. Both use PIN {FIRST_REAL_ERIE_PARCEL.pin}. The County-formatted SBL is the runtime geometry lookup key.</p>
+              <p className={styles.note}>Identifier reconciliation: Erie County GIS returns SBL {FIRST_REAL_ERIE_PARCEL.countySbl}; the City schedule stores the same parcel as raw SBL {FIRST_REAL_ERIE_PARCEL.cityScheduleRawSbl}; the City preservation survey publishes SBL {cityRecord.sbl} for {cityRecord.address}. These sources converge on the same parcel identity while retaining their original identifier formats.</p>
+              <p className={styles.note}>The City preservation survey is useful evidence of historical building identity, use, age, architect and style. It does not certify the current footprint, height, condition, ownership or title.</p>
               <p className={styles.note}>A spatial intersection is not enough to identify a building. The current County candidate is preserved in provenance for investigation but is excluded from the property twin until a parcel-specific geometry relationship can be defended.</p>
               <p className={styles.note}>LiDAR tile discovery proves authoritative point-cloud coverage only. Voxel Vault will not mark height as measured until accepted building geometry exists and a reproducible roof-versus-ground method passes its quality and uncertainty gates.</p>
             </section>
           </>
         )}
 
-        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography verified when source checks pass · parcel-specific physical geometry currently unverified · LiDAR coverage separate · ownership unverified.</footer>
+        <footer className={styles.footer}>Voxel Vault · first real Erie County parcel evidence path · geography verified when source checks pass · City historic identity cross-referenced · parcel-specific physical geometry currently unverified · LiDAR coverage separate · ownership unverified.</footer>
       </div>
     </main>
   );

--- a/lib/real-estate/buffalo-preservation-evidence.js
+++ b/lib/real-estate/buffalo-preservation-evidence.js
@@ -1,0 +1,45 @@
+export const BUFFALO_PRESERVATION_READY_SURVEY_URL = 'https://www.buffalony.gov/DocumentCenter/View/9463/PreservationReadySurvey';
+
+export const FIRST_REAL_BUFFALO_PRESERVATION_RECORD = Object.freeze({
+  sbl: '111.38-3-8',
+  address: '618 MAIN ST',
+  alternativeAddress: '620 Main',
+  propertyName: 'DICKINSON JEWELRY/MARTIN JACOBI BLDG',
+  propertyDescription: 'Office bldg.',
+  yearBuilt: 1919,
+  architect: 'Esenwein & Johnson',
+  style: 'Neoclassical',
+  historicDistrictName: 'Theatre Local H.D.',
+  surveyRecommendation: 'Cert Local HD (contrib.)',
+  source: Object.freeze({
+    authority: 'City of Buffalo Preservation Board / Preservation Ready Survey',
+    sourceUrl: BUFFALO_PRESERVATION_READY_SURVEY_URL,
+    evidenceKind: 'official_published_historic_inventory',
+    observedAt: '2026-08-28',
+  }),
+  verificationEffects: Object.freeze({
+    confirmsParcelSblCrossReference: true,
+    confirmsHistoricBuildingIdentity: true,
+    confirmsCurrentBuildingFootprint: false,
+    confirmsCurrentBuildingHeight: false,
+    confirmsCurrentCondition: false,
+    establishesDeedOwnership: false,
+    establishesTitle: false,
+    createsInvestmentRights: false,
+    createsBlockchainRights: false,
+  }),
+});
+
+export function validateFirstRealBuffaloPreservationRecord(record = FIRST_REAL_BUFFALO_PRESERVATION_RECORD) {
+  if (record.sbl !== '111.38-3-8') throw new Error('Buffalo preservation record SBL must remain 111.38-3-8.');
+  if (record.address !== '618 MAIN ST') throw new Error('Buffalo preservation record address must remain 618 MAIN ST.');
+  if (record.alternativeAddress !== '620 Main') throw new Error('Buffalo preservation record must preserve the 620 Main alternative address.');
+  if (record.yearBuilt !== 1919) throw new Error('Buffalo preservation record year must remain the City survey value 1919.');
+  if (record.propertyDescription !== 'Office bldg.') throw new Error('Buffalo preservation record use must remain the City survey value.');
+  if (!record.source?.sourceUrl?.startsWith('https://www.buffalony.gov/')) throw new Error('Buffalo preservation evidence must retain the official City source URL.');
+  if (record.verificationEffects?.confirmsCurrentBuildingFootprint !== false) throw new Error('Historic inventory must not self-verify a current footprint.');
+  if (record.verificationEffects?.confirmsCurrentBuildingHeight !== false) throw new Error('Historic inventory must not self-verify current height.');
+  if (record.verificationEffects?.establishesDeedOwnership !== false) throw new Error('Historic inventory must not establish deed ownership.');
+  if (record.verificationEffects?.establishesTitle !== false) throw new Error('Historic inventory must not establish title.');
+  return record;
+}


### PR DESCRIPTION
## What this adds
- Adds a small fail-closed evidence module for the City of Buffalo Preservation Ready Survey entry tied to SBL `111.38-3-8`.
- Cross-references 618 Main with the City-published alternative address 620 Main and the Dickinson Jewelry / Martin Jacobi Building historic identity.
- Surfaces the City survey's 1919 date, office-building use, Esenwein & Johnson attribution, Neoclassical style, and Theatre Local Historic District reference on the real parcel page.

## What this deliberately does not do
- Does not create or accept a current building footprint.
- Does not populate current building height.
- Does not change `PHYSICAL UNVERIFIED` or `verifiedSpatialTwin=false`.
- Does not establish current condition, deed ownership, title, investment rights, or blockchain rights.

This gives the first real parcel a stronger official identity chain while keeping current physical verification fail-closed.