### PR TITLE
Reopen exact property drafts in 3D and sync them across devices

### DIFF
--- a/app/vault/PropertyDraftSyncBridge.js
+++ b/app/vault/PropertyDraftSyncBridge.js
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import { savePropertyDraftToAccount, syncLocalPropertyDraftsToAccount } from '../../lib/property-drafts-account';
+
+export default function PropertyDraftSyncBridge() {
+  const sessionRef = useRef(null);
+  const clientRef = useRef(null);
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+
+    async function apply(client, nextSession) {
+      sessionRef.current = nextSession || null;
+      if (!nextSession?.user) return;
+      try { await syncLocalPropertyDraftsToAccount(client, nextSession.user); } catch {}
+    }
+
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      await apply(client, data.session || null);
+      const auth = client.auth.onAuthStateChange((_event, next) => { if (active) apply(client, next); });
+      subscription = auth.data.subscription;
+    }).catch(() => {});
+
+    async function onSaved(event) {
+      const draft = event?.detail;
+      const session = sessionRef.current;
+      const client = clientRef.current;
+      if (!draft?.id || !session?.user || !client) return;
+      try { await savePropertyDraftToAccount(client, session.user, draft); } catch {}
+    }
+
+    window.addEventListener('voxel-vault:property-draft-saved', onSaved);
+    return () => {
+      active = false;
+      subscription?.unsubscribe?.();
+      window.removeEventListener('voxel-vault:property-draft-saved', onSaved);
+    };
+  }, []);
+
+  return null;
+}

--- a/app/vault/layout.js
+++ b/app/vault/layout.js
@@ -1,8 +1,10 @@
+import PropertyDraftSyncBridge from './PropertyDraftSyncBridge';
+
 export const metadata = {
   title: 'My Vault | Voxel Vault',
   description: 'Verified creator assets, wallet collectibles, user-bound provider positions and observed income inside the Voxel Vault financial OS.',
 };
 
 export default function VaultLayout({ children }) {
-  return children;
+  return <><PropertyDraftSyncBridge />{children}</>;
 }

