### PR TITLE
Clarify world coverage and unify iPhone interactions

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -3,6 +3,7 @@ import FinancialOSNav from './components/FinancialOSNav';
 import AppCommandCenter from './components/AppCommandCenter';
 import './vault-fallback.css';
 import './futuristic-vault.css';
+import './spatial-os-interactions.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 

--- a/app/spatial-os-interactions.css
+++ b/app/spatial-os-interactions.css
@@ -1,0 +1,75 @@
+:root {
+  --vv-accent: #9ff5df;
+  --vv-accent-soft: rgba(159, 245, 223, .12);
+  --vv-border: rgba(171, 235, 212, .16);
+  --vv-focus: rgba(159, 245, 223, .92);
+  --vv-radius-control: 14px;
+  --vv-tap-min: 44px;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  overscroll-behavior-y: none;
+}
+
+a,
+button,
+[role='button'],
+input,
+select,
+textarea {
+  -webkit-tap-highlight-color: transparent;
+}
+
+a,
+button,
+[role='button'] {
+  touch-action: manipulation;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--vv-focus);
+  outline-offset: 3px;
+}
+
+::selection {
+  background: rgba(159, 245, 223, .24);
+}
+
+@media (pointer: coarse) {
+  button,
+  [role='button'] {
+    min-height: var(--vv-tap-min);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: .001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .001ms !important;
+  }
+}

--- a/app/vault/earth/GlobalEarthGlobe.js
+++ b/app/vault/earth/GlobalEarthGlobe.js
@@ -79,12 +79,9 @@ export default function GlobalEarthGlobe({
       }
       setVisitedCount(visitedRef.current.size);
       setLastCoverage({
-        latitude: Number(data.latitude),
-        longitude: Number(data.longitude),
         tileCount: Number(data.tileCount || 0),
         buildingCount: Number(data.buildingCount || 0),
-        source: data.coverage?.source || 'Overture Maps Foundation Buildings PMTiles',
-        scope: data.coverage?.scope || 'global-on-demand',
+        source: data.coverage?.source || 'Overture Maps Foundation',
       });
 
       const incoming = Array.isArray(data.buildings) ? data.buildings : [];
@@ -122,23 +119,25 @@ export default function GlobalEarthGlobe({
     }
   }, [atlasBuildings, onAtlasSelect, onLocation]);
 
-  return <PlanetStreamGlobe
-    listings={listings}
-    selectedId={selectedId}
-    onSelect={onSelect}
-    atlasBuildings={combinedBuildings}
-    selectedAtlasId={selectedAtlasId}
-    onAtlasSelect={chooseAtlas}
-    onLocation={onLocation}
-    onViewport={streamViewport}
-    streaming={streaming}
-    coverage={{
-      visitedRegions: visitedCount,
-      streamedBuildings: streamedBuildings.length,
-      detailedBuildings: atlasBuildings.length,
-      visibleMarkers: combinedBuildings.length,
-      lastCoverage,
-      truthLabel: 'MAP REFERENCE · NOT TITLE',
-    }}
-  />;
+  return <div className="worldStreamShell">
+    <PlanetStreamGlobe
+      listings={listings}
+      selectedId={selectedId}
+      onSelect={onSelect}
+      atlasBuildings={combinedBuildings}
+      selectedAtlasId={selectedAtlasId}
+      onAtlasSelect={chooseAtlas}
+      onLocation={onLocation}
+      onViewport={streamViewport}
+      streaming={streaming}
+    />
+    <div className="worldCoverage" aria-live="polite">
+      <div><b>{visitedCount}</b><span>REGIONS VISITED</span></div>
+      <div><b>{streamedBuildings.length}</b><span>STREAMED MAP BUILDINGS</span></div>
+      <div><b>{atlasBuildings.length}</b><span>DETAILED LOCAL BUILDINGS</span></div>
+      <em>MAP REFERENCE · NOT TITLE</em>
+      {lastCoverage ? <small>LAST LOAD · {lastCoverage.tileCount} TILE{lastCoverage.tileCount === 1 ? '' : 'S'} · {lastCoverage.buildingCount} SOURCE BUILDINGS · {lastCoverage.source}</small> : <small>Rotate or tap LOAD HERE to progressively read the visible Overture region.</small>}
+    </div>
+    <style jsx>{`.worldStreamShell{position:absolute;inset:0}.worldCoverage{position:absolute;z-index:4;left:12px;bottom:12px;max-width:min(560px,calc(100% - 24px));display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px;padding:8px;border:1px solid rgba(255,255,255,.1);border-radius:16px;background:rgba(4,10,12,.78);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);color:#edf7f3;pointer-events:none}.worldCoverage div{display:grid;gap:2px;min-width:0;padding:5px 7px;border-radius:10px;background:rgba(255,255,255,.04)}.worldCoverage b{font-size:13px}.worldCoverage span{font-size:6px;letter-spacing:.08em;color:#8fa59e;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.worldCoverage em{grid-column:1/-1;font-style:normal;font-size:7px;font-weight:950;letter-spacing:.12em;color:#ffbd98}.worldCoverage small{grid-column:1/-1;font-size:7px;line-height:1.4;color:#849690}@media(max-width:640px){.worldCoverage{left:9px;right:9px;bottom:9px;max-width:none}.worldCoverage b{font-size:11px}.worldCoverage span{font-size:5.5px}.worldCoverage small{display:none}}`}</style>
+  </div>;
 }

