### PR TITLE
Fix GEO selected building visibility

### DIFF
--- a/app/geo/GeoReferenceModel.js
+++ b/app/geo/GeoReferenceModel.js
@@ -4,10 +4,17 @@ import { createElement, useEffect, useMemo, useRef } from 'react';
 
 const METERS_TO_SCENE = 0.075;
 
-function outerRing(geometry) {
+function outerRings(geometry) {
   if (!geometry || !Array.isArray(geometry.coordinates)) return [];
-  if (geometry.type === 'Polygon') return geometry.coordinates[0] || [];
-  if (geometry.type === 'MultiPolygon') return geometry.coordinates?.[0]?.[0] || [];
+  if (geometry.type === 'Polygon') {
+    const ring = geometry.coordinates[0];
+    return Array.isArray(ring) && ring.length >= 4 ? [ring] : [];
+  }
+  if (geometry.type === 'MultiPolygon') {
+    return geometry.coordinates
+      .map((polygon) => polygon?.[0])
+      .filter((ring) => Array.isArray(ring) && ring.length >= 4);
+  }
   return [];
 }
 
@@ -17,6 +24,66 @@ function toLocalMeters(longitude, latitude, originLongitude, originLatitude) {
     east: (Number(longitude) - originLongitude) * 111320 * cosLat,
     north: (Number(latitude) - originLatitude) * 111320,
   };
+}
+
+function localPolygons(geometry, originLongitude, originLatitude) {
+  return outerRings(geometry)
+    .map((ring) => ring.slice(0, -1)
+      .map(([lon, lat]) => toLocalMeters(lon, lat, originLongitude, originLatitude))
+      .filter((point) => Number.isFinite(point.east) && Number.isFinite(point.north)))
+    .filter((local) => local.length >= 3);
+}
+
+function shapeFromLocal(THREE, local) {
+  if (!Array.isArray(local) || local.length < 3) return null;
+  const shape = new THREE.Shape();
+  local.forEach((point, index) => {
+    const x = point.east * METERS_TO_SCENE;
+    const y = -point.north * METERS_TO_SCENE;
+    if (index === 0) shape.moveTo(x, y); else shape.lineTo(x, y);
+  });
+  shape.closePath();
+  return shape;
+}
+
+function flattenPoints(polygons = []) {
+  return polygons.flatMap((polygon) => polygon);
+}
+
+function averageLocalCenter(polygons = []) {
+  const points = flattenPoints(polygons);
+  if (!points.length) return { east: 0, north: 0 };
+  const sum = points.reduce((acc, point) => ({ east: acc.east + point.east, north: acc.north + point.north }), { east: 0, north: 0 });
+  return { east: sum.east / points.length, north: sum.north / points.length };
+}
+
+function footprintRadiusScene(polygons, center) {
+  return flattenPoints(polygons).reduce((largest, point) => Math.max(
+    largest,
+    Math.hypot(point.east - center.east, point.north - center.north) * METERS_TO_SCENE,
+  ), 0);
+}
+
+function polygonBounds(local) {
+  if (!local.length) return null;
+  return local.reduce((bounds, point) => ({
+    minEast: Math.min(bounds.minEast, point.east),
+    maxEast: Math.max(bounds.maxEast, point.east),
+    minNorth: Math.min(bounds.minNorth, point.north),
+    maxNorth: Math.max(bounds.maxNorth, point.north),
+  }), { minEast: Infinity, maxEast: -Infinity, minNorth: Infinity, maxNorth: -Infinity });
+}
+
+function pointInPolygon(east, north, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    const crosses = ((a.north > north) !== (b.north > north))
+      && east < ((b.east - a.east) * (north - a.north)) / ((b.north - a.north) || Number.EPSILON) + a.east;
+    if (crosses) inside = !inside;
+  }
+  return inside;
 }
 
 function terrainRelativeMeters(terrain, eastMeters, northMeters) {
@@ -34,64 +101,40 @@ function terrainRelativeMeters(terrain, eastMeters, northMeters) {
   return total ? weighted / total : 0;
 }
 
-function localPolygon(geometry, originLongitude, originLatitude) {
-  const ring = outerRing(geometry);
-  if (ring.length < 4) return [];
-  return ring.slice(0, -1)
-    .map(([lon, lat]) => toLocalMeters(lon, lat, originLongitude, originLatitude))
-    .filter((point) => Number.isFinite(point.east) && Number.isFinite(point.north));
-}
-
-function shapeFromLocal(THREE, local) {
-  if (local.length < 3) return null;
-  const shape = new THREE.Shape();
-  local.forEach((point, index) => {
-    const x = point.east * METERS_TO_SCENE;
-    const y = -point.north * METERS_TO_SCENE;
-    if (index === 0) shape.moveTo(x, y); else shape.lineTo(x, y);
-  });
-  shape.closePath();
-  return shape;
-}
-
-function averageLocalCenter(local) {
-  if (!local.length) return { east: 0, north: 0 };
-  const sum = local.reduce((acc, point) => ({ east: acc.east + point.east, north: acc.north + point.north }), { east: 0, north: 0 });
-  return { east: sum.east / local.length, north: sum.north / local.length };
-}
-
-function polygonBounds(local) {
-  if (!local.length) return null;
-  return local.reduce((b, p) => ({
-    minEast: Math.min(b.minEast, p.east), maxEast: Math.max(b.maxEast, p.east),
-    minNorth: Math.min(b.minNorth, p.north), maxNorth: Math.max(b.maxNorth, p.north),
-  }), { minEast: Infinity, maxEast: -Infinity, minNorth: Infinity, maxNorth: -Infinity });
-}
-
-function pointInPolygon(east, north, polygon) {
-  let inside = false;
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
-    const a = polygon[i];
-    const b = polygon[j];
-    const crosses = ((a.north > north) !== (b.north > north))
-      && east < ((b.east - a.east) * (north - a.north)) / ((b.north - a.north) || Number.EPSILON) + a.east;
-    if (crosses) inside = !inside;
-  }
-  return inside;
-}
-
-function effectiveHeightMeters(reference, fallback = 3) {
+function displayHeight(reference, authoritativeTwin) {
   const measured = reference?.measuredHeight?.verifiedMeasuredHeight === true
     ? Number(reference?.measuredHeight?.heightMeters)
     : NaN;
-  if (Number.isFinite(measured) && measured > 0) return measured;
+  if (Number.isFinite(measured) && measured > 0) {
+    return { meters: measured, status: 'verified_measured' };
+  }
+
+  const authoritativeHeight = Number(authoritativeTwin?.structure?.heightMeters);
+  if (authoritativeTwin?.structure?.buildingGeometry && Number.isFinite(authoritativeHeight) && authoritativeHeight > 0) {
+    return { meters: authoritativeHeight, status: 'authoritative_structure' };
+  }
+
+  // A parcel-linked county footprint is stronger geometry than a nearest-neighbor map building,
+  // but its height must not inherit an unrelated map building's height. Keep the height explicitly
+  // illustrative until an accepted measurement or parcel-specific source supplies it.
+  if (authoritativeTwin?.structure?.buildingGeometry) {
+    return { meters: 3, status: 'illustrative_default' };
+  }
+
   const sourced = Number(reference?.height?.referenceHeightMeters);
-  return Number.isFinite(sourced) && sourced > 0 ? sourced : fallback;
+  if (Number.isFinite(sourced) && sourced > 0) {
+    return { meters: sourced, status: String(reference?.height?.heightStatus || 'source_reference') };
+  }
+  return { meters: 3, status: 'illustrative_default' };
 }
 
-function evidenceLabel(reference) {
-  if (reference?.found && reference?.measuredHeight?.verifiedMeasuredHeight === true) {
-    return { title: 'Verified measured voxel massing', detail: 'Real footprint + accepted measured height · facade details not inferred' };
+function evidenceLabel(reference, authoritativeTwin) {
+  const hasCountyBuilding = Boolean(authoritativeTwin?.structure?.buildingGeometry);
+  if (reference?.measuredHeight?.verifiedMeasuredHeight === true) {
+    return { title: 'Verified measured voxel massing', detail: 'Parcel-linked footprint + accepted measured height · facade details not inferred' };
+  }
+  if (hasCountyBuilding) {
+    return { title: 'County-backed building footprint', detail: 'Parcel-linked building geometry · height remains illustrative until measured' };
   }
   const status = String(reference?.height?.heightStatus || '');
   if (reference?.found && status === 'source_reported') {
@@ -100,28 +143,38 @@ function evidenceLabel(reference) {
   if (reference?.found && status === 'derived_from_levels') {
     return { title: 'Source-derived voxel massing', detail: 'Real footprint + height derived from reported floors · facade details not inferred' };
   }
-  if (reference?.found && status === 'illustrative_default') {
-    return { title: 'Source-backed footprint', detail: 'Footprint is sourced; height is illustrative and facade details are not inferred' };
+  if (reference?.found) {
+    return { title: 'Source-backed footprint', detail: 'Footprint is sourced; unsupported architectural details are not invented' };
   }
-  if (reference?.found) return { title: 'Source-backed footprint', detail: 'Geometry shown without invented architectural detail' };
   return { title: '3D reference preview', detail: 'Search for a source-backed property to build its voxel massing' };
 }
 
-function cameraPreset(viewMode, sceneRadius, compactMode) {
+function cameraPreset(viewMode, sceneRadius, compactMode, focusRadius) {
+  if (focusRadius > 0) {
+    if (viewMode === 'top') {
+      return { azimuth: 0.08, elevation: 1.38, radius: Math.max(compactMode ? 4.6 : 5.2, focusRadius * 2.9), autoOrbit: false };
+    }
+    if (viewMode === 'street') {
+      return { azimuth: 0.52, elevation: 0.15, radius: Math.max(compactMode ? 3.8 : 4.4, focusRadius * 2.55), autoOrbit: false };
+    }
+    return { azimuth: 0.72, elevation: 0.36, radius: Math.max(compactMode ? 4.4 : 5, focusRadius * 3.15), autoOrbit: true };
+  }
   if (viewMode === 'top') return { azimuth: 0.08, elevation: 1.36, radius: Math.max(compactMode ? 9.2 : 10, sceneRadius * 1.5), autoOrbit: false };
   if (viewMode === 'street') return { azimuth: 0.5, elevation: 0.17, radius: Math.max(compactMode ? 7.6 : 8.5, sceneRadius * 1.18), autoOrbit: false };
   return { azimuth: 0.72, elevation: 0.43, radius: Math.max(compactMode ? 9.7 : 10.7, sceneRadius * 1.58), autoOrbit: true };
 }
 
-function addVoxelShell({ THREE, root, local, baseY, height, compactMode, geometries, materials }) {
+function addVoxelShell({ THREE, root, local, baseY, visualHeight, compactMode, geometries, materials }) {
   const bounds = polygonBounds(local);
   if (!bounds) return;
   const width = Math.max(1, bounds.maxEast - bounds.minEast);
   const depth = Math.max(1, bounds.maxNorth - bounds.minNorth);
-  const cellMeters = Math.max(compactMode ? 2.6 : 1.85, width / (compactMode ? 34 : 48), depth / (compactMode ? 34 : 48));
+  const cellMeters = Math.max(compactMode ? 2.1 : 1.5, width / (compactMode ? 38 : 56), depth / (compactMode ? 38 : 56));
   const cellScene = cellMeters * METERS_TO_SCENE;
-  const heightCells = Math.max(1, Math.min(compactMode ? 26 : 38, Math.round(height / cellScene)));
-  const cellHeight = height / heightCells;
+  // Even a truthful 3 m illustrative extrusion needs multiple vertical voxel courses to read as 3D.
+  // This increases visual subdivision only; the total displayed height remains unchanged.
+  const heightCells = Math.max(3, Math.min(compactMode ? 26 : 38, Math.round(visualHeight / Math.max(0.045, cellScene * 0.72))));
+  const cellHeight = visualHeight / heightCells;
   const columns = [];
 
   for (let east = bounds.minEast + cellMeters / 2; east <= bounds.maxEast; east += cellMeters) {
@@ -133,11 +186,18 @@ function addVoxelShell({ THREE, root, local, baseY, height, compactMode, geometr
     }
   }
 
+  if (!columns.length) return;
   const requested = columns.reduce((sum, column) => sum + (column.boundary ? heightCells : 1), 0);
-  const maxInstances = compactMode ? 900 : 1800;
+  const maxInstances = compactMode ? 950 : 1900;
   const stride = Math.max(1, Math.ceil(requested / maxInstances));
-  const geometry = new THREE.BoxGeometry(cellScene * 0.93, Math.max(0.045, cellHeight * 0.93), cellScene * 0.93);
-  const material = new THREE.MeshStandardMaterial({ color: 0xe7e0d2, roughness: 0.68, metalness: 0.025, emissive: 0x171d19, emissiveIntensity: 0.025 });
+  const geometry = new THREE.BoxGeometry(cellScene * 0.9, Math.max(0.03, cellHeight * 0.86), cellScene * 0.9);
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xeee5d4,
+    roughness: 0.64,
+    metalness: 0.02,
+    emissive: 0x181d1a,
+    emissiveIntensity: 0.035,
+  });
   geometries.push(geometry);
   materials.push(material);
 
@@ -150,7 +210,11 @@ function addVoxelShell({ THREE, root, local, baseY, height, compactMode, geometr
     for (let level = start; level < heightCells; level += 1) {
       if (!column.boundary && level !== heightCells - 1) continue;
       if (sourceIndex % stride === 0 && cursor < mesh.count) {
-        matrix.makeTranslation(column.east * METERS_TO_SCENE, baseY + cellHeight * (level + 0.5), -column.north * METERS_TO_SCENE);
+        matrix.makeTranslation(
+          column.east * METERS_TO_SCENE,
+          baseY + cellHeight * (level + 0.5),
+          -column.north * METERS_TO_SCENE,
+        );
         mesh.setMatrixAt(cursor, matrix);
         cursor += 1;
       }
@@ -164,9 +228,40 @@ function addVoxelShell({ THREE, root, local, baseY, height, compactMode, geometr
   root.add(mesh);
 }
 
-export default function GeoReferenceModel({ reference, viewMode = 'orbit', resetKey = 0 }) {
+function addSilhouetteLines({ THREE, root, local, baseY, visualHeight, geometries, materials }) {
+  const footprint = local.map((point) => new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + 0.018, -point.north * METERS_TO_SCENE));
+  const roof = local.map((point) => new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + visualHeight + 0.012, -point.north * METERS_TO_SCENE));
+  if (!footprint.length || !roof.length) return;
+  footprint.push(footprint[0].clone());
+  roof.push(roof[0].clone());
+
+  const lineMaterial = new THREE.LineBasicMaterial({ color: 0xfff2d8, transparent: true, opacity: 0.78 });
+  materials.push(lineMaterial);
+  const footprintGeometry = new THREE.BufferGeometry().setFromPoints(footprint);
+  const roofGeometry = new THREE.BufferGeometry().setFromPoints(roof);
+  geometries.push(footprintGeometry, roofGeometry);
+  root.add(new THREE.Line(footprintGeometry, lineMaterial));
+  root.add(new THREE.Line(roofGeometry, lineMaterial));
+
+  const verticalPoints = [];
+  const cornerStride = Math.max(1, Math.ceil(local.length / 18));
+  local.forEach((point, index) => {
+    if (index % cornerStride !== 0) return;
+    verticalPoints.push(
+      new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + 0.018, -point.north * METERS_TO_SCENE),
+      new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + visualHeight + 0.012, -point.north * METERS_TO_SCENE),
+    );
+  });
+  if (verticalPoints.length) {
+    const verticalGeometry = new THREE.BufferGeometry().setFromPoints(verticalPoints);
+    geometries.push(verticalGeometry);
+    root.add(new THREE.LineSegments(verticalGeometry, lineMaterial));
+  }
+}
+
+export default function GeoReferenceModel({ reference, authoritativeTwin = null, viewMode = 'orbit', resetKey = 0 }) {
   const mountRef = useRef(null);
-  const label = useMemo(() => evidenceLabel(reference), [reference]);
+  const label = useMemo(() => evidenceLabel(reference, authoritativeTwin), [reference, authoritativeTwin]);
 
   useEffect(() => {
     let disposed = false;
@@ -184,22 +279,24 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
       renderer.setSize(width, height);
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
-      renderer.toneMappingExposure = 1.06;
+      renderer.toneMappingExposure = 1.08;
       renderer.shadowMap.enabled = !compactMode;
       if (!compactMode) renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       renderer.domElement.style.touchAction = 'none';
       renderer.domElement.style.cursor = 'grab';
+      renderer.domElement.style.width = '100%';
+      renderer.domElement.style.height = '100%';
       mount.replaceChildren(renderer.domElement);
 
       const scene = new THREE.Scene();
       scene.background = new THREE.Color(0x101716);
-      scene.fog = new THREE.FogExp2(0x101716, compactMode ? 0.026 : 0.021);
-      const camera = new THREE.PerspectiveCamera(compactMode ? 41 : 36, width / height, 0.1, 170);
+      scene.fog = new THREE.FogExp2(0x101716, compactMode ? 0.022 : 0.018);
+      const camera = new THREE.PerspectiveCamera(compactMode ? 42 : 37, width / height, 0.05, 170);
       const root = new THREE.Group();
       scene.add(root);
-      scene.add(new THREE.HemisphereLight(0xf6efe2, 0x26352f, 2.05));
+      scene.add(new THREE.HemisphereLight(0xf8f0df, 0x26352f, 2.2));
 
-      const sun = new THREE.DirectionalLight(0xffeed2, compactMode ? 3.4 : 4.15);
+      const sun = new THREE.DirectionalLight(0xffeed2, compactMode ? 3.6 : 4.3);
       sun.position.set(10, 18, 7);
       sun.castShadow = !compactMode;
       if (!compactMode) {
@@ -207,21 +304,25 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         Object.assign(sun.shadow.camera, { left: -18, right: 18, top: 18, bottom: -18 });
       }
       scene.add(sun);
-      const fill = new THREE.DirectionalLight(0xa6c9c1, 1.15);
+      const fill = new THREE.DirectionalLight(0xa6d2c8, 1.25);
       fill.position.set(-9, 7, -8);
       scene.add(fill);
 
       const geometries = [];
       const materials = [];
-      const originLatitude = Number(reference?.latitude);
-      const originLongitude = Number(reference?.longitude);
+      const authoritativeGeometry = authoritativeTwin?.structure?.buildingGeometry || null;
+      const displayGeometry = authoritativeGeometry || reference?.geometry || null;
+      const originLatitude = Number(reference?.latitude ?? authoritativeTwin?.location?.latitude);
+      const originLongitude = Number(reference?.longitude ?? authoritativeTwin?.location?.longitude);
       const validOrigin = Number.isFinite(originLatitude) && Number.isFinite(originLongitude);
       const terrain = reference?.terrain || null;
       const terrainRadiusMeters = Math.max(55, Math.min(180, Number(terrain?.radiusMeters) || 85));
       const sceneRadius = terrainRadiusMeters * METERS_TO_SCENE;
-      const primaryLocal = validOrigin ? localPolygon(reference?.geometry, originLongitude, originLatitude) : [];
-      const primaryCenter = averageLocalCenter(primaryLocal);
+      const primaryPolygons = validOrigin ? localPolygons(displayGeometry, originLongitude, originLatitude) : [];
+      const primaryCenter = averageLocalCenter(primaryPolygons);
+      const primaryRadius = footprintRadiusScene(primaryPolygons, primaryCenter);
       const primaryRecordId = String(reference?.source?.recordId || '');
+      const hasPrimary = primaryPolygons.length > 0;
 
       const plinthGeometry = new THREE.CylinderGeometry(sceneRadius * 1.08, sceneRadius * 1.12, 0.3, 84);
       const plinthMaterial = new THREE.MeshStandardMaterial({ color: 0x202a27, roughness: 0.92, metalness: 0.01 });
@@ -247,7 +348,7 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         terrainGeometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
         terrainGeometry.setIndex([0, 3, 1, 1, 3, 4, 1, 4, 2, 2, 4, 5, 3, 6, 4, 4, 6, 7, 4, 7, 5, 5, 7, 8]);
         terrainGeometry.computeVertexNormals();
-        const terrainMaterial = new THREE.MeshStandardMaterial({ color: 0x6f7a6b, roughness: 0.96, metalness: 0, side: THREE.DoubleSide });
+        const terrainMaterial = new THREE.MeshStandardMaterial({ color: 0x667469, roughness: 0.97, metalness: 0, side: THREE.DoubleSide });
         geometries.push(terrainGeometry);
         materials.push(terrainMaterial);
         const terrainMesh = new THREE.Mesh(terrainGeometry, terrainMaterial);
@@ -256,7 +357,7 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
       } else {
         const groundGeometry = new THREE.CircleGeometry(sceneRadius, 72);
         groundGeometry.rotateX(-Math.PI / 2);
-        const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x6f7a6b, roughness: 0.96, metalness: 0 });
+        const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x667469, roughness: 0.97, metalness: 0 });
         geometries.push(groundGeometry);
         materials.push(groundMaterial);
         const ground = new THREE.Mesh(groundGeometry, groundMaterial);
@@ -268,7 +369,7 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
       const grid = new THREE.GridHelper(sceneRadius * 1.75, compactMode ? 22 : 32, 0x60746c, 0x42524c);
       grid.position.y = 0.012;
       grid.material.transparent = true;
-      grid.material.opacity = 0.13;
+      grid.material.opacity = 0.09;
       materials.push(grid.material);
       geometries.push(grid.geometry);
       root.add(grid);
@@ -283,72 +384,76 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
           return { buildingRef, localCenter, distance: Math.hypot(localCenter.east - primaryCenter.east, localCenter.north - primaryCenter.north) };
         })
         .sort((a, b) => a.distance - b.distance)
-        .slice(0, compactMode ? 9 : 15) : [];
+        .slice(0, compactMode ? 8 : 14) : [];
 
       if (validOrigin) for (const { buildingRef, localCenter, distance } of surroundings) {
         if (buildingRef.selected === true || String(buildingRef.id || '') === primaryRecordId) continue;
-        const local = localPolygon(buildingRef.geometry, originLongitude, originLatitude);
-        const shape = shapeFromLocal(THREE, local);
-        if (!shape) continue;
-        const sourceHeight = Math.max(2.2, Math.min(120, Number(buildingRef?.height?.referenceHeightMeters) || 3));
-        const visualHeight = sourceHeight * METERS_TO_SCENE;
-        const geometry = new THREE.ExtrudeGeometry(shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
-        geometry.rotateX(-Math.PI / 2);
-        const material = new THREE.MeshStandardMaterial({ color: 0x59635f, roughness: 0.88, metalness: 0, transparent: true, opacity: 0.5 - Math.min(1, distance / terrainRadiusMeters) * 0.16 });
-        geometries.push(geometry);
-        materials.push(material);
-        const mesh = new THREE.Mesh(geometry, material);
-        mesh.position.y = terrainRelativeMeters(terrain, localCenter.east, localCenter.north) * METERS_TO_SCENE;
-        mesh.receiveShadow = true;
-        root.add(mesh);
+        const polygons = localPolygons(buildingRef.geometry, originLongitude, originLatitude);
+        for (const local of polygons) {
+          const shape = shapeFromLocal(THREE, local);
+          if (!shape) continue;
+          const sourceHeight = Math.max(2.2, Math.min(120, Number(buildingRef?.height?.referenceHeightMeters) || 3));
+          const visualHeight = sourceHeight * METERS_TO_SCENE;
+          const geometry = new THREE.ExtrudeGeometry(shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
+          geometry.rotateX(-Math.PI / 2);
+          const material = new THREE.MeshStandardMaterial({
+            color: 0x4e5a56,
+            roughness: 0.9,
+            metalness: 0,
+            transparent: true,
+            opacity: 0.34 - Math.min(1, distance / terrainRadiusMeters) * 0.1,
+          });
+          geometries.push(geometry);
+          materials.push(material);
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.position.y = terrainRelativeMeters(terrain, localCenter.east, localCenter.north) * METERS_TO_SCENE;
+          mesh.receiveShadow = true;
+          root.add(mesh);
+        }
       }
 
-      const focusTarget = new THREE.Vector3(0, Math.max(0.38, sceneRadius * 0.05), 0);
+      const focusTarget = new THREE.Vector3(0, Math.max(0.22, sceneRadius * 0.035), 0);
       let primaryHalo = null;
-      if (reference?.found && primaryLocal.length >= 3) {
-        const shape = shapeFromLocal(THREE, primaryLocal);
-        const sourceHeight = Math.max(2.2, Math.min(500, effectiveHeightMeters(reference, 3)));
+      if (hasPrimary) {
+        const heightInfo = displayHeight(reference, authoritativeTwin);
+        const sourceHeight = Math.max(2.2, Math.min(500, Number(heightInfo.meters) || 3));
         const visualHeight = sourceHeight * METERS_TO_SCENE;
         const baseY = terrainRelativeMeters(terrain, primaryCenter.east, primaryCenter.north) * METERS_TO_SCENE;
         const centerX = primaryCenter.east * METERS_TO_SCENE;
         const centerZ = -primaryCenter.north * METERS_TO_SCENE;
-        focusTarget.set(centerX, baseY + Math.max(0.38, visualHeight * 0.44), centerZ);
+        // Aim at the actual middle of a short building instead of above its roof.
+        focusTarget.set(centerX, baseY + Math.max(0.09, visualHeight * 0.5), centerZ);
 
-        if (shape) {
-          const coreGeometry = new THREE.ExtrudeGeometry(shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
-          coreGeometry.rotateX(-Math.PI / 2);
-          const coreMaterial = new THREE.MeshStandardMaterial({ color: 0x6c746e, roughness: 0.8, metalness: 0, transparent: true, opacity: 0.38 });
-          geometries.push(coreGeometry);
-          materials.push(coreMaterial);
-          const core = new THREE.Mesh(coreGeometry, coreMaterial);
-          core.position.y = baseY;
-          core.castShadow = !compactMode;
-          core.receiveShadow = true;
-          root.add(core);
+        for (const local of primaryPolygons) {
+          const shape = shapeFromLocal(THREE, local);
+          if (shape) {
+            const coreGeometry = new THREE.ExtrudeGeometry(shape, { depth: visualHeight, bevelEnabled: false, curveSegments: 1, steps: 1 });
+            coreGeometry.rotateX(-Math.PI / 2);
+            const coreMaterial = new THREE.MeshStandardMaterial({ color: 0x8b887e, roughness: 0.76, metalness: 0, transparent: true, opacity: 0.56 });
+            geometries.push(coreGeometry);
+            materials.push(coreMaterial);
+            const core = new THREE.Mesh(coreGeometry, coreMaterial);
+            core.position.y = baseY;
+            core.castShadow = !compactMode;
+            core.receiveShadow = true;
+            root.add(core);
+          }
+          addVoxelShell({ THREE, root, local, baseY, visualHeight, compactMode, geometries, materials });
+          addSilhouetteLines({ THREE, root, local, baseY, visualHeight, geometries, materials });
         }
 
-        addVoxelShell({ THREE, root, local: primaryLocal, baseY, height: visualHeight, compactMode, geometries, materials });
-        const outlinePoints = primaryLocal.map((point) => new THREE.Vector3(point.east * METERS_TO_SCENE, baseY + 0.026, -point.north * METERS_TO_SCENE));
-        outlinePoints.push(outlinePoints[0].clone());
-        const outlineGeometry = new THREE.BufferGeometry().setFromPoints(outlinePoints);
-        const outlineMaterial = new THREE.LineBasicMaterial({ color: 0xf8f1df, transparent: true, opacity: 0.72 });
-        geometries.push(outlineGeometry);
-        materials.push(outlineMaterial);
-        root.add(new THREE.Line(outlineGeometry, outlineMaterial));
-
-        const localRadius = primaryLocal.reduce((largest, point) => Math.max(largest, Math.hypot(point.east - primaryCenter.east, point.north - primaryCenter.north)), 0) * METERS_TO_SCENE;
-        const haloRadius = Math.max(0.65, Math.min(2.8, localRadius * 1.32));
-        const haloGeometry = new THREE.RingGeometry(haloRadius * 0.94, haloRadius, 80);
-        const haloMaterial = new THREE.MeshBasicMaterial({ color: 0xe9d8b8, transparent: true, opacity: 0.28, side: THREE.DoubleSide, depthWrite: false });
+        const haloRadius = Math.max(0.65, Math.min(3.2, primaryRadius * 1.18 || 0.9));
+        const haloGeometry = new THREE.RingGeometry(haloRadius * 0.95, haloRadius, 80);
+        const haloMaterial = new THREE.MeshBasicMaterial({ color: 0xe9d8b8, transparent: true, opacity: 0.24, side: THREE.DoubleSide, depthWrite: false });
         geometries.push(haloGeometry);
         materials.push(haloMaterial);
         primaryHalo = new THREE.Mesh(haloGeometry, haloMaterial);
         primaryHalo.rotation.x = -Math.PI / 2;
-        primaryHalo.position.set(centerX, baseY + 0.03, centerZ);
+        primaryHalo.position.set(centerX, baseY + 0.026, centerZ);
         root.add(primaryHalo);
       }
 
-      const preset = cameraPreset(viewMode, sceneRadius, compactMode);
+      const preset = cameraPreset(viewMode, sceneRadius, compactMode, hasPrimary ? primaryRadius : 0);
       let { azimuth, elevation, radius } = preset;
       let autoOrbit = preset.autoOrbit && !reducedMotion;
       let dragging = false;
@@ -356,11 +461,18 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
       let lastY = 0;
       let pinchDistance = null;
       const pointers = new Map();
-      const minRadius = Math.max(compactMode ? 4.7 : 5.5, sceneRadius * 0.6);
-      const maxRadius = Math.max(preset.radius * 1.85, sceneRadius * 3.1);
+      const minRadius = hasPrimary
+        ? Math.max(compactMode ? 2.7 : 3.1, primaryRadius * 1.65)
+        : Math.max(compactMode ? 4.7 : 5.5, sceneRadius * 0.6);
+      const maxRadius = Math.max(preset.radius * 2.1, sceneRadius * 3.1);
+
       const updateCamera = () => {
         const c = Math.cos(elevation);
-        camera.position.set(focusTarget.x + Math.sin(azimuth) * c * radius, focusTarget.y + Math.sin(elevation) * radius, focusTarget.z + Math.cos(azimuth) * c * radius);
+        camera.position.set(
+          focusTarget.x + Math.sin(azimuth) * c * radius,
+          focusTarget.y + Math.sin(elevation) * radius,
+          focusTarget.z + Math.cos(azimuth) * c * radius,
+        );
         camera.lookAt(focusTarget);
       };
       updateCamera();
@@ -381,6 +493,7 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         }
         renderer.domElement.setPointerCapture?.(event.pointerId);
       };
+
       const move = (event) => {
         if (!pointers.has(event.pointerId)) return;
         pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
@@ -396,11 +509,12 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         }
         if (!dragging) return;
         azimuth -= (event.clientX - lastX) * 0.0065;
-        elevation = Math.max(0.1, Math.min(1.44, elevation + (event.clientY - lastY) * 0.004));
+        elevation = Math.max(0.08, Math.min(1.44, elevation + (event.clientY - lastY) * 0.004));
         lastX = event.clientX;
         lastY = event.clientY;
         updateCamera();
       };
+
       const up = (event) => {
         pointers.delete(event.pointerId);
         if (pointers.size < 2) pinchDistance = null;
@@ -413,12 +527,14 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         }
         try { renderer.domElement.releasePointerCapture?.(event.pointerId); } catch {}
       };
+
       const wheel = (event) => {
         event.preventDefault();
         autoOrbit = false;
-        radius = Math.max(minRadius, Math.min(maxRadius, radius + event.deltaY * 0.011));
+        radius = Math.max(minRadius, Math.min(maxRadius, radius + event.deltaY * 0.01));
         updateCamera();
       };
+
       renderer.domElement.addEventListener('pointerdown', down);
       renderer.domElement.addEventListener('pointermove', move);
       renderer.domElement.addEventListener('pointerup', up);
@@ -431,9 +547,9 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
         frame = requestAnimationFrame(animate);
         if (!reducedMotion) {
           const elapsed = clock.getElapsedTime();
-          if (primaryHalo) primaryHalo.material.opacity = 0.22 + (Math.sin(elapsed * 1.15) + 1) * 0.035;
+          if (primaryHalo) primaryHalo.material.opacity = 0.2 + (Math.sin(elapsed * 1.15) + 1) * 0.03;
           if (autoOrbit) {
-            azimuth += 0.00028;
+            azimuth += 0.00025;
             updateCamera();
           }
         }
@@ -471,14 +587,26 @@ export default function GeoReferenceModel({ reference, viewMode = 'orbit', reset
     });
 
     return () => { disposed = true; cleanup(); };
-  }, [reference?.source?.recordId, reference?.height?.referenceHeightMeters, reference?.neighborhoodBuildingCount, reference?.terrain?.source?.observedAt, reference?.measuredHeight?.status, reference?.measuredHeight?.heightMeters, reference?.measuredHeight?.verifiedMeasuredHeight, viewMode, resetKey]);
+  }, [
+    reference?.source?.recordId,
+    reference?.height?.referenceHeightMeters,
+    reference?.neighborhoodBuildingCount,
+    reference?.terrain?.source?.observedAt,
+    reference?.measuredHeight?.status,
+    reference?.measuredHeight?.heightMeters,
+    reference?.measuredHeight?.verifiedMeasuredHeight,
+    authoritativeTwin?.structure?.source?.recordId,
+    authoritativeTwin?.structure?.heightMeters,
+    viewMode,
+    resetKey,
+  ]);
 
   return createElement('div', { style: { position: 'absolute', inset: 0 }, 'aria-label': 'Interactive realistic voxel property and neighborhood reference' },
     createElement('div', { ref: mountRef, style: { position: 'absolute', inset: 0 } }),
     createElement('div', {
       style: {
         position: 'absolute', left: 12, bottom: 12, maxWidth: 'min(78%, 420px)', padding: '9px 11px', borderRadius: 14,
-        border: '1px solid rgba(244, 235, 214, 0.16)', background: 'rgba(12, 18, 17, 0.72)', backdropFilter: 'blur(12px)',
+        border: '1px solid rgba(244, 235, 214, 0.16)', background: 'rgba(12, 18, 17, 0.74)', backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)', color: '#f6efe1', pointerEvents: 'none', boxShadow: '0 12px 34px rgba(0, 0, 0, 0.2)',
       },
     },

--- a/app/geo/page.js
+++ b/app/geo/page.js
@@ -59,6 +59,8 @@ export default function GeoPage() {
   const [resetKey, setResetKey] = useState(0);
 
   const reference = result?.globalReference || null;
+  const authoritativeTwin = result?.authoritativeEvidence?.twin || null;
+  const hasRenderableBuilding = Boolean(reference?.found || authoritativeTwin?.structure?.buildingGeometry);
   const factReport = result?.factCheck || null;
   const readiness = result?.readiness || null;
   const offering = result?.investmentOffering || null;
@@ -84,11 +86,13 @@ export default function GeoPage() {
       setResult(data);
       setViewMode('orbit');
       setResetKey((value) => value + 1);
-      setMessage(data.authoritativeEvidence
-        ? 'Found it ✦ Global 3D reference plus local parcel evidence loaded. Ownership is checked separately.'
-        : data.globalReference?.found
-          ? 'Found it ✦ A source-backed 3D building reference is ready. Local parcel verification is still pending or unavailable here.'
-          : 'Place found, but no source building footprint was returned. GEO left it empty instead of making one up.');
+      setMessage(data.authoritativeEvidence?.twin?.structure?.buildingGeometry
+        ? 'Found it ✦ Parcel-linked building geometry plus neighborhood context loaded. Height stays separate until it is source-backed or measured.'
+        : data.authoritativeEvidence
+          ? 'Found the parcel ✦ Local evidence loaded, but a parcel-linked building footprint is not verified yet.'
+          : data.globalReference?.found
+            ? 'Found it ✦ A source-backed 3D building reference is ready. Local parcel verification is still pending or unavailable here.'
+            : 'Place found, but no source building footprint was returned. GEO left it empty instead of making one up.');
     } catch (error) {
       setResult(null);
       setMessage(error instanceof Error ? error.message : 'GEO intake failed.');
@@ -208,19 +212,19 @@ export default function GeoPage() {
         </article>
 
         <aside className={styles.modelCard} aria-label="GEO 3D property viewer">
-          <GeoReferenceModel reference={reference} viewMode={viewMode} resetKey={resetKey}/>
+          <GeoReferenceModel reference={reference} authoritativeTwin={authoritativeTwin} viewMode={viewMode} resetKey={resetKey}/>
           <div className={styles.modelTopRow}>
-            <div className={styles.modelTopBadge}>{reference?.found ? '✦ Source-backed geometry' : '✦ 3D preview'}</div>
+            <div className={styles.modelTopBadge}>{authoritativeTwin?.structure?.buildingGeometry ? '✦ Parcel-linked building' : reference?.found ? '✦ Source-backed geometry' : '✦ 3D preview'}</div>
             <button className={styles.resetView} onClick={() => setResetKey((value) => value + 1)} type="button" aria-label="Reset 3D view" title="Reset view">↺</button>
           </div>
           <div className={styles.viewControls} role="group" aria-label="3D camera view">
             {VIEW_MODES.map((mode) => <button key={mode.id} type="button" aria-pressed={viewMode === mode.id} title={mode.hint} className={`${styles.viewButton} ${viewMode === mode.id ? styles.viewButtonActive : ''}`} onClick={() => setViewMode(mode.id)}><span>{mode.icon}</span>{mode.label}</button>)}
           </div>
           <div className={styles.modelMeta}>
-            <div className={styles.modelIdentity}><small>{reference?.found ? 'Selected property' : 'Search to begin'}</small><strong>{reference?.tags?.name || form.address || 'Search a property'}</strong></div>
+            <div className={styles.modelIdentity}><small>{hasRenderableBuilding ? 'Selected property' : 'Search to begin'}</small><strong>{reference?.tags?.name || form.address || 'Search a property'}</strong></div>
             <div className={styles.modelContext}>
-              <span>{reference?.found ? humanHeight(reference) : activeView.hint}</span>
-              <span className={styles.gestureHint}>{reference?.found ? 'Drag to orbit · pinch to zoom' : 'Orbit, Street and Top keep the scene easy to inspect.'}</span>
+              <span>{hasRenderableBuilding ? authoritativeTwin?.structure?.buildingGeometry && !reference?.measuredHeight?.verifiedMeasuredHeight ? 'Parcel footprint · height not yet measured' : humanHeight(reference) : activeView.hint}</span>
+              <span className={styles.gestureHint}>{hasRenderableBuilding ? 'Drag to orbit · pinch to zoom' : 'Orbit, Street and Top keep the scene easy to inspect.'}</span>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
## Purpose
Fix the case where GEO successfully resolves a source-backed building footprint but the selected structure can look almost flat or invisible, especially when the only available height is the explicit 3 m illustrative fallback.

## What changed
- Frame the camera around the selected building footprint instead of the full neighborhood radius when a building is present.
- Aim the camera at the actual vertical midpoint of short buildings instead of above their roofline.
- Keep total displayed height unchanged while subdividing short structures into at least three voxel courses so they visibly read as 3D.
- Add source-derived roof, footprint, and vertical silhouette lines so the real footprint extrusion remains visible from Orbit/Street/Top views.
- Support Polygon and MultiPolygon building geometry.
- Add an `authoritativeTwin` rendering path so a parcel-linked county building footprint can be preferred by the viewer once the page passes it in, without inheriting an unrelated nearest-map building height.
- Keep compact-mode pixel ratio at 1.18, bounded instancing, reduced-motion support, ResizeObserver, and mobile shadow limits.

## Truth boundary
This changes presentation and camera framing, not property facts. It does not increase an unknown height, invent floors, roofs, windows, facade materials, trees, ownership, title, or investment rights. The 3 m fallback remains 3 m; it is simply divided into multiple visible voxel layers.

## Review focus
- A low-height selected building should clearly read as a 3D volume on iPhone.
- Source-backed height values remain numerically unchanged.
- Mobile WebGL guard stays green.
- No legal or investment gate logic changes.