--- a/app/vault/property-drafts/[draftId]/page.js
+++ b/app/vault/property-drafts/[draftId]/page.js
@@ -19,14 +19,15 @@ function fidelityLabel(value) {
 
 function savedReference(draft) {
   if (!draft) return null;
+  const parcelOnly = draft.geometryKind === 'parcel-boundary';
   const lat = Number(draft?.coordinates?.latitude);
   const lng = Number(draft?.coordinates?.longitude);
   const height = Number(draft?.evidence?.calibratedVisualHeightMeters);
   return {
-    found: Boolean(draft.geometry),
+    found: Boolean(draft.geometry && !parcelOnly),
     latitude: Number.isFinite(lat) ? lat : null,
     longitude: Number.isFinite(lng) ? lng : null,
-    geometry: draft.geometry || null,
+    geometry: parcelOnly ? null : (draft.geometry || null),
     tags: { name: draft.label || 'Saved property draft' },
     height: Number.isFinite(height) && height > 0 ? {
       referenceHeightMeters: height,
@@ -43,17 +44,17 @@ function savedReference(draft) {
   };
 }
 
-function liveEarthHref(draft) {
-  const lat = Number(draft?.coordinates?.latitude);
-  const lng = Number(draft?.coordinates?.longitude);
-  const params = new URLSearchParams();
-  if (Number.isFinite(lat) && Number.isFinite(lng)) {
-    params.set('lat', String(lat));
-    params.set('lng', String(lng));
-  }
-  if (draft?.label) params.set('q', draft.label);
-  params.set('view', 'voxel');
-  return `/vault/earth?${params.toString()}`;
+function savedAuthoritativeTwin(draft) {
+  if (!draft || draft.geometryKind !== 'parcel-boundary' || !draft.geometry) return null;
+  return {
+    location: {
+      parcelGeometry: draft.geometry,
+      latitude: draft?.coordinates?.latitude ?? null,
+      longitude: draft?.coordinates?.longitude ?? null,
+      source: { authority: draft?.evidence?.mapAuthority || 'Saved parcel evidence' },
+    },
+    structure: { buildingGeometry: null },
+  };
 }
 
 export default function SavedPropertyDraft3DPage() {
@@ -61,9 +62,11 @@ export default function SavedPropertyDraft3DPage() {
   const draftId = String(params?.draftId || '');
   const [draft, setDraft] = useState(null);
   const [status, setStatus] = useState('Opening your saved 3D property snapshot…');
+  const [liveStatus, setLiveStatus] = useState('');
   const [session, setSession] = useState(null);
   const [busy, setBusy] = useState(false);
   const reference = useMemo(() => savedReference(draft), [draft]);
+  const authoritativeTwin = useMemo(() => savedAuthoritativeTwin(draft), [draft]);
 
   useEffect(() => {
     let active = true;
@@ -121,24 +124,48 @@ export default function SavedPropertyDraft3DPage() {
     }
   }
 
+  async function refreshLiveEvidence() {
+    const lat = Number(draft?.coordinates?.latitude);
+    const lng = Number(draft?.coordinates?.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      setLiveStatus('This saved draft does not contain usable coordinates for a live map refresh.');
+      return;
+    }
+    setBusy(true);
+    setLiveStatus('Checking current source-backed map evidence near the saved coordinates…');
+    try {
+      const query = new URLSearchParams({ lat: String(lat), lng: String(lng), radius: '180' });
+      const response = await fetch(`/api/world-atlas/inspect?${query.toString()}`, { cache: 'no-store' });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok) throw new Error(data?.error || 'Current map evidence could not be loaded.');
+      const source = data?.sourceStatus?.fallbackUsed ? 'OpenStreetMap fallback' : 'Overture';
+      setLiveStatus(data.buildingCount
+        ? `Current ${source} evidence returns ${data.buildingCount} nearby source-backed building${data.buildingCount === 1 ? '' : 's'}. Your saved 3D snapshot was not changed.`
+        : `The current ${source} lookup resolved the location but returned no building footprint. Your saved snapshot remains unchanged.`);
+    } catch (error) {
+      setLiveStatus(`${String(error?.message || error)} Your saved snapshot remains unchanged.`);
+    } finally { setBusy(false); }
+  }
+
   if (!draft) return <main className="page"><header><Link href="/vault/property-drafts">← DRAFTS</Link><span>VOXEL VAULT · SAVED 3D</span></header><section className="missing"><b>{status}</b>{!session ? <button onClick={signIn} disabled={busy}>{busy ? 'CONNECTING…' : 'CONTINUE WITH GOOGLE'}</button> : null}<Link href="/vault/earth">EXPLORE EARTH</Link></section><style jsx>{styles}</style></main>;
 
   return <main className="page">
     <header><Link href="/vault/property-drafts">← DRAFTS</Link><span>EXACT SAVED 3D SNAPSHOT</span><Link href="/vault/properties/claim">VERIFY ↗</Link></header>
     <section className="hero"><small>{fidelityLabel(draft.fidelity)}</small><h1>{draft.label || 'Saved property draft'}</h1><p>{status} This viewer uses the geometry saved with the draft; live map updates do not silently replace it.</p></section>
-    <section className="viewer"><GeoReferenceModel reference={reference} authoritativeTwin={null} viewMode="orbit" resetKey={0}/></section>
+    <section className="viewer"><GeoReferenceModel reference={reference} authoritativeTwin={authoritativeTwin} viewMode="orbit" resetKey={0}/></section>
     <section className="panel">
       <div><small>SAVED SOURCE</small><b>{draft?.evidence?.mapAuthority || 'Saved draft evidence'}</b></div>
-      <div><small>FOOTPRINT</small><b>{draft?.evidence?.exactParcelLinkedBuilding ? 'PARCEL-LINKED' : draft?.evidence?.sourceBackedBuilding ? 'SOURCE-BACKED' : 'REFERENCE'}</b></div>
+      <div><small>GEOMETRY</small><b>{draft.geometryKind === 'parcel-boundary' ? 'PARCEL · NO BUILDING INVENTED' : draft?.evidence?.exactParcelLinkedBuilding ? 'PARCEL-LINKED BUILDING' : draft?.evidence?.sourceBackedBuilding ? 'SOURCE-BACKED BUILDING' : 'REFERENCE'}</b></div>
       <div><small>MINT</small><b>{draft?.blockchain?.minted ? 'MINTED' : 'NOT REQUIRED'}</b></div>
       <div><small>TITLE</small><b>{draft?.legal?.titleVerified ? 'VERIFIED' : 'SEPARATE'}</b></div>
     </section>
-    <div className="actions"><Link className="primary" href={liveEarthHref(draft)}>REFRESH LIVE EVIDENCE IN EARTH</Link><Link href="/vault/properties/claim">VERIFY PROPERTY RIGHTS</Link></div>
-    <p className="truth">This is the exact saved digital geometry snapshot, not a deed or guaranteed perfect replica. Refreshing Earth checks current source evidence separately; it does not overwrite this saved draft unless you save a newer version.</p>
+    <div className="actions"><button className="primary" onClick={refreshLiveEvidence} disabled={busy}>{busy ? 'CHECKING CURRENT EVIDENCE…' : 'CHECK CURRENT MAP EVIDENCE'}</button><Link href="/vault/earth">OPEN EARTH</Link><Link href="/vault/properties/claim">VERIFY PROPERTY RIGHTS</Link></div>
+    {liveStatus ? <div className="live" role="status">{liveStatus}</div> : null}
+    <p className="truth">This is the exact saved digital geometry snapshot, not a deed or guaranteed perfect replica. Parcel-only drafts stay parcels; Voxel Vault does not extrude vacant land into a fake building. Checking current evidence never overwrites this saved draft unless you explicitly save a newer version.</p>
     <style jsx>{styles}</style>
   </main>;
 }
 
 const styles = `
-:global(body){margin:0;background:#07090c;color:#f5f7f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,4vw,58px) 86px;background:radial-gradient(circle at 75% 7%,rgba(121,239,188,.1),transparent 30%),#07090c}header{display:flex;justify-content:space-between;gap:12px;align-items:center;font-size:8px;font-weight:950;letter-spacing:.12em;color:#7f8a86}header a{color:#a5afac;text-decoration:none}.hero{max-width:980px;margin:56px auto 20px}.hero small{font-size:7px;letter-spacing:.15em;color:#7fe0bb;font-weight:950}.hero h1{font-size:clamp(34px,6vw,72px);line-height:.95;letter-spacing:-.055em;margin:9px 0 13px}.hero p{max-width:760px;color:#85908c;font-size:10px;line-height:1.65}.viewer{max-width:1050px;height:min(64vh,650px);min-height:390px;margin:0 auto;border:1px solid rgba(255,255,255,.08);border-radius:25px;overflow:hidden;background:#0b0e11}.panel{max-width:1050px;margin:12px auto;display:grid;grid-template-columns:repeat(4,1fr);gap:7px}.panel div{padding:12px;border:1px solid rgba(255,255,255,.07);border-radius:13px;background:rgba(255,255,255,.025)}.panel small{display:block;color:#67736f;font-size:6px;font-weight:950;letter-spacing:.1em}.panel b{display:block;margin-top:5px;font-size:9px}.actions{max-width:1050px;margin:10px auto;display:grid;grid-template-columns:1.3fr 1fr;gap:8px}.actions a{display:grid;place-items:center;min-height:46px;border:1px solid rgba(255,255,255,.08);border-radius:12px;text-decoration:none;color:#a8b3af;font-size:7px;font-weight:950;letter-spacing:.08em}.actions .primary{background:#7fe0bb;color:#06100c;border-color:#7fe0bb}.truth{max-width:1050px;margin:12px auto;color:#64706b;font-size:8px;line-height:1.6}.missing{max-width:720px;margin:110px auto;padding:28px;border:1px dashed rgba(121,239,188,.24);border-radius:20px;display:grid;gap:12px}.missing b{font-size:13px}.missing button,.missing a{border:0;border-radius:11px;padding:12px;background:#7fe0bb;color:#06100c;text-align:center;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.08em}@media(max-width:620px){.page{padding:15px 12px 74px}.hero{margin-top:42px}.viewer{height:55vh;min-height:360px}.panel{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr}}
+:global(body){margin:0;background:#07090c;color:#f5f7f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,4vw,58px) 86px;background:radial-gradient(circle at 75% 7%,rgba(121,239,188,.1),transparent 30%),#07090c}header{display:flex;justify-content:space-between;gap:12px;align-items:center;font-size:8px;font-weight:950;letter-spacing:.12em;color:#7f8a86}header a{color:#a5afac;text-decoration:none}.hero{max-width:980px;margin:56px auto 20px}.hero small{font-size:7px;letter-spacing:.15em;color:#7fe0bb;font-weight:950}.hero h1{font-size:clamp(34px,6vw,72px);line-height:.95;letter-spacing:-.055em;margin:9px 0 13px}.hero p{max-width:760px;color:#85908c;font-size:10px;line-height:1.65}.viewer{max-width:1050px;height:min(64vh,650px);min-height:390px;margin:0 auto;border:1px solid rgba(255,255,255,.08);border-radius:25px;overflow:hidden;background:#0b0e11}.panel{max-width:1050px;margin:12px auto;display:grid;grid-template-columns:repeat(4,1fr);gap:7px}.panel div{padding:12px;border:1px solid rgba(255,255,255,.07);border-radius:13px;background:rgba(255,255,255,.025)}.panel small{display:block;color:#67736f;font-size:6px;font-weight:950;letter-spacing:.1em}.panel b{display:block;margin-top:5px;font-size:9px}.actions{max-width:1050px;margin:10px auto;display:grid;grid-template-columns:1.3fr .7fr 1fr;gap:8px}.actions a,.actions button{display:grid;place-items:center;min-height:46px;border:1px solid rgba(255,255,255,.08);border-radius:12px;text-decoration:none;color:#a8b3af;background:transparent;font:inherit;font-size:7px;font-weight:950;letter-spacing:.08em}.actions .primary{background:#7fe0bb;color:#06100c;border-color:#7fe0bb}.live{max-width:1050px;margin:10px auto;padding:11px 12px;border:1px solid rgba(121,239,188,.14);border-radius:12px;background:rgba(121,239,188,.035);color:#91b9aa;font-size:8px;line-height:1.55}.truth{max-width:1050px;margin:12px auto;color:#64706b;font-size:8px;line-height:1.6}.missing{max-width:720px;margin:110px auto;padding:28px;border:1px dashed rgba(121,239,188,.24);border-radius:20px;display:grid;gap:12px}.missing b{font-size:13px}.missing button,.missing a{border:0;border-radius:11px;padding:12px;background:#7fe0bb;color:#06100c;text-align:center;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.08em}@media(max-width:620px){.page{padding:15px 12px 74px}.hero{margin-top:42px}.viewer{height:55vh;min-height:360px}.panel{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr}}
 `;

--- a/app/vault/property-drafts/[draftId]/page.js
+++ b/app/vault/property-drafts/[draftId]/page.js
@@ -1,0 +1,144 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import GeoReferenceModel from '../../../geo/GeoReferenceModel';
+import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
+import { mergePropertyDraftRecords, readPropertyDraft, replaceLocalPropertyDrafts } from '../../../../lib/property-drafts';
+import { loadAccountPropertyDrafts } from '../../../../lib/property-drafts-account';
+
+function fidelityLabel(value) {
+  if (value === 'parcel-linked-ready-for-high-fidelity') return 'PARCEL-LINKED · HIGH-FIDELITY READY';
+  if (value === 'source-backed-ready-for-high-fidelity') return 'SOURCE-BACKED · HIGH-FIDELITY READY';
+  if (value === 'parcel-linked-3d-draft') return 'PARCEL-LINKED 3D DRAFT';
+  if (value === 'source-backed-3d-draft') return 'SOURCE-BACKED 3D DRAFT';
+  if (value === 'parcel-3d-draft') return 'PARCEL 3D DRAFT';
+  return 'LOCATION REFERENCE';
+}
+
+function savedReference(draft) {
+  if (!draft) return null;
+  const lat = Number(draft?.coordinates?.latitude);
+  const lng = Number(draft?.coordinates?.longitude);
+  const height = Number(draft?.evidence?.calibratedVisualHeightMeters);
+  return {
+    found: Boolean(draft.geometry),
+    latitude: Number.isFinite(lat) ? lat : null,
+    longitude: Number.isFinite(lng) ? lng : null,
+    geometry: draft.geometry || null,
+    tags: { name: draft.label || 'Saved property draft' },
+    height: Number.isFinite(height) && height > 0 ? {
+      referenceHeightMeters: height,
+      heightStatus: 'saved_calibrated_reference',
+      heightSource: draft?.evidence?.mapAuthority || 'Saved property draft',
+    } : null,
+    matchStrategy: draft?.evidence?.exactParcelLinkedBuilding ? 'saved_parcel_linked_draft' : 'saved_source_backed_draft',
+    source: {
+      authority: draft?.evidence?.mapAuthority || 'Saved Voxel Vault draft',
+      license: draft?.evidence?.mapLicense || '',
+      sourceUrl: draft?.evidence?.mapSourceUrl || '',
+    },
+    neighborhoodBuildings: [],
+  };
+}
+
+function liveEarthHref(draft) {
+  const lat = Number(draft?.coordinates?.latitude);
+  const lng = Number(draft?.coordinates?.longitude);
+  const params = new URLSearchParams();
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    params.set('lat', String(lat));
+    params.set('lng', String(lng));
+  }
+  if (draft?.label) params.set('q', draft.label);
+  params.set('view', 'voxel');
+  return `/vault/earth?${params.toString()}`;
+}
+
+export default function SavedPropertyDraft3DPage() {
+  const params = useParams();
+  const draftId = String(params?.draftId || '');
+  const [draft, setDraft] = useState(null);
+  const [status, setStatus] = useState('Opening your saved 3D property snapshot…');
+  const [session, setSession] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const reference = useMemo(() => savedReference(draft), [draft]);
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    async function restore(client, nextSession) {
+      if (!active) return;
+      setSession(nextSession || null);
+      const local = readPropertyDraft(draftId);
+      if (local) {
+        setDraft(local);
+        setStatus('Loaded the exact geometry snapshot saved in your Vault.');
+        return;
+      }
+      if (!nextSession?.user) {
+        setStatus('This draft is not stored on this device. Sign in to restore synced property drafts.');
+        return;
+      }
+      try {
+        const cloud = await loadAccountPropertyDrafts(client, nextSession.user);
+        const merged = mergePropertyDraftRecords(cloud);
+        replaceLocalPropertyDrafts(merged);
+        const restored = merged.find((item) => item.id === draftId) || null;
+        if (!active) return;
+        setDraft(restored);
+        setStatus(restored ? 'Restored this exact saved 3D property snapshot from your account.' : 'This draft was not found in your synced account library.');
+      } catch (error) {
+        if (active) setStatus(String(error?.message || error || 'Could not restore this draft.'));
+      }
+    }
+    getSupabaseBrowserAsync().then(async (client) => {
+      const { data } = await client.auth.getSession();
+      await restore(client, data.session || null);
+      const auth = client.auth.onAuthStateChange((_event, next) => restore(client, next));
+      subscription = auth.data.subscription;
+    }).catch(() => {
+      const local = readPropertyDraft(draftId);
+      if (active) {
+        setDraft(local);
+        setStatus(local ? 'Loaded the exact geometry snapshot saved on this device.' : 'This draft is not stored on this device.');
+      }
+    });
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, [draftId]);
+
+  async function signIn() {
+    setBusy(true);
+    try {
+      const client = await getSupabaseBrowserAsync();
+      const redirectTo = new URL(`/vault/property-drafts/${encodeURIComponent(draftId)}`, window.location.origin).toString();
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo } });
+      if (error) throw error;
+    } catch (error) {
+      setStatus(String(error?.message || error || 'Could not start sign-in.'));
+      setBusy(false);
+    }
+  }
+
+  if (!draft) return <main className="page"><header><Link href="/vault/property-drafts">← DRAFTS</Link><span>VOXEL VAULT · SAVED 3D</span></header><section className="missing"><b>{status}</b>{!session ? <button onClick={signIn} disabled={busy}>{busy ? 'CONNECTING…' : 'CONTINUE WITH GOOGLE'}</button> : null}<Link href="/vault/earth">EXPLORE EARTH</Link></section><style jsx>{styles}</style></main>;
+
+  return <main className="page">
+    <header><Link href="/vault/property-drafts">← DRAFTS</Link><span>EXACT SAVED 3D SNAPSHOT</span><Link href="/vault/properties/claim">VERIFY ↗</Link></header>
+    <section className="hero"><small>{fidelityLabel(draft.fidelity)}</small><h1>{draft.label || 'Saved property draft'}</h1><p>{status} This viewer uses the geometry saved with the draft; live map updates do not silently replace it.</p></section>
+    <section className="viewer"><GeoReferenceModel reference={reference} authoritativeTwin={null} viewMode="orbit" resetKey={0}/></section>
+    <section className="panel">
+      <div><small>SAVED SOURCE</small><b>{draft?.evidence?.mapAuthority || 'Saved draft evidence'}</b></div>
+      <div><small>FOOTPRINT</small><b>{draft?.evidence?.exactParcelLinkedBuilding ? 'PARCEL-LINKED' : draft?.evidence?.sourceBackedBuilding ? 'SOURCE-BACKED' : 'REFERENCE'}</b></div>
+      <div><small>MINT</small><b>{draft?.blockchain?.minted ? 'MINTED' : 'NOT REQUIRED'}</b></div>
+      <div><small>TITLE</small><b>{draft?.legal?.titleVerified ? 'VERIFIED' : 'SEPARATE'}</b></div>
+    </section>
+    <div className="actions"><Link className="primary" href={liveEarthHref(draft)}>REFRESH LIVE EVIDENCE IN EARTH</Link><Link href="/vault/properties/claim">VERIFY PROPERTY RIGHTS</Link></div>
+    <p className="truth">This is the exact saved digital geometry snapshot, not a deed or guaranteed perfect replica. Refreshing Earth checks current source evidence separately; it does not overwrite this saved draft unless you save a newer version.</p>
+    <style jsx>{styles}</style>
+  </main>;
+}
+
+const styles = `
+:global(body){margin:0;background:#07090c;color:#f5f7f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,4vw,58px) 86px;background:radial-gradient(circle at 75% 7%,rgba(121,239,188,.1),transparent 30%),#07090c}header{display:flex;justify-content:space-between;gap:12px;align-items:center;font-size:8px;font-weight:950;letter-spacing:.12em;color:#7f8a86}header a{color:#a5afac;text-decoration:none}.hero{max-width:980px;margin:56px auto 20px}.hero small{font-size:7px;letter-spacing:.15em;color:#7fe0bb;font-weight:950}.hero h1{font-size:clamp(34px,6vw,72px);line-height:.95;letter-spacing:-.055em;margin:9px 0 13px}.hero p{max-width:760px;color:#85908c;font-size:10px;line-height:1.65}.viewer{max-width:1050px;height:min(64vh,650px);min-height:390px;margin:0 auto;border:1px solid rgba(255,255,255,.08);border-radius:25px;overflow:hidden;background:#0b0e11}.panel{max-width:1050px;margin:12px auto;display:grid;grid-template-columns:repeat(4,1fr);gap:7px}.panel div{padding:12px;border:1px solid rgba(255,255,255,.07);border-radius:13px;background:rgba(255,255,255,.025)}.panel small{display:block;color:#67736f;font-size:6px;font-weight:950;letter-spacing:.1em}.panel b{display:block;margin-top:5px;font-size:9px}.actions{max-width:1050px;margin:10px auto;display:grid;grid-template-columns:1.3fr 1fr;gap:8px}.actions a{display:grid;place-items:center;min-height:46px;border:1px solid rgba(255,255,255,.08);border-radius:12px;text-decoration:none;color:#a8b3af;font-size:7px;font-weight:950;letter-spacing:.08em}.actions .primary{background:#7fe0bb;color:#06100c;border-color:#7fe0bb}.truth{max-width:1050px;margin:12px auto;color:#64706b;font-size:8px;line-height:1.6}.missing{max-width:720px;margin:110px auto;padding:28px;border:1px dashed rgba(121,239,188,.24);border-radius:20px;display:grid;gap:12px}.missing b{font-size:13px}.missing button,.missing a{border:0;border-radius:11px;padding:12px;background:#7fe0bb;color:#06100c;text-align:center;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.08em}@media(max-width:620px){.page{padding:15px 12px 74px}.hero{margin-top:42px}.viewer{height:55vh;min-height:360px}.panel{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr}}
+`;

