### PR TITLE
Add verified rentals and renter-only minted voxel layers

### DIFF
--- a/app/api/admin/rentals/route.ts
+++ b/app/api/admin/rentals/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../lib/admin-auth';
+import { assertRentalTransition } from '../../../../lib/real-estate/property-rental';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function clean(value: unknown, max = 180) {
+  return String(value || '').trim().slice(0, max);
+}
+function integer(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : fallback;
+}
+function uuid(value: unknown) {
+  const text = clean(value, 80);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(text) ? text : '';
+}
+function sha256(value: unknown) {
+  const text = clean(value, 128).toLowerCase();
+  return /^[0-9a-f]{64}$/.test(text) ? text : '';
+}
+function dateOnly(value: unknown) {
+  const text = clean(value, 16);
+  return /^\d{4}-\d{2}-\d{2}$/.test(text) ? text : '';
+}
+
+async function getLease(admin: any, leaseId: string) {
+  const { data, error } = await admin
+    .from('vault_property_leases')
+    .select('id,status,lease_verified_at,termination_verified_at,termination_reference_hash,tenant_user_id')
+    .eq('id', leaseId)
+    .maybeSingle();
+  if (error) throw new Error('Rental storage is unavailable.');
+  return data || null;
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error, setupRequired: auth.setupRequired === true }, { status: auth.status });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const action = clean(body?.action, 40);
+
+    if (action === 'verify-lease') {
+      const propertyFingerprint = sha256(body?.propertyFingerprint);
+      const tenantUserId = uuid(body?.tenantUserId);
+      const agreementHash = sha256(body?.agreementHash);
+      const propertyLabel = clean(body?.propertyLabel, 160);
+      const provider = clean(body?.provider, 80);
+      const providerLeaseId = clean(body?.providerLeaseId, 160);
+      const monthlyRentMinor = integer(body?.monthlyRentMinor, -1);
+      const dueDay = integer(body?.dueDay, 0);
+      const startsOn = dateOnly(body?.startsOn) || null;
+      const endsOn = dateOnly(body?.endsOn) || null;
+      const currency = clean(body?.currency || 'USD', 8).toUpperCase();
+
+      if (!propertyFingerprint || !tenantUserId || !agreementHash || !propertyLabel || monthlyRentMinor < 0 || dueDay < 1 || dueDay > 28) {
+        return NextResponse.json({ ok: false, error: 'Verified property identity, tenant, lease hash and valid rent terms are required.' }, { status: 400 });
+      }
+
+      const { data: identity, error: identityError } = await auth.admin
+        .from('vault_property_identities')
+        .select('id,canonical_state,registry_verified')
+        .eq('property_fingerprint', propertyFingerprint)
+        .maybeSingle();
+      if (identityError) throw new Error('Canonical property identity storage is unavailable.');
+      if (!identity || !['verified', 'passport-minted'].includes(String(identity.canonical_state || ''))) {
+        return NextResponse.json({ ok: false, error: 'A real lease cannot activate until the exact parcel identity is verified.' }, { status: 409 });
+      }
+
+      const verifiedAt = new Date().toISOString();
+      assertRentalTransition('pending-verification', 'current', { leaseVerifiedAt: verifiedAt });
+      const { data, error } = await auth.admin
+        .from('vault_property_leases')
+        .insert({
+          property_identity_id: identity.id,
+          tenant_user_id: tenantUserId,
+          property_label: propertyLabel,
+          provider,
+          provider_lease_id: providerLeaseId,
+          monthly_rent_minor: monthlyRentMinor,
+          currency,
+          due_day: dueDay,
+          starts_on: startsOn,
+          ends_on: endsOn,
+          status: 'current',
+          agreement_hash: agreementHash,
+          lease_verified_at: verifiedAt,
+          updated_at: verifiedAt,
+        })
+        .select('id,property_identity_id,tenant_user_id,property_label,status,lease_verified_at')
+        .single();
+      if (error) throw new Error(`Verified lease could not be recorded: ${error.message}`);
+      return NextResponse.json({ ok: true, lease: data, livePaymentCollectionEnabled: false });
+    }
+
+    if (action === 'record-payment') {
+      const leaseId = uuid(body?.leaseId);
+      const dueOn = dateOnly(body?.dueOn);
+      const amountDueMinor = integer(body?.amountDueMinor, -1);
+      const amountPaidMinor = integer(body?.amountPaidMinor, -1);
+      const paymentStatus = clean(body?.status, 20);
+      const provider = clean(body?.provider, 80);
+      const providerPaymentId = clean(body?.providerPaymentId, 160);
+      const paidAt = body?.paidAt ? clean(body.paidAt, 40) : null;
+      if (!leaseId || !dueOn || amountDueMinor < 0 || amountPaidMinor < 0 || !['upcoming','due','paid','late','disputed'].includes(paymentStatus)) {
+        return NextResponse.json({ ok: false, error: 'Valid reconciled payment data is required.' }, { status: 400 });
+      }
+      const lease = await getLease(auth.admin, leaseId);
+      if (!lease) return NextResponse.json({ ok: false, error: 'Lease not found.' }, { status: 404 });
+      if (lease.status === 'ended') return NextResponse.json({ ok: false, error: 'Ended leases are read-only.' }, { status: 409 });
+
+      const now = new Date().toISOString();
+      const { data: payment, error } = await auth.admin
+        .from('vault_rental_payments')
+        .upsert({
+          lease_id: leaseId,
+          due_on: dueOn,
+          amount_due_minor: amountDueMinor,
+          amount_paid_minor: amountPaidMinor,
+          currency: clean(body?.currency || 'USD', 8).toUpperCase(),
+          status: paymentStatus,
+          provider,
+          provider_payment_id: providerPaymentId,
+          paid_at: paymentStatus === 'paid' ? (paidAt || now) : null,
+          updated_at: now,
+        }, { onConflict: 'lease_id,due_on' })
+        .select('id,lease_id,due_on,amount_due_minor,amount_paid_minor,currency,status,paid_at')
+        .single();
+      if (error) throw new Error('Payment reconciliation could not be saved.');
+
+      let nextLeaseStatus = lease.status;
+      if (paymentStatus === 'late' && lease.status === 'current') nextLeaseStatus = 'late';
+      if (paymentStatus === 'paid' && lease.status === 'late') nextLeaseStatus = 'current';
+      if (nextLeaseStatus !== lease.status) {
+        assertRentalTransition(lease.status, nextLeaseStatus, { leaseVerifiedAt: lease.lease_verified_at });
+        await auth.admin.from('vault_property_leases').update({ status: nextLeaseStatus, updated_at: now }).eq('id', leaseId);
+      }
+      return NextResponse.json({ ok: true, payment, leaseStatus: nextLeaseStatus, automaticEviction: false });
+    }
+
+    if (action === 'set-status') {
+      const leaseId = uuid(body?.leaseId);
+      const toStatus = clean(body?.status, 32);
+      if (!leaseId) return NextResponse.json({ ok: false, error: 'Lease ID is required.' }, { status: 400 });
+      const lease = await getLease(auth.admin, leaseId);
+      if (!lease) return NextResponse.json({ ok: false, error: 'Lease not found.' }, { status: 404 });
+
+      const terminationVerifiedAt = toStatus === 'ended' ? clean(body?.terminationVerifiedAt, 40) : lease.termination_verified_at;
+      const terminationReferenceHash = toStatus === 'ended' ? sha256(body?.terminationReferenceHash) : lease.termination_reference_hash;
+      assertRentalTransition(lease.status, toStatus, {
+        leaseVerifiedAt: lease.lease_verified_at,
+        terminationVerifiedAt,
+        terminationReferenceHash,
+      });
+
+      const now = new Date().toISOString();
+      const { data, error } = await auth.admin
+        .from('vault_property_leases')
+        .update({
+          status: toStatus,
+          termination_verified_at: toStatus === 'ended' ? terminationVerifiedAt : lease.termination_verified_at,
+          termination_reference_hash: toStatus === 'ended' ? terminationReferenceHash : lease.termination_reference_hash,
+          updated_at: now,
+        })
+        .eq('id', leaseId)
+        .select('id,status,lease_verified_at,termination_verified_at')
+        .single();
+      if (error) throw new Error('Rental status could not be updated.');
+
+      if (toStatus === 'ended') {
+        await auth.admin
+          .from('vault_tenant_voxel_attachments')
+          .update({ status: 'archived', archived_at: now })
+          .eq('lease_id', leaseId)
+          .eq('tenant_user_id', lease.tenant_user_id)
+          .eq('status', 'active');
+      }
+
+      return NextResponse.json({
+        ok: true,
+        lease: data,
+        tenantLayerArchived: toStatus === 'ended',
+        ownedVoxelAssetsTransferredOrBurned: false,
+        automaticEviction: false,
+      });
+    }
+
+    return NextResponse.json({ ok: false, error: 'Unknown rental reconciliation action.' }, { status: 400 });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Rental reconciliation failed.' }, { status: 400 });
+  }
+}

