### PR TITLE
Add GEO terrain, surrounding buildings and measured-height gate

### DIFF
--- a/app/api/geo/intake/route.ts
+++ b/app/api/geo/intake/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { fetchErieCountyEvidence } from '../../../../lib/real-estate/erie-county-evidence.js';
-import { fetchGlobalBuildingReference, geocodeGeoAddress } from '../../../../lib/real-estate/global-building-reference.js';
+import { geocodeGeoAddress } from '../../../../lib/real-estate/global-building-reference.js';
+import { fetchGlobalNeighborhoodReference } from '../../../../lib/real-estate/global-neighborhood-reference.js';
+import { fetchUsgsTerrainReference } from '../../../../lib/real-estate/usgs-terrain-reference.js';
+import { fetchNysErieLidarCoverage } from '../../../../lib/real-estate/nys-lidar-evidence.js';
+import { evaluateMeasuredBuildingHeight } from '../../../../lib/real-estate/measured-building-height.js';
 import { buildGeoPropertyReadiness, buildGlobalReferenceRequest, normalizeGeoPropertyIntake } from '../../../../lib/real-estate/geo-property-onboarding.js';
 import { factCheckProperty, PROPERTY_FACT_SOURCE_KINDS } from '../../../../lib/real-estate/property-fact-check.js';
 
@@ -21,6 +25,17 @@ function globalFacts(reference: any) {
       sourceUrl: reference.source?.sourceUrl,
       note: 'Reference building geometry only; not a cadastral parcel boundary.',
     },
+    {
+      field: 'nearby_building_count',
+      label: 'Nearby source building count',
+      value: reference.neighborhoodBuildingCount ?? 0,
+      sourceKind: PROPERTY_FACT_SOURCE_KINDS.GLOBAL_MAP,
+      authority: reference.source?.authority,
+      recordId: `neighborhood:${reference.source?.recordId || 'reference'}`,
+      observedAt: reference.source?.observedAt,
+      sourceUrl: reference.source?.sourceUrl,
+      note: 'Count of nearby source-backed global map building footprints returned for the 3D reference scene.',
+    },
   ];
   if (reference.tags?.building) facts.push({
     field: 'building_type', label: 'Building type', value: reference.tags.building,
@@ -36,6 +51,63 @@ function globalFacts(reference: any) {
     field: 'building_height_reported', label: 'Source-reported height', value: reference.tags.height,
     sourceKind: PROPERTY_FACT_SOURCE_KINDS.GLOBAL_MAP, authority: reference.source?.authority,
     recordId: reference.source?.recordId, observedAt: reference.source?.observedAt, sourceUrl: reference.source?.sourceUrl,
+  });
+  return facts;
+}
+
+function terrainFacts(terrain: any) {
+  if (!terrain?.available) return [];
+  return [
+    {
+      field: 'ground_elevation_reference',
+      label: 'Ground elevation reference',
+      value: terrain.referenceElevationMeters,
+      sourceKind: PROPERTY_FACT_SOURCE_KINDS.JURISDICTION_GIS,
+      authority: terrain.source?.authority,
+      recordId: `EPQS:${terrain.latitude},${terrain.longitude}`,
+      observedAt: terrain.source?.observedAt,
+      sourceUrl: terrain.source?.sourceUrl,
+      note: 'USGS 3DEP interpolated elevation reference. Not a surveyed control elevation and not a building roof height.',
+    },
+    {
+      field: 'terrain_relief_reference',
+      label: 'Local terrain relief reference',
+      value: terrain.reliefMeters,
+      sourceKind: PROPERTY_FACT_SOURCE_KINDS.JURISDICTION_GIS,
+      authority: terrain.source?.authority,
+      recordId: `EPQS-GRID:${terrain.latitude},${terrain.longitude}`,
+      observedAt: terrain.source?.observedAt,
+      sourceUrl: terrain.source?.sourceUrl,
+      note: 'Difference between minimum and maximum sampled ground elevations in the local 3×3 reference grid.',
+    },
+  ];
+}
+
+function lidarFacts(lidarCoverage: any, measuredHeight: any) {
+  if (!lidarCoverage) return [];
+  const facts: any[] = [
+    {
+      field: 'lidar_coverage',
+      label: 'NYS LiDAR coverage',
+      value: lidarCoverage.coverageStatus,
+      sourceKind: PROPERTY_FACT_SOURCE_KINDS.JURISDICTION_GIS,
+      authority: lidarCoverage.source?.authority,
+      recordId: lidarCoverage.tiles?.[0]?.filename || lidarCoverage.collection,
+      observedAt: lidarCoverage.source?.observedAt,
+      sourceUrl: lidarCoverage.source?.sourceUrl,
+      note: 'Coverage proves an official LiDAR tile exists for the area. It does not by itself measure this building.',
+    },
+  ];
+  if (measuredHeight?.verifiedMeasuredHeight) facts.push({
+    field: 'building_height_measured',
+    label: 'Measured building height',
+    value: measuredHeight.heightMeters,
+    sourceKind: PROPERTY_FACT_SOURCE_KINDS.JURISDICTION_GIS,
+    authority: measuredHeight.sourceAuthority,
+    recordId: measuredHeight.sourceRecordId,
+    observedAt: measuredHeight.observedAt,
+    sourceUrl: lidarCoverage.source?.sourceUrl,
+    note: `Roof-minus-ground LiDAR measurement; documented uncertainty ${measuredHeight.uncertaintyMeters} m.`,
   });
   return facts;
 }