--- a/app/vault/property-drafts/page.js
+++ b/app/vault/property-drafts/page.js
@@ -1,8 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
 import { deletePropertyDraft, exportPropertyDraft, readPropertyDrafts } from '../../../lib/property-drafts';
+import { deletePropertyDraftFromAccount, syncLocalPropertyDraftsToAccount } from '../../../lib/property-drafts-account';
 
 function fidelityLabel(value) {
   if (value === 'parcel-linked-ready-for-high-fidelity') return 'PARCEL-LINKED · HIGH-FIDELITY READY';
@@ -21,13 +23,93 @@ function coordinateText(draft) {
 
 export default function PropertyDraftsPage() {
   const [drafts, setDrafts] = useState([]);
+  const [session, setSession] = useState(null);
+  const [syncStatus, setSyncStatus] = useState('Saved drafts work on this device without an account.');
+  const [busy, setBusy] = useState('');
+  const clientRef = useRef(null);
 
   function refresh() { setDrafts(readPropertyDrafts()); }
-  useEffect(() => { refresh(); }, []);
 
-  function remove(id) {
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    refresh();
+    async function apply(client, nextSession) {
+      if (!active) return;
+      setSession(nextSession || null);
+      if (!nextSession?.user) {
+        refresh();
+        setSyncStatus('Local mode · sign in with Google to sync these drafts between iPhone and desktop.');
+        return;
+      }
+      setBusy('sync');
+      setSyncStatus('Merging browser + account property drafts…');
+      try {
+        const merged = await syncLocalPropertyDraftsToAccount(client, nextSession.user);
+        if (!active) return;
+        setDrafts(merged);
+        setSyncStatus(`Google sync active · ${merged.length} property draft${merged.length === 1 ? '' : 's'} available on this account.`);
+      } catch (error) {
+        if (active) {
+          refresh();
+          setSyncStatus(String(error?.message || error || 'Cloud sync is unavailable. Your local drafts are still safe on this device.'));
+        }
+      } finally {
+        if (active) setBusy('');
+      }
+    }
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      await apply(client, data.session || null);
+      const auth = client.auth.onAuthStateChange((_event, next) => apply(client, next));
+      subscription = auth.data.subscription;
+    }).catch(() => { if (active) setSyncStatus('Local mode · account sync is not configured on this deployment.'); });
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  async function signIn() {
+    setBusy('signin');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: new URL('/vault/property-drafts', window.location.origin).toString() } });
+      if (error) throw error;
+    } catch (error) {
+      setSyncStatus(String(error?.message || error || 'Could not start Google sign-in.'));
+      setBusy('');
+    }
+  }
+
+  async function signOut() {
+    setBusy('signout');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signOut();
+      if (error) throw error;
+      setSession(null);
+      refresh();
+      setSyncStatus('Signed out · local drafts remain on this device.');
+    } catch (error) {
+      setSyncStatus(String(error?.message || error || 'Could not sign out.'));
+    } finally { setBusy(''); }
+  }
+
+  async function remove(id) {
     deletePropertyDraft(id);
     refresh();
+    if (!session?.user) return;
+    setBusy(id);
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      await deletePropertyDraftFromAccount(client, session.user, id);
+      setSyncStatus('Draft removed from this device and your synced account library.');
+    } catch (error) {
+      setSyncStatus(`Removed locally, but account deletion needs attention: ${String(error?.message || error)}`);
+    } finally { setBusy(''); }
   }
 
   return <main className="page">