--- a/app/api/vault/rentals/[leaseId]/attachments/route.ts
+++ b/app/api/vault/rentals/[leaseId]/attachments/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../../../lib/user-auth';
+import { loadAccountVoxel } from '../../../../../../lib/voxelpop-account';
+import { canAttachMintedVoxel, canTenantUseProperty } from '../../../../../../lib/real-estate/property-rental';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Context = { params: Promise<{ leaseId: string }> };
+
+function clean(value: unknown, max = 180) {
+  return String(value || '').trim().slice(0, max);
+}
+
+async function ownLease(admin: any, userId: string, leaseId: string) {
+  const { data, error } = await admin
+    .from('vault_property_leases')
+    .select('id,tenant_user_id,status,lease_verified_at,termination_verified_at')
+    .eq('id', leaseId)
+    .eq('tenant_user_id', userId)
+    .maybeSingle();
+  if (error) throw new Error('Rental storage is unavailable.');
+  return data || null;
+}
+
+export async function POST(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const body = await request.json().catch(() => ({}));
+    const sessionId = clean(body?.sessionId, 180);
+    if (!leaseId || !sessionId) return NextResponse.json({ ok: false, error: 'Choose a minted voxel first.' }, { status: 400 });
+
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+
+    const record = await loadAccountVoxel(auth.admin as any, auth.user, sessionId);
+    const tokenId = clean(record?.payload?.mint?.tokenId, 96);
+    const accountMintConfirmed = Boolean(record && tokenId);
+    const allowed = canAttachMintedVoxel({
+      status: lease.status,
+      leaseVerifiedAt: lease.lease_verified_at,
+      terminationVerifiedAt: lease.termination_verified_at,
+      tokenId,
+      accountMintConfirmed,
+    });
+    if (!allowed) {
+      return NextResponse.json({
+        ok: false,
+        error: accountMintConfirmed
+          ? 'This tenant layer is read-only until a verified active lease exists.'
+          : 'Only a voxel with a confirmed mint in your signed-in Creator Gallery can be attached permanently.',
+      }, { status: 409 });
+    }
+
+    const voxelName = clean(record?.payload?.asset?.name || 'Minted voxel', 120);
+    const { data, error } = await auth.admin
+      .from('vault_tenant_voxel_attachments')
+      .upsert({
+        lease_id: leaseId,
+        tenant_user_id: auth.user.id,
+        voxel_session_id: sessionId,
+        token_id: tokenId,
+        voxel_name: voxelName,
+        status: 'active',
+        archived_at: null,
+      }, { onConflict: 'lease_id,voxel_session_id' })
+      .select('id,lease_id,voxel_session_id,token_id,voxel_name,status,placed_transform,created_at,archived_at')
+      .single();
+    if (error) throw new Error('The minted voxel could not be attached to this rental.');
+
+    return NextResponse.json({
+      ok: true,
+      attachment: data,
+      truth: 'The voxel stays your separate digital asset. Attaching it does not change the real property, lease, deed or ownership rights.',
+    }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Tenant voxel attachment failed.' }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const body = await request.json().catch(() => ({}));
+    const attachmentId = clean(body?.attachmentId, 80);
+    if (!leaseId || !attachmentId) return NextResponse.json({ ok: false, error: 'Attachment ID is required.' }, { status: 400 });
+
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+    if (!canTenantUseProperty({ status: lease.status, leaseVerifiedAt: lease.lease_verified_at, terminationVerifiedAt: lease.termination_verified_at })) {
+      return NextResponse.json({ ok: false, error: 'An ended or unverified tenant layer is read-only.' }, { status: 409 });
+    }
+
+    const { error } = await auth.admin
+      .from('vault_tenant_voxel_attachments')
+      .delete()
+      .eq('id', attachmentId)
+      .eq('lease_id', leaseId)
+      .eq('tenant_user_id', auth.user.id);
+    if (error) throw new Error('The voxel could not be removed from this tenant layer.');
+
+    return NextResponse.json({ ok: true, assetStillOwned: true }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Tenant voxel removal failed.' }, { status: 400 });
+  }
+}

--- a/app/api/vault/rentals/[leaseId]/attachments/route.ts
+++ b/app/api/vault/rentals/[leaseId]/attachments/route.ts
@@ -13,6 +13,15 @@ const MAX_SIGNATURE_AGE_MS = 10 * 60 * 1000;
 
 type Context = { params: Promise<{ leaseId: string }> };
 
+type TenantVoxelEligibility = {
+  status: string;
+  leaseVerifiedAt?: string | null;
+  terminationVerifiedAt?: string | null;
+  tokenId: string;
+  accountMintConfirmed: boolean;
+  walletOwnershipVerified: boolean;
+};
+
 function clean(value: unknown, max = 180) {
   return String(value || '').trim().slice(0, max);
 }
@@ -124,14 +133,15 @@ export async function POST(request: Request, context: Context) {
       signature,
     });
 
-    const allowed = canAttachMintedVoxel({
-      status: lease.status,
+    const eligibility: TenantVoxelEligibility = {
+      status: String(lease.status || ''),
       leaseVerifiedAt: lease.lease_verified_at,
       terminationVerifiedAt: lease.termination_verified_at,
       tokenId,
       accountMintConfirmed,
       walletOwnershipVerified: true,
-    });
+    };
+    const allowed = canAttachMintedVoxel(eligibility as any);
     if (!allowed) return NextResponse.json({ ok: false, error: 'This minted voxel cannot be attached to the tenant layer.' }, { status: 409 });
 
     const voxelName = clean(record?.payload?.asset?.name || 'Minted voxel', 120);

--- a/app/api/vault/rentals/[leaseId]/attachments/route.ts
+++ b/app/api/vault/rentals/[leaseId]/attachments/route.ts
@@ -1,15 +1,81 @@
+import { createHash } from 'node:crypto';
+import { Contract, getAddress, JsonRpcProvider, verifyMessage } from 'ethers';
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../../../../lib/user-auth';
 import { loadAccountVoxel } from '../../../../../../lib/voxelpop-account';