@@ -113,17 +185,26 @@ export async function POST(request: Request) {
 
     let globalReference = null;
     let globalReferenceError = '';
+    let terrain = null;
+    let terrainError = '';
+
     if (intake.hasCoordinates) {
-      try {
-        globalReference = await fetchGlobalBuildingReference({ latitude: intake.latitude, longitude: intake.longitude });
-      } catch (error) {
-        globalReferenceError = error instanceof Error ? error.message : 'Global building reference lookup failed.';
-      }
+      const [neighborhoodResult, terrainResult] = await Promise.allSettled([
+        fetchGlobalNeighborhoodReference({ latitude: intake.latitude, longitude: intake.longitude, radiusMeters: 130 }),
+        fetchUsgsTerrainReference({ latitude: intake.latitude, longitude: intake.longitude, countryCode: intake.countryCode, radiusMeters: 90 }),
+      ]);
+      if (neighborhoodResult.status === 'fulfilled') globalReference = neighborhoodResult.value;
+      else globalReferenceError = neighborhoodResult.reason instanceof Error ? neighborhoodResult.reason.message : 'Global neighborhood lookup failed.';
+      if (terrainResult.status === 'fulfilled') terrain = terrainResult.value;
+      else terrainError = terrainResult.reason instanceof Error ? terrainResult.reason.message : 'Terrain reference lookup failed.';
     }
 
     let authoritativeEvidence = null;
     let authoritativeError = '';
+    let lidarCoverage = null;
+    let lidarError = '';
     const isErie = intake.countryCode === 'US' && intake.subdivisionCode === 'NY' && intake.countyCode === 'ERIE';
+
     if (isErie && (intake.pin || intake.sbl)) {
       try {
         const candidate = await fetchErieCountyEvidence(intake.pin ? { pin: intake.pin } : { sbl: intake.sbl });
@@ -135,9 +216,30 @@ export async function POST(request: Request) {
       }
     }
 
+    if (isErie && intake.hasCoordinates) {
+      try {
+        lidarCoverage = await fetchNysErieLidarCoverage({ latitude: intake.latitude, longitude: intake.longitude });
+      } catch (error) {
+        lidarError = error instanceof Error ? error.message : 'NYS LiDAR coverage lookup failed.';
+      }
+    }
+
+    const measuredHeight = evaluateMeasuredBuildingHeight({
+      acceptedBuildingGeometry: authoritativeEvidence?.twin?.structure?.buildingGeometry || null,
+      lidarCoverage,
+      measurement: null,
+    });
+
+    if (globalReference) globalReference = { ...globalReference, terrain, measuredHeight, lidarCoverage };
+
     const factCheck = factCheckProperty({
       propertyId: authoritativeEvidence?.twin?.propertyId || intake.parcelId || intake.pin || intake.sbl || intake.address || 'GEO:REFERENCE',
-      facts: [...globalFacts(globalReference), ...erieFacts(authoritativeEvidence)],
+      facts: [
+        ...globalFacts(globalReference),
+        ...terrainFacts(terrain),
+        ...erieFacts(authoritativeEvidence),
+        ...lidarFacts(lidarCoverage, measuredHeight),
+      ],
     });
     const globalRequest = buildGlobalReferenceRequest(intake);
     const readiness = buildGeoPropertyReadiness({
@@ -153,6 +255,11 @@ export async function POST(request: Request) {
       geocode,
       globalReference,
       globalReferenceError,
+      terrain,
+      terrainError,
+      lidarCoverage,
+      lidarError,
+      measuredHeight,
       authoritativeEvidence,
       authoritativeError,
       factCheck,
@@ -161,13 +268,18 @@ export async function POST(request: Request) {
         ...globalRequest,
         overtureRelease: '2026-07-22.0',
         overtureBuildingsPmtiles: 'https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-07-22.0/buildings.pmtiles',
-        note: 'GEO fetches/cache-bounds around a requested property instead of storing the entire planet in the web app. Overture is a global reference layer; jurisdiction sources remain the parcel authority where available.',
+        terrainAdapter: intake.countryCode === 'US' ? 'USGS 3DEP EPQS 3×3 ground-elevation reference grid' : 'no authoritative terrain adapter attached for this country yet',
+        neighborhoodAdapter: 'OpenStreetMap / Overpass nearby building footprints',
+        measuredHeightPolicy: 'Measured building height requires accepted parcel-specific building geometry plus actual roof/ground LiDAR processing. Coverage or ground elevation alone cannot satisfy the gate.',
+        note: 'GEO fetches/cache-bounds around a requested property instead of storing the entire planet in the web app. Overture/OSM are global reference layers; jurisdiction sources remain the parcel authority where available.',
       },
       legalEffects: {
         createsOwnership: false,
         createsSecurity: false,
         verifiesTitle: false,
         transfersFunds: false,
+        terrainCreatesPropertyRights: false,
+        neighborhoodGeometryCreatesParcelRights: false,
       },
     }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
   } catch (error) {

--- a/app/geo/GeoReferenceModel.js
+++ b/app/geo/GeoReferenceModel.js
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from 'react';
 
+const METERS_TO_SCENE = 0.075;
+
 function outerRing(geometry) {
   if (!geometry || !Array.isArray(geometry.coordinates)) return [];
   if (geometry.type === 'Polygon') return Array.isArray(geometry.coordinates[0]) ? geometry.coordinates[0] : [];
@@ -16,6 +18,47 @@ function numericLevels(reference, sourceHeightMeters) {
   return 1;
 }
 
+function toLocalMeters(longitude, latitude, originLongitude, originLatitude) {
+  const cosLat = Math.max(0.15, Math.cos(originLatitude * Math.PI / 180));
+  return {
+    east: (Number(longitude) - originLongitude) * 111320 * cosLat,
+    north: (Number(latitude) - originLatitude) * 111320,
+  };
+}
+
+function terrainRelativeMeters(terrain, eastMeters, northMeters) {
+  const samples = Array.isArray(terrain?.samples) ? terrain.samples : [];
+  if (!terrain?.available || !samples.length) return 0;
+  let weighted = 0;
+  let weightTotal = 0;
+  for (const sample of samples) {
+    const dx = eastMeters - Number(sample.eastMeters || 0);
+    const dz = northMeters - Number(sample.northMeters || 0);
+    const distanceSquared = dx * dx + dz * dz;
+    const weight = 1 / Math.max(1, distanceSquared);
+    weighted += Number(sample.relativeElevationMeters || 0) * weight;
+    weightTotal += weight;
+  }
+  return weightTotal > 0 ? weighted / weightTotal : 0;
+}
+
+function shapeFromGeometry(THREE, geometry, originLongitude, originLatitude) {
+  const ring = outerRing(geometry);
+  if (ring.length < 4) return null;
+  const local = ring.slice(0, -1)
+    .map(([lon, lat]) => toLocalMeters(lon, lat, originLongitude, originLatitude))
+    .filter((point) => Number.isFinite(point.east) && Number.isFinite(point.north));
+  if (local.length < 3) return null;
+  const shape = new THREE.Shape();
+  local.forEach((point, index) => {
+    const x = point.east * METERS_TO_SCENE;
+    const zAsShapeY = -point.north * METERS_TO_SCENE;
+    if (index === 0) shape.moveTo(x, zAsShapeY); else shape.lineTo(x, zAsShapeY);
+  });
+  shape.closePath();
+  return { shape, local };
+}
+
 export default function GeoReferenceModel({ reference }) {
   const mountRef = useRef(null);
 
@@ -28,7 +71,7 @@ export default function GeoReferenceModel({ reference }) {
       const width = Math.max(300, mount.clientWidth || 320);
       const height = Math.max(320, mount.clientHeight || 400);
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.35));
       renderer.setSize(width, height);
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.shadowMap.enabled = false;
@@ -37,14 +80,14 @@ export default function GeoReferenceModel({ reference }) {
       mount.appendChild(renderer.domElement);
 
       const scene = new THREE.Scene();
-      scene.fog = new THREE.Fog(0x07100d, 22, 44);
-      const camera = new THREE.PerspectiveCamera(36, width / height, 0.1, 100);
-      scene.add(new THREE.HemisphereLight(0xf5fff9, 0x06100d, 2.35));
-      const sun = new THREE.DirectionalLight(0xffffff, 3.2);
-      sun.position.set(8, 12, 9);
+      scene.fog = new THREE.Fog(0x07100d, 20, 39);
+      const camera = new THREE.PerspectiveCamera(37, width / height, 0.1, 120);
+      scene.add(new THREE.HemisphereLight(0xf5fff9, 0x06100d, 2.15));
+      const sun = new THREE.DirectionalLight(0xffffff, 3.1);
+      sun.position.set(10, 16, 10);
       scene.add(sun);
-      const accent = new THREE.PointLight(0x7ce9c4, 24, 28);
-      accent.position.set(-6, 6, 7);
+      const accent = new THREE.PointLight(0x7ce9c4, 18, 32);
+      accent.position.set(-7, 7, 8);
       scene.add(accent);
 
       const root = new THREE.Group();
@@ -54,107 +97,144 @@ export default function GeoReferenceModel({ reference }) {
       const mat = (params) => { const material = new THREE.MeshStandardMaterial(params); materials.push(material); return material; };
       const lineMat = (params) => { const material = new THREE.LineBasicMaterial(params); materials.push(material); return material; };
 
-      const groundGeometry = new THREE.CylinderGeometry(6.65, 6.95, 0.32, 64);
-      geometries.push(groundGeometry);
-      const ground = new THREE.Mesh(groundGeometry, mat({ color: 0x13231d, roughness: 0.92, metalness: 0.03 }));
-      ground.position.y = -0.27;
-      root.add(ground);
+      const originLatitude = Number(reference?.latitude);
+      const originLongitude = Number(reference?.longitude);
+      const validOrigin = Number.isFinite(originLatitude) && Number.isFinite(originLongitude);
+      const terrain = reference?.terrain || null;
+      const terrainRadiusMeters = Math.max(60, Math.min(180, Number(terrain?.radiusMeters) || 90));
+      const sceneRadius = terrainRadiusMeters * METERS_TO_SCENE;
 
-      const grid = new THREE.GridHelper(11.8, 18, 0x315d4f, 0x1a332a);
-      grid.position.y = -0.095;
-      const gridMaterials = Array.isArray(grid.material) ? grid.material : [grid.material];
-      gridMaterials.forEach((material) => { material.transparent = true; material.opacity = 0.22; materials.push(material); });
-      root.add(grid);
+      const baseGeometry = new THREE.CylinderGeometry(sceneRadius * 1.08, sceneRadius * 1.13, 0.26, 72);
+      geometries.push(baseGeometry);
+      const base = new THREE.Mesh(baseGeometry, mat({ color: 0x101d18, roughness: 0.95, metalness: 0.02 }));
+      base.position.y = -0.32;
+      root.add(base);
 
-      const orbitGeometry = new THREE.RingGeometry(5.9, 6.02, 96);
-      geometries.push(orbitGeometry);
-      const orbitRing = new THREE.Mesh(orbitGeometry, mat({ color: 0x7ce9c4, emissive: 0x164c3c, emissiveIntensity: 0.9, transparent: true, opacity: 0.72, side: THREE.DoubleSide }));
-      orbitRing.rotation.x = -Math.PI / 2;
-      orbitRing.position.y = -0.075;
-      root.add(orbitRing);
-
-      const polygonRing = outerRing(reference?.geometry);
-      if (reference?.found && polygonRing.length >= 4) {
-        const lat0 = Number(polygonRing[0][1]);
-        const lon0 = Number(polygonRing[0][0]);
-        const cosLat = Math.max(0.2, Math.cos(lat0 * Math.PI / 180));
-        const rawPoints = polygonRing.slice(0, -1).map(([lon, lat]) => ({
-          x: (Number(lon) - lon0) * 111320 * cosLat,
-          y: (Number(lat) - lat0) * 111320,
-        })).filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
-
-        if (rawPoints.length >= 3) {
-          const xs = rawPoints.map((point) => point.x);
-          const ys = rawPoints.map((point) => point.y);
-          const minX = Math.min(...xs), maxX = Math.max(...xs), minY = Math.min(...ys), maxY = Math.max(...ys);
-          const span = Math.max(maxX - minX, maxY - minY, 1);
-          const scale = 7.1 / span;
-          const centerX = (minX + maxX) / 2;
-          const centerY = (minY + maxY) / 2;
-          const points = rawPoints.map((point) => ({ x: (point.x - centerX) * scale, y: (point.y - centerY) * scale }));
-          const shape = new THREE.Shape();
-          points.forEach((point, index) => {
-            if (index === 0) shape.moveTo(point.x, point.y); else shape.lineTo(point.x, point.y);
-          });
-          shape.closePath();
-
-          const sourceHeight = Math.max(0.5, Number(reference?.height?.referenceHeightMeters) || 3);
-          const visualHeight = Math.max(0.8, Math.min(8.2, sourceHeight * scale));
-          const levels = numericLevels(reference, sourceHeight);
-
-          const footprintPoints = points.map((point) => new THREE.Vector3(point.x, 0.015, -point.y));
-          if (footprintPoints.length) footprintPoints.push(footprintPoints[0].clone());
-          const footprintGeometry = new THREE.BufferGeometry().setFromPoints(footprintPoints);
-          geometries.push(footprintGeometry);
-          root.add(new THREE.Line(footprintGeometry, lineMat({ color: 0x7ce9c4, transparent: true, opacity: 0.9 })));
-
-          const buildingGeometry = new THREE.ExtrudeGeometry(shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
-          buildingGeometry.rotateX(-Math.PI / 2);
-          geometries.push(buildingGeometry);
-          const buildingMaterial = mat({ color: 0xcbd4d0, roughness: 0.58, metalness: 0.06, transparent: true, opacity: 0.96 });
-          const building = new THREE.Mesh(buildingGeometry, buildingMaterial);
-          root.add(building);
-
-          const edgesGeometry = new THREE.EdgesGeometry(buildingGeometry, 18);
-          geometries.push(edgesGeometry);
-          root.add(new THREE.LineSegments(edgesGeometry, lineMat({ color: 0x8bf1ce, transparent: true, opacity: 0.72 })));
-
-          const roofGeometry = new THREE.ShapeGeometry(shape);
-          roofGeometry.rotateX(-Math.PI / 2);
-          geometries.push(roofGeometry);
-          const roof = new THREE.Mesh(roofGeometry, mat({ color: 0xe6eeea, roughness: 0.4, metalness: 0.08, transparent: true, opacity: 0.95, side: THREE.DoubleSide }));
-          roof.position.y = visualHeight + 0.012;
-          root.add(roof);
-
-          const bandCount = Math.min(levels - 1, 11);
-          for (let floor = 1; floor <= bandCount; floor += 1) {
-            const y = visualHeight * (floor / levels);
-            const bandPoints = points.map((point) => new THREE.Vector3(point.x, y, -point.y));
-            if (bandPoints.length) bandPoints.push(bandPoints[0].clone());
-            const bandGeometry = new THREE.BufferGeometry().setFromPoints(bandPoints);
-            geometries.push(bandGeometry);
-            root.add(new THREE.Line(bandGeometry, lineMat({ color: 0x5cae93, transparent: true, opacity: 0.34 })));
+      if (terrain?.available && Array.isArray(terrain.samples) && terrain.samples.length >= 4) {
+        const sorted = [...terrain.samples].sort((a, b) => Number(a.row) - Number(b.row) || Number(a.column) - Number(b.column));
+        const vertices = [];
+        for (let row = 0; row < 3; row += 1) {
+          for (let column = 0; column < 3; column += 1) {
+            const sample = sorted.find((item) => Number(item.row) === row && Number(item.column) === column);
+            const east = Number(sample?.eastMeters ?? (column - 1) * terrainRadiusMeters);
+            const north = Number(sample?.northMeters ?? (row - 1) * terrainRadiusMeters);
+            const elevation = Number(sample?.relativeElevationMeters || 0);
+            vertices.push(east * METERS_TO_SCENE, elevation * METERS_TO_SCENE, -north * METERS_TO_SCENE);
           }
-
-          const pillarGeometry = new THREE.CylinderGeometry(0.025, 0.025, visualHeight, 5);
-          geometries.push(pillarGeometry);
-          const pillarMaterial = mat({ color: 0x7ce9c4, emissive: 0x173d32, emissiveIntensity: 0.5, roughness: 0.45 });
-          const stride = Math.max(1, Math.ceil(points.length / 18));
-          points.filter((_, index) => index % stride === 0).slice(0, 18).forEach((point) => {
-            const pillar = new THREE.Mesh(pillarGeometry, pillarMaterial);
-            pillar.position.set(point.x, visualHeight / 2, -point.y);
-            root.add(pillar);
-          });
-
-          const beaconGeometry = new THREE.RingGeometry(Math.max(0.35, Math.min(2.4, span * scale * 0.23)), Math.max(0.41, Math.min(2.48, span * scale * 0.23 + 0.08)), 64);
-          geometries.push(beaconGeometry);
-          const beacon = new THREE.Mesh(beaconGeometry, mat({ color: 0xffffff, emissive: 0x356f5e, emissiveIntensity: 0.8, transparent: true, opacity: 0.32, side: THREE.DoubleSide }));
-          beacon.rotation.x = -Math.PI / 2;
-          beacon.position.y = visualHeight + 0.075;
-          root.add(beacon);
         }
+        const indices = [];
+        for (let row = 0; row < 2; row += 1) {
+          for (let column = 0; column < 2; column += 1) {
+            const a = row * 3 + column;
+            const b = a + 1;
+            const c = a + 3;
+            const d = c + 1;
+            indices.push(a, c, b, b, c, d);
+          }
+        }
+        const terrainGeometry = new THREE.BufferGeometry();
+        terrainGeometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+        terrainGeometry.setIndex(indices);
+        terrainGeometry.computeVertexNormals();
+        geometries.push(terrainGeometry);
+        const terrainMesh = new THREE.Mesh(terrainGeometry, mat({ color: 0x1d3028, roughness: 0.96, metalness: 0.01, side: THREE.DoubleSide }));
+        root.add(terrainMesh);
+        const terrainEdges = new THREE.EdgesGeometry(terrainGeometry, 1);
+        geometries.push(terrainEdges);
+        root.add(new THREE.LineSegments(terrainEdges, lineMat({ color: 0x4f8b76, transparent: true, opacity: 0.34 })));
       } else {
-        const markerGeometry = new THREE.TorusGeometry(2.3, 0.1, 12, 72);
+        const flatGeometry = new THREE.CircleGeometry(sceneRadius, 64);
+        flatGeometry.rotateX(-Math.PI / 2);
+        geometries.push(flatGeometry);
+        const flat = new THREE.Mesh(flatGeometry, mat({ color: 0x172720, roughness: 0.96, metalness: 0.01 }));
+        flat.position.y = -0.04;
+        root.add(flat);
+      }
+
+      const compassGeometry = new THREE.RingGeometry(sceneRadius * 0.97, sceneRadius, 96);
+      geometries.push(compassGeometry);
+      const compass = new THREE.Mesh(compassGeometry, mat({ color: 0x7ce9c4, emissive: 0x123b30, emissiveIntensity: 0.7, transparent: true, opacity: 0.5, side: THREE.DoubleSide }));
+      compass.rotation.x = -Math.PI / 2;
+      compass.position.y = -0.025;
+      root.add(compass);
+
+      const surroundings = Array.isArray(reference?.neighborhoodBuildings) ? reference.neighborhoodBuildings.slice(0, 20) : [];
+      const primaryRecordId = String(reference?.source?.recordId || '');
+
+      if (validOrigin) {
+        for (const buildingRef of surroundings) {
+          if (!buildingRef?.geometry) continue;
+          const isPrimary = buildingRef.selected === true || String(buildingRef.id || '') === primaryRecordId;
+          if (isPrimary) continue;
+          const shaped = shapeFromGeometry(THREE, buildingRef.geometry, originLongitude, originLatitude);
+          if (!shaped) continue;
+          const center = buildingRef.center || {};
+          const localCenter = toLocalMeters(center.longitude ?? originLongitude, center.latitude ?? originLatitude, originLongitude, originLatitude);
+          const baseY = terrainRelativeMeters(terrain, localCenter.east, localCenter.north) * METERS_TO_SCENE;
+          const sourceHeight = Math.max(2.2, Math.min(120, Number(buildingRef?.height?.referenceHeightMeters) || 3));
+          const visualHeight = Math.max(0.18, sourceHeight * METERS_TO_SCENE);
+          const geometry = new THREE.ExtrudeGeometry(shaped.shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
+          geometry.rotateX(-Math.PI / 2);
+          geometries.push(geometry);
+          const mesh = new THREE.Mesh(geometry, mat({ color: 0x465b53, roughness: 0.76, metalness: 0.03, transparent: true, opacity: 0.7 }));
+          mesh.position.y = baseY;
+          root.add(mesh);
+          const edges = new THREE.EdgesGeometry(geometry, 28);
+          geometries.push(edges);
+          const lines = new THREE.LineSegments(edges, lineMat({ color: 0x76988b, transparent: true, opacity: 0.25 }));
+          lines.position.y = baseY;
+          root.add(lines);
+        }
+      }
+
+      const primaryGeometry = reference?.geometry;
+      const shapedPrimary = validOrigin ? shapeFromGeometry(THREE, primaryGeometry, originLongitude, originLatitude) : null;
+      if (reference?.found && shapedPrimary) {
+        const sourceHeight = Math.max(2.2, Math.min(500, Number(reference?.height?.referenceHeightMeters) || 3));
+        const visualHeight = Math.max(0.24, sourceHeight * METERS_TO_SCENE);
+        const levels = numericLevels(reference, sourceHeight);
+        const center = reference?.neighborhoodBuildings?.[0]?.center || { longitude: originLongitude, latitude: originLatitude };
+        const localCenter = toLocalMeters(center.longitude ?? originLongitude, center.latitude ?? originLatitude, originLongitude, originLatitude);
+        const baseY = terrainRelativeMeters(terrain, localCenter.east, localCenter.north) * METERS_TO_SCENE;
+
+        const buildingGeometry = new THREE.ExtrudeGeometry(shapedPrimary.shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
+        buildingGeometry.rotateX(-Math.PI / 2);
+        geometries.push(buildingGeometry);
+        const building = new THREE.Mesh(buildingGeometry, mat({ color: 0xd7e0dc, roughness: 0.54, metalness: 0.06, transparent: true, opacity: 0.98 }));
+        building.position.y = baseY;
+        root.add(building);
+
+        const edgesGeometry = new THREE.EdgesGeometry(buildingGeometry, 18);
+        geometries.push(edgesGeometry);
+        const edges = new THREE.LineSegments(edgesGeometry, lineMat({ color: 0x8bf1ce, transparent: true, opacity: 0.86 }));
+        edges.position.y = baseY;
+        root.add(edges);
+
+        const footprintPoints = shapedPrimary.local.map((point) => new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + 0.018, -point.north * METERS_TO_SCENE));
+        if (footprintPoints.length) footprintPoints.push(footprintPoints[0].clone());
+        const footprintGeometry = new THREE.BufferGeometry().setFromPoints(footprintPoints);
+        geometries.push(footprintGeometry);
+        root.add(new THREE.Line(footprintGeometry, lineMat({ color: 0x7ce9c4, transparent: true, opacity: 0.95 })));
+
+        const bandCount = Math.min(levels - 1, 12);
+        for (let floor = 1; floor <= bandCount; floor += 1) {
+          const y = baseY + visualHeight * (floor / levels);
+          const bandPoints = shapedPrimary.local.map((point) => new THREE.Vector3(point.east * METERS_TO_SCENE, y, -point.north * METERS_TO_SCENE));
+          if (bandPoints.length) bandPoints.push(bandPoints[0].clone());
+          const bandGeometry = new THREE.BufferGeometry().setFromPoints(bandPoints);
+          geometries.push(bandGeometry);
+          root.add(new THREE.Line(bandGeometry, lineMat({ color: 0x6fc4a7, transparent: true, opacity: 0.42 })));
+        }
+
+        const beaconRadius = Math.max(0.45, Math.min(2.4, 1.2 + Number(reference?.distanceMeters || 0) * 0.002));
+        const beaconGeometry = new THREE.RingGeometry(beaconRadius, beaconRadius + 0.08, 72);
+        geometries.push(beaconGeometry);
+        const beacon = new THREE.Mesh(beaconGeometry, mat({ color: 0xffffff, emissive: 0x356f5e, emissiveIntensity: 0.9, transparent: true, opacity: 0.44, side: THREE.DoubleSide }));
+        beacon.rotation.x = -Math.PI / 2;
+        beacon.position.set(localCenter.east * METERS_TO_SCENE, baseY + visualHeight + 0.08, -localCenter.north * METERS_TO_SCENE);
+        root.add(beacon);
+      } else {
+        const markerGeometry = new THREE.TorusGeometry(1.2, 0.08, 12, 72);
         geometries.push(markerGeometry);
         const marker = new THREE.Mesh(markerGeometry, mat({ color: 0x7ce9c4, emissive: 0x164c3c, emissiveIntensity: 1.15 }));
         marker.rotation.x = -Math.PI / 2;
@@ -163,8 +243,8 @@ export default function GeoReferenceModel({ reference }) {
       }
 
       let azimuth = 0.72;
-      let elevation = 0.5;
-      let radius = 17;
+      let elevation = 0.53;
+      let radius = Math.max(14, sceneRadius * 2.25);
       let dragging = false;
       let autoOrbit = true;
       let lastX = 0;
@@ -172,7 +252,7 @@ export default function GeoReferenceModel({ reference }) {
       const updateCamera = () => {
         const c = Math.cos(elevation);
         camera.position.set(Math.sin(azimuth) * c * radius, Math.sin(elevation) * radius, Math.cos(azimuth) * c * radius);
-        camera.lookAt(0, 1.55, 0);
+        camera.lookAt(0, 0.8, 0);
       };
       updateCamera();
       const down = (event) => {
@@ -185,7 +265,7 @@ export default function GeoReferenceModel({ reference }) {
       const move = (event) => {
         if (!dragging) return;
         azimuth -= (event.clientX - lastX) * 0.008;
-        elevation = Math.max(0.18, Math.min(1.08, elevation + (event.clientY - lastY) * 0.005));
+        elevation = Math.max(0.16, Math.min(1.08, elevation + (event.clientY - lastY) * 0.005));
         lastX = event.clientX;
         lastY = event.clientY;
         updateCamera();
@@ -196,7 +276,7 @@ export default function GeoReferenceModel({ reference }) {
       };
       const wheel = (event) => {
         autoOrbit = false;
-        radius = Math.max(8.5, Math.min(26, radius + event.deltaY * 0.012));
+        radius = Math.max(sceneRadius * 1.15, Math.min(sceneRadius * 3.5, radius + event.deltaY * 0.014));
         updateCamera();
       };
       renderer.domElement.addEventListener('pointerdown', down);
@@ -208,9 +288,9 @@ export default function GeoReferenceModel({ reference }) {
       let frame = 0;
       const animate = () => {
         frame = requestAnimationFrame(animate);
-        orbitRing.rotation.z += 0.00125;
+        compass.rotation.z += 0.00075;
         if (autoOrbit) {
-          azimuth += 0.0011;
+          azimuth += 0.00085;
           updateCamera();
         }
         renderer.render(scene, camera);
@@ -241,7 +321,7 @@ export default function GeoReferenceModel({ reference }) {
       };
     });
     return () => { disposed = true; cleanup(); };
-  }, [reference?.source?.recordId, reference?.height?.referenceHeightMeters, reference?.tags?.levels]);
+  }, [reference?.source?.recordId, reference?.height?.referenceHeightMeters, reference?.neighborhoodBuildingCount, reference?.terrain?.source?.observedAt, reference?.measuredHeight?.status]);
 
   return <div ref={mountRef} style={{ position: 'absolute', inset: 0 }} />;
 }

--- a/lib/real-estate/global-neighborhood-reference.js
+++ b/lib/real-estate/global-neighborhood-reference.js
@@ -1,0 +1,193 @@
+const DEFAULT_OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+const OSM_ATTRIBUTION_URL = 'https://www.openstreetmap.org/copyright';
+const APP_USER_AGENT = 'VoxelVault-GEO/1.0 (+https://www.voxelvault.io)';
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const cache = new Map();
+let publicQueue = Promise.resolve();
+
+const clean = (value) => String(value ?? '').trim();
+const finite = (value) => value !== null && value !== undefined && clean(value) !== '' && Number.isFinite(Number(value));
+
+function coordinate(value, min, max, label) {
+  if (!finite(value)) throw new Error(`${label} is required.`);
+  const number = Number(value);
+  if (number < min || number > max) throw new Error(`${label} is outside its valid range.`);
+  return number;
+}
+
+function parseMeters(value) {
+  const text = clean(value).toLowerCase();
+  if (!text) return null;
+  const feet = text.match(/^([0-9]+(?:\.[0-9]+)?)\s*(?:ft|feet|foot)$/);
+  if (feet) return Number(feet[1]) * 0.3048;
+  const meters = text.match(/^([0-9]+(?:\.[0-9]+)?)\s*(?:m|meter|meters)?$/);
+  return meters ? Number(meters[1]) : null;
+}
+
+function parseLevels(value) {
+  const number = Number(clean(value).split(';')[0]);
+  return Number.isFinite(number) && number > 0 && number < 300 ? number : null;
+}
+
+function chooseHeight(tags = {}) {
+  const reported = parseMeters(tags.height);
+  if (reported && reported > 0 && reported < 1000) {
+    return { referenceHeightMeters: Number(reported.toFixed(3)), heightStatus: 'source_reported', heightSource: 'OpenStreetMap height tag', measuredHeightAccepted: false };
+  }
+  const levels = parseLevels(tags['building:levels']);
+  if (levels) {
+    return { referenceHeightMeters: Number((levels * 3).toFixed(3)), heightStatus: 'derived_from_levels', heightSource: `${levels} source-reported level(s) × 3 m illustrative floor height`, measuredHeightAccepted: false };
+  }
+  return { referenceHeightMeters: 3, heightStatus: 'illustrative_default', heightSource: '3 m illustrative extrusion because no source height or level count was available', measuredHeightAccepted: false };
+}
+
+function ringFromWay(element) {
+  if (!Array.isArray(element?.geometry) || element.geometry.length < 3) return null;
+  const ring = element.geometry
+    .map((point) => [Number(point?.lon), Number(point?.lat)])
+    .filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat));
+  if (ring.length < 3) return null;
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (first[0] !== last[0] || first[1] !== last[1]) ring.push([...first]);
+  return ring.length >= 4 ? ring : null;
+}
+
+function centroid(ring) {
+  const points = ring.slice(0, -1);
+  if (!points.length) return null;
+  const sum = points.reduce((acc, [lon, lat]) => ({ lon: acc.lon + lon, lat: acc.lat + lat }), { lon: 0, lat: 0 });
+  return { longitude: sum.lon / points.length, latitude: sum.lat / points.length };
+}
+
+function haversineMeters(lat1, lon1, lat2, lon2) {
+  const toRad = (degrees) => degrees * Math.PI / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 6371000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function cacheRead(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.storedAt > CACHE_TTL_MS) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function cacheWrite(key, value) {
+  if (cache.size > 400) cache.delete(cache.keys().next().value);
+  cache.set(key, { storedAt: Date.now(), value });
+  return value;
+}
+
+async function serializedPublicRequest(task) {
+  const next = publicQueue.then(task, task);
+  publicQueue = next.catch(() => {});
+  return next;
+}
+
+function normalizeBuilding(candidate, selectedId) {
+  const tags = candidate.element?.tags || {};
+  const id = Number(candidate.element?.id);
+  return {
+    id: Number.isFinite(id) ? `way:${id}` : `building:${candidate.distanceMeters.toFixed(1)}`,
+    selected: Number.isFinite(id) && id === selectedId,
+    distanceMeters: Number(candidate.distanceMeters.toFixed(2)),
+    center: candidate.center,
+    geometry: { type: 'Polygon', coordinates: [candidate.ring] },
+    tags: {
+      building: clean(tags.building),
+      name: clean(tags.name),
+      height: clean(tags.height),
+      levels: clean(tags['building:levels']),
+      houseNumber: clean(tags['addr:housenumber']),
+      street: clean(tags['addr:street']),
+    },
+    height: chooseHeight(tags),
+    sourceUrl: Number.isFinite(id) ? `https://www.openstreetmap.org/way/${id}` : 'https://www.openstreetmap.org/',
+  };
+}
+
+export async function fetchGlobalNeighborhoodReference(input = {}, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') throw new Error('No fetch implementation is available for global neighborhood lookup.');
+  const latitude = coordinate(input.latitude, -90, 90, 'Latitude');
+  const longitude = coordinate(input.longitude, -180, 180, 'Longitude');
+  const radiusMeters = Math.max(60, Math.min(220, Number(input.radiusMeters) || 130));
+  const overpassUrl = clean(process.env.OVERPASS_API_URL || options.overpassUrl || DEFAULT_OVERPASS_URL);
+  const cacheKey = `${overpassUrl}|${latitude.toFixed(5)}|${longitude.toFixed(5)}|${Math.round(radiusMeters)}`;
+  const cached = cacheRead(cacheKey);
+  if (cached) return { ...cached, cacheStatus: 'warm-instance-hit' };
+
+  const query = `[out:json][timeout:14];way(around:${Math.round(radiusMeters)},${latitude},${longitude})["building"];out body geom qt 45;`;
+  const execute = async () => {
+    const response = await fetchImpl(overpassUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'User-Agent': APP_USER_AGENT,
+        Referer: 'https://www.voxelvault.io/geo',
+      },
+      body: new URLSearchParams({ data: query }).toString(),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(17000),
+    });
+    if (!response.ok) throw new Error(`Global neighborhood source returned HTTP ${response.status}.`);
+    return response;
+  };
+
+  const response = overpassUrl === DEFAULT_OVERPASS_URL ? await serializedPublicRequest(execute) : await execute();
+  const payload = await response.json().catch(() => null);
+  const candidates = (Array.isArray(payload?.elements) ? payload.elements : [])
+    .map((element) => {
+      const ring = ringFromWay(element);
+      const center = ring ? centroid(ring) : null;
+      if (!ring || !center) return null;
+      return { element, ring, center, distanceMeters: haversineMeters(latitude, longitude, center.latitude, center.longitude) };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.distanceMeters - b.distanceMeters);
+
+  const selected = candidates[0] || null;
+  const selectedId = Number(selected?.element?.id);
+  const buildings = candidates.slice(0, 24).map((candidate) => normalizeBuilding(candidate, selectedId));
+  const primary = buildings[0] || null;
+  const source = {
+    authority: 'OpenStreetMap contributors via Overpass API',
+    observedAt: new Date().toISOString(),
+    sourceUrl: primary?.sourceUrl || 'https://www.openstreetmap.org/',
+    attributionUrl: OSM_ATTRIBUTION_URL,
+    license: 'ODbL',
+    publicServiceUsage: overpassUrl === DEFAULT_OVERPASS_URL ? 'small-scale serialized lookup; configure OVERPASS_API_URL for production scale' : 'configured Overpass-compatible provider',
+  };
+
+  return cacheWrite(cacheKey, {
+    found: Boolean(primary),
+    latitude,
+    longitude,
+    radiusMeters,
+    cacheStatus: 'miss',
+    neighborhoodBuildingCount: buildings.length,
+    neighborhoodBuildings: buildings,
+    geometry: primary?.geometry || null,
+    tags: primary?.tags || {},
+    height: primary?.height || { referenceHeightMeters: 3, heightStatus: 'illustrative_default', heightSource: 'No selected building footprint was found.', measuredHeightAccepted: false },
+    distanceMeters: primary?.distanceMeters ?? null,
+    matchStrategy: primary ? 'nearest_source_building_within_neighborhood' : 'none',
+    source: { ...source, recordId: primary?.id || '' },
+    legalEffects: {
+      authoritativeParcelBoundary: false,
+      verifiesTitle: false,
+      createsOwnership: false,
+      verifiedMeasuredHeight: false,
+    },
+    note: primary
+      ? 'The selected and surrounding building footprints are source-backed global map references. Their height may be source-reported, derived from levels, or illustrative; none becomes legal parcel/title evidence.'
+      : 'No nearby OSM building footprint was returned. GEO must not invent a property-specific footprint.',
+  });
+}

--- a/lib/real-estate/measured-building-height.js
+++ b/lib/real-estate/measured-building-height.js
@@ -1,0 +1,100 @@
+const clean = (value) => String(value ?? '').trim();
+const finite = (value) => value !== null && value !== undefined && clean(value) !== '' && Number.isFinite(Number(value));
+
+export function evaluateMeasuredBuildingHeight(input = {}) {
+  const acceptedBuildingGeometry = input.acceptedBuildingGeometry || null;
+  const lidarCoverage = input.lidarCoverage || null;
+  const measurement = input.measurement || null;
+  const hasAcceptedFootprint = Boolean(acceptedBuildingGeometry && ['Polygon', 'MultiPolygon'].includes(acceptedBuildingGeometry.type));
+  const hasLidarCoverage = lidarCoverage?.coverageStatus === 'covered' && Array.isArray(lidarCoverage?.tiles) && lidarCoverage.tiles.length > 0;
+
+  if (!hasAcceptedFootprint) {
+    return {
+      status: 'blocked_missing_building_geometry',
+      verifiedMeasuredHeight: false,
+      heightMeters: null,
+      hasLidarCoverage,
+      note: 'A parcel-specific accepted building footprint is required before LiDAR roof/ground samples can be assigned to this building. Coverage alone is not a height measurement.',
+    };
+  }
+
+  if (!hasLidarCoverage) {
+    return {
+      status: 'blocked_missing_lidar_coverage',
+      verifiedMeasuredHeight: false,
+      heightMeters: null,
+      hasLidarCoverage: false,
+      note: 'No approved LiDAR coverage is attached to this building footprint yet.',
+    };
+  }
+
+  if (!measurement) {
+    return {
+      status: 'lidar_coverage_ready_for_measurement',
+      verifiedMeasuredHeight: false,
+      heightMeters: null,
+      hasLidarCoverage: true,
+      note: 'Authoritative LiDAR coverage and an accepted footprint are present, but roof/ground point-cloud samples have not been processed yet.',
+    };
+  }
+
+  const roofElevationMeters = finite(measurement.roofElevationMeters) ? Number(measurement.roofElevationMeters) : null;
+  const groundElevationMeters = finite(measurement.groundElevationMeters) ? Number(measurement.groundElevationMeters) : null;
+  const uncertaintyMeters = finite(measurement.uncertaintyMeters) ? Number(measurement.uncertaintyMeters) : null;
+  const roofSampleCount = Number(measurement.roofSampleCount || 0);
+  const groundSampleCount = Number(measurement.groundSampleCount || 0);
+  const sourceAuthority = clean(measurement.sourceAuthority);
+  const method = clean(measurement.method);
+  const footprintRecordId = clean(measurement.footprintRecordId);
+  const sourceRecordId = clean(measurement.sourceRecordId);
+  const observedAt = clean(measurement.observedAt);
+
+  const blockers = [
+    roofElevationMeters === null ? 'roof elevation is missing' : '',
+    groundElevationMeters === null ? 'ground elevation is missing' : '',
+    roofSampleCount < 3 ? 'at least 3 roof samples are required' : '',
+    groundSampleCount < 3 ? 'at least 3 ground samples are required' : '',
+    uncertaintyMeters === null || uncertaintyMeters < 0 || uncertaintyMeters > 2 ? 'measurement uncertainty must be documented and <= 2 m' : '',
+    !sourceAuthority ? 'source authority is required' : '',
+    !method ? 'measurement method is required' : '',
+    !footprintRecordId ? 'accepted footprint record id is required' : '',
+    !sourceRecordId ? 'LiDAR/source record id is required' : '',
+    !observedAt ? 'measurement observation timestamp is required' : '',
+  ].filter(Boolean);
+
+  const rawHeight = roofElevationMeters !== null && groundElevationMeters !== null ? roofElevationMeters - groundElevationMeters : null;
+  if (rawHeight !== null && (rawHeight <= 0 || rawHeight > 500)) blockers.push('roof-minus-ground height is outside a defensible building range');
+
+  if (blockers.length) {
+    return {
+      status: 'measurement_rejected',
+      verifiedMeasuredHeight: false,
+      heightMeters: null,
+      hasLidarCoverage: true,
+      blockers,
+      note: 'The supplied LiDAR measurement did not satisfy GEO measured-height evidence requirements.',
+    };
+  }
+
+  return {
+    status: 'verified_measured_height',
+    verifiedMeasuredHeight: true,
+    heightMeters: Number(rawHeight.toFixed(3)),
+    roofElevationMeters: Number(roofElevationMeters.toFixed(3)),
+    groundElevationMeters: Number(groundElevationMeters.toFixed(3)),
+    uncertaintyMeters: Number(uncertaintyMeters.toFixed(3)),
+    roofSampleCount,
+    groundSampleCount,
+    method,
+    sourceAuthority,
+    sourceRecordId,
+    footprintRecordId,
+    observedAt,
+    note: 'Measured height is accepted only as a physical building measurement. It does not establish parcel ownership, title, market value, or investment rights.',
+    legalEffects: {
+      establishesDeedOwnership: false,
+      establishesInvestmentRights: false,
+      guaranteesValue: false,
+    },
+  };
+}

--- a/lib/real-estate/measured-building-height.js
+++ b/lib/real-estate/measured-building-height.js
@@ -1,11 +1,17 @@
 const clean = (value) => String(value ?? '').trim();
 const finite = (value) => value !== null && value !== undefined && clean(value) !== '' && Number.isFinite(Number(value));
 
+function hasUsableGeometry(geometry) {
+  if (!geometry || !['Polygon', 'MultiPolygon'].includes(geometry.type)) return false;
+  const polygonRing = geometry.type === 'Polygon' ? geometry.coordinates?.[0] : geometry.coordinates?.[0]?.[0];
+  return Array.isArray(polygonRing) && polygonRing.length >= 4;
+}
+
 export function evaluateMeasuredBuildingHeight(input = {}) {
   const acceptedBuildingGeometry = input.acceptedBuildingGeometry || null;
   const lidarCoverage = input.lidarCoverage || null;
   const measurement = input.measurement || null;
-  const hasAcceptedFootprint = Boolean(acceptedBuildingGeometry && ['Polygon', 'MultiPolygon'].includes(acceptedBuildingGeometry.type));
+  const hasAcceptedFootprint = hasUsableGeometry(acceptedBuildingGeometry);
   const hasLidarCoverage = lidarCoverage?.coverageStatus === 'covered' && Array.isArray(lidarCoverage?.tiles) && lidarCoverage.tiles.length > 0;
 
   if (!hasAcceptedFootprint) {
@@ -48,6 +54,9 @@ export function evaluateMeasuredBuildingHeight(input = {}) {
   const footprintRecordId = clean(measurement.footprintRecordId);
   const sourceRecordId = clean(measurement.sourceRecordId);
   const observedAt = clean(measurement.observedAt);
+  const trustedSource = measurement.trustedSource === true;
+  const footprintMatchVerified = measurement.footprintMatchVerified === true;
+  const groundMethodValidated = measurement.groundMethodValidated === true;
 
   const blockers = [
     roofElevationMeters === null ? 'roof elevation is missing' : '',
@@ -60,6 +69,9 @@ export function evaluateMeasuredBuildingHeight(input = {}) {
     !footprintRecordId ? 'accepted footprint record id is required' : '',
     !sourceRecordId ? 'LiDAR/source record id is required' : '',
     !observedAt ? 'measurement observation timestamp is required' : '',
+    !trustedSource ? 'measurement must arrive through a trusted source path' : '',
+    !footprintMatchVerified ? 'building footprint match must be independently verified' : '',
+    !groundMethodValidated ? 'ground-reference method must be independently validated' : '',
   ].filter(Boolean);
 
   const rawHeight = roofElevationMeters !== null && groundElevationMeters !== null ? roofElevationMeters - groundElevationMeters : null;
@@ -72,7 +84,7 @@ export function evaluateMeasuredBuildingHeight(input = {}) {
       heightMeters: null,
       hasLidarCoverage: true,
       blockers,
-      note: 'The supplied LiDAR measurement did not satisfy GEO measured-height evidence requirements.',
+      note: 'The supplied LiDAR measurement did not satisfy GEO measured-height evidence requirements and cannot self-verify.',
     };
   }
 
@@ -90,6 +102,9 @@ export function evaluateMeasuredBuildingHeight(input = {}) {
     sourceRecordId,
     footprintRecordId,
     observedAt,
+    trustedSource,
+    footprintMatchVerified,
+    groundMethodValidated,
     note: 'Measured height is accepted only as a physical building measurement. It does not establish parcel ownership, title, market value, or investment rights.',
     legalEffects: {
       establishesDeedOwnership: false,

--- a/lib/real-estate/usgs-terrain-reference.js
+++ b/lib/real-estate/usgs-terrain-reference.js
@@ -1,0 +1,168 @@
+const DEFAULT_EPQS_URL = 'https://epqs.nationalmap.gov/v1/json';
+const TERRAIN_CACHE_TTL_MS = 30 * 60 * 1000;
+const terrainCache = new Map();
+
+const clean = (value) => String(value ?? '').trim();
+const finite = (value) => value !== null && value !== undefined && clean(value) !== '' && Number.isFinite(Number(value));
+
+function coordinate(value, min, max, label) {
+  if (!finite(value)) throw new Error(`${label} is required.`);
+  const number = Number(value);
+  if (number < min || number > max) throw new Error(`${label} is outside its valid range.`);
+  return number;
+}
+
+function cacheRead(key) {
+  const entry = terrainCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.storedAt > TERRAIN_CACHE_TTL_MS) {
+    terrainCache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function cacheWrite(key, value) {
+  if (terrainCache.size > 300) terrainCache.delete(terrainCache.keys().next().value);
+  terrainCache.set(key, { storedAt: Date.now(), value });
+  return value;
+}
+
+function pointAtOffset(latitude, longitude, eastMeters, northMeters) {
+  const latDelta = northMeters / 111320;
+  const lonScale = Math.max(0.15, Math.cos(latitude * Math.PI / 180));
+  const lonDelta = eastMeters / (111320 * lonScale);
+  return {
+    latitude: latitude + latDelta,
+    longitude: longitude + lonDelta,
+    eastMeters,
+    northMeters,
+  };
+}
+
+function parseEpqsPayload(payload) {
+  const value = Number(payload?.value ?? payload?.Elevation ?? payload?.USGS_Elevation_Point_Query_Service?.Elevation_Query?.Elevation);
+  if (!Number.isFinite(value) || value <= -999999) return null;
+  return {
+    elevationMeters: value,
+    dataSource: clean(payload?.dataSource ?? payload?.Data_Source ?? payload?.USGS_Elevation_Point_Query_Service?.Elevation_Query?.Data_Source),
+    resolutionMeters: Number.isFinite(Number(payload?.resolution)) ? Number(payload.resolution) : null,
+    rasterId: clean(payload?.rasterId),
+    date: clean(payload?.date),
+  };
+}
+
+async function fetchElevationPoint(point, options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== 'function') throw new Error('No fetch implementation is available for USGS terrain lookup.');
+  const endpoint = clean(process.env.USGS_EPQS_URL || options.epqsUrl || DEFAULT_EPQS_URL);
+  const url = new URL(endpoint);
+  url.searchParams.set('x', String(point.longitude));
+  url.searchParams.set('y', String(point.latitude));
+  url.searchParams.set('wkid', '4326');
+  url.searchParams.set('units', 'Meters');
+  url.searchParams.set('includeDate', 'true');
+  const response = await fetchImpl(url, {
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(Number(options.timeoutMs) || 8000),
+  });
+  if (!response.ok) throw new Error(`USGS terrain source returned HTTP ${response.status}.`);
+  const payload = await response.json().catch(() => null);
+  const parsed = parseEpqsPayload(payload || {});
+  if (!parsed) throw new Error('USGS terrain source did not return a usable elevation.');
+  return { ...point, ...parsed };
+}
+
+export async function fetchUsgsTerrainReference(input = {}, options = {}) {
+  const latitude = coordinate(input.latitude, -90, 90, 'Latitude');
+  const longitude = coordinate(input.longitude, -180, 180, 'Longitude');
+  const countryCode = clean(input.countryCode || 'US').toUpperCase();
+  const radiusMeters = Math.max(30, Math.min(180, Number(input.radiusMeters) || 90));
+
+  if (countryCode !== 'US') {
+    return {
+      available: false,
+      status: 'unsupported_country',
+      terrainVerifiedSurvey: false,
+      samples: [],
+      note: 'The current authoritative terrain adapter is USGS 3DEP for U.S. locations. GEO keeps the global scene flat rather than inventing elevation outside this adapter.',
+    };
+  }
+
+  const endpoint = clean(process.env.USGS_EPQS_URL || options.epqsUrl || DEFAULT_EPQS_URL);
+  const cacheKey = `${endpoint}|${latitude.toFixed(5)}|${longitude.toFixed(5)}|${Math.round(radiusMeters)}`;
+  const cached = cacheRead(cacheKey);
+  if (cached) return { ...cached, cacheStatus: 'warm-instance-hit' };
+
+  const offsets = [-radiusMeters, 0, radiusMeters];
+  const points = [];
+  offsets.forEach((northMeters, row) => {
+    offsets.forEach((eastMeters, column) => {
+      points.push({ ...pointAtOffset(latitude, longitude, eastMeters, northMeters), row, column });
+    });
+  });
+
+  const settled = await Promise.allSettled(points.map((point) => fetchElevationPoint(point, options)));
+  const successful = settled
+    .map((result, index) => result.status === 'fulfilled' ? { ...result.value, row: points[index].row, column: points[index].column } : null)
+    .filter(Boolean);
+
+  if (successful.length < 4) {
+    return cacheWrite(cacheKey, {
+      available: false,
+      status: 'insufficient_samples',
+      cacheStatus: 'miss',
+      terrainVerifiedSurvey: false,
+      samples: successful,
+      sampleCount: successful.length,
+      note: 'USGS elevation reference did not return enough samples to build a terrain surface. GEO keeps the scene flat rather than fabricating terrain.',
+      source: {
+        authority: 'U.S. Geological Survey 3D Elevation Program',
+        service: 'Elevation Point Query Service',
+        sourceUrl: 'https://www.usgs.gov/the-national-map-data-delivery/gis-data-download',
+      },
+    });
+  }
+
+  const elevations = successful.map((sample) => sample.elevationMeters);
+  const minElevationMeters = Math.min(...elevations);
+  const maxElevationMeters = Math.max(...elevations);
+  const center = successful.find((sample) => sample.row === 1 && sample.column === 1) || successful[0];
+  const referenceElevationMeters = center.elevationMeters;
+  const samples = successful.map((sample) => ({
+    ...sample,
+    relativeElevationMeters: Number((sample.elevationMeters - referenceElevationMeters).toFixed(3)),
+  }));
+
+  return cacheWrite(cacheKey, {
+    available: true,
+    status: 'source_backed_terrain_reference',
+    cacheStatus: 'miss',
+    latitude,
+    longitude,
+    radiusMeters,
+    gridSize: 3,
+    sampleCount: samples.length,
+    referenceElevationMeters: Number(referenceElevationMeters.toFixed(3)),
+    minElevationMeters: Number(minElevationMeters.toFixed(3)),
+    maxElevationMeters: Number(maxElevationMeters.toFixed(3)),
+    reliefMeters: Number((maxElevationMeters - minElevationMeters).toFixed(3)),
+    samples,
+    terrainVerifiedSurvey: false,
+    source: {
+      authority: 'U.S. Geological Survey 3D Elevation Program',
+      service: 'Elevation Point Query Service',
+      sourceUrl: 'https://www.usgs.gov/the-national-map-data-delivery/gis-data-download',
+      endpoint,
+      observedAt: new Date().toISOString(),
+      caveat: 'EPQS elevations are interpolated from 3DEP elevation services and are not official surveyed control elevations.',
+    },
+    legalEffects: {
+      establishesParcelBoundary: false,
+      establishesBuildingHeight: false,
+      establishesDeedOwnership: false,
+    },
+    note: 'Source-backed ground elevation reference for visualization. This does not measure the building roof height and does not upgrade a property to VERIFIED SPATIAL TWIN.',
+  });
+}

--- a/scripts/test-geo-property-onboarding.mjs
+++ b/scripts/test-geo-property-onboarding.mjs
@@ -19,6 +19,9 @@ import {
   factCheckProperty,
 } from '../lib/real-estate/property-fact-check.js';
 import { fetchGlobalBuildingReference } from '../lib/real-estate/global-building-reference.js';
+import { fetchGlobalNeighborhoodReference } from '../lib/real-estate/global-neighborhood-reference.js';
+import { fetchUsgsTerrainReference } from '../lib/real-estate/usgs-terrain-reference.js';
+import { evaluateMeasuredBuildingHeight } from '../lib/real-estate/measured-building-height.js';
 
 const penny = buildPropertyOwnershipGoal({ targetPropertyPriceCents: 10_000_000, savedCents: 0, contributionCents: 1 });
 assert.equal(penny.contributionCents, 1);
@@ -136,5 +139,120 @@ assert.equal(building.height.referenceHeightMeters, 6);
 assert.equal(building.height.heightStatus, 'derived_from_levels');
 assert.equal(building.height.measuredHeightAccepted, false);
 assert.equal(building.legalEffects.createsOwnership, false);
+
+const neighborhoodFetch = async () => ({
+  ok: true,
+  json: async () => ({ elements: [
+    {
+      type: 'way', id: 200,
+      tags: { building: 'yes', 'building:levels': '3' },
+      geometry: [
+        { lat: 42.00000, lon: -78.00000 },
+        { lat: 42.00000, lon: -77.99990 },
+        { lat: 42.00010, lon: -77.99990 },
+        { lat: 42.00010, lon: -78.00000 },
+        { lat: 42.00000, lon: -78.00000 },
+      ],
+    },
+    {
+      type: 'way', id: 201,
+      tags: { building: 'yes', height: '12 m' },
+      geometry: [
+        { lat: 42.00025, lon: -78.00000 },
+        { lat: 42.00025, lon: -77.99990 },
+        { lat: 42.00035, lon: -77.99990 },
+        { lat: 42.00035, lon: -78.00000 },
+        { lat: 42.00025, lon: -78.00000 },
+      ],
+    },
+  ] }),
+});
+const neighborhood = await fetchGlobalNeighborhoodReference({ latitude: 42.00005, longitude: -77.99995 }, { fetchImpl: neighborhoodFetch, overpassUrl: 'https://example.test' });
+assert.equal(neighborhood.found, true);
+assert.equal(neighborhood.neighborhoodBuildingCount, 2);
+assert.equal(neighborhood.neighborhoodBuildings[0].selected, true);
+assert.equal(neighborhood.neighborhoodBuildings[0].height.referenceHeightMeters, 9);
+assert.equal(neighborhood.neighborhoodBuildings[1].height.referenceHeightMeters, 12);
+assert.equal(neighborhood.legalEffects.authoritativeParcelBoundary, false);
+
+const terrainFetch = async (url) => {
+  const parsed = new URL(url);
+  const x = Number(parsed.searchParams.get('x'));
+  const y = Number(parsed.searchParams.get('y'));
+  return {
+    ok: true,
+    json: async () => ({
+      value: 180 + (x + 78) * 25 + (y - 42) * 40,
+      dataSource: '3DEP test surface',
+      resolution: 1,
+      rasterId: 'test-raster',
+      date: '2026-08-28',
+    }),
+  };
+};
+const terrain = await fetchUsgsTerrainReference({ latitude: 42, longitude: -78, countryCode: 'US', radiusMeters: 90 }, { fetchImpl: terrainFetch, epqsUrl: 'https://example.test/elevation' });
+assert.equal(terrain.available, true);
+assert.equal(terrain.sampleCount, 9);
+assert.equal(terrain.samples.length, 9);
+assert.equal(terrain.terrainVerifiedSurvey, false);
+assert.equal(terrain.legalEffects.establishesBuildingHeight, false);
+assert.ok(terrain.reliefMeters > 0);
+const unsupportedTerrain = await fetchUsgsTerrainReference({ latitude: 48, longitude: 2, countryCode: 'FR' }, { fetchImpl: terrainFetch, epqsUrl: 'https://example.test/elevation' });
+assert.equal(unsupportedTerrain.available, false);
+assert.equal(unsupportedTerrain.status, 'unsupported_country');
+
+const coverageOnly = {
+  coverageStatus: 'covered',
+  tiles: [{ filename: 'tile.las' }],
+};
+const missingFootprintHeight = evaluateMeasuredBuildingHeight({ acceptedBuildingGeometry: null, lidarCoverage: coverageOnly });
+assert.equal(missingFootprintHeight.status, 'blocked_missing_building_geometry');
+assert.equal(missingFootprintHeight.verifiedMeasuredHeight, false);
+assert.equal(missingFootprintHeight.heightMeters, null);
+
+const acceptedFootprint = { type: 'Polygon', coordinates: [[[-78,42],[-77.9999,42],[-77.9999,42.0001],[-78,42]]] };
+const readyForMeasurement = evaluateMeasuredBuildingHeight({ acceptedBuildingGeometry: acceptedFootprint, lidarCoverage: coverageOnly });
+assert.equal(readyForMeasurement.status, 'lidar_coverage_ready_for_measurement');
+assert.equal(readyForMeasurement.verifiedMeasuredHeight, false);
+
+const verifiedHeight = evaluateMeasuredBuildingHeight({
+  acceptedBuildingGeometry: acceptedFootprint,
+  lidarCoverage: coverageOnly,
+  measurement: {
+    roofElevationMeters: 120,
+    groundElevationMeters: 105,
+    uncertaintyMeters: 0.5,
+    roofSampleCount: 8,
+    groundSampleCount: 6,
+    sourceAuthority: 'Official LiDAR authority',
+    method: 'parcel-footprint roof percentile minus ground reference',
+    footprintRecordId: 'building:1',
+    sourceRecordId: 'tile.las',
+    observedAt: '2026-08-28T00:00:00Z',
+  },
+});
+assert.equal(verifiedHeight.status, 'verified_measured_height');
+assert.equal(verifiedHeight.verifiedMeasuredHeight, true);
+assert.equal(verifiedHeight.heightMeters, 15);
+assert.equal(verifiedHeight.legalEffects.establishesDeedOwnership, false);
+
+const rejectedHeight = evaluateMeasuredBuildingHeight({
+  acceptedBuildingGeometry: acceptedFootprint,
+  lidarCoverage: coverageOnly,
+  measurement: {
+    roofElevationMeters: 120,
+    groundElevationMeters: 105,
+    uncertaintyMeters: 3,
+    roofSampleCount: 8,
+    groundSampleCount: 6,
+    sourceAuthority: 'Official LiDAR authority',
+    method: 'test',
+    footprintRecordId: 'building:1',
+    sourceRecordId: 'tile.las',
+    observedAt: '2026-08-28T00:00:00Z',
+  },
+});
+assert.equal(rejectedHeight.status, 'measurement_rejected');
+assert.equal(rejectedHeight.verifiedMeasuredHeight, false);
 
 console.log('GEO property onboarding truth tests passed');

--- a/scripts/test-geo-property-onboarding.mjs
+++ b/scripts/test-geo-property-onboarding.mjs
@@ -215,6 +215,26 @@ const readyForMeasurement = evaluateMeasuredBuildingHeight({ acceptedBuildingGeo
 assert.equal(readyForMeasurement.status, 'lidar_coverage_ready_for_measurement');
 assert.equal(readyForMeasurement.verifiedMeasuredHeight, false);
 
+const selfClaimedHeight = evaluateMeasuredBuildingHeight({
+  acceptedBuildingGeometry: acceptedFootprint,
+  lidarCoverage: coverageOnly,
+  measurement: {
+    roofElevationMeters: 120,
+    groundElevationMeters: 105,
+    uncertaintyMeters: 0.5,
+    roofSampleCount: 8,
+    groundSampleCount: 6,
+    sourceAuthority: 'Claimed authority',
+    method: 'user supplied',
+    footprintRecordId: 'building:1',
+    sourceRecordId: 'tile.las',
+    observedAt: '2026-08-28T00:00:00Z',
+  },
+});
+assert.equal(selfClaimedHeight.status, 'measurement_rejected');
+assert.equal(selfClaimedHeight.verifiedMeasuredHeight, false);
+assert.ok(selfClaimedHeight.blockers.some((item) => item.includes('trusted source')));
+
 const verifiedHeight = evaluateMeasuredBuildingHeight({
   acceptedBuildingGeometry: acceptedFootprint,
   lidarCoverage: coverageOnly,
@@ -229,6 +249,9 @@ const verifiedHeight = evaluateMeasuredBuildingHeight({
     footprintRecordId: 'building:1',
     sourceRecordId: 'tile.las',
     observedAt: '2026-08-28T00:00:00Z',
+    trustedSource: true,
+    footprintMatchVerified: true,
+    groundMethodValidated: true,
   },
 });
 assert.equal(verifiedHeight.status, 'verified_measured_height');
@@ -250,6 +273,9 @@ const rejectedHeight = evaluateMeasuredBuildingHeight({
     footprintRecordId: 'building:1',
     sourceRecordId: 'tile.las',
     observedAt: '2026-08-28T00:00:00Z',
+    trustedSource: true,
+    footprintMatchVerified: true,
+    groundMethodValidated: true,
   },
 });
 assert.equal(rejectedHeight.status, 'measurement_rejected');


### PR DESCRIPTION
## Purpose
Upgrade GEO from an isolated building extrusion into a source-backed neighborhood-scale 3D scene while preserving the existing fail-closed property truth model.

## 3D / geography
- Adds a U.S. terrain adapter using USGS 3DEP Elevation Point Query Service.
- Samples a bounded 3x3 ground-elevation grid around the selected property and renders it as local terrain.
- Adds a global nearby-building adapter using OpenStreetMap / Overpass and returns up to 24 nearby source footprints.
- Reworks the WebGL viewer onto one meter-based coordinate system so terrain, the selected building, and nearby buildings align geographically.
- Surrounding buildings use source-reported height when present, levels-derived height when available, otherwise a clearly illustrative default.

## Measured building height
- Adds a strict measured-height evidence gate.
- LiDAR coverage alone never becomes building height.
- Requires accepted parcel-specific building geometry, LiDAR coverage, roof and ground samples, documented uncertainty <= 2m, trusted-source provenance, independently verified footprint match, and validated ground-reference method.
- User/self-supplied formatted measurements cannot self-verify.
- 618 Main remains blocked because its parcel-specific building footprint is not currently accepted.

## Erie / LiDAR
- GEO intake now reads NYS official LiDAR coverage for Erie County locations.
- Coverage is exposed as source evidence only; it does not promote the property to VERIFIED SPATIAL TWIN.

## Truth boundaries
- USGS EPQS is labeled interpolated 3DEP ground-elevation reference, not surveyed control elevation.
- Terrain does not establish roof height, parcel boundary, title, ownership, value, or investment rights.
- OSM surrounding footprints remain global reference geometry, not cadastral boundaries.

## Tests
- Adds global neighborhood reference coverage.
- Adds mocked 3x3 USGS terrain tests.
- Proves terrain cannot establish building height.
- Proves LiDAR coverage without footprint cannot establish height.
- Proves self-claimed height evidence is rejected.
- Proves only trusted, validated roof-minus-ground evidence can satisfy the measured-height gate.