@@ -35,7 +117,8 @@ export default function PropertyDraftsPage() {
     <section className="hero">
       <small>NO WALLET REQUIRED · NO MINT REQUIRED</small>
       <h1>Your property<br/><em>drafts.</em></h1>
-      <p>Every saved item here is a 3D property representation built from the evidence Voxel Vault actually had. Keep it offchain forever, improve it later, verify the underlying property separately, or mint a digital provenance record only if you want to.</p>
+      <p>Every saved item here is a 3D property representation built from the evidence Voxel Vault actually had. Open the exact saved model, keep it offchain forever, improve it later, or verify the underlying property separately.</p>
+      <div className="sync"><div><b>{session?.user ? 'ACCOUNT SYNC ON' : 'LOCAL + OPTIONAL CLOUD'}</b><span>{syncStatus}</span></div>{session?.user ? <button onClick={signOut} disabled={Boolean(busy)}>{busy === 'signout' ? 'SIGNING OUT…' : 'SIGN OUT'}</button> : <button onClick={signIn} disabled={Boolean(busy)}>{busy === 'signin' ? 'CONNECTING…' : 'CONTINUE WITH GOOGLE'}</button>}</div>
     </section>
 
     {drafts.length ? <section className="grid">{drafts.map((draft) => <article key={draft.id}>
@@ -48,16 +131,16 @@ export default function PropertyDraftsPage() {
           <div><b>{draft.evidence?.exactParcelLinkedBuilding ? 'YES' : draft.evidence?.sourceBackedBuilding ? 'MAP' : '—'}</b><span>3D FOOTPRINT</span></div>
           <div><b>{draft.evidence?.openStreetPhotoCount || 0}</b><span>OPEN PHOTOS</span></div>
           <div><b>{draft.evidence?.reconstructionReferenceCount || 0}</b><span>3D REFERENCES</span></div>
-          <div><b>NO</b><span>MINTED</span></div>
+          <div><b>{draft.blockchain?.minted ? 'YES' : 'NO'}</b><span>MINTED</span></div>
         </div>
-        <div className="actions"><Link href="/vault/earth">OPEN EARTH</Link><button type="button" onClick={() => exportPropertyDraft(draft)}>EXPORT</button><button type="button" onClick={() => remove(draft.id)}>REMOVE</button></div>
+        <div className="actions"><Link href={`/vault/property-drafts/${encodeURIComponent(draft.id)}`}>OPEN EXACT 3D</Link><button type="button" onClick={() => exportPropertyDraft(draft)}>EXPORT</button><button type="button" onClick={() => remove(draft.id)} disabled={busy === draft.id}>{busy === draft.id ? 'REMOVING…' : 'REMOVE'}</button></div>
         <Link className="verify" href="/vault/properties/claim">Verify property rights before any ownership claim →</Link>
         <p className="legal">Saving this model does not create deed/title, investment rights, rent rights, or guaranteed value. Minting remains optional and does not change that.</p>
       </div>
     </article>)}</section> : <section className="empty"><b>NO SAVED 3D PROPERTY DRAFTS YET</b><span>Open Earth, select a source-backed property, and tap Save 3D Draft. No blockchain step is required.</span><Link href="/vault/earth">EXPLORE EARTH →</Link></section>}
 
     <style jsx>{`
-      :global(body){margin:0;background:#07090c;color:#f5f7f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:20px clamp(16px,4vw,58px) 88px;background:radial-gradient(circle at 72% 8%,rgba(121,239,188,.09),transparent 30%),#07090c}header{display:flex;justify-content:space-between;align-items:center;gap:14px;font-size:8px;font-weight:950;letter-spacing:.12em;color:#77827f}header a{color:#9aa5a2;text-decoration:none}.hero{max-width:900px;margin:82px 0 34px}.hero small{font-size:8px;font-weight:950;letter-spacing:.16em;color:#7fe0bb}.hero h1{font-size:clamp(56px,8vw,105px);line-height:.87;letter-spacing:-.07em;margin:14px 0 22px}.hero h1 em{font-style:normal;color:#76807d}.hero p{max-width:720px;font-size:12px;line-height:1.75;color:#87918e}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(290px,1fr));gap:14px}.grid article{overflow:hidden;border:1px solid rgba(255,255,255,.08);border-radius:24px;background:linear-gradient(145deg,rgba(255,255,255,.045),rgba(255,255,255,.012))}.visual{height:190px;position:relative;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(121,239,188,.12),transparent 28%),linear-gradient(#12171b,#090b0e)}.parcel{position:absolute;left:10%;right:10%;bottom:15%;height:34%;border:2px solid rgba(121,239,188,.3);transform:perspective(330px) rotateX(60deg);border-radius:14px}.mass{position:absolute;left:28%;right:28%;bottom:30%;height:38%;background:#c9cec8;box-shadow:0 22px 45px rgba(0,0,0,.42)}.mass:before{content:'';position:absolute;left:-7%;right:-7%;top:-10%;height:13%;background:#3d4544}.mass i{position:absolute;bottom:18%;width:17%;height:32%;background:#7fe0bb;opacity:.72}.mass i:nth-child(1){left:12%}.mass i:nth-child(2){left:42%}.mass i:nth-child(3){right:12%}.visual span{position:absolute;top:14px;left:14px;right:14px;width:max-content;max-width:calc(100% - 28px);font-size:7px;line-height:1.3;font-weight:950;letter-spacing:.1em;padding:7px 9px;border-radius:999px;background:rgba(3,7,8,.72);border:1px solid rgba(255,255,255,.1);color:#b9e9d6}.body{padding:18px}.body>small{font-size:7px;font-weight:950;letter-spacing:.12em;color:#6f7c78}.body h2{font-size:23px;letter-spacing:-.045em;margin:5px 0 4px}.coord{font-size:9px;color:#7f8986;margin:0 0 15px}.facts{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:0 0 14px}.facts div{border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:9px;background:rgba(0,0,0,.12)}.facts b{display:block;font-size:12px}.facts span{display:block;margin-top:3px;font-size:5px;font-weight:950;letter-spacing:.08em;color:#65716d}.actions{display:grid;grid-template-columns:1fr auto auto;gap:7px}.actions a,.actions button{border:0;border-radius:11px;padding:11px 12px;font:inherit;font-size:7px;font-weight:950;letter-spacing:.09em;text-align:center;text-decoration:none;background:#eef3f1;color:#0a0d0c;cursor:pointer}.actions button{background:rgba(255,255,255,.07);color:#a7b1ae}.verify{display:block;margin-top:10px;color:#8cdabd;text-decoration:none;font-size:8px;font-weight:850}.legal{margin:10px 0 0;color:#616c68;font-size:7px;line-height:1.5}.empty{max-width:760px;padding:28px;border:1px dashed rgba(121,239,188,.22);border-radius:22px;background:rgba(121,239,188,.025)}.empty b{display:block;font-size:12px;letter-spacing:.08em}.empty span{display:block;color:#7f8b87;font-size:10px;line-height:1.6;margin:8px 0 18px}.empty a{display:inline-block;padding:12px 14px;border-radius:12px;background:#7fe0bb;color:#06100c;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.1em}@media(max-width:620px){.page{padding:16px 14px 76px}.hero{margin-top:55px}.hero h1{font-size:56px}.grid{grid-template-columns:1fr}.facts{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr 1fr}.actions a{grid-column:1/-1}}
+      :global(body){margin:0;background:#07090c;color:#f5f7f8;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:20px clamp(16px,4vw,58px) 88px;background:radial-gradient(circle at 72% 8%,rgba(121,239,188,.09),transparent 30%),#07090c}header{display:flex;justify-content:space-between;align-items:center;gap:14px;font-size:8px;font-weight:950;letter-spacing:.12em;color:#77827f}header a{color:#9aa5a2;text-decoration:none}.hero{max-width:900px;margin:82px 0 34px}.hero small{font-size:8px;font-weight:950;letter-spacing:.16em;color:#7fe0bb}.hero h1{font-size:clamp(56px,8vw,105px);line-height:.87;letter-spacing:-.07em;margin:14px 0 22px}.hero h1 em{font-style:normal;color:#76807d}.hero>p{max-width:720px;font-size:12px;line-height:1.75;color:#87918e}.sync{margin-top:18px;max-width:760px;display:flex;justify-content:space-between;align-items:center;gap:14px;padding:12px 13px;border:1px solid rgba(121,239,188,.16);border-radius:15px;background:rgba(121,239,188,.035)}.sync b{display:block;font-size:7px;letter-spacing:.12em;color:#9bdcc4}.sync span{display:block;margin-top:4px;color:#74817c;font-size:8px;line-height:1.45}.sync button{flex:0 0 auto;border:0;border-radius:10px;padding:10px 12px;background:#7fe0bb;color:#06100c;font-size:7px;font-weight:950;letter-spacing:.08em}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(290px,1fr));gap:14px}.grid article{overflow:hidden;border:1px solid rgba(255,255,255,.08);border-radius:24px;background:linear-gradient(145deg,rgba(255,255,255,.045),rgba(255,255,255,.012))}.visual{height:190px;position:relative;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(121,239,188,.12),transparent 28%),linear-gradient(#12171b,#090b0e)}.parcel{position:absolute;left:10%;right:10%;bottom:15%;height:34%;border:2px solid rgba(121,239,188,.3);transform:perspective(330px) rotateX(60deg);border-radius:14px}.mass{position:absolute;left:28%;right:28%;bottom:30%;height:38%;background:#c9cec8;box-shadow:0 22px 45px rgba(0,0,0,.42)}.mass:before{content:'';position:absolute;left:-7%;right:-7%;top:-10%;height:13%;background:#3d4544}.mass i{position:absolute;bottom:18%;width:17%;height:32%;background:#7fe0bb;opacity:.72}.mass i:nth-child(1){left:12%}.mass i:nth-child(2){left:42%}.mass i:nth-child(3){right:12%}.visual span{position:absolute;top:14px;left:14px;right:14px;width:max-content;max-width:calc(100% - 28px);font-size:7px;line-height:1.3;font-weight:950;letter-spacing:.1em;padding:7px 9px;border-radius:999px;background:rgba(3,7,8,.72);border:1px solid rgba(255,255,255,.1);color:#b9e9d6}.body{padding:18px}.body>small{font-size:7px;font-weight:950;letter-spacing:.12em;color:#6f7c78}.body h2{font-size:23px;letter-spacing:-.045em;margin:5px 0 4px}.coord{font-size:9px;color:#7f8986;margin:0 0 15px}.facts{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:0 0 14px}.facts div{border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:9px;background:rgba(0,0,0,.12)}.facts b{display:block;font-size:12px}.facts span{display:block;margin-top:3px;font-size:5px;font-weight:950;letter-spacing:.08em;color:#65716d}.actions{display:grid;grid-template-columns:1fr auto auto;gap:7px}.actions a,.actions button{border:0;border-radius:11px;padding:11px 12px;font:inherit;font-size:7px;font-weight:950;letter-spacing:.09em;text-align:center;text-decoration:none;background:#eef3f1;color:#0a0d0c;cursor:pointer}.actions button{background:rgba(255,255,255,.07);color:#a7b1ae}.verify{display:block;margin-top:10px;color:#8cdabd;text-decoration:none;font-size:8px;font-weight:850}.legal{margin:10px 0 0;color:#616c68;font-size:7px;line-height:1.5}.empty{max-width:760px;padding:28px;border:1px dashed rgba(121,239,188,.22);border-radius:22px;background:rgba(121,239,188,.025)}.empty b{display:block;font-size:12px;letter-spacing:.08em}.empty span{display:block;color:#7f8b87;font-size:10px;line-height:1.6;margin:8px 0 18px}.empty a{display:inline-block;padding:12px 14px;border-radius:12px;background:#7fe0bb;color:#06100c;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.1em}@media(max-width:620px){.page{padding:16px 14px 76px}.hero{margin-top:55px}.hero h1{font-size:56px}.sync{display:grid}.sync button{justify-self:start}.grid{grid-template-columns:1fr}.facts{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr 1fr}.actions a{grid-column:1/-1}}
     `}</style>
   </main>;
 }

--- a/lib/property-drafts-account.ts
+++ b/lib/property-drafts-account.ts
@@ -1,0 +1,92 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { mergePropertyDraftRecords, readPropertyDrafts, replaceLocalPropertyDrafts } from './property-drafts';
+
+export type PropertyDraft = {
+  id: string;
+  type?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: any;
+};
+
+function googleDisplayName(user: User) {
+  const metadata = user.user_metadata || {};
+  return String(metadata.full_name || metadata.name || user.email || 'Voxel Vault user').slice(0, 50);
+}
+
+function generatedHandle(user: User) {
+  return `vv_${user.id.replaceAll('-', '').slice(0, 12)}`.toLowerCase();
+}
+
+function validDraft(value: unknown): value is PropertyDraft {
+  if (!value || typeof value !== 'object') return false;
+  const draft = value as PropertyDraft;
+  return Boolean(draft.id && draft.type === 'voxel-vault-property-3d-draft');
+}
+
+async function readProfile(supabase: SupabaseClient, user: User) {
+  const { data, error } = await supabase
+    .from('vault_profiles')
+    .select('user_id,handle,display_name,bio,avatar_style')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (error) throw new Error(`Property draft account storage is unavailable: ${error.message}`);
+  return data;
+}
+
+function profileDraftLibrary(profile: any): PropertyDraft[] {
+  const raw = profile?.avatar_style?.property_draft_library;
+  return Array.isArray(raw) ? raw.filter(validDraft) : [];
+}
+
+async function writeProfileDraftLibrary(
+  supabase: SupabaseClient,
+  user: User,
+  profile: any,
+  library: PropertyDraft[],
+) {
+  const currentStyle = profile?.avatar_style && typeof profile.avatar_style === 'object' ? profile.avatar_style : {};
+  const bounded = mergePropertyDraftRecords(library);
+  const { error } = await supabase.from('vault_profiles').upsert({
+    user_id: user.id,
+    handle: profile?.handle || generatedHandle(user),
+    display_name: profile?.display_name || googleDisplayName(user),
+    bio: profile?.bio || '',
+    avatar_style: { ...currentStyle, property_draft_library: bounded },
+    updated_at: new Date().toISOString(),
+  });
+  if (error) throw new Error(`Could not save 3D property drafts to your account: ${error.message}`);
+  return bounded;
+}
+
+export async function loadAccountPropertyDrafts(supabase: SupabaseClient, user: User) {
+  const profile = await readProfile(supabase, user);
+  return profileDraftLibrary(profile);
+}
+
+export async function syncLocalPropertyDraftsToAccount(supabase: SupabaseClient, user: User) {
+  const profile = await readProfile(supabase, user);
+  const cloud = profileDraftLibrary(profile);
+  const local = readPropertyDrafts();
+  const merged = mergePropertyDraftRecords(cloud, local);
+  await writeProfileDraftLibrary(supabase, user, profile, merged);
+  replaceLocalPropertyDrafts(merged);
+  return merged;
+}
+
+export async function savePropertyDraftToAccount(supabase: SupabaseClient, user: User, draft: PropertyDraft) {
+  if (!validDraft(draft)) return [];
+  const profile = await readProfile(supabase, user);
+  const cloud = profileDraftLibrary(profile);
+  const merged = mergePropertyDraftRecords(cloud, [draft]);
+  await writeProfileDraftLibrary(supabase, user, profile, merged);
+  return merged;
+}
+
+export async function deletePropertyDraftFromAccount(supabase: SupabaseClient, user: User, draftId: string) {
+  if (!draftId) return [];
+  const profile = await readProfile(supabase, user);
+  const cloud = profileDraftLibrary(profile).filter((draft) => draft.id !== draftId);
+  const saved = await writeProfileDraftLibrary(supabase, user, profile, cloud);
+  return saved;
+}

--- a/lib/property-drafts.js
+++ b/lib/property-drafts.js
@@ -200,6 +200,7 @@ export function savePropertyDraft(draft) {
   };
   const merged = mergePropertyDraftRecords([next], readPropertyDrafts());
   replaceLocalPropertyDrafts(merged);
+  window.dispatchEvent(new CustomEvent('voxel-vault:property-draft-saved', { detail: next }));
   return next;
 }
 