-import { canAttachMintedVoxel, canTenantUseProperty } from '../../../../../../lib/real-estate/property-rental';
+import { canAttachMintedVoxel, canTenantUseProperty, tenantVoxelOwnershipMessage } from '../../../../../../lib/real-estate/property-rental';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+const OWNER_OF_ABI = ['function ownerOf(uint256 tokenId) view returns (address)'];
+const MAX_SIGNATURE_AGE_MS = 10 * 60 * 1000;
 
 type Context = { params: Promise<{ leaseId: string }> };
 
 function clean(value: unknown, max = 180) {
   return String(value || '').trim().slice(0, max);
+}
+
+function currentNftConfig() {
+  const contract = clean(process.env.NEXT_PUBLIC_VOXEL_NFT_ADDRESS, 80);
+  const rpc = clean(
+    process.env.VOXEL_NFT_RPC_URL || process.env.NEXT_PUBLIC_EVM_RPC_URL || process.env.SEPOLIA_RPC_URL,
+    1200
+  );
+  const rawChainId = clean(process.env.NEXT_PUBLIC_EVM_CHAIN_ID || '0xaa36a7', 32);
+  let chainId = 11155111;
+  try { chainId = Number(BigInt(rawChainId)); } catch {}
+  if (!/^0x[a-fA-F0-9]{40}$/.test(contract) || !/^https?:\/\//i.test(rpc) || !Number.isSafeInteger(chainId)) return null;
+  return { contract: getAddress(contract), rpc, chainId };
+}
+
+function freshSignedAt(value: unknown) {
+  const text = clean(value, 40);
+  const parsed = Date.parse(text);
+  if (!Number.isFinite(parsed)) return null;
+  const age = Date.now() - parsed;
+  if (age < -60_000 || age > MAX_SIGNATURE_AGE_MS) return null;
+  return new Date(parsed).toISOString();
+}
+
+async function verifyCurrentTokenOwner({ userId, leaseId, sessionId, tokenId, signedAt, signature }: {
+  userId: string;
+  leaseId: string;
+  sessionId: string;
+  tokenId: string;
+  signedAt: string;
+  signature: string;
+}) {
+  const config = currentNftConfig();
+  if (!config) throw new Error('On-chain Voxel ownership verification is not configured for this deployment.');
+  if (!/^\d+$/.test(tokenId)) throw new Error('The minted voxel token ID is invalid.');
+  const validSignedAt = freshSignedAt(signedAt);
+  if (!validSignedAt) throw new Error('Wallet ownership proof expired. Try Add minted voxel again.');
+  if (!/^0x[a-fA-F0-9]+$/.test(signature)) throw new Error('Wallet signature is required.');
+
+  const message = tenantVoxelOwnershipMessage({ userId, leaseId, sessionId, tokenId, signedAt: validSignedAt });
+  let signer: string;
+  try {
+    signer = getAddress(verifyMessage(message, signature));
+  } catch {
+    throw new Error('Wallet ownership signature could not be verified.');
+  }
+
+  const provider = new JsonRpcProvider(config.rpc, config.chainId, { staticNetwork: true });
+  try {
+    const nft = new Contract(config.contract, OWNER_OF_ABI, provider);
+    const owner = getAddress(await nft.ownerOf(BigInt(tokenId)));
+    if (owner !== signer) throw new Error('The signing wallet is not the current on-chain owner of this voxel.');
+    return {
+      walletAddress: signer,
+      tokenContract: config.contract,
+      ownershipVerifiedAt: new Date().toISOString(),
+      ownershipProofHash: createHash('sha256').update(signature).digest('hex'),
+    };
+  } finally {
+    provider.destroy();
+  }
 }
 
 async function ownLease(admin: any, userId: string, leaseId: string) {
@@ -32,6 +98,8 @@ export async function POST(request: Request, context: Context) {
     const leaseId = clean(rawLeaseId, 80);
     const body = await request.json().catch(() => ({}));
     const sessionId = clean(body?.sessionId, 180);
+    const signature = clean(body?.signature, 1200);
+    const signedAt = clean(body?.signedAt, 40);
     if (!leaseId || !sessionId) return NextResponse.json({ ok: false, error: 'Choose a minted voxel first.' }, { status: 400 });
 
     const lease = await ownLease(auth.admin, auth.user.id, leaseId);
@@ -40,21 +108,31 @@ export async function POST(request: Request, context: Context) {
     const record = await loadAccountVoxel(auth.admin as any, auth.user, sessionId);
     const tokenId = clean(record?.payload?.mint?.tokenId, 96);
     const accountMintConfirmed = Boolean(record && tokenId);
+    if (!accountMintConfirmed) {
+      return NextResponse.json({ ok: false, error: 'Only a voxel with a confirmed mint in your signed-in Creator Gallery can be attached permanently.' }, { status: 409 });
+    }
+    if (!canTenantUseProperty({ status: lease.status, leaseVerifiedAt: lease.lease_verified_at, terminationVerifiedAt: lease.termination_verified_at })) {
+      return NextResponse.json({ ok: false, error: 'This tenant layer is read-only until a verified active lease exists.' }, { status: 409 });
+    }
+
+    const ownership = await verifyCurrentTokenOwner({
+      userId: auth.user.id,
+      leaseId,
+      sessionId,
+      tokenId,
+      signedAt,
+      signature,
+    });
+
     const allowed = canAttachMintedVoxel({
       status: lease.status,
       leaseVerifiedAt: lease.lease_verified_at,
       terminationVerifiedAt: lease.termination_verified_at,
       tokenId,
       accountMintConfirmed,
+      walletOwnershipVerified: true,
     });
-    if (!allowed) {
-      return NextResponse.json({
-        ok: false,
-        error: accountMintConfirmed
-          ? 'This tenant layer is read-only until a verified active lease exists.'
-          : 'Only a voxel with a confirmed mint in your signed-in Creator Gallery can be attached permanently.',
-      }, { status: 409 });
-    }
+    if (!allowed) return NextResponse.json({ ok: false, error: 'This minted voxel cannot be attached to the tenant layer.' }, { status: 409 });
 
     const voxelName = clean(record?.payload?.asset?.name || 'Minted voxel', 120);
     const { data, error } = await auth.admin
@@ -64,17 +142,22 @@ export async function POST(request: Request, context: Context) {
         tenant_user_id: auth.user.id,
         voxel_session_id: sessionId,
         token_id: tokenId,
+        token_contract: ownership.tokenContract,
+        wallet_address: ownership.walletAddress,
+        ownership_proof_hash: ownership.ownershipProofHash,
+        ownership_verified_at: ownership.ownershipVerifiedAt,
         voxel_name: voxelName,
         status: 'active',
         archived_at: null,
       }, { onConflict: 'lease_id,voxel_session_id' })
-      .select('id,lease_id,voxel_session_id,token_id,voxel_name,status,placed_transform,created_at,archived_at')
+      .select('id,lease_id,voxel_session_id,token_id,token_contract,wallet_address,ownership_verified_at,voxel_name,status,placed_transform,created_at,archived_at')
       .single();
     if (error) throw new Error('The minted voxel could not be attached to this rental.');
 
     return NextResponse.json({
       ok: true,
       attachment: data,
+      ownershipVerifiedOnChain: true,
       truth: 'The voxel stays your separate digital asset. Attaching it does not change the real property, lease, deed or ownership rights.',
     }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
   } catch (error) {

--- a/app/api/vault/rentals/route.ts
+++ b/app/api/vault/rentals/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../lib/user-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function missingRentalTables(error: any) {
+  return error?.code === '42P01' || /vault_property_leases|vault_rental_payments|vault_tenant_voxel_attachments/i.test(String(error?.message || ''));
+}
+
+function paymentSort(a: any, b: any) {
+  return String(a?.due_on || '').localeCompare(String(b?.due_on || ''));
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error, setupRequired: auth.setupRequired === true }, { status: auth.status });
+
+  const { data: leases, error: leaseError } = await auth.admin
+    .from('vault_property_leases')
+    .select('id,property_identity_id,property_label,provider,monthly_rent_minor,currency,due_day,starts_on,ends_on,status,lease_verified_at,termination_verified_at,updated_at')
+    .eq('tenant_user_id', auth.user.id)
+    .order('updated_at', { ascending: false });
+
+  if (leaseError) {
+    if (missingRentalTables(leaseError)) {
+      return NextResponse.json({
+        ok: true,
+        setupRequired: true,
+        leases: [],
+        note: 'Rental storage is not installed in this environment yet. Apply migration 020 before recording real leases.',
+      }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+    }
+    return NextResponse.json({ ok: false, error: 'Your private rental records could not be loaded.' }, { status: 500 });
+  }
+
+  const rows = Array.isArray(leases) ? leases : [];
+  if (!rows.length) {
+    return NextResponse.json({ ok: true, setupRequired: false, leases: [] }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  }
+
+  const leaseIds = rows.map((lease: any) => lease.id);
+  const [{ data: payments, error: paymentError }, { data: attachments, error: attachmentError }] = await Promise.all([
+    auth.admin
+      .from('vault_rental_payments')
+      .select('id,lease_id,due_on,amount_due_minor,amount_paid_minor,currency,status,paid_at,updated_at')
+      .in('lease_id', leaseIds)
+      .order('due_on', { ascending: true }),
+    auth.admin
+      .from('vault_tenant_voxel_attachments')
+      .select('id,lease_id,voxel_session_id,token_id,voxel_name,status,placed_transform,created_at,archived_at')
+      .eq('tenant_user_id', auth.user.id)
+      .in('lease_id', leaseIds)
+      .order('created_at', { ascending: true }),
+  ]);
+
+  if (paymentError || attachmentError) {
+    return NextResponse.json({ ok: false, error: 'Your rental details could not be loaded completely.' }, { status: 500 });
+  }
+
+  const paymentRows = Array.isArray(payments) ? payments : [];
+  const attachmentRows = Array.isArray(attachments) ? attachments : [];
+  const payload = rows.map((lease: any) => {
+    const leasePayments = paymentRows.filter((payment: any) => payment.lease_id === lease.id).sort(paymentSort);
+    const unpaid = leasePayments.find((payment: any) => !['paid'].includes(String(payment.status || '').toLowerCase())) || null;
+    return {
+      id: lease.id,
+      propertyIdentityId: lease.property_identity_id,
+      propertyLabel: lease.property_label,
+      provider: lease.provider || '',
+      monthlyRentMinor: Number(lease.monthly_rent_minor || 0),
+      currency: lease.currency || 'USD',
+      dueDay: Number(lease.due_day || 1),
+      startsOn: lease.starts_on,
+      endsOn: lease.ends_on,
+      status: lease.status,
+      leaseVerified: Boolean(lease.lease_verified_at),
+      terminationVerified: Boolean(lease.termination_verified_at),
+      nextPayment: unpaid,
+      payments: leasePayments,
+      attachments: attachmentRows.filter((attachment: any) => attachment.lease_id === lease.id),
+    };
+  });
+
+  return NextResponse.json({ ok: true, setupRequired: false, leases: payload }, {
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}

--- a/app/vault/rentals/page.js
+++ b/app/vault/rentals/page.js
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { getWallet } from '../../../lib/blockchain';
+import { tenantVoxelOwnershipMessage } from '../../../lib/real-estate/property-rental';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
 import { loadAccountVoxels, summarizeVoxel } from '../../../lib/voxelpop-account';
 import styles from './rentals.module.css';
@@ -120,23 +122,34 @@ export default function RentalsPage() {
     }
   }
 
-  async function attachVoxel(leaseId, sessionId) {
-    if (!session?.access_token) return;
-    setBusy(`attach:${leaseId}:${sessionId}`);
-    setMessage('Adding your minted voxel…');
+  async function attachVoxel(leaseId, voxel) {
+    if (!session?.access_token || !session?.user || !voxel?.sessionId || !voxel?.mint?.tokenId) return;
+    setBusy(`attach:${leaseId}:${voxel.sessionId}`);
+    setMessage('Verify the wallet that owns this voxel…');
     try {
+      const { signer } = await getWallet();
+      const signedAt = new Date().toISOString();
+      const ownershipMessage = tenantVoxelOwnershipMessage({
+        userId: session.user.id,
+        leaseId,
+        sessionId: voxel.sessionId,
+        tokenId: voxel.mint.tokenId,
+        signedAt,
+      });
+      const signature = await signer.signMessage(ownershipMessage);
+      setMessage('Wallet verified. Adding your voxel…');
       const response = await fetch(`/api/vault/rentals/${encodeURIComponent(leaseId)}/attachments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
-        body: JSON.stringify({ sessionId }),
+        body: JSON.stringify({ sessionId: voxel.sessionId, signedAt, signature }),
       });
       const data = await response.json().catch(() => ({}));
-      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Could not add that voxel.');
+      if (!response.ok || data?.ok === false || data?.ownershipVerifiedOnChain !== true) throw new Error(data?.error || 'Could not verify and add that voxel.');
       setPickerLeaseId('');
-      setMessage('Added. The voxel is still your separate asset—it is just associated with this rental.');
+      setMessage('Added. On-chain ownership was checked, and the voxel is still your separate asset.');
       await refreshAll();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not add that voxel.');
+      setMessage(error instanceof Error ? error.message : 'Could not verify and add that voxel.');
     } finally {
       setBusy('');
     }
@@ -240,8 +253,8 @@ export default function RentalsPage() {
                 </div>
 
                 {pickerLeaseId === lease.id && editable ? <div className={styles.picker}>
-                  {availableVoxels.length ? availableVoxels.map((voxel) => <button key={voxel.sessionId} onClick={() => attachVoxel(lease.id, voxel.sessionId)} disabled={busy.startsWith('attach:')}>
-                    <img src={voxel.image} alt=""/><span><b>{voxel.name.replaceAll('-', ' ')}</b><small>Minted #{voxel.mint.tokenId}</small></span>
+                  {availableVoxels.length ? availableVoxels.map((voxel) => <button key={voxel.sessionId} onClick={() => attachVoxel(lease.id, voxel)} disabled={busy.startsWith('attach:')}>
+                    <img src={voxel.image} alt=""/><span><b>{voxel.name.replaceAll('-', ' ')}</b><small>Minted #{voxel.mint.tokenId} · wallet check</small></span>
                   </button>) : <div className={styles.pickerEmpty}>No unused minted voxels yet. <Link href="/studio">Create one →</Link></div>}
                 </div> : null}
 
@@ -254,7 +267,7 @@ export default function RentalsPage() {
                       {editable && attachment.status === 'active' ? <button onClick={() => removeVoxel(lease.id, attachment.id)} disabled={busy === `remove:${attachment.id}`}>Remove</button> : null}
                     </div>;
                   })}
-                </div> : <div className={styles.layerEmpty}>Your minted furniture, art, pets and other voxels can live here without becoming part of the deed or verified building geometry.</div>}
+                </div> : <div className={styles.layerEmpty}>Your minted furniture, art, pets and other voxels can live here. Wallet ownership is checked before permanent placement, and the voxel never becomes part of the deed or verified building geometry.</div>}
               </section>
 
               <div className={styles.providerNote}>

--- a/app/vault/rentals/page.js
+++ b/app/vault/rentals/page.js
@@ -1,0 +1,273 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import { loadAccountVoxels, summarizeVoxel } from '../../../lib/voxelpop-account';
+import styles from './rentals.module.css';
+
+function money(minor, currency = 'USD') {
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(Number(minor || 0) / 100);
+  } catch {
+    return `$${(Number(minor || 0) / 100).toFixed(2)}`;
+  }
+}
+
+function dateLabel(value) {
+  if (!value) return '';
+  const parsed = new Date(`${value}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) return String(value);
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function statusLabel(status) {
+  return {
+    'pending-verification': 'LEASE PENDING',
+    current: 'CURRENT',
+    late: 'LATE',
+    notice: 'NOTICE',
+    'legal-process': 'LEGAL PROCESS',
+    ended: 'LEASE ENDED',
+  }[String(status || '')] || 'UNKNOWN';
+}
+
+function tenantCanEdit(lease) {
+  return Boolean(lease?.leaseVerified && !lease?.terminationVerified && ['current', 'late', 'notice', 'legal-process'].includes(String(lease?.status || '')));
+}
+
+export default function RentalsPage() {
+  const [session, setSession] = useState(null);
+  const [authReady, setAuthReady] = useState(false);
+  const [leases, setLeases] = useState([]);
+  const [mintedVoxels, setMintedVoxels] = useState([]);
+  const [setupRequired, setSetupRequired] = useState(false);
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('');
+  const [pickerLeaseId, setPickerLeaseId] = useState('');
+  const clientRef = useRef(null);
+
+  const voxelBySession = useMemo(() => new Map(mintedVoxels.map((voxel) => [voxel.sessionId, voxel])), [mintedVoxels]);
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      if (active) {
+        setSession(data.session || null);
+        setAuthReady(true);
+      }
+      const auth = client.auth.onAuthStateChange((_event, next) => {
+        if (!active) return;
+        setSession(next || null);
+        setAuthReady(true);
+      });
+      subscription = auth.data.subscription;
+    }).catch(() => setAuthReady(true));
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
+    if (!session?.access_token || !session?.user) {
+      setLeases([]);
+      setMintedVoxels([]);
+      return;
+    }
+    refreshAll(session);
+  }, [session?.access_token, session?.user?.id]);
+
+  async function refreshAll(activeSession = session) {
+    if (!activeSession?.access_token || !activeSession?.user) return;
+    setBusy('load');
+    setMessage('');
+    try {
+      const [rentalResponse, voxelRecords] = await Promise.all([
+        fetch('/api/vault/rentals', {
+          cache: 'no-store',
+          headers: { Authorization: `Bearer ${activeSession.access_token}` },
+        }),
+        loadAccountVoxels(clientRef.current || await getSupabaseBrowserAsync(), activeSession.user),
+      ]);
+      const rentalData = await rentalResponse.json().catch(() => ({}));
+      if (!rentalResponse.ok || rentalData?.ok === false) throw new Error(rentalData?.error || 'Could not load your rentals.');
+      setLeases(Array.isArray(rentalData?.leases) ? rentalData.leases : []);
+      setSetupRequired(rentalData?.setupRequired === true);
+      setMintedVoxels((Array.isArray(voxelRecords) ? voxelRecords : []).map(summarizeVoxel).filter((voxel) => voxel?.mint?.tokenId));
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not load your rentals.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function signIn() {
+    setBusy('signin');
+    setMessage('');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.href },
+      });
+      if (error) throw error;
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not start sign-in.');
+      setBusy('');
+    }
+  }
+
+  async function attachVoxel(leaseId, sessionId) {
+    if (!session?.access_token) return;
+    setBusy(`attach:${leaseId}:${sessionId}`);
+    setMessage('Adding your minted voxel…');
+    try {
+      const response = await fetch(`/api/vault/rentals/${encodeURIComponent(leaseId)}/attachments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ sessionId }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Could not add that voxel.');
+      setPickerLeaseId('');
+      setMessage('Added. The voxel is still your separate asset—it is just associated with this rental.');
+      await refreshAll();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not add that voxel.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function removeVoxel(leaseId, attachmentId) {
+    if (!session?.access_token) return;
+    setBusy(`remove:${attachmentId}`);
+    setMessage('');
+    try {
+      const response = await fetch(`/api/vault/rentals/${encodeURIComponent(leaseId)}/attachments`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ attachmentId }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Could not remove that voxel.');
+      setMessage('Removed from this property. The voxel is still in your Vault.');
+      await refreshAll();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not remove that voxel.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  return <main className={styles.page}>
+    <section className={styles.shell}>
+      <nav className={styles.nav}>
+        <Link href="/" className={styles.brand}>VOXEL VAULT</Link>
+        <Link href="/vault" className={styles.navLink}>Vault</Link>
+      </nav>
+
+      <header className={styles.header}>
+        <div className={styles.kicker}>MY VAULT · RENTED</div>
+        <h1>Your place.<br/><em>Your voxels.</em></h1>
+        <p>A verified rental can live in your Vault while you are the tenant. Your own minted voxels can move in with you.</p>
+      </header>
+
+      <div className={styles.flow} aria-label="Rental flow">
+        <span>LEASE</span><i>→</i><span>PAY MONTHLY</span><i>→</i><span>DECORATE</span><i>→</i><span>MOVE OUT</span>
+      </div>
+
+      {!authReady || busy === 'load' ? <div className={styles.empty}>Loading your rented properties…</div> : null}
+
+      {authReady && !session?.user ? <section className={styles.signinCard}>
+        <div className={styles.bigIcon}>⌂</div>
+        <h2>Sign in to see rentals.</h2>
+        <p>Lease and payment details stay private to your signed-in account.</p>
+        <button onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening…' : 'Sign in with Google'}</button>
+      </section> : null}
+
+      {session?.user && setupRequired ? <section className={styles.noticeCard}>
+        <b>Rental storage is being prepared.</b>
+        <span>Real leases stay locked until the private rental migration is installed and a verified lease/provider record exists.</span>
+      </section> : null}
+
+      {session?.user && !setupRequired && !leases.length && busy !== 'load' ? <section className={styles.signinCard}>
+        <div className={styles.bigIcon}>🏠</div>
+        <h2>No rented property yet.</h2>
+        <p>A property appears here only after a real rental agreement is verified. Uploading or minting a house does not make you its tenant.</p>
+        <Link className={styles.linkButton} href="/property">Explore a property</Link>
+      </section> : null}
+
+      <div className={styles.leaseList}>
+        {leases.map((lease) => {
+          const editable = tenantCanEdit(lease);
+          const nextPayment = lease.nextPayment;
+          const attached = Array.isArray(lease.attachments) ? lease.attachments : [];
+          const attachedIds = new Set(attached.map((item) => item.voxel_session_id));
+          const availableVoxels = mintedVoxels.filter((voxel) => !attachedIds.has(voxel.sessionId));
+          return <article className={styles.leaseCard} key={lease.id}>
+            <div className={styles.propertyVisual}>
+              <div className={styles.house}>⌂</div>
+              <span className={`${styles.status} ${styles[`status_${String(lease.status || '').replaceAll('-', '_')}`] || ''}`}>{statusLabel(lease.status)}</span>
+            </div>
+
+            <div className={styles.leaseBody}>
+              <div className={styles.propertyLabel}>{lease.propertyLabel || 'Verified rented property'}</div>
+              <div className={styles.rent}>{money(lease.monthlyRentMinor, lease.currency)}<small>/ month</small></div>
+              <div className={styles.facts}>
+                <span><b>Lease</b>{lease.leaseVerified ? 'Verified' : 'Pending'}</span>
+                <span><b>Next</b>{nextPayment ? `${money(nextPayment.amount_due_minor, nextPayment.currency)} · ${dateLabel(nextPayment.due_on)}` : `Due day ${lease.dueDay}`}</span>
+                <span><b>Payment</b>{nextPayment ? String(nextPayment.status || 'upcoming').toUpperCase() : 'Provider managed'}</span>
+              </div>
+
+              {['late', 'notice', 'legal-process'].includes(lease.status) ? <div className={styles.legalNote}>
+                <b>{lease.status === 'late' ? 'Payment is late.' : lease.status === 'notice' ? 'A lease notice is recorded.' : 'A legal process is recorded.'}</b>
+                <span>Voxel Vault does not automatically evict or remove tenancy because of a late payment. Real lease and local legal process control.</span>
+              </div> : null}
+
+              {lease.status === 'ended' ? <div className={styles.archivedNote}>
+                <b>Lease ended · tenant layer archived</b>
+                <span>Your attached voxels are still yours. This property layer is now read-only.</span>
+              </div> : null}
+
+              <section className={styles.tenantLayer}>
+                <div className={styles.layerHead}>
+                  <div><span>TENANT LAYER</span><h3>Things you brought with you.</h3></div>
+                  {editable ? <button className={styles.addButton} onClick={() => setPickerLeaseId(pickerLeaseId === lease.id ? '' : lease.id)}>+ Add minted voxel</button> : null}
+                </div>
+
+                {pickerLeaseId === lease.id && editable ? <div className={styles.picker}>
+                  {availableVoxels.length ? availableVoxels.map((voxel) => <button key={voxel.sessionId} onClick={() => attachVoxel(lease.id, voxel.sessionId)} disabled={busy.startsWith('attach:')}>
+                    <img src={voxel.image} alt=""/><span><b>{voxel.name.replaceAll('-', ' ')}</b><small>Minted #{voxel.mint.tokenId}</small></span>
+                  </button>) : <div className={styles.pickerEmpty}>No unused minted voxels yet. <Link href="/studio">Create one →</Link></div>}
+                </div> : null}
+
+                {attached.length ? <div className={styles.attachedGrid}>
+                  {attached.map((attachment) => {
+                    const voxel = voxelBySession.get(attachment.voxel_session_id);
+                    return <div className={styles.voxelCard} key={attachment.id}>
+                      {voxel?.image ? <img src={voxel.image} alt={attachment.voxel_name || 'Attached voxel'}/> : <div className={styles.voxelFallback}>◆</div>}
+                      <div><b>{attachment.voxel_name || 'Minted voxel'}</b><small>#{attachment.token_id} · {String(attachment.status || 'active').toUpperCase()}</small></div>
+                      {editable && attachment.status === 'active' ? <button onClick={() => removeVoxel(lease.id, attachment.id)} disabled={busy === `remove:${attachment.id}`}>Remove</button> : null}
+                    </div>;
+                  })}
+                </div> : <div className={styles.layerEmpty}>Your minted furniture, art, pets and other voxels can live here without becoming part of the deed or verified building geometry.</div>}
+              </section>
+
+              <div className={styles.providerNote}>
+                <b>Real lease + payments</b>
+                <span>{lease.provider ? `${lease.provider} is the recorded lease/payment source.` : 'Signing and rent collection stay with the verified property manager/provider until a production integration is connected.'}</span>
+              </div>
+            </div>
+          </article>;
+        })}
+      </div>
+
+      {message ? <div className={styles.message} role="status">{message}</div> : null}
+      <footer className={styles.truth}>A Rental Pass or voxel layer records digital access/status only. It is not the lease itself, does not replace landlord-tenant law, and cannot automatically evict a tenant.</footer>
+    </section>
+  </main>;
+}

--- a/app/vault/rentals/rentals.module.css
+++ b/app/vault/rentals/rentals.module.css
@@ -1,0 +1,96 @@
+.page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(201, 255, 84, .28), transparent 28rem),
+    radial-gradient(circle at 88% 26%, rgba(113, 56, 245, .15), transparent 32rem),
+    #fffaf0;
+  color: #3e2b24;
+  padding: max(20px, env(safe-area-inset-top)) 18px max(48px, env(safe-area-inset-bottom));
+}
+
+.shell { width: min(720px, 100%); margin: 0 auto; }
+.nav { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.brand { color: #7138f5; font-weight: 950; letter-spacing: -.04em; text-decoration: none; }
+.navLink { color: #5a3f34; font-weight: 850; text-decoration: underline; text-underline-offset: 4px; }
+
+.header { text-align: center; padding: 52px 8px 28px; }
+.kicker { color: #7138f5; font-size: 11px; font-weight: 950; letter-spacing: .18em; }
+.header h1 { margin: 12px 0 14px; font-size: clamp(48px, 12vw, 82px); line-height: .86; letter-spacing: -.075em; font-weight: 950; }
+.header h1 em { color: #7138f5; font-style: normal; }
+.header p { max-width: 530px; margin: 0 auto; color: #745e53; font-size: 17px; line-height: 1.55; font-weight: 650; }
+
+.flow { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 7px; margin: 0 auto 24px; font-size: 10px; font-weight: 950; letter-spacing: .08em; color: #765f55; }
+.flow span { background: rgba(255,255,255,.72); border: 1px solid rgba(72,45,35,.09); border-radius: 999px; padding: 8px 10px; }
+.flow i { color: #7138f5; font-style: normal; }
+
+.empty, .signinCard, .noticeCard { border: 1px solid rgba(72,45,35,.1); background: rgba(255,255,255,.76); border-radius: 34px; padding: 30px; text-align: center; box-shadow: 0 18px 45px rgba(83,54,34,.08); }
+.empty { color: #765f55; font-weight: 750; }
+.signinCard { padding: 52px 28px; }
+.bigIcon { font-size: 58px; }
+.signinCard h2 { margin: 12px 0 8px; font-size: 29px; letter-spacing: -.04em; }
+.signinCard p { margin: 0 auto; max-width: 480px; color: #7a655a; line-height: 1.5; font-weight: 650; }
+.signinCard button, .linkButton { display: inline-flex; justify-content: center; margin-top: 22px; border: 0; border-radius: 999px; padding: 15px 24px; background: #7138f5; color: white; text-decoration: none; font-weight: 950; font-size: 15px; }
+.noticeCard { display: grid; gap: 6px; text-align: left; background: #fff0c8; }
+.noticeCard span { color: #755e4f; line-height: 1.45; }
+
+.leaseList { display: grid; gap: 22px; }
+.leaseCard { overflow: hidden; border: 1px solid rgba(72,45,35,.1); border-radius: 38px; background: rgba(255,255,255,.82); box-shadow: 0 22px 54px rgba(83,54,34,.1); }
+.propertyVisual { min-height: 210px; position: relative; display: grid; place-items: center; background: linear-gradient(145deg, #2e174d, #5b3191 55%, #8262b0); }
+.house { font-size: 102px; line-height: 1; color: #fffaf0; filter: drop-shadow(0 10px 22px rgba(0,0,0,.2)); }
+.status { position: absolute; top: 16px; left: 16px; background: #fffaf0; color: #4d342a; border-radius: 999px; padding: 9px 12px; font-size: 10px; font-weight: 950; letter-spacing: .1em; }
+.status_late, .status_notice { background: #ffd27d; }
+.status_legal_process { background: #ffb6a6; }
+.status_ended { background: #d9d1ca; }
+
+.leaseBody { padding: 24px; }
+.propertyLabel { color: #6e584e; font-weight: 800; font-size: 14px; }
+.rent { margin-top: 5px; font-size: clamp(42px, 10vw, 64px); line-height: 1; letter-spacing: -.065em; font-weight: 950; color: #34231d; }
+.rent small { margin-left: 7px; font-size: 13px; letter-spacing: 0; color: #8a766b; }
+.facts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; margin-top: 20px; }
+.facts span { min-width: 0; padding: 13px; border-radius: 20px; background: #f8f2e9; color: #59443b; font-size: 12px; font-weight: 850; overflow-wrap: anywhere; }
+.facts b { display: block; margin-bottom: 4px; color: #988479; font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
+
+.legalNote, .archivedNote, .providerNote { margin-top: 16px; border-radius: 22px; padding: 16px; display: grid; gap: 5px; }
+.legalNote { background: #fff0c8; }
+.archivedNote { background: #eee8e1; }
+.providerNote { background: #efe9ff; }
+.legalNote span, .archivedNote span, .providerNote span { color: #715f55; font-size: 12px; line-height: 1.45; font-weight: 650; }
+
+.tenantLayer { margin-top: 24px; border: 2px solid rgba(113,56,245,.12); border-radius: 30px; background: #fffafc; padding: 18px; }
+.layerHead { display: flex; align-items: flex-end; justify-content: space-between; gap: 14px; }
+.layerHead span { color: #7138f5; font-size: 9px; letter-spacing: .14em; font-weight: 950; }
+.layerHead h3 { margin: 4px 0 0; font-size: 20px; letter-spacing: -.035em; }
+.addButton { flex: 0 0 auto; border: 0; border-radius: 999px; padding: 11px 14px; background: #c9ff54; color: #283215; font-size: 12px; font-weight: 950; }
+.layerEmpty { margin-top: 16px; border-radius: 20px; background: #f6f0f7; padding: 18px; color: #7b6877; font-size: 13px; line-height: 1.45; font-weight: 650; }
+
+.picker { margin-top: 14px; display: grid; gap: 8px; }
+.picker > button { width: 100%; border: 1px solid rgba(113,56,245,.12); border-radius: 19px; background: white; padding: 8px; display: flex; align-items: center; gap: 11px; text-align: left; color: #3e2b24; }
+.picker img { width: 58px; height: 58px; border-radius: 15px; object-fit: cover; background: #2e174d; }
+.picker span { display: grid; gap: 3px; }
+.picker b { text-transform: capitalize; }
+.picker small { color: #806d63; }
+.pickerEmpty { padding: 14px; color: #765f55; font-size: 13px; font-weight: 700; }
+.pickerEmpty a { color: #7138f5; }
+
+.attachedGrid { display: grid; gap: 8px; margin-top: 14px; }
+.voxelCard { display: grid; grid-template-columns: 58px 1fr auto; align-items: center; gap: 11px; padding: 8px; border-radius: 19px; background: white; border: 1px solid rgba(72,45,35,.08); }
+.voxelCard img, .voxelFallback { width: 58px; height: 58px; border-radius: 15px; object-fit: cover; background: #2e174d; }
+.voxelFallback { display: grid; place-items: center; color: #c9ff54; font-size: 25px; }
+.voxelCard > div:nth-child(2) { min-width: 0; display: grid; gap: 3px; }
+.voxelCard b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-transform: capitalize; }
+.voxelCard small { color: #806d63; }
+.voxelCard button { border: 0; border-radius: 999px; background: #f1e9e4; color: #634f45; padding: 9px 11px; font-size: 11px; font-weight: 900; }
+
+.message { position: sticky; bottom: max(14px, env(safe-area-inset-bottom)); margin: 18px auto 0; width: fit-content; max-width: 100%; border-radius: 999px; background: #3b254e; color: white; padding: 11px 16px; font-size: 12px; font-weight: 750; box-shadow: 0 8px 28px rgba(48,30,64,.2); }
+.truth { max-width: 570px; margin: 26px auto 0; text-align: center; color: #8c776d; font-size: 11px; line-height: 1.5; font-weight: 650; }
+
+@media (max-width: 560px) {
+  .page { padding-left: 12px; padding-right: 12px; }
+  .header { padding-top: 42px; }
+  .facts { grid-template-columns: 1fr; }
+  .layerHead { align-items: flex-start; flex-direction: column; }
+  .addButton { width: 100%; padding: 13px; }
+  .voxelCard { grid-template-columns: 52px 1fr; }
+  .voxelCard img, .voxelFallback { width: 52px; height: 52px; }
+  .voxelCard button { grid-column: 1 / -1; width: 100%; }
+}

--- a/docs/PROPERTY_RENTALS.md
+++ b/docs/PROPERTY_RENTALS.md
@@ -1,0 +1,125 @@
+# Voxel Vault Property Rentals
+
+Voxel Vault rentals are a **private digital companion to a real lease**, not a replacement for landlord-tenant law, a property manager, an e-signature provider, or the authoritative lease document.
+
+## Simple renter flow
+
+```text
+Verified property
+      |
+      v
+Real rental offer / lease provider
+      |
+      v
+Tenant reviews + signs real rental agreement
+      |
+      v
+Provider / authorized reviewer verifies executed lease
+      |
+      v
+Rented property appears in My Vault
+      |
+      +--> monthly rent status
+      |
+      +--> tenant-only voxel layer
+      |       |
+      |       +--> renter's separately owned minted voxels
+      |
+      v
+Lease remains current / late / notice / legal process
+      |
+      v
+Lawful termination verified
+      |
+      v
+Tenant layer becomes archived/read-only
+```
+
+The consumer UI stays condensed as:
+
+`LEASE → PAY MONTHLY → DECORATE → MOVE OUT`
+
+## Real lease is authoritative
+
+A Voxel Vault rental must not become `current` merely because a user clicks a button or mints a token. Activation requires a real lease/provider record and an executed-agreement hash verified through the owner/provider reconciliation path.
+
+The agreement itself, tenant identity documents, bank information and other confidential lease material must remain private and must never be placed in public NFT metadata.
+
+A future production e-sign adapter must return a provider-verified execution event/reference before the lease can become active. Until such a provider is configured, Voxel Vault records only reviewed/provider-reconciled lease state; it does not pretend to execute a legal lease.
+
+## Monthly rent
+
+The lease record stores the agreed monthly amount, currency and due day. Individual payment periods can be reconciled as:
+
+- `upcoming`
+- `due`
+- `paid`
+- `late`
+- `disputed`
+
+Production collection must remain with a reviewed property manager/payment provider until Voxel Vault has an approved integration. The platform must not invent payment confirmations from a client-side button.
+
+A late payment may move the workflow from `current` to `late`, but **late rent does not automatically end tenancy**.
+
+## No automatic eviction
+
+Rental workflow states are:
+
+`pending-verification → current ↔ late → notice → legal-process → ended`
+
+Routes may also return from `notice` or `legal-process` to `current` when the real-world situation is cured/resolved.
+
+`ended` is fail-closed: it requires verified termination evidence and a reference hash. The application must never implement `late → automatic eviction`, automatic lockout, automatic possession transfer, or automatic destruction of tenant rights based only on an unpaid digital balance.
+
+Actual notices, termination, eviction, possession and move-out obligations are governed by the executed lease and applicable law/provider/court process.
+
+## Tenant voxel layer
+
+An active verified tenant gets a private **Tenant Layer** associated with the canonical property identity.
+
+Permanent tenant-layer associations require a minted VoxelPop asset in that same signed-in account. Examples:
+
+- furniture
+- art
+- pets/characters
+- plants
+- appliances
+- collectibles
+- other personal 3D voxels
+
+An attachment is only a spatial/digital association. It does not become part of the deed, verified building geometry, landlord property, leasehold estate, security deposit, or physical premises.
+
+When the lease ends lawfully:
+
+- the tenant layer becomes archived/read-only;
+- tenant placement records are archived;
+- the renter's separately owned voxel/token is **not burned, transferred or deleted**;
+- the renter can continue to hold/use that voxel elsewhere subject to its normal digital-asset rights.
+
+## Rental Pass direction
+
+A future Rental Pass may mirror the verified lease status as a non-transferable or tightly restricted digital credential. It must not be presented as the lease itself and must not create occupancy rights independently of the authoritative agreement.
+
+If implemented, it should be issued only after executed-lease verification and should expire/archive only after the corresponding real lease has lawfully ended.
+
+## Current V1 limitations
+
+This implementation provides:
+
+- private lease/payment/tenant-layer storage;
+- owner/provider reconciliation APIs;
+- a signed-in renter Vault view;
+- monthly payment status display;
+- tenant attachment of account-confirmed minted voxels;
+- fail-closed lawful-termination gating.
+
+It does **not** yet provide:
+
+- a production e-signature provider;
+- live rent collection/autopay;
+- automated legal notices;
+- court filing or eviction execution;
+- a mainnet Rental Pass mint;
+- public tenant or lease metadata.
+
+Those capabilities must remain disabled until the exact provider, legal, privacy, payment and jurisdiction requirements are reviewed and connected.

--- a/lib/product-map.js
+++ b/lib/product-map.js
@@ -2,6 +2,7 @@ export const SIMPLE_PROPERTY_DOCK = Object.freeze([
   { id: 'home', href: '/', label: 'Home', icon: 'V' },
   { id: 'add', href: '/property', label: 'Add', icon: '+' },
   { id: 'vault', href: '/vault/property-drafts', label: 'Vault', icon: '◇' },
+  { id: 'rented', href: '/vault/rentals', label: 'Rented', icon: '⌂' },
   { id: 'world', href: '/world', label: 'World', icon: '◎' },
 ]);
 
@@ -44,9 +45,10 @@ export const APP_SECTIONS = Object.freeze([
   {
     id: 'money',
     eyebrow: 'MONEY + OWNERSHIP',
-    title: 'Invest, observe, verify',
-    description: 'Keep provider-backed investments, observed income and direct-property planning clearly separated.',
+    title: 'Invest, rent, own, verify',
+    description: 'Keep rentals, provider-backed investments, observed income and direct-property ownership clearly separated.',
     items: [
+      { id: 'rentals', href: '/vault/rentals', label: 'Rented home', icon: '⌂', description: 'See a verified lease, monthly payment status and the renter-only minted-voxel layer.', badge: 'LEASE' },
       { id: 'invest', href: '/real-estate/reits', label: 'Investments', icon: '$', description: 'Browse provider-backed real-estate securities and sandbox/live states.', badge: 'PROVIDER' },
       { id: 'income', href: '/vault/income', label: 'Income', icon: '↗', description: 'See observed provider payment history without invented yield.', badge: 'OBSERVED' },
       { id: 'acquire', href: '/real-estate/acquire', label: 'Direct ownership', icon: '⌂', description: 'Plan the normal diligence, title and closing path toward real property ownership.', badge: 'DEED PATH' },
@@ -87,14 +89,16 @@ export function isSimplePropertyRoute(pathname = '/') {
   return path === '/'
     || path === '/property' || path.startsWith('/property/')
     || path === '/world' || path.startsWith('/world/')
-    || path === '/vault/property-drafts' || path.startsWith('/vault/property-drafts/');
+    || path === '/vault/property-drafts' || path.startsWith('/vault/property-drafts/')
+    || path === '/vault/rentals' || path.startsWith('/vault/rentals/');
 }
 
 export function simplePropertyDockItemForPath(pathname = '/') {
   const path = String(pathname || '/');
   if (path === '/property' || path.startsWith('/property/')) return SIMPLE_PROPERTY_DOCK[1];
   if (path === '/vault/property-drafts' || path.startsWith('/vault/property-drafts/')) return SIMPLE_PROPERTY_DOCK[2];
-  if (path === '/world' || path.startsWith('/world/')) return SIMPLE_PROPERTY_DOCK[3];
+  if (path === '/vault/rentals' || path.startsWith('/vault/rentals/')) return SIMPLE_PROPERTY_DOCK[3];
+  if (path === '/world' || path.startsWith('/world/')) return SIMPLE_PROPERTY_DOCK[4];
   return SIMPLE_PROPERTY_DOCK[0];
 }
 

--- a/lib/real-estate/property-rental.js
+++ b/lib/real-estate/property-rental.js
@@ -1,0 +1,85 @@
+export const RENTAL_STATUSES = Object.freeze([
+  'pending-verification',
+  'current',
+  'late',
+  'notice',
+  'legal-process',
+  'ended',
+]);
+
+const tenantUseStatuses = new Set(['current', 'late', 'notice', 'legal-process']);
+
+export function isRentalStatus(value) {
+  return RENTAL_STATUSES.includes(String(value || ''));
+}
+
+export function canTenantUseProperty({ status, leaseVerifiedAt, terminationVerifiedAt } = {}) {
+  if (!leaseVerifiedAt) return false;
+  if (terminationVerifiedAt) return false;
+  return tenantUseStatuses.has(String(status || ''));
+}
+
+export function canEndLease({ terminationVerifiedAt, terminationReferenceHash } = {}) {
+  return Boolean(terminationVerifiedAt && String(terminationReferenceHash || '').trim());
+}
+
+export function assertRentalTransition(fromStatus, toStatus, evidence = {}) {
+  const from = String(fromStatus || 'pending-verification');
+  const to = String(toStatus || '');
+  if (!isRentalStatus(from) || !isRentalStatus(to)) throw new Error('Unknown rental status.');
+
+  const allowed = {
+    'pending-verification': new Set(['pending-verification', 'current']),
+    current: new Set(['current', 'late', 'notice', 'legal-process', 'ended']),
+    late: new Set(['late', 'current', 'notice', 'legal-process', 'ended']),
+    notice: new Set(['notice', 'current', 'legal-process', 'ended']),
+    'legal-process': new Set(['legal-process', 'current', 'ended']),
+    ended: new Set(['ended']),
+  };
+
+  if (!allowed[from]?.has(to)) throw new Error(`Rental status cannot move from ${from} to ${to}.`);
+  if (to !== 'pending-verification' && !evidence.leaseVerifiedAt) {
+    throw new Error('A real lease must be verified before tenant rights become active.');
+  }
+  if (to === 'ended' && !canEndLease(evidence)) {
+    throw new Error('Lease-end status requires verified lawful termination evidence.');
+  }
+  return true;
+}
+
+export function canAttachMintedVoxel({ status, leaseVerifiedAt, terminationVerifiedAt, tokenId, accountMintConfirmed } = {}) {
+  return canTenantUseProperty({ status, leaseVerifiedAt, terminationVerifiedAt })
+    && Boolean(accountMintConfirmed)
+    && Boolean(String(tokenId ?? '').trim());
+}
+
+export function archiveTenantAttachments(attachments = [], archivedAt = new Date().toISOString()) {
+  return (Array.isArray(attachments) ? attachments : []).map((attachment) => ({
+    ...attachment,
+    status: 'archived',
+    archivedAt,
+  }));
+}
+
+export function rentalStatusLabel(status) {
+  const labels = {
+    'pending-verification': 'LEASE PENDING',
+    current: 'CURRENT',
+    late: 'LATE',
+    notice: 'NOTICE',
+    'legal-process': 'LEGAL PROCESS',
+    ended: 'LEASE ENDED',
+  };
+  return labels[String(status || '')] || 'UNKNOWN';
+}
+
+export function rentalTruth() {
+  return {
+    automaticEviction: false,
+    latePaymentEndsTenancy: false,
+    leaseRequired: true,
+    lawfulTerminationRequired: true,
+    attachmentRequiresConfirmedMint: true,
+    tenantKeepsOwnedVoxelAfterLease: true,
+  };
+}

--- a/lib/real-estate/property-rental.js
+++ b/lib/real-estate/property-rental.js
@@ -47,10 +47,24 @@ export function assertRentalTransition(fromStatus, toStatus, evidence = {}) {
   return true;
 }
 
-export function canAttachMintedVoxel({ status, leaseVerifiedAt, terminationVerifiedAt, tokenId, accountMintConfirmed } = {}) {
+export function canAttachMintedVoxel({ status, leaseVerifiedAt, terminationVerifiedAt, tokenId, accountMintConfirmed, walletOwnershipVerified = false } = {}) {
   return canTenantUseProperty({ status, leaseVerifiedAt, terminationVerifiedAt })
     && Boolean(accountMintConfirmed)
+    && Boolean(walletOwnershipVerified)
     && Boolean(String(tokenId ?? '').trim());
+}
+
+export function tenantVoxelOwnershipMessage({ userId, leaseId, sessionId, tokenId, signedAt } = {}) {
+  return [
+    'Voxel Vault tenant voxel placement',
+    `User: ${String(userId || '').trim()}`,
+    `Lease: ${String(leaseId || '').trim()}`,
+    `Session: ${String(sessionId || '').trim()}`,
+    `Token: ${String(tokenId ?? '').trim()}`,
+    `Signed at: ${String(signedAt || '').trim()}`,
+    'Purpose: prove current wallet ownership before associating this minted voxel with a rented property.',
+    'This signature does not transfer the voxel, property, lease, money, or any ownership right.',
+  ].join('\n');
 }
 
 export function archiveTenantAttachments(attachments = [], archivedAt = new Date().toISOString()) {
@@ -80,6 +94,7 @@ export function rentalTruth() {
     leaseRequired: true,
     lawfulTerminationRequired: true,
     attachmentRequiresConfirmedMint: true,
+    attachmentRequiresWalletOwnershipProof: true,
     tenantKeepsOwnedVoxelAfterLease: true,
   };
 }

--- a/scripts/test-global-rent-engine.mjs
+++ b/scripts/test-global-rent-engine.mjs
@@ -17,7 +17,7 @@ const rental = await importSource('../lib/real-estate/property-rental.js');
 
 const { LIVE_ACQUISITION_ENABLED, buildAcquisitionPlan, demoAssetCatalog, rankAssets } = engine;
 const { evaluateJurisdictionGate, requiredJurisdictionChecks } = jurisdiction;
-const { canAttachMintedVoxel, canEndLease, canTenantUseProperty, assertRentalTransition, archiveTenantAttachments, rentalTruth } = rental;
+const { canAttachMintedVoxel, canEndLease, canTenantUseProperty, assertRentalTransition, archiveTenantAttachments, rentalTruth, tenantVoxelOwnershipMessage } = rental;
 
 assert.equal(LIVE_ACQUISITION_ENABLED, false, 'live acquisition must remain disabled in the pilot');
 
@@ -63,13 +63,25 @@ assert.equal(canAttachMintedVoxel({
   leaseVerifiedAt: '2026-08-01T00:00:00Z',
   tokenId: '42',
   accountMintConfirmed: true,
-}), true, 'confirmed minted voxel may be associated with an active rental');
+  walletOwnershipVerified: true,
+}), true, 'account-confirmed mint plus current wallet owner proof may be associated with an active rental');
+assert.equal(canAttachMintedVoxel({
+  status: 'current',
+  leaseVerifiedAt: '2026-08-01T00:00:00Z',
+  tokenId: '42',
+  accountMintConfirmed: true,
+  walletOwnershipVerified: false,
+}), false, 'a stored token ID alone is not enough to attach a voxel');
 assert.equal(canAttachMintedVoxel({
   status: 'current',
   leaseVerifiedAt: '2026-08-01T00:00:00Z',
   tokenId: '',
   accountMintConfirmed: false,
+  walletOwnershipVerified: false,
 }), false, 'unminted creation must not be permanently attached');
+
+const ownershipMessage = tenantVoxelOwnershipMessage({ userId: 'user-1', leaseId: 'lease-1', sessionId: 'voxel-1', tokenId: '42', signedAt: '2026-08-29T00:00:00.000Z' });
+assert.match(ownershipMessage, /does not transfer the voxel, property, lease, money, or any ownership right/i, 'wallet proof must be non-transactional and narrowly scoped');
 
 const archived = archiveTenantAttachments([{ id: 'attachment-1', tokenId: '42', voxelSessionId: 'voxel-1', status: 'active' }], '2026-09-01T00:00:00Z');
 assert.equal(archived[0].status, 'archived', 'lease end archives tenant placement');
@@ -79,24 +91,37 @@ assert.equal(archived[0].voxelSessionId, 'voxel-1', 'lease end must not transfer
 const truth = rentalTruth();
 assert.equal(truth.automaticEviction, false, 'application must never claim automatic eviction');
 assert.equal(truth.latePaymentEndsTenancy, false, 'late payment cannot itself terminate occupancy rights');
+assert.equal(truth.attachmentRequiresWalletOwnershipProof, true, 'permanent tenant placement must require current wallet ownership proof');
 assert.equal(truth.tenantKeepsOwnedVoxelAfterLease, true, 'renter keeps separately owned voxels after lease end');
 
-const [migration, tenantApi, adminApi, rentalPage] = await Promise.all([
+const [migration, tenantApi, adminApi, rentalPage, productMap, rentalDocs] = await Promise.all([
   source('../supabase/migrations/020_property_rentals.sql'),
   source('../app/api/vault/rentals/[leaseId]/attachments/route.ts'),
   source('../app/api/admin/rentals/route.ts'),
   source('../app/vault/rentals/page.js'),
+  source('../lib/product-map.js'),
+  source('../docs/PROPERTY_RENTALS.md'),
 ]);
 
 assert.match(migration, /status <> 'ended'[\s\S]*termination_verified_at is not null[\s\S]*termination_reference_hash/i, 'database must require termination evidence before ended state');
 assert.doesNotMatch(migration, /for insert to authenticated|for update to authenticated|for delete to authenticated/i, 'tenants must not self-verify or mutate authoritative lease/payment rows directly');
-assert.match(tenantApi, /loadAccountVoxel/, 'tenant attachment API must verify the signed-in account voxel record server-side');
-assert.match(tenantApi, /payload\?\.mint\?\.tokenId/, 'permanent attachment requires a confirmed mint token ID');
+assert.match(migration, /ownership_proof_hash/, 'tenant placement must retain a non-secret audit hash of wallet ownership proof');
+assert.match(migration, /ownership_verified_at/, 'tenant placement must record when wallet ownership was checked');
+assert.match(tenantApi, /loadAccountVoxel/, 'tenant attachment API must bind placement to the signed-in account voxel record');
+assert.match(tenantApi, /verifyMessage/, 'tenant attachment API must verify a wallet signature server-side');
+assert.match(tenantApi, /ownerOf/, 'tenant attachment API must check current on-chain token ownership');
+assert.match(tenantApi, /walletOwnershipVerified:\s*true/, 'permanent attachment may pass only after wallet and chain verification');
+assert.match(tenantApi, /ownershipVerifiedOnChain:\s*true/, 'successful attachment response must disclose that current chain ownership was verified');
 assert.match(adminApi, /requireVoxelVaultAdmin/, 'lease/payment reconciliation must be owner/provider-gated');
 assert.match(adminApi, /automaticEviction:\s*false/, 'admin rental API must explicitly deny automatic eviction semantics');
 assert.match(adminApi, /status:\s*'archived'/, 'verified lease end archives tenant placements instead of deleting assets');
 assert.match(rentalPage, /does not automatically evict/i, 'renter UI must explain late payment does not automatically evict');
-assert.match(rentalPage, /The voxel is still your separate asset/i, 'renter UI must preserve separate ownership of attached voxels');
+assert.match(rentalPage, /getWallet/, 'renter must explicitly connect/sign with the current token-owning wallet before placement');
+assert.match(rentalPage, /On-chain ownership was checked/i, 'renter UI must disclose successful current-owner verification');
 assert.match(rentalPage, /PAY MONTHLY/, 'renter UI should keep the monthly payment flow simple and visible');
+assert.match(productMap, /href: '\/vault\/rentals', label: 'Rented'/, 'Rented must be discoverable from the simple VoxelPop property dock');
+assert.match(productMap, /path === '\/vault\/rentals'/, 'Rented must stay inside the simplified property navigation mode');
+assert.match(rentalDocs, /does \*\*not\*\* yet provide:[\s\S]*production e-signature provider/i, 'docs must fail closed about legal lease execution');
+assert.match(rentalDocs, /late rent does not automatically end tenancy/i, 'docs must preserve lawful termination boundary');
 
-console.log('Global rent + legal tenant-layer safety checks passed.');
+console.log('Global rent + legal tenant-layer safety checks passed: verified lease -> monthly status -> Rented Vault -> wallet-owned minted voxels -> lawful lease end/archive, never automatic eviction.');

--- a/scripts/test-global-rent-engine.mjs
+++ b/scripts/test-global-rent-engine.mjs
@@ -7,11 +7,17 @@ async function importSource(path) {
   return import(url);
 }
 
+async function source(path) {
+  return readFile(new URL(path, import.meta.url), 'utf8');
+}
+
 const engine = await importSource('../lib/real-estate/global-asset-engine.js');
 const jurisdiction = await importSource('../lib/real-estate/jurisdiction-gate.js');
+const rental = await importSource('../lib/real-estate/property-rental.js');
 
 const { LIVE_ACQUISITION_ENABLED, buildAcquisitionPlan, demoAssetCatalog, rankAssets } = engine;
 const { evaluateJurisdictionGate, requiredJurisdictionChecks } = jurisdiction;
+const { canAttachMintedVoxel, canEndLease, canTenantUseProperty, assertRentalTransition, archiveTenantAttachments, rentalTruth } = rental;
 
 assert.equal(LIVE_ACQUISITION_ENABLED, false, 'live acquisition must remain disabled in the pilot');
 
@@ -36,4 +42,61 @@ assert.ok(plan.purchases.every((asset) => asset.acquisitionCost > 0), 'only vali
 const tinyPlan = buildAcquisitionPlan({ capital: 400, reserveFloor: 0.1 });
 assert.equal(tinyPlan.purchases.length, 0, 'engine must keep cash rather than force an unaffordable purchase');
 
-console.log('Global rent engine safety checks passed.');
+// Real rental V1: payment delinquency may change workflow status, but does not itself
+// terminate the lease or remove tenant-layer permissions.
+for (const status of ['current', 'late', 'notice', 'legal-process']) {
+  assert.equal(canTenantUseProperty({ status, leaseVerifiedAt: '2026-08-01T00:00:00Z' }), true, `${status} must retain tenant-layer access before lawful termination`);
+}
+assert.equal(canTenantUseProperty({ status: 'pending-verification', leaseVerifiedAt: null }), false, 'unverified lease cannot create tenant rights');
+assert.equal(canTenantUseProperty({ status: 'ended', leaseVerifiedAt: '2026-08-01T00:00:00Z', terminationVerifiedAt: '2026-09-01T00:00:00Z' }), false, 'ended lease must make tenant layer read-only');
+assert.equal(canEndLease({ terminationVerifiedAt: '2026-09-01T00:00:00Z', terminationReferenceHash: 'a'.repeat(64) }), true, 'verified termination evidence can close a lease');
+assert.equal(canEndLease({ terminationVerifiedAt: '', terminationReferenceHash: '' }), false, 'late rent alone cannot close a lease');
+assert.throws(() => assertRentalTransition('late', 'ended', { leaseVerifiedAt: '2026-08-01T00:00:00Z' }), /lawful termination/i, 'late rent must never auto-end tenancy');
+assert.equal(assertRentalTransition('late', 'ended', {
+  leaseVerifiedAt: '2026-08-01T00:00:00Z',
+  terminationVerifiedAt: '2026-09-01T00:00:00Z',
+  terminationReferenceHash: 'b'.repeat(64),
+}), true, 'lawfully verified termination may end the digital tenant layer');
+
+assert.equal(canAttachMintedVoxel({
+  status: 'current',
+  leaseVerifiedAt: '2026-08-01T00:00:00Z',
+  tokenId: '42',
+  accountMintConfirmed: true,
+}), true, 'confirmed minted voxel may be associated with an active rental');
+assert.equal(canAttachMintedVoxel({
+  status: 'current',
+  leaseVerifiedAt: '2026-08-01T00:00:00Z',
+  tokenId: '',
+  accountMintConfirmed: false,
+}), false, 'unminted creation must not be permanently attached');
+
+const archived = archiveTenantAttachments([{ id: 'attachment-1', tokenId: '42', voxelSessionId: 'voxel-1', status: 'active' }], '2026-09-01T00:00:00Z');
+assert.equal(archived[0].status, 'archived', 'lease end archives tenant placement');
+assert.equal(archived[0].tokenId, '42', 'lease end must not burn or delete renter-owned token identity');
+assert.equal(archived[0].voxelSessionId, 'voxel-1', 'lease end must not transfer/delete renter-owned voxel record');
+
+const truth = rentalTruth();
+assert.equal(truth.automaticEviction, false, 'application must never claim automatic eviction');
+assert.equal(truth.latePaymentEndsTenancy, false, 'late payment cannot itself terminate occupancy rights');
+assert.equal(truth.tenantKeepsOwnedVoxelAfterLease, true, 'renter keeps separately owned voxels after lease end');
+
+const [migration, tenantApi, adminApi, rentalPage] = await Promise.all([
+  source('../supabase/migrations/020_property_rentals.sql'),
+  source('../app/api/vault/rentals/[leaseId]/attachments/route.ts'),
+  source('../app/api/admin/rentals/route.ts'),
+  source('../app/vault/rentals/page.js'),
+]);
+
+assert.match(migration, /status <> 'ended'[\s\S]*termination_verified_at is not null[\s\S]*termination_reference_hash/i, 'database must require termination evidence before ended state');
+assert.doesNotMatch(migration, /for insert to authenticated|for update to authenticated|for delete to authenticated/i, 'tenants must not self-verify or mutate authoritative lease/payment rows directly');
+assert.match(tenantApi, /loadAccountVoxel/, 'tenant attachment API must verify the signed-in account voxel record server-side');
+assert.match(tenantApi, /payload\?\.mint\?\.tokenId/, 'permanent attachment requires a confirmed mint token ID');
+assert.match(adminApi, /requireVoxelVaultAdmin/, 'lease/payment reconciliation must be owner/provider-gated');
+assert.match(adminApi, /automaticEviction:\s*false/, 'admin rental API must explicitly deny automatic eviction semantics');
+assert.match(adminApi, /status:\s*'archived'/, 'verified lease end archives tenant placements instead of deleting assets');
+assert.match(rentalPage, /does not automatically evict/i, 'renter UI must explain late payment does not automatically evict');
+assert.match(rentalPage, /The voxel is still your separate asset/i, 'renter UI must preserve separate ownership of attached voxels');
+assert.match(rentalPage, /PAY MONTHLY/, 'renter UI should keep the monthly payment flow simple and visible');
+
+console.log('Global rent + legal tenant-layer safety checks passed.');

--- a/supabase/migrations/020_property_rentals.sql
+++ b/supabase/migrations/020_property_rentals.sql
@@ -1,0 +1,100 @@
+-- Private real-property rental records. These rows are not public NFT metadata.
+-- A lease, payment record, notice or court/property-manager action remains authoritative
+-- through the applicable real-world contract/provider/legal process.
+
+create table if not exists public.vault_property_leases (
+  id uuid primary key default gen_random_uuid(),
+  property_identity_id uuid not null references public.vault_property_identities(id) on delete restrict,
+  tenant_user_id uuid not null references auth.users(id) on delete cascade,
+  property_label text not null default '' check (char_length(property_label) <= 160),
+  provider text not null default '' check (char_length(provider) <= 80),
+  provider_lease_id text not null default '' check (char_length(provider_lease_id) <= 160),
+  monthly_rent_minor bigint not null default 0 check (monthly_rent_minor >= 0),
+  currency text not null default 'USD' check (char_length(currency) between 3 and 8),
+  due_day smallint not null default 1 check (due_day between 1 and 28),
+  starts_on date,
+  ends_on date,
+  status text not null default 'pending-verification'
+    check (status in ('pending-verification','current','late','notice','legal-process','ended')),
+  agreement_hash text not null default '' check (char_length(agreement_hash) <= 128),
+  lease_verified_at timestamptz,
+  termination_verified_at timestamptz,
+  termination_reference_hash text not null default '' check (char_length(termination_reference_hash) <= 128),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ends_on is null or starts_on is null or ends_on >= starts_on),
+  check (status = 'pending-verification' or lease_verified_at is not null),
+  check (
+    status <> 'ended'
+    or (termination_verified_at is not null and char_length(termination_reference_hash) > 0)
+  )
+);
+
+create table if not exists public.vault_rental_payments (
+  id uuid primary key default gen_random_uuid(),
+  lease_id uuid not null references public.vault_property_leases(id) on delete cascade,
+  due_on date not null,
+  amount_due_minor bigint not null default 0 check (amount_due_minor >= 0),
+  amount_paid_minor bigint not null default 0 check (amount_paid_minor >= 0),
+  currency text not null default 'USD' check (char_length(currency) between 3 and 8),
+  status text not null default 'upcoming'
+    check (status in ('upcoming','due','paid','late','disputed')),
+  provider text not null default '' check (char_length(provider) <= 80),
+  provider_payment_id text not null default '' check (char_length(provider_payment_id) <= 160),
+  paid_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (lease_id, due_on)
+);
+
+create table if not exists public.vault_tenant_voxel_attachments (
+  id uuid primary key default gen_random_uuid(),
+  lease_id uuid not null references public.vault_property_leases(id) on delete cascade,
+  tenant_user_id uuid not null references auth.users(id) on delete cascade,
+  voxel_session_id text not null check (char_length(voxel_session_id) between 1 and 180),
+  token_id text not null check (char_length(token_id) between 1 and 96),
+  voxel_name text not null default '' check (char_length(voxel_name) <= 120),
+  status text not null default 'active' check (status in ('active','archived')),
+  placed_transform jsonb not null default '{"position":[0,0,0],"rotation":[0,0,0],"scale":[1,1,1]}'::jsonb,
+  created_at timestamptz not null default now(),
+  archived_at timestamptz,
+  unique (lease_id, voxel_session_id)
+);
+
+alter table public.vault_property_leases enable row level security;
+alter table public.vault_rental_payments enable row level security;
+alter table public.vault_tenant_voxel_attachments enable row level security;
+
+-- Tenant reads are intentionally narrow. There are no authenticated client write policies;
+-- writes go through authenticated server routes so lease state cannot be self-verified.
+create policy "tenants read own leases"
+on public.vault_property_leases
+for select to authenticated
+using (tenant_user_id = auth.uid());
+
+create policy "tenants read own rental payments"
+on public.vault_rental_payments
+for select to authenticated
+using (
+  exists (
+    select 1 from public.vault_property_leases lease
+    where lease.id = lease_id and lease.tenant_user_id = auth.uid()
+  )
+);
+
+create policy "tenants read own voxel attachments"
+on public.vault_tenant_voxel_attachments
+for select to authenticated
+using (tenant_user_id = auth.uid());
+
+create index if not exists vault_property_leases_tenant_idx
+  on public.vault_property_leases(tenant_user_id, status, updated_at desc);
+
+create index if not exists vault_property_leases_identity_idx
+  on public.vault_property_leases(property_identity_id, status);
+
+create index if not exists vault_rental_payments_lease_idx
+  on public.vault_rental_payments(lease_id, due_on desc);
+
+create index if not exists vault_tenant_voxel_attachments_lease_idx
+  on public.vault_tenant_voxel_attachments(lease_id, status, created_at);

--- a/supabase/migrations/020_property_rentals.sql
+++ b/supabase/migrations/020_property_rentals.sql
@@ -53,6 +53,10 @@ create table if not exists public.vault_tenant_voxel_attachments (
   tenant_user_id uuid not null references auth.users(id) on delete cascade,
   voxel_session_id text not null check (char_length(voxel_session_id) between 1 and 180),
   token_id text not null check (char_length(token_id) between 1 and 96),
+  token_contract text not null check (char_length(token_contract) between 1 and 80),
+  wallet_address text not null check (char_length(wallet_address) between 1 and 80),
+  ownership_proof_hash text not null check (char_length(ownership_proof_hash) = 64),
+  ownership_verified_at timestamptz not null,
   voxel_name text not null default '' check (char_length(voxel_name) <= 120),
   status text not null default 'active' check (status in ('active','archived')),
   placed_transform jsonb not null default '{"position":[0,0,0],"rotation":[0,0,0],"scale":[1,1,1]}'::jsonb,
@@ -78,7 +82,8 @@ for select to authenticated
 using (
   exists (
     select 1 from public.vault_property_leases lease
-    where lease.id = lease_id and lease.tenant_user_id = auth.uid()
+    where lease.id = public.vault_rental_payments.lease_id
+      and lease.tenant_user_id = auth.uid()
   )
 );
 


### PR DESCRIPTION
## What this adds

A safe V1 rental experience that fits the condensed VoxelPop property flow without pretending Voxel Vault is a court, landlord, property manager, e-sign provider, or deed system.

### Renter flow
`VERIFIED LEASE → PAY MONTHLY → RENTED VAULT → ADD MINTED VOXELS → LAWFUL LEASE END → ARCHIVED TENANT LAYER`

- New `/vault/rentals` warm VoxelPop-style renter wing.
- Simple dock is now `Home · Add · Vault · Rented · World`.
- Shows monthly rent, due/payment status, lease state, and tenant-only voxel layer.
- Late/notice/legal-process states do not automatically remove digital tenant access.

### Real lease + payment boundaries
- New private migration `020_property_rentals.sql` for leases, payment periods, and tenant voxel placements.
- Tenant can read only their own private rental records; authenticated clients have no direct write policy for authoritative lease/payment state.
- Owner/provider reconciliation API activates a lease only after an already-verified canonical parcel is bound to a reviewed executed-agreement hash.
- Payment reconciliation can move `current ↔ late`; it never auto-evicts.
- `ended` requires verified termination timestamp + reference hash.
- Ending the lease archives tenant placement records instead of burning/transferring/deleting the renter's voxels.

### Minted voxel placement
- Permanent placement requires the voxel to exist as a confirmed mint in the signed-in VoxelPop account library.
- The renter then signs a narrowly-scoped ownership message with the wallet.
- Server recovers the signer and calls `ownerOf(tokenId)` on the configured Voxel NFT contract before attachment.
- Only a current on-chain owner can create the permanent tenant association.
- The proof is stored as a hash + verification timestamp, not as a private key or transaction authority.

### Fail-closed production state
- No production e-sign provider is claimed.
- No live rent collection/autopay is claimed.
- No automatic legal notices, filing, eviction, lockout, or possession transfer.
- No mainnet Rental Pass mint yet.
- Lease docs, tenant PII and payment details stay out of public NFT metadata.

### Regression protection
`npm run test:global-rent` now enforces no automatic eviction, lawful termination evidence, renter retention of owned voxels, no client self-verification of authoritative lease state, wallet signature + on-chain ownerOf checks for placement, and Rented navigation discoverability.