--- a/app/vault/earth/GlobalEarthGlobe.js
+++ b/app/vault/earth/GlobalEarthGlobe.js
@@ -44,6 +44,8 @@ export default function GlobalEarthGlobe({
 }) {
   const [streamedBuildings, setStreamedBuildings] = useState([]);
   const [streaming, setStreaming] = useState(false);
+  const [visitedCount, setVisitedCount] = useState(0);
+  const [lastCoverage, setLastCoverage] = useState(null);
   const visitedRef = useRef(new Map());
   const inflightRef = useRef(new Set());
   const streamedRef = useRef([]);
@@ -75,6 +77,15 @@ export default function GlobalEarthGlobe({
         const oldest = visitedRef.current.keys().next().value;
         if (oldest) visitedRef.current.delete(oldest);
       }
+      setVisitedCount(visitedRef.current.size);
+      setLastCoverage({
+        latitude: Number(data.latitude),
+        longitude: Number(data.longitude),
+        tileCount: Number(data.tileCount || 0),
+        buildingCount: Number(data.buildingCount || 0),
+        source: data.coverage?.source || 'Overture Maps Foundation Buildings PMTiles',
+        scope: data.coverage?.scope || 'global-on-demand',
+      });
 
       const incoming = Array.isArray(data.buildings) ? data.buildings : [];
       if (incoming.length) {
@@ -121,5 +132,13 @@ export default function GlobalEarthGlobe({
     onLocation={onLocation}
     onViewport={streamViewport}
     streaming={streaming}
+    coverage={{
+      visitedRegions: visitedCount,
+      streamedBuildings: streamedBuildings.length,
+      detailedBuildings: atlasBuildings.length,
+      visibleMarkers: combinedBuildings.length,
+      lastCoverage,
+      truthLabel: 'MAP REFERENCE · NOT TITLE',
+    }}
   />;
 }

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 const nav = fs.readFileSync(new URL('../app/components/FinancialOSNav.js', import.meta.url), 'utf8');
 const commandCenter = fs.readFileSync(new URL('../app/components/AppCommandCenter.js', import.meta.url), 'utf8');
 const productMap = fs.readFileSync(new URL('../lib/product-map.js', import.meta.url), 'utf8');
+const interactions = fs.readFileSync(new URL('../app/spatial-os-interactions.css', import.meta.url), 'utf8');
 const rootHome = fs.readFileSync(new URL('../app/page.js', import.meta.url), 'utf8');
 const more = fs.readFileSync(new URL('../app/more/page.js', import.meta.url), 'utf8');
 const integrationsPage = fs.readFileSync(new URL('../app/admin/integrations/page.js', import.meta.url), 'utf8');
@@ -30,8 +31,16 @@ assert.match(nav, /safe-area-inset-bottom/);
 assert.doesNotMatch(nav, /FINANCIAL_PREFIXES|financialRoute/, 'global app shell should no longer be restricted to a finance-only prefix list');
 assert.match(layout, /FinancialOSNav/);
 assert.match(layout, /AppCommandCenter/);
+assert.match(layout, /spatial-os-interactions\.css/);
 assert.match(layout, /Spatial Asset OS/);
 assert.doesNotMatch(vaultLayout, /VaultPortalNav/);
+
+assert.match(interactions, /--vv-tap-min:\s*44px/, 'coarse-pointer controls should keep an iPhone-friendly minimum target');
+assert.match(interactions, /@media \(pointer: coarse\)/, 'shared interactions should adapt to touch devices');
+assert.match(interactions, /:focus-visible/, 'keyboard focus must stay visible across the app shell');
+assert.match(interactions, /prefers-reduced-motion: reduce/, 'shared shell must respect reduced motion');
+assert.match(interactions, /-webkit-text-size-adjust:\s*100%/, 'iPhone text resizing should remain stable');
+assert.doesNotMatch(interactions, /background:\s*#(?:000|05060b)|color-scheme:/i, 'shared interaction polish must not force one visual theme onto every subsystem');
 
 assert.match(commandCenter, /APP_DOCK, APP_SECTIONS/, 'command center should index the canonical product map instead of maintaining another route list');
 assert.match(commandCenter, /metaKey \|\| event\.ctrlKey/, 'command center should support desktop keyboard invocation');
@@ -83,4 +92,4 @@ assert.match(home, /Fail-closed for real money/);
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault app organization + command center + Financial OS coherence regression tests passed');
+console.log('Voxel Vault app organization + command center + shared interaction + Financial OS coherence regression tests passed');

--- a/scripts/test-global-earth.mjs
+++ b/scripts/test-global-earth.mjs
@@ -50,6 +50,11 @@ assert.match(planetGlobe, /onViewport/, 'Settled globe movement must be able to 
 assert.match(globeController, /MAX_STREAMED_BUILDINGS = 420/, 'Worldwide exploration must cap accumulated client markers.');
 assert.match(globeController, /MAX_VISITED_REGIONS = 96/, 'Worldwide exploration must cap visited-region memory.');
 assert.match(globeController, /streamed globe markers are fast map references only/i, 'streamed marker selection must deepen through the normal evidence workflow.');
+assert.match(globeController, /REGIONS VISITED/, 'globe should expose in-session region coverage rather than pretending all Earth data is loaded locally');
+assert.match(globeController, /STREAMED MAP BUILDINGS/, 'globe should label streamed buildings as map references');
+assert.match(globeController, /DETAILED LOCAL BUILDINGS/, 'globe should distinguish detailed local lookup results from fast streamed references');
+assert.match(globeController, /MAP REFERENCE · NOT TITLE/, 'coverage HUD must keep map coverage legally separate from title');
+assert.doesNotMatch(globeController, /OWNED PROPERTIES|VERIFIED HOUSES|DEEDS LOADED/i, 'coverage telemetry must never convert map references into ownership or verification claims');
 assert.match(streamRoute, /s-maxage=300/, 'Visible-region streaming should use a bounded shared cache.');
 assert.match(streamLib, /global-on-demand/, 'World atlas streaming must describe itself as global on-demand coverage.');
 assert.match(streamLib, /createsOwnership:\s*false/, 'Streaming map markers must never create ownership.');
@@ -60,4 +65,4 @@ assert.match(env, /DOMAIN_CLIENT_SECRET=/, 'Domain client secret must be documen
 assert.match(env, /EARTH_PARTNER_FEEDS_JSON=/, 'Additional licensed provider config must be documented.');
 assert.doesNotMatch(env, /NEXT_PUBLIC_DOMAIN_CLIENT_SECRET|NEXT_PUBLIC_BRIDGE_ACCESS_TOKEN|NEXT_PUBLIC_EARTH_PARTNER/, 'Listing-provider secrets must never be client-exposed.');
 
-console.log('Global Earth federation safety checks passed: worldwide streamed navigation, authorized listings, source currencies, visible provider gaps, bounded map references, deed/title boundaries, and verification-first digital twins remain intact.');
+console.log('Global Earth federation safety checks passed: worldwide streamed navigation, honest coverage HUD, authorized listings, source currencies, visible provider gaps, bounded map references, deed/title boundaries, and verification-first digital twins remain intact.');


### PR DESCRIPTION
Continue the Spatial OS polish after #374. Adds an honest in-session Earth coverage HUD showing regions visited, streamed map buildings, detailed local buildings and the latest Overture tile load while explicitly labeling the streamed layer `MAP REFERENCE · NOT TITLE`. Adds shared touch/focus/reduced-motion interaction rules across the organized app: 44px coarse-pointer targets, stable iPhone text sizing, visible keyboard focus, tap-highlight cleanup and reduced-motion behavior without forcing one visual theme across legacy subsystems. Regression coverage prevents streamed map counts from being relabeled as owned/verified property and guards the shared interaction layer.