--- a/lib/property-drafts.js
+++ b/lib/property-drafts.js
@@ -117,6 +117,39 @@ function safeParse(value, fallback) {
   try { return JSON.parse(value); } catch { return fallback; }
 }
 
+function timestamp(value) {
+  const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function isPropertyDraftRecord(value) {
+  return Boolean(value && typeof value === 'object' && value.id && value.type === 'voxel-vault-property-3d-draft');
+}
+
+export function mergePropertyDraftRecords(...groups) {
+  const map = new Map();
+  for (const group of groups) {
+    for (const draft of Array.isArray(group) ? group : []) {
+      if (!isPropertyDraftRecord(draft)) continue;
+      const previous = map.get(draft.id);
+      if (!previous || timestamp(draft.updatedAt) >= timestamp(previous.updatedAt)) {
+        map.set(draft.id, {
+          ...draft,
+          createdAt: previous?.createdAt || draft.createdAt || new Date(0).toISOString(),
+          blockchain: {
+            ...(draft.blockchain || {}),
+            minted: Boolean(previous?.blockchain?.minted || draft?.blockchain?.minted),
+            optional: true,
+          },
+        });
+      }
+    }
+  }
+  return Array.from(map.values())
+    .sort((a, b) => timestamp(b.updatedAt) - timestamp(a.updatedAt))
+    .slice(0, MAX_DRAFTS);
+}
+
 export function propertyDraftStorageKey(id) {
   return `${DRAFT_PREFIX}${encodeURIComponent(String(id || ''))}`;
 }
@@ -134,7 +167,20 @@ export function readPropertyDrafts() {
   if (typeof window === 'undefined') return [];
   const ids = safeParse(window.localStorage.getItem(INDEX_KEY), []);
   if (!Array.isArray(ids)) return [];
-  return ids.map((id) => readPropertyDraft(id)).filter(Boolean).sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')));
+  return ids.map((id) => readPropertyDraft(id)).filter(isPropertyDraftRecord).sort((a, b) => timestamp(b.updatedAt) - timestamp(a.updatedAt));
+}
+
+export function replaceLocalPropertyDrafts(drafts) {
+  if (typeof window === 'undefined') return [];
+  const next = mergePropertyDraftRecords(drafts);
+  const previousIds = safeParse(window.localStorage.getItem(INDEX_KEY), []);
+  const nextIds = next.map((draft) => draft.id);
+  for (const previousId of Array.isArray(previousIds) ? previousIds : []) {
+    if (previousId && !nextIds.includes(previousId)) window.localStorage.removeItem(propertyDraftStorageKey(previousId));
+  }
+  for (const draft of next) window.localStorage.setItem(propertyDraftStorageKey(draft.id), JSON.stringify(draft));
+  window.localStorage.setItem(INDEX_KEY, JSON.stringify(nextIds));
+  return next;
 }
 
 export function savePropertyDraft(draft) {
@@ -152,16 +198,8 @@ export function savePropertyDraft(draft) {
       optional: true,
     },
   };
-  window.localStorage.setItem(propertyDraftStorageKey(next.id), JSON.stringify(next));
-
-  const currentIds = safeParse(window.localStorage.getItem(INDEX_KEY), []);
-  const allIds = [next.id, ...(Array.isArray(currentIds) ? currentIds : []).filter((id) => id !== next.id)];
-  const ids = allIds.slice(0, MAX_DRAFTS);
-  const overflowIds = allIds.slice(MAX_DRAFTS);
-  window.localStorage.setItem(INDEX_KEY, JSON.stringify(ids));
-  for (const stale of overflowIds) {
-    if (stale) window.localStorage.removeItem(propertyDraftStorageKey(stale));
-  }
+  const merged = mergePropertyDraftRecords([next], readPropertyDrafts());
+  replaceLocalPropertyDrafts(merged);
   return next;
 }
 

--- a/scripts/test-property-draft-funnel.mjs
+++ b/scripts/test-property-draft-funnel.mjs
@@ -2,8 +2,12 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const drafts = fs.readFileSync(new URL('../lib/property-drafts.js', import.meta.url), 'utf8');
+const account = fs.readFileSync(new URL('../lib/property-drafts-account.ts', import.meta.url), 'utf8');
+const syncBridge = fs.readFileSync(new URL('../app/vault/PropertyDraftSyncBridge.js', import.meta.url), 'utf8');
+const vaultLayout = fs.readFileSync(new URL('../app/vault/layout.js', import.meta.url), 'utf8');
 const truth = fs.readFileSync(new URL('../app/vault/earth/PropertyTruthStack.js', import.meta.url), 'utf8');
 const vaultPage = fs.readFileSync(new URL('../app/vault/property-drafts/page.js', import.meta.url), 'utf8');
+const draftViewer = fs.readFileSync(new URL('../app/vault/property-drafts/[draftId]/page.js', import.meta.url), 'utf8');
 const earthPage = fs.readFileSync(new URL('../app/vault/earth/page.js', import.meta.url), 'utf8');
 
 assert.match(drafts, /type:\s*'voxel-vault-property-3d-draft'/, 'saved objects must be explicit 3D property drafts');
@@ -11,10 +15,20 @@ assert.match(drafts, /minted:\s*false/, 'new property drafts must start unminted
 assert.match(drafts, /optional:\s*true/, 'blockchain minting must remain optional');
 assert.match(drafts, /ownershipRightsCreatedByDraft:\s*false/, 'saving a 3D draft must never create property rights');
 assert.match(drafts, /ownershipRightsCreatedByMint:\s*false/, 'minting a digital model must never be represented as creating real-property rights');
-assert.match(drafts, /MAX_DRAFTS = 24/, 'browser draft storage must stay bounded for mobile devices');
-assert.match(drafts, /overflowIds = allIds\.slice\(MAX_DRAFTS\)/, 'storage overflow must be identified, not merely hidden from the index');
-assert.match(drafts, /removeItem\(propertyDraftStorageKey\(stale\)\)/, 'overflow property records must be removed from browser storage');
-assert.match(drafts, /localStorage\.setItem\(propertyDraftStorageKey/, '3D drafts must be savable without a wallet');
+assert.match(drafts, /MAX_DRAFTS = 24/, 'property draft storage must stay bounded for mobile devices');
+assert.match(drafts, /mergePropertyDraftRecords/, 'browser and cloud drafts must have a deterministic merge path');
+assert.match(drafts, /timestamp\(draft\.updatedAt\) >= timestamp\(previous\.updatedAt\)/, 'newest draft update must win per stable draft id');
+assert.match(drafts, /replaceLocalPropertyDrafts/, 'synced account drafts must be materializable back to local storage');
+assert.match(drafts, /voxel-vault:property-draft-saved/, 'a successful local save must notify the Vault sync bridge');
+assert.match(drafts, /localStorage\.setItem\(propertyDraftStorageKey/, '3D drafts must remain savable without a wallet');
+
+assert.match(account, /avatar_style: \{ \.\.\.currentStyle, property_draft_library: bounded \}/, 'account sync must reuse the existing profile JSON without a new auth system');
+assert.match(account, /syncLocalPropertyDraftsToAccount/, 'local and account property drafts must merge on sign-in');
+assert.match(account, /deletePropertyDraftFromAccount/, 'deleting a synced draft must remove it from the account library');
+assert.match(account, /mergePropertyDraftRecords\(cloud, local\)/, 'cloud and browser libraries must merge by stable draft id');
+assert.match(syncBridge, /voxel-vault:property-draft-saved/, 'Vault-wide sync must react immediately after Earth saves a draft');
+assert.match(syncBridge, /savePropertyDraftToAccount/, 'signed-in saves must mirror to account storage automatically');
+assert.match(vaultLayout, /PropertyDraftSyncBridge/, 'automatic property draft sync must be mounted across Vault routes');
 
 assert.match(truth, /PROPERTY → 3D VOXEL MAKER/, 'Earth evidence must expose the 3D-first maker funnel');
 assert.match(truth, /NO MINT REQUIRED/, 'the primary property flow must clearly work without minting');
@@ -25,16 +39,24 @@ assert.match(truth, />VERIFY</, 'property-right verification must remain separat
 assert.match(truth, />MINT</, 'minting may remain available as a later step');
 assert.match(truth, /MINTING IS A LATER CHOICE, NOT THE CREATION STEP/, 'minting must never be the event that creates the property draft');
 assert.match(truth, /savePropertyDraft\(draft\)/, 'Earth must save the selected property draft without a mint transaction');
-assert.match(truth, /\/vault\/property-drafts/, 'Earth must link to the saved draft vault');
-assert.match(truth, /\/vault\/properties\/claim/, 'Earth must route real-property rights to the verification workflow');
 assert.doesNotMatch(truth, /mintVoxelFlip|eth_requestAccounts|MetaMask/, 'the 3D draft maker must not require wallet code');
 
 assert.match(vaultPage, /NO WALLET REQUIRED · NO MINT REQUIRED/, 'saved drafts page must remain explicitly offchain-capable');
-assert.match(vaultPage, /readPropertyDrafts/, 'saved drafts page must read the non-minted draft library');
-assert.match(vaultPage, /exportPropertyDraft/, 'users must be able to export their saved 3D property record');
+assert.match(vaultPage, /syncLocalPropertyDraftsToAccount/, 'saved drafts page must expose cross-device account sync');
+assert.match(vaultPage, /CONTINUE WITH GOOGLE/, 'users must be able to opt into account sync');
+assert.match(vaultPage, /OPEN EXACT 3D/, 'saved draft cards must reopen their exact saved model');
+assert.match(vaultPage, /\/vault\/property-drafts\/\$\{encodeURIComponent\(draft\.id\)\}/, 'saved cards must deep-link by stable draft id');
+assert.match(vaultPage, /deletePropertyDraftFromAccount/, 'synced deletions must not reappear from cloud storage');
 assert.match(vaultPage, /Saving this model does not create deed\/title/, 'saved draft page must preserve the legal/title boundary');
+
+assert.match(draftViewer, /readPropertyDraft\(draftId\)/, 'exact viewer must first load the saved local geometry snapshot');
+assert.match(draftViewer, /loadAccountPropertyDrafts/, 'exact viewer must restore a missing local snapshot from the signed-in account');
+assert.match(draftViewer, /geometry: draft\.geometry \|\| null/, 'exact viewer must render saved geometry rather than a fresh nearest-building guess');
+assert.match(draftViewer, /GeoReferenceModel/, 'saved property geometry must reopen inside the real 3D renderer');
+assert.match(draftViewer, /live map updates do not silently replace it/, 'viewer must explain that the snapshot is stable until explicitly updated');
+assert.match(draftViewer, /not a deed or guaranteed perfect replica/i, 'exact viewer must keep legal and fidelity claims conservative');
 
 assert.match(earthPage, /PropertyTruthStack/, 'the 3D-first funnel must remain mounted in the main Earth property experience');
 assert.match(earthPage, /automatic|MESHY|Meshy/i, 'Earth must keep its existing controlled high-fidelity reconstruction layer');
 
-console.log('3D-first property funnel checks passed: every source-backed property can exist as an offchain draft first, saving is wallet-free, storage stays bounded, verification stays separate, and minting remains optional.');
+console.log('3D property draft checks passed: exact snapshots reopen in 3D, browser saves stay wallet-free, signed-in drafts sync across devices, synced deletion is supported, truth boundaries remain explicit, and minting stays optional.');

--- a/scripts/test-property-draft-funnel.mjs
+++ b/scripts/test-property-draft-funnel.mjs
@@ -51,12 +51,15 @@ assert.match(vaultPage, /Saving this model does not create deed\/title/, 'saved 
 
 assert.match(draftViewer, /readPropertyDraft\(draftId\)/, 'exact viewer must first load the saved local geometry snapshot');
 assert.match(draftViewer, /loadAccountPropertyDrafts/, 'exact viewer must restore a missing local snapshot from the signed-in account');
-assert.match(draftViewer, /geometry: draft\.geometry \|\| null/, 'exact viewer must render saved geometry rather than a fresh nearest-building guess');
+assert.match(draftViewer, /geometry: parcelOnly \? null : \(draft\.geometry \|\| null\)/, 'parcel-only geometry must not be extruded as a fake building');
+assert.match(draftViewer, /parcelGeometry: draft\.geometry/, 'parcel-only drafts must still render their saved parcel geometry');
+assert.match(draftViewer, /PARCEL · NO BUILDING INVENTED/, 'land drafts must disclose that no structure was invented');
 assert.match(draftViewer, /GeoReferenceModel/, 'saved property geometry must reopen inside the real 3D renderer');
 assert.match(draftViewer, /live map updates do not silently replace it/, 'viewer must explain that the snapshot is stable until explicitly updated');
+assert.match(draftViewer, /CHECK CURRENT MAP EVIDENCE/, 'viewer must be able to compare the saved snapshot with current map evidence without overwriting it');
 assert.match(draftViewer, /not a deed or guaranteed perfect replica/i, 'exact viewer must keep legal and fidelity claims conservative');
 
 assert.match(earthPage, /PropertyTruthStack/, 'the 3D-first funnel must remain mounted in the main Earth property experience');
 assert.match(earthPage, /automatic|MESHY|Meshy/i, 'Earth must keep its existing controlled high-fidelity reconstruction layer');
 
-console.log('3D property draft checks passed: exact snapshots reopen in 3D, browser saves stay wallet-free, signed-in drafts sync across devices, synced deletion is supported, truth boundaries remain explicit, and minting stays optional.');
+console.log('3D property draft checks passed: exact snapshots reopen in 3D, vacant land stays parcel-only, browser saves stay wallet-free, signed-in drafts sync across devices, synced deletion is supported, live evidence comparison does not overwrite the snapshot, and minting stays optional.');


### PR DESCRIPTION
## What this changes

Extends the 3D-first property funnel so saved drafts behave like real reusable assets instead of one-device bookmarks.

### Exact reopen
- Every saved property draft now deep-links to `/vault/property-drafts/[draftId]`.
- The viewer loads the exact saved geometry snapshot first, rather than silently choosing a fresh nearest building.
- Missing local drafts can be restored from the signed-in account library.
- Current map evidence can be checked separately without overwriting the saved snapshot.
- Parcel-only / vacant-land drafts render as parcel geometry and explicitly do **not** invent a building.

### Cross-device account sync
- Reuses the existing Supabase `vault_profiles.avatar_style` JSON used by VoxelPop; no second login or identity system.
- Adds a bounded `property_draft_library` with deterministic merge by stable draft ID; newest `updatedAt` wins.
- Vault-wide sync bridge mirrors signed-in saves from Earth to the account automatically.
- Drafts page shows local-vs-account sync state and offers Google sign-in.
- Synced deletion removes the draft from both the current device and account library so it does not reappear later.
- Local/offchain mode still works without Google, wallet, MetaMask, checkout or minting.

### Truth / safety boundaries
- Saving/syncing a 3D draft never creates deed/title, rent rights, investment rights or guaranteed value.
- A saved model is not labeled a perfect replica unless evidence supports that level of fidelity.
- Vacant land is never extruded into a fake structure.
- Minting remains optional and downstream of the draft workflow.

### Regression coverage
Expands `test-property-draft-funnel.mjs` to guard exact 3D reopening, land truth, current-evidence comparison, account merge behavior, automatic save sync, cross-device restore and synced deletion.