### PR TITLE
Add private room photos and a 3D renter decorator

### DIFF
--- a/app/api/vault/rentals/[leaseId]/attachments/route.ts
+++ b/app/api/vault/rentals/[leaseId]/attachments/route.ts
@@ -26,6 +26,27 @@ function clean(value: unknown, max = 180) {
   return String(value || '').trim().slice(0, max);
 }
 
+function finite(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function boundedTransform(value: any) {
+  const position = Array.isArray(value?.position) ? value.position : [];
+  const rotation = Array.isArray(value?.rotation) ? value.rotation : [];
+  const scale = Array.isArray(value?.scale) ? value.scale : [];
+  const uniformScale = clamp(finite(scale[0], 1), 0.3, 2.2);
+  return {
+    position: [clamp(finite(position[0]), -3.45, 3.45), 0, clamp(finite(position[2]), -2.45, 2.45)],
+    rotation: [0, clamp(finite(rotation[1]), -Math.PI * 8, Math.PI * 8), 0],
+    scale: [uniformScale, uniformScale, uniformScale],
+  };
+}
+
 function currentNftConfig() {
   const contract = clean(process.env.NEXT_PUBLIC_VOXEL_NFT_ADDRESS, 80);
   const rpc = clean(
@@ -172,6 +193,47 @@ export async function POST(request: Request, context: Context) {
     }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
   } catch (error) {
     return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Tenant voxel attachment failed.' }, { status: 400 });
+  }
+}
+
+export async function PATCH(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const body = await request.json().catch(() => ({}));
+    const attachmentId = clean(body?.attachmentId, 80);
+    if (!leaseId || !attachmentId) return NextResponse.json({ ok: false, error: 'Attachment ID is required.' }, { status: 400 });
+
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+    if (!canTenantUseProperty({ status: lease.status, leaseVerifiedAt: lease.lease_verified_at, terminationVerifiedAt: lease.termination_verified_at })) {
+      return NextResponse.json({ ok: false, error: 'An ended or unverified tenant layer is read-only.' }, { status: 409 });
+    }
+
+    const transform = boundedTransform(body?.transform);
+    const { data, error } = await auth.admin
+      .from('vault_tenant_voxel_attachments')
+      .update({ placed_transform: transform })
+      .eq('id', attachmentId)
+      .eq('lease_id', leaseId)
+      .eq('tenant_user_id', auth.user.id)
+      .eq('status', 'active')
+      .select('id,lease_id,voxel_session_id,token_id,voxel_name,status,placed_transform,created_at,archived_at')
+      .maybeSingle();
+    if (error) throw new Error('The room layout could not be saved.');
+    if (!data) return NextResponse.json({ ok: false, error: 'That voxel is not an active item in this rental.' }, { status: 404 });
+
+    return NextResponse.json({
+      ok: true,
+      attachment: data,
+      transformBounded: true,
+      truth: 'This saves only the renter decoration layer. Canonical property geometry is unchanged.',
+    }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Room layout save failed.' }, { status: 400 });
   }
 }
 

--- a/app/api/vault/rentals/[leaseId]/room-photo/route.ts
+++ b/app/api/vault/rentals/[leaseId]/room-photo/route.ts
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../../../../lib/user-auth';
+import { canTenantUseProperty } from '../../../../../../../lib/real-estate/property-rental';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const BUCKET = 'voxel-system';
+const MAX_BYTES = 8 * 1024 * 1024;
+const ALLOWED_TYPES = new Map([
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/webp', 'webp'],
+]);
+
+type Context = { params: Promise<{ leaseId: string }> };
+
+function clean(value: unknown, max = 240) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function safeSegment(value: unknown, fallback = 'room') {
+  const text = clean(value, 180).replace(/[^a-zA-Z0-9_.:-]+/g, '-').replace(/^-+|-+$/g, '');
+  return text || fallback;
+}
+
+function missingRoomTable(error: any) {
+  return error?.code === '42P01' || /vault_rental_room_references/i.test(String(error?.message || ''));
+}
+
+async function ensureBucket(admin: any) {
+  const { data, error } = await admin.storage.listBuckets();
+  if (error) throw new Error('Private room-photo storage is unavailable.');
+  if (!data?.some((bucket: any) => bucket.name === BUCKET)) {
+    const created = await admin.storage.createBucket(BUCKET, { public: false, fileSizeLimit: '75MB' });
+    if (created.error && !/already exists/i.test(String(created.error.message || ''))) {
+      throw new Error('Private room-photo storage could not be prepared.');
+    }
+  }
+}
+
+async function ownLease(admin: any, userId: string, leaseId: string) {
+  const { data, error } = await admin
+    .from('vault_property_leases')
+    .select('id,tenant_user_id,status,lease_verified_at,termination_verified_at')
+    .eq('id', leaseId)
+    .eq('tenant_user_id', userId)
+    .maybeSingle();
+  if (error) throw new Error('Rental storage is unavailable.');
+  return data || null;
+}
+
+async function readReference(admin: any, userId: string, leaseId: string) {
+  const { data, error } = await admin
+    .from('vault_rental_room_references')
+    .select('lease_id,tenant_user_id,storage_path,content_type,file_digest,rights_confirmed_at,updated_at')
+    .eq('lease_id', leaseId)
+    .eq('tenant_user_id', userId)
+    .maybeSingle();
+  if (error) {
+    if (missingRoomTable(error)) return { setupRequired: true, row: null };
+    throw new Error('Your private room reference could not be loaded.');
+  }
+  return { setupRequired: false, row: data || null };
+}
+
+async function signedReference(admin: any, row: any) {
+  if (!row?.storage_path) return null;
+  const signed = await admin.storage.from(BUCKET).createSignedUrl(row.storage_path, 6 * 60 * 60);
+  if (signed.error || !signed.data?.signedUrl) throw new Error('The private room photo could not be opened.');
+  return {
+    url: signed.data.signedUrl,
+    storagePath: row.storage_path,
+    uploadedAt: row.updated_at,
+    rightsConfirmedAt: row.rights_confirmed_at,
+    rightsBasis: 'tenant-supplied-room-reference',
+    truth: 'Private decoration reference only. It is not a verified floor plan or canonical property geometry.',
+  };
+}
+
+export async function GET(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+
+    const result = await readReference(auth.admin, auth.user.id, leaseId);
+    if (result.setupRequired) {
+      return NextResponse.json({ ok: true, setupRequired: true, reference: null }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+    }
+    return NextResponse.json({ ok: true, setupRequired: false, reference: await signedReference(auth.admin, result.row) }, {
+      headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+    });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Room photo could not be loaded.' }, { status: 400 });
+  }
+}
+
+export async function POST(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+    if (!canTenantUseProperty({ status: lease.status, leaseVerifiedAt: lease.lease_verified_at, terminationVerifiedAt: lease.termination_verified_at })) {
+      return NextResponse.json({ ok: false, error: 'Room decoration is read-only until a verified active lease exists.' }, { status: 409 });
+    }
+
+    const form = await request.formData();
+    const photo = form.get('photo');
+    const rightsConfirmed = clean(form.get('rightsConfirmed'), 16) === 'true';
+    if (!(photo instanceof File)) return NextResponse.json({ ok: false, error: 'Choose a room photo first.' }, { status: 400 });
+    if (!rightsConfirmed) return NextResponse.json({ ok: false, error: 'Confirm that you took this room photo or have permission to use it.' }, { status: 400 });
+
+    const extension = ALLOWED_TYPES.get(String(photo.type || '').toLowerCase());
+    if (!extension) return NextResponse.json({ ok: false, error: 'Use a JPG, PNG, or WebP room photo.' }, { status: 415 });
+    if (photo.size <= 0 || photo.size > MAX_BYTES) return NextResponse.json({ ok: false, error: 'Room photos must be smaller than 8 MB.' }, { status: 413 });
+
+    const existing = await readReference(auth.admin, auth.user.id, leaseId);
+    if (existing.setupRequired) {
+      return NextResponse.json({ ok: false, setupRequired: true, error: 'Room-photo storage needs migration 021 before uploads can be saved.' }, { status: 503 });
+    }
+
+    const bytes = await photo.arrayBuffer();
+    const digest = createHash('sha256').update(Buffer.from(bytes)).digest('hex');
+    const path = `rental-room-references/${safeSegment(auth.user.id, 'user')}/${safeSegment(leaseId, 'lease')}/${digest}.${extension}`;
+    await ensureBucket(auth.admin);
+
+    const uploaded = await auth.admin.storage.from(BUCKET).upload(path, bytes, {
+      contentType: photo.type,
+      cacheControl: '0',
+      upsert: true,
+    });
+    if (uploaded.error) throw new Error('The room photo could not be stored privately.');
+
+    const now = new Date().toISOString();
+    const { data, error } = await auth.admin
+      .from('vault_rental_room_references')
+      .upsert({
+        lease_id: leaseId,
+        tenant_user_id: auth.user.id,
+        storage_path: path,
+        content_type: photo.type,
+        file_digest: digest,
+        rights_confirmed_at: now,
+        updated_at: now,
+      }, { onConflict: 'lease_id' })
+      .select('lease_id,tenant_user_id,storage_path,content_type,file_digest,rights_confirmed_at,updated_at')
+      .single();
+    if (error) throw new Error('The room photo could not be linked to this rental.');
+
+    if (existing.row?.storage_path && existing.row.storage_path !== path) {
+      await auth.admin.storage.from(BUCKET).remove([existing.row.storage_path]).catch(() => {});
+    }
+
+    return NextResponse.json({ ok: true, setupRequired: false, reference: await signedReference(auth.admin, data) }, {
+      headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+    });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Room photo upload failed.' }, { status: 400 });
+  }
+}
+
+export async function DELETE(request: Request, context: Context) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const { leaseId: rawLeaseId } = await context.params;
+    const leaseId = clean(rawLeaseId, 80);
+    const lease = await ownLease(auth.admin, auth.user.id, leaseId);
+    if (!lease) return NextResponse.json({ ok: false, error: 'That rental is not in your Vault.' }, { status: 404 });
+
+    const existing = await readReference(auth.admin, auth.user.id, leaseId);
+    if (existing.setupRequired) return NextResponse.json({ ok: true, setupRequired: true, removed: false });
+    if (existing.row?.storage_path) await auth.admin.storage.from(BUCKET).remove([existing.row.storage_path]).catch(() => {});
+
+    const { error } = await auth.admin
+      .from('vault_rental_room_references')
+      .delete()
+      .eq('lease_id', leaseId)
+      .eq('tenant_user_id', auth.user.id);
+    if (error) throw new Error('The room photo could not be removed.');
+
+    return NextResponse.json({ ok: true, removed: true }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Room photo removal failed.' }, { status: 400 });
+  }
+}

--- a/app/api/vault/rentals/[leaseId]/room-photo/route.ts
+++ b/app/api/vault/rentals/[leaseId]/room-photo/route.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
-import { requireVoxelVaultUser } from '../../../../../../../lib/user-auth';
-import { canTenantUseProperty } from '../../../../../../../lib/real-estate/property-rental';
+import { requireVoxelVaultUser } from '../../../../../../lib/user-auth';
+import { canTenantUseProperty } from '../../../../../../lib/real-estate/property-rental';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/vault/rentals/BasicRoomDecorator.js
+++ b/app/vault/rentals/BasicRoomDecorator.js
@@ -1,0 +1,394 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const ROOM_X = 3.45;
+const ROOM_Z = 2.45;
+const STEP = 0.35;
+const ROTATE_STEP = Math.PI / 4;
+
+function number(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeTransform(raw, index = 0) {
+  const position = Array.isArray(raw?.position) ? raw.position : [];
+  const rotation = Array.isArray(raw?.rotation) ? raw.rotation : [];
+  const scale = Array.isArray(raw?.scale) ? raw.scale : [];
+  const untouchedDefault = position.every((value) => number(value) === 0) && rotation.every((value) => number(value) === 0) && scale.every((value) => number(value, 1) === 1);
+  const fallbackX = ((index % 3) - 1) * 1.15;
+  const fallbackZ = (Math.floor(index / 3) % 3 - 1) * .85;
+  const uniformScale = clamp(number(scale[0], 1), .3, 2.2);
+  return {
+    position: [
+      clamp(untouchedDefault && index ? fallbackX : number(position[0]), -ROOM_X, ROOM_X),
+      0,
+      clamp(untouchedDefault && index ? fallbackZ : number(position[2]), -ROOM_Z, ROOM_Z),
+    ],
+    rotation: [0, number(rotation[1]), 0],
+    scale: [uniformScale, uniformScale, uniformScale],
+  };
+}
+
+function sameItems(a, b) {
+  return a.length === b.length && a.every((item, index) => item.id === b[index]?.id && item.modelUrl === b[index]?.modelUrl);
+}
+
+export default function BasicRoomDecorator({ items = [], editable = false, savingId = '', onSave }) {
+  const mountRef = useRef(null);
+  const rootsRef = useRef(new Map());
+  const selectionRef = useRef(null);
+  const [selectedId, setSelectedId] = useState(items[0]?.id || '');
+  const [sceneError, setSceneError] = useState('');
+  const [transforms, setTransforms] = useState(() => Object.fromEntries(items.map((item, index) => [item.id, normalizeTransform(item.placedTransform, index)])));
+  const previousItems = useRef(items);
+
+  useEffect(() => {
+    if (!sameItems(previousItems.current, items)) {
+      setTransforms(Object.fromEntries(items.map((item, index) => [item.id, normalizeTransform(item.placedTransform, index)])));
+      setSelectedId((current) => items.some((item) => item.id === current) ? current : items[0]?.id || '');
+      previousItems.current = items;
+    }
+  }, [items]);
+
+  const selected = useMemo(() => items.find((item) => item.id === selectedId) || null, [items, selectedId]);
+  const selectedTransform = selected ? transforms[selected.id] || normalizeTransform(selected.placedTransform) : null;
+
+  useEffect(() => {
+    if (!mountRef.current) return undefined;
+    let dead = false;
+    let frame = 0;
+    let observer = null;
+    let renderer = null;
+    let scene = null;
+    let camera = null;
+    const resources = [];
+    const roots = new Map();
+    rootsRef.current = roots;
+    setSceneError('');
+
+    Promise.all([
+      import('three'),
+      import('three/examples/jsm/loaders/GLTFLoader.js'),
+    ]).then(([THREE, loaderModule]) => {
+      if (dead || !mountRef.current) return;
+      const mount = mountRef.current;
+      const width = Math.max(280, mount.clientWidth || 360);
+      const height = Math.max(300, mount.clientHeight || 380);
+      const compact = width < 720 || window.matchMedia?.('(pointer: coarse)')?.matches;
+      try {
+        renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false, powerPreference: 'high-performance' });
+      } catch {
+        setSceneError('3D room preview is unavailable in this browser.');
+        return;
+      }
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.15 : 1.35));
+      renderer.setSize(width, height);
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      renderer.toneMapping = THREE.ACESFilmicToneMapping;
+      renderer.toneMappingExposure = 1.05;
+      renderer.shadowMap.enabled = !compact;
+      renderer.domElement.style.touchAction = 'none';
+      mount.innerHTML = '';
+      mount.appendChild(renderer.domElement);
+
+      scene = new THREE.Scene();
+      scene.background = new THREE.Color(0xf7efe5);
+      scene.add(new THREE.HemisphereLight(0xfffbf1, 0x765f86, 2.5));
+      const key = new THREE.DirectionalLight(0xffffff, 3.8);
+      key.position.set(4, 8, 6);
+      key.castShadow = !compact;
+      scene.add(key);
+
+      camera = new THREE.PerspectiveCamera(42, width / height, .1, 50);
+      let orbit = .76;
+      let distance = 9.2;
+      const cameraTarget = new THREE.Vector3(0, .9, 0);
+      const updateCamera = () => {
+        camera.position.set(Math.sin(orbit) * distance, 5.1, Math.cos(orbit) * distance);
+        camera.lookAt(cameraTarget);
+      };
+      updateCamera();
+
+      const floorGeometry = new THREE.BoxGeometry(7.6, .12, 5.6);
+      const floorMaterial = new THREE.MeshStandardMaterial({ color: 0xeadac5, roughness: .92 });
+      const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+      floor.position.y = -.06;
+      floor.receiveShadow = !compact;
+      scene.add(floor);
+      resources.push(floorGeometry, floorMaterial);
+
+      const wallMaterial = new THREE.MeshStandardMaterial({ color: 0xfffbf4, roughness: .98 });
+      const backGeometry = new THREE.BoxGeometry(7.6, 3.4, .1);
+      const back = new THREE.Mesh(backGeometry, wallMaterial);
+      back.position.set(0, 1.7, -2.85);
+      back.receiveShadow = !compact;
+      scene.add(back);
+      const sideGeometry = new THREE.BoxGeometry(.1, 3.4, 5.6);
+      const side = new THREE.Mesh(sideGeometry, wallMaterial);
+      side.position.set(-3.85, 1.7, 0);
+      side.receiveShadow = !compact;
+      scene.add(side);
+      resources.push(wallMaterial, backGeometry, sideGeometry);
+
+      const grid = new THREE.GridHelper(7.2, 12, 0xd0bca6, 0xe6d8c8);
+      grid.position.y = .012;
+      scene.add(grid);
+
+      const selectionGeometry = new THREE.RingGeometry(.45, .53, 40);
+      const selectionMaterial = new THREE.MeshBasicMaterial({ color: 0x7138f5, side: THREE.DoubleSide, transparent: true, opacity: .88 });
+      const selection = new THREE.Mesh(selectionGeometry, selectionMaterial);
+      selection.rotation.x = -Math.PI / 2;
+      selection.position.y = .025;
+      selection.visible = false;
+      scene.add(selection);
+      selectionRef.current = selection;
+      resources.push(selectionGeometry, selectionMaterial);
+
+      const loader = new loaderModule.GLTFLoader();
+      items.forEach((item, index) => {
+        const root = new THREE.Group();
+        root.userData.attachmentId = item.id;
+        roots.set(item.id, root);
+        scene.add(root);
+
+        const addPlaceholder = () => {
+          const geometry = new THREE.BoxGeometry(.9, .9, .9);
+          const material = new THREE.MeshStandardMaterial({ color: index % 2 ? 0xc9ff54 : 0xff9b5e, roughness: .7 });
+          const box = new THREE.Mesh(geometry, material);
+          box.position.y = .45;
+          box.castShadow = !compact;
+          box.userData.attachmentId = item.id;
+          root.add(box);
+          resources.push(geometry, material);
+        };
+
+        if (!item.modelUrl) {
+          addPlaceholder();
+          return;
+        }
+
+        loader.load(item.modelUrl, (gltf) => {
+          if (dead) return;
+          const model = gltf.scene;
+          model.traverse((object) => {
+            if (!object?.isMesh) return;
+            object.userData.attachmentId = item.id;
+            object.castShadow = !compact;
+            object.receiveShadow = !compact;
+          });
+          const box = new THREE.Box3().setFromObject(model);
+          const size = new THREE.Vector3();
+          box.getSize(size);
+          const largest = Math.max(size.x, size.y, size.z, .001);
+          const fit = 1.25 / largest;
+          model.scale.setScalar(fit);
+          const fittedBox = new THREE.Box3().setFromObject(model);
+          model.position.y -= fittedBox.min.y;
+          root.add(model);
+        }, undefined, addPlaceholder);
+      });
+
+      const raycaster = new THREE.Raycaster();
+      const pointer = new THREE.Vector2();
+      let dragStart = null;
+      let moved = false;
+      const pointers = new Map();
+      let pinchStart = 0;
+      const pointerDistance = () => {
+        const pair = [...pointers.values()].slice(0, 2);
+        return pair.length === 2 ? Math.hypot(pair[0].x - pair[1].x, pair[0].y - pair[1].y) : 0;
+      };
+      const down = (event) => {
+        pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+        renderer.domElement.setPointerCapture?.(event.pointerId);
+        moved = false;
+        dragStart = { x: event.clientX, orbit };
+        if (pointers.size === 2) pinchStart = pointerDistance();
+      };
+      const move = (event) => {
+        if (!pointers.has(event.pointerId)) return;
+        pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+        if (pointers.size >= 2) {
+          const next = pointerDistance();
+          if (pinchStart) distance = clamp(distance - (next - pinchStart) * .012, 7, 12.5);
+          pinchStart = next;
+          updateCamera();
+          moved = true;
+          return;
+        }
+        if (!dragStart) return;
+        const dx = event.clientX - dragStart.x;
+        if (Math.abs(dx) > 3) moved = true;
+        orbit = dragStart.orbit - dx * .008;
+        updateCamera();
+      };
+      const up = (event) => {
+        pointers.delete(event.pointerId);
+        renderer.domElement.releasePointerCapture?.(event.pointerId);
+        if (pointers.size < 2) pinchStart = 0;
+        if (!moved && camera && scene) {
+          const rect = renderer.domElement.getBoundingClientRect();
+          pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+          pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+          raycaster.setFromCamera(pointer, camera);
+          const hits = raycaster.intersectObjects([...roots.values()], true);
+          const id = hits.map((hit) => {
+            let object = hit.object;
+            while (object && !object.userData?.attachmentId) object = object.parent;
+            return object?.userData?.attachmentId || '';
+          }).find(Boolean);
+          if (id) setSelectedId(id);
+        }
+        dragStart = null;
+      };
+      renderer.domElement.addEventListener('pointerdown', down);
+      renderer.domElement.addEventListener('pointermove', move);
+      renderer.domElement.addEventListener('pointerup', up);
+      renderer.domElement.addEventListener('pointercancel', up);
+
+      let visible = true;
+      observer = typeof IntersectionObserver !== 'undefined'
+        ? new IntersectionObserver((entries) => { visible = entries.some((entry) => entry.isIntersecting); }, { rootMargin: '100px' })
+        : null;
+      observer?.observe(mount);
+      const animate = () => {
+        frame = requestAnimationFrame(animate);
+        if (!visible || !renderer || !scene || !camera) return;
+        renderer.render(scene, camera);
+      };
+      animate();
+
+      const resize = () => {
+        if (!mountRef.current || !renderer || !camera) return;
+        const nextWidth = Math.max(280, mountRef.current.clientWidth || 360);
+        const nextHeight = Math.max(300, mountRef.current.clientHeight || 380);
+        renderer.setSize(nextWidth, nextHeight);
+        camera.aspect = nextWidth / nextHeight;
+        camera.updateProjectionMatrix();
+      };
+      window.addEventListener('resize', resize);
+
+      return () => {
+        window.removeEventListener('resize', resize);
+        renderer?.domElement?.removeEventListener('pointerdown', down);
+        renderer?.domElement?.removeEventListener('pointermove', move);
+        renderer?.domElement?.removeEventListener('pointerup', up);
+        renderer?.domElement?.removeEventListener('pointercancel', up);
+      };
+    }).catch(() => {
+      if (!dead) setSceneError('The Basic Room could not start. Your saved layout is still safe.');
+    });
+
+    return () => {
+      dead = true;
+      cancelAnimationFrame(frame);
+      observer?.disconnect?.();
+      rootsRef.current.clear();
+      selectionRef.current = null;
+      resources.forEach((resource) => resource?.dispose?.());
+      renderer?.dispose?.();
+      if (mountRef.current) mountRef.current.innerHTML = '';
+    };
+  }, [items]);
+
+  useEffect(() => {
+    for (const item of items) {
+      const root = rootsRef.current.get(item.id);
+      const transform = transforms[item.id];
+      if (!root || !transform) continue;
+      root.position.set(transform.position[0], 0, transform.position[2]);
+      root.rotation.set(0, transform.rotation[1], 0);
+      root.scale.setScalar(transform.scale[0]);
+    }
+    const selection = selectionRef.current;
+    const transform = selectedId ? transforms[selectedId] : null;
+    if (selection && transform) {
+      selection.position.set(transform.position[0], .025, transform.position[2]);
+      selection.scale.setScalar(Math.max(.8, transform.scale[0]));
+      selection.visible = true;
+    } else if (selection) {
+      selection.visible = false;
+    }
+  }, [items, transforms, selectedId]);
+
+  function changeSelected(mutator) {
+    if (!editable || !selectedId) return;
+    setTransforms((current) => {
+      const previous = current[selectedId] || normalizeTransform(null);
+      const next = mutator(previous);
+      return { ...current, [selectedId]: normalizeTransform(next) };
+    });
+  }
+
+  function move(dx, dz) {
+    changeSelected((current) => ({ ...current, position: [current.position[0] + dx, 0, current.position[2] + dz] }));
+  }
+
+  function rotate() {
+    changeSelected((current) => ({ ...current, rotation: [0, current.rotation[1] + ROTATE_STEP, 0] }));
+  }
+
+  function resize(delta) {
+    changeSelected((current) => {
+      const size = clamp(current.scale[0] + delta, .3, 2.2);
+      return { ...current, scale: [size, size, size] };
+    });
+  }
+
+  function reset() {
+    if (!selected) return;
+    setTransforms((current) => ({ ...current, [selected.id]: normalizeTransform(selected.placedTransform) }));
+  }
+
+  return <section className="roomDecorator">
+    <div className="roomHeading">
+      <div><span>BASIC ROOM · DECORATION LAYER</span><h4>Arrange your place.</h4></div>
+      <small>Not a verified floor plan.</small>
+    </div>
+
+    <div className="roomCanvasWrap">
+      <div ref={mountRef} className="roomCanvas" aria-label="Interactive basic 3D room for tenant voxel decoration" />
+      {!items.length ? <div className="roomEmpty"><b>Your room is ready.</b><span>Add a minted voxel to start decorating.</span></div> : null}
+      {sceneError ? <div className="roomError">{sceneError}</div> : null}
+      <div className="roomHint">DRAG TO TURN ROOM · PINCH TO ZOOM · TAP A VOXEL</div>
+    </div>
+
+    {items.length ? <>
+      <div className="itemTabs" aria-label="Choose a room item">
+        {items.map((item) => <button type="button" key={item.id} className={selectedId === item.id ? 'active' : ''} onClick={() => setSelectedId(item.id)}>{item.name || 'Voxel'}</button>)}
+      </div>
+
+      <div className="roomControls" aria-label="Move selected voxel">
+        <button type="button" onClick={() => move(-STEP, 0)} disabled={!editable}>←<span>Left</span></button>
+        <button type="button" onClick={() => move(0, -STEP)} disabled={!editable}>↑<span>Back</span></button>
+        <button type="button" onClick={() => move(0, STEP)} disabled={!editable}>↓<span>Forward</span></button>
+        <button type="button" onClick={() => move(STEP, 0)} disabled={!editable}>→<span>Right</span></button>
+        <button type="button" onClick={rotate} disabled={!editable}>↻<span>Rotate</span></button>
+        <button type="button" onClick={() => resize(-.15)} disabled={!editable}>−<span>Smaller</span></button>
+        <button type="button" onClick={() => resize(.15)} disabled={!editable}>＋<span>Larger</span></button>
+      </div>
+
+      <div className="roomActions">
+        <button type="button" className="roomReset" onClick={reset} disabled={!editable}>Reset</button>
+        <button type="button" className="roomSave" onClick={() => selected && onSave?.(selected.id, selectedTransform)} disabled={!editable || !selected || savingId === selected?.id}>{savingId === selected?.id ? 'Saving…' : 'Save layout'}</button>
+      </div>
+      {!editable ? <p className="roomReadOnly">This tenant layer is read-only because the lease is not currently editable.</p> : null}
+    </> : null}
+
+    <style jsx>{`
+      .roomDecorator{margin-top:16px;border-radius:24px;background:#f6f0ff;padding:12px;border:1px solid rgba(113,56,245,.12)}
+      .roomHeading{display:flex;align-items:flex-end;justify-content:space-between;gap:12px;padding:5px 5px 10px}.roomHeading span{font-size:8px;letter-spacing:.14em;font-weight:950;color:#7138f5}.roomHeading h4{margin:3px 0 0;font-size:18px;letter-spacing:-.03em}.roomHeading small{color:#826f7e;font-size:10px;font-weight:750}
+      .roomCanvasWrap{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:#f7efe5}.roomCanvas{position:absolute;inset:0}.roomHint{position:absolute;left:8px;right:8px;bottom:8px;text-align:center;font-size:7px;letter-spacing:.08em;font-weight:900;color:#786a65;pointer-events:none}.roomEmpty,.roomError{position:absolute;inset:0;display:grid;place-content:center;text-align:center;padding:24px;color:#725f76;pointer-events:none}.roomEmpty b{font-size:20px}.roomEmpty span{font-size:12px;margin-top:4px}.roomError{background:#fff8f2;color:#8c5d55;font-size:12px}
+      .itemTabs{display:flex;gap:7px;overflow-x:auto;padding:10px 1px 3px;scrollbar-width:none}.itemTabs::-webkit-scrollbar{display:none}.itemTabs button{border:1px solid rgba(113,56,245,.15);background:white;border-radius:999px;padding:9px 12px;white-space:nowrap;color:#65515f;font-size:11px;font-weight:850}.itemTabs button.active{background:#7138f5;color:white;border-color:#7138f5}
+      .roomControls{display:grid;grid-template-columns:repeat(4,1fr);gap:7px;margin-top:9px}.roomControls button{min-height:54px;border:0;border-radius:16px;background:white;color:#4c3947;font-size:20px;font-weight:950;box-shadow:inset 0 0 0 1px rgba(72,45,35,.08)}.roomControls span{display:block;font-size:8px;letter-spacing:.04em;margin-top:2px;color:#8b7886}.roomControls button:disabled{opacity:.45}
+      .roomActions{display:grid;grid-template-columns:1fr 2fr;gap:8px;margin-top:9px}.roomActions button{min-height:48px;border:0;border-radius:16px;font-weight:950}.roomReset{background:#ece5e1;color:#624f47}.roomSave{background:#7138f5;color:white}.roomActions button:disabled{opacity:.5}.roomReadOnly{margin:9px 2px 2px;font-size:10px;color:#87737f;text-align:center}
+      @media(max-width:520px){.roomHeading{align-items:flex-start;flex-direction:column;gap:3px}.roomCanvasWrap{min-height:300px}.roomControls{grid-template-columns:repeat(4,1fr)}.roomControls button{min-height:58px}.roomActions{grid-template-columns:1fr 1.8fr}}
+    `}</style>
+  </section>;
+}

--- a/app/vault/rentals/RentalDecoratorPreview.js
+++ b/app/vault/rentals/RentalDecoratorPreview.js
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import BasicRoomDecorator from './BasicRoomDecorator';
+
+const demoItems = [
+  { id: 'preview-sofa', name: 'Sofa', modelUrl: '', placedTransform: { position: [-1.15, 0, -.4], rotation: [0, 0, 0], scale: [1.3, 1.3, 1.3] } },
+  { id: 'preview-plant', name: 'Plant', modelUrl: '', placedTransform: { position: [1.55, 0, -1.1], rotation: [0, .7, 0], scale: [.7, .7, .7] } },
+  { id: 'preview-art', name: 'Art', modelUrl: '', placedTransform: { position: [.45, 0, 1.05], rotation: [0, -.4, 0], scale: [.55, .55, .55] } },
+];
+
+export default function RentalDecoratorPreview() {
+  const [photoUrl, setPhotoUrl] = useState('');
+  const [message, setMessage] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => () => {
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+  }, [photoUrl]);
+
+  function choosePhoto() {
+    inputRef.current?.click();
+  }
+
+  function selectPhoto(event) {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) return;
+    if (!String(file.type || '').startsWith('image/') && !/\.(heic|heif)$/i.test(String(file.name || ''))) {
+      setMessage('Choose a room image.');
+      return;
+    }
+    if (file.size > 12 * 1024 * 1024) {
+      setMessage('Choose an image smaller than 12 MB.');
+      return;
+    }
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+    setPhotoUrl(URL.createObjectURL(file));
+    setMessage('Preview photo loaded on this device only. A real renter upload is saved privately after lease verification.');
+  }
+
+  return <section className="preview">
+    <div className="previewHead">
+      <div><span>TRY IT · PREVIEW ONLY</span><h2>See the renter room.</h2></div>
+      <b>NO LEASE CREATED</b>
+    </div>
+    <p className="intro">This lets you inspect the interior flow right now. Nothing here creates tenancy, saves rent, or changes a real property.</p>
+
+    <div className="photo">
+      {photoUrl ? <img src={photoUrl} alt="Local room preview"/> : <div><strong>＋ Upload a room image</strong><small>Use a photo or screenshot as your visual reference.</small></div>}
+      <span>ROOM REFERENCE · NOT VERIFIED FLOOR PLAN</span>
+    </div>
+    <input ref={inputRef} className="hidden" type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
+    <button className="upload" type="button" onClick={choosePhoto}>{photoUrl ? 'Choose another room image' : 'Upload room image'}</button>
+
+    <BasicRoomDecorator
+      items={demoItems}
+      editable
+      savingId=""
+      onSave={() => setMessage('Preview layout looks good. Real renter layouts save privately to that verified lease.')}
+    />
+
+    {message ? <div className="msg" role="status">{message}</div> : null}
+    <p className="truth">The colored preview blocks stand in for minted VoxelPop GLBs. In a real rental, the renter’s verified minted 3D models are loaded instead.</p>
+
+    <style jsx>{`
+      .preview{margin-top:18px;border-radius:34px;padding:18px;background:rgba(255,255,255,.78);border:2px dashed rgba(113,56,245,.2);box-shadow:0 18px 45px rgba(83,54,34,.07)}
+      .previewHead{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}.previewHead span{font-size:9px;letter-spacing:.15em;font-weight:950;color:#7138f5}.previewHead h2{margin:4px 0 0;font-size:28px;letter-spacing:-.045em}.previewHead b{border-radius:999px;background:#efe9ff;color:#7138f5;padding:8px 10px;font-size:8px;letter-spacing:.08em;white-space:nowrap}.intro{margin:9px 0 14px;color:#79645a;font-size:13px;line-height:1.5;font-weight:650}
+      .photo{position:relative;overflow:hidden;border-radius:24px;background:#2e174d;min-height:180px}.photo img{display:block;width:100%;height:220px;object-fit:cover}.photo>div{min-height:190px;display:grid;place-content:center;text-align:center;color:#fffaf0}.photo strong{font-size:21px}.photo small{margin-top:5px;color:#d9cbea}.photo>span{position:absolute;left:10px;bottom:10px;border-radius:999px;background:rgba(255,250,240,.94);color:#614f47;padding:8px 10px;font-size:8px;letter-spacing:.07em;font-weight:950}.hidden{display:none}.upload{width:100%;min-height:50px;margin-top:9px;border:0;border-radius:17px;background:#7138f5;color:white;font-weight:950;font-size:13px}.msg{margin-top:10px;border-radius:16px;padding:11px 13px;background:#3b254e;color:white;font-size:11px;font-weight:750}.truth{margin:10px 3px 0;color:#8a756c;font-size:10px;line-height:1.45;font-weight:650}
+      @media(max-width:520px){.preview{padding:13px;border-radius:28px}.previewHead{flex-direction:column;gap:6px}.photo img{height:195px}}
+    `}</style>
+  </section>;
+}

--- a/app/vault/rentals/RentalRoomPanel.js
+++ b/app/vault/rentals/RentalRoomPanel.js
@@ -1,0 +1,228 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import BasicRoomDecorator from './BasicRoomDecorator';
+
+function isHeic(file) {
+  return /image\/(heic|heif)/i.test(String(file?.type || '')) || /\.(heic|heif)$/i.test(String(file?.name || ''));
+}
+
+function supportedPhoto(file) {
+  return ['image/jpeg', 'image/png', 'image/webp'].includes(String(file?.type || '').toLowerCase()) || isHeic(file);
+}
+
+async function normalizeIphonePhoto(file) {
+  if (!isHeic(file)) return file;
+  const url = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = url;
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = () => reject(new Error('HEIC preview could not be decoded.'));
+    });
+    const maxEdge = 2400;
+    const scale = Math.min(1, maxEdge / Math.max(image.naturalWidth || 1, image.naturalHeight || 1));
+    const width = Math.max(1, Math.round((image.naturalWidth || 1) * scale));
+    const height = Math.max(1, Math.round((image.naturalHeight || 1) * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Photo conversion is unavailable on this device.');
+    context.drawImage(image, 0, 0, width, height);
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', .92));
+    if (!blob) throw new Error('Photo conversion failed.');
+    const name = String(file.name || 'room-photo.heic').replace(/\.(heic|heif)$/i, '.jpg');
+    return new File([blob], name || 'room-photo.jpg', { type: 'image/jpeg', lastModified: Date.now() });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export default function RentalRoomPanel({ session, lease, attachments = [], voxelBySession, editable = false, onRefresh }) {
+  const [reference, setReference] = useState(null);
+  const [setupRequired, setSetupRequired] = useState(false);
+  const [pendingPhoto, setPendingPhoto] = useState(null);
+  const [pendingPreview, setPendingPreview] = useState('');
+  const [rightsConfirmed, setRightsConfirmed] = useState(false);
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('');
+  const inputRef = useRef(null);
+
+  const roomItems = useMemo(() => attachments.map((attachment) => {
+    const voxel = voxelBySession?.get?.(attachment.voxel_session_id);
+    return {
+      id: attachment.id,
+      name: attachment.voxel_name || voxel?.name || 'Voxel',
+      modelUrl: voxel?.modelUrl || '',
+      image: voxel?.image || '',
+      placedTransform: attachment.placed_transform || null,
+    };
+  }), [attachments, voxelBySession]);
+
+  useEffect(() => {
+    if (!session?.access_token || !lease?.id) return;
+    let active = true;
+    fetch(`/api/vault/rentals/${encodeURIComponent(lease.id)}/room-photo`, {
+      cache: 'no-store',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    }).then(async (response) => {
+      const data = await response.json().catch(() => ({}));
+      if (!active) return;
+      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Room photo could not be loaded.');
+      setReference(data?.reference || null);
+      setSetupRequired(data?.setupRequired === true);
+    }).catch((error) => {
+      if (active) setMessage(error instanceof Error ? error.message : 'Room photo could not be loaded.');
+    });
+    return () => { active = false; };
+  }, [session?.access_token, lease?.id]);
+
+  useEffect(() => () => {
+    if (pendingPreview) URL.revokeObjectURL(pendingPreview);
+  }, [pendingPreview]);
+
+  function choosePhoto() {
+    inputRef.current?.click();
+  }
+
+  async function selectPhoto(event) {
+    const selected = event.target.files?.[0];
+    event.target.value = '';
+    if (!selected) return;
+    if (!supportedPhoto(selected)) return setMessage('Choose a JPG, PNG, WebP, HEIC, or HEIF room photo.');
+    if (selected.size > 12 * 1024 * 1024) return setMessage('Choose a room photo smaller than 12 MB.');
+    setBusy('prepare');
+    setMessage(isHeic(selected) ? 'Preparing your iPhone room photo…' : 'Preparing your room photo…');
+    try {
+      const photo = await normalizeIphonePhoto(selected);
+      if (photo.size > 8 * 1024 * 1024) throw new Error('This room photo is still too large. Try a screenshot or smaller version.');
+      if (pendingPreview) URL.revokeObjectURL(pendingPreview);
+      setPendingPhoto(photo);
+      setPendingPreview(URL.createObjectURL(photo));
+      setRightsConfirmed(false);
+      setMessage('Photo ready. Confirm you can use it, then save it to this rental.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'This iPhone photo could not be prepared. A screenshot will work too.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function uploadPhoto() {
+    if (!session?.access_token || !lease?.id || !pendingPhoto) return;
+    if (!rightsConfirmed) return setMessage('Confirm that you took this room photo or have permission to use it.');
+    setBusy('upload');
+    setMessage('Saving your room photo privately…');
+    try {
+      const form = new FormData();
+      form.append('photo', pendingPhoto);
+      form.append('rightsConfirmed', 'true');
+      const response = await fetch(`/api/vault/rentals/${encodeURIComponent(lease.id)}/room-photo`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        body: form,
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Room photo could not be saved.');
+      setReference(data.reference || null);
+      setSetupRequired(false);
+      setPendingPhoto(null);
+      if (pendingPreview) URL.revokeObjectURL(pendingPreview);
+      setPendingPreview('');
+      setRightsConfirmed(false);
+      setMessage('Room photo saved privately. Use it as your visual guide while decorating.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Room photo could not be saved.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function removePhoto() {
+    if (!session?.access_token || !lease?.id) return;
+    setBusy('remove-photo');
+    setMessage('');
+    try {
+      const response = await fetch(`/api/vault/rentals/${encodeURIComponent(lease.id)}/room-photo`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok === false) throw new Error(data?.error || 'Room photo could not be removed.');
+      setReference(null);
+      setMessage('Room reference removed. Your saved voxel layout is unchanged.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Room photo could not be removed.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function saveLayout(attachmentId, transform) {
+    if (!session?.access_token || !lease?.id || !attachmentId) return;
+    setBusy(`layout:${attachmentId}`);
+    setMessage('Saving room layout…');
+    try {
+      const response = await fetch(`/api/vault/rentals/${encodeURIComponent(lease.id)}/attachments`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ attachmentId, transform }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok === false || data?.transformBounded !== true) throw new Error(data?.error || 'Room layout could not be saved.');
+      setMessage('Layout saved. This only changes your renter decoration layer.');
+      await onRefresh?.();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Room layout could not be saved.');
+    } finally {
+      setBusy('');
+    }
+  }
+
+  const visualUrl = pendingPreview || reference?.url || '';
+
+  return <section className="rentalRoomPanel">
+    <div className="roomIntro">
+      <div><span>DECORATE</span><h3>Make the room yours.</h3></div>
+      <small>Private tenant layer</small>
+    </div>
+
+    <div className="roomPhotoCard">
+      {visualUrl ? <img src={visualUrl} alt="Private renter-supplied room reference"/> : <div className="photoBlank"><b>＋ Room photo</b><span>Optional visual reference</span></div>}
+      <div className="photoBadge">ROOM REFERENCE · NOT VERIFIED FLOOR PLAN</div>
+    </div>
+
+    <input ref={inputRef} className="hiddenInput" type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
+
+    {pendingPhoto ? <div className="photoConfirm">
+      <label><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
+      <button type="button" onClick={uploadPhoto} disabled={!rightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Saving…' : 'Use this room photo'}</button>
+      <button type="button" className="quiet" onClick={choosePhoto}>Choose another</button>
+    </div> : <div className="photoActions">
+      <button type="button" onClick={choosePhoto} disabled={!editable || busy === 'prepare'}>{busy === 'prepare' ? 'Preparing…' : reference ? 'Replace room photo' : 'Upload room photo'}</button>
+      {reference ? <button type="button" className="quiet" onClick={removePhoto} disabled={busy === 'remove-photo'}>{busy === 'remove-photo' ? 'Removing…' : 'Remove photo'}</button> : null}
+    </div>}
+
+    {setupRequired ? <p className="setupNote">Room-photo storage is ready in code but migration 021 still needs to be applied in this environment.</p> : null}
+    <p className="photoTruth">Your upload stays private and is only a decoration reference. It does not become property evidence, a lease document, or canonical building geometry.</p>
+
+    <BasicRoomDecorator
+      items={roomItems}
+      editable={editable}
+      savingId={busy.startsWith('layout:') ? busy.slice('layout:'.length) : ''}
+      onSave={saveLayout}
+    />
+
+    {message ? <div className="roomMessage" role="status">{message}</div> : null}
+
+    <style jsx>{`
+      .rentalRoomPanel{margin-top:18px;border-radius:28px;background:#fff7ef;padding:14px;border:1px solid rgba(72,45,35,.08)}
+      .roomIntro{display:flex;align-items:flex-end;justify-content:space-between;gap:12px;padding:4px 3px 11px}.roomIntro span{font-size:9px;letter-spacing:.15em;font-weight:950;color:#7138f5}.roomIntro h3{margin:3px 0 0;font-size:22px;letter-spacing:-.04em}.roomIntro small{font-size:10px;color:#8b756c;font-weight:750}
+      .roomPhotoCard{position:relative;min-height:170px;border-radius:22px;overflow:hidden;background:#2e174d}.roomPhotoCard img{display:block;width:100%;height:230px;object-fit:cover}.photoBlank{min-height:190px;display:grid;place-content:center;text-align:center;color:#fffaf0}.photoBlank b{font-size:22px}.photoBlank span{font-size:11px;margin-top:4px;color:#ded0ef}.photoBadge{position:absolute;left:10px;bottom:10px;max-width:calc(100% - 20px);border-radius:999px;padding:8px 10px;background:rgba(255,250,240,.92);color:#614f47;font-size:8px;letter-spacing:.08em;font-weight:950}
+      .hiddenInput{display:none}.photoActions,.photoConfirm{display:grid;gap:8px;margin-top:10px}.photoActions{grid-template-columns:1fr auto}.photoActions button,.photoConfirm button{min-height:46px;border:0;border-radius:16px;padding:0 16px;background:#7138f5;color:white;font-size:12px;font-weight:950}.photoActions .quiet,.photoConfirm .quiet{background:#eee6e0;color:#66524a}.photoConfirm label{display:flex;align-items:flex-start;gap:10px;padding:12px;border-radius:16px;background:white;color:#67534b;font-size:12px;font-weight:750;line-height:1.35}.photoConfirm input{width:19px;height:19px;flex:0 0 auto}.photoTruth,.setupNote{margin:9px 3px 0;font-size:10px;line-height:1.45;color:#89746a;font-weight:650}.setupNote{padding:10px 12px;border-radius:14px;background:#fff0c8;color:#755b45}.roomMessage{margin-top:10px;border-radius:15px;background:#3b254e;color:white;padding:10px 12px;font-size:11px;font-weight:750;line-height:1.4}
+      @media(max-width:520px){.roomIntro{align-items:flex-start;flex-direction:column;gap:2px}.roomPhotoCard img{height:200px}.photoActions{grid-template-columns:1fr}.photoActions button,.photoConfirm button{min-height:50px}}
+    `}</style>
+  </section>;
+}

--- a/app/vault/rentals/page.js
+++ b/app/vault/rentals/page.js
@@ -6,6 +6,7 @@ import { getWallet } from '../../../lib/blockchain';
 import { tenantVoxelOwnershipMessage } from '../../../lib/real-estate/property-rental';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
 import { loadAccountVoxels, summarizeVoxel } from '../../../lib/voxelpop-account';
+import RentalDecoratorPreview from './RentalDecoratorPreview';
 import RentalRoomPanel from './RentalRoomPanel';
 import styles from './rentals.module.css';
 
@@ -214,6 +215,8 @@ export default function RentalsPage() {
         <p>A property appears here only after a real rental agreement is verified. Uploading or minting a house does not make you its tenant.</p>
         <Link className={styles.linkButton} href="/property">Explore a property</Link>
       </section> : null}
+
+      {authReady && !leases.length && busy !== 'load' ? <RentalDecoratorPreview/> : null}
 
       <div className={styles.leaseList}>
         {leases.map((lease) => {

--- a/app/vault/rentals/page.js
+++ b/app/vault/rentals/page.js
@@ -6,6 +6,7 @@ import { getWallet } from '../../../lib/blockchain';
 import { tenantVoxelOwnershipMessage } from '../../../lib/real-estate/property-rental';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
 import { loadAccountVoxels, summarizeVoxel } from '../../../lib/voxelpop-account';
+import RentalRoomPanel from './RentalRoomPanel';
 import styles from './rentals.module.css';
 
 function money(minor, currency = 'USD') {
@@ -186,11 +187,11 @@ export default function RentalsPage() {
       <header className={styles.header}>
         <div className={styles.kicker}>MY VAULT · RENTED</div>
         <h1>Your place.<br/><em>Your voxels.</em></h1>
-        <p>A verified rental can live in your Vault while you are the tenant. Your own minted voxels can move in with you.</p>
+        <p>A verified rental can live in your Vault while you are the tenant. Upload a room reference and move your own minted voxels into a private decoration layer.</p>
       </header>
 
       <div className={styles.flow} aria-label="Rental flow">
-        <span>LEASE</span><i>→</i><span>PAY MONTHLY</span><i>→</i><span>DECORATE</span><i>→</i><span>MOVE OUT</span>
+        <span>LEASE</span><i>→</i><span>PAY MONTHLY</span><i>→</i><span>UPLOAD ROOM</span><i>→</i><span>DECORATE</span><i>→</i><span>MOVE OUT</span>
       </div>
 
       {!authReady || busy === 'load' ? <div className={styles.empty}>Loading your rented properties…</div> : null}
@@ -198,7 +199,7 @@ export default function RentalsPage() {
       {authReady && !session?.user ? <section className={styles.signinCard}>
         <div className={styles.bigIcon}>⌂</div>
         <h2>Sign in to see rentals.</h2>
-        <p>Lease and payment details stay private to your signed-in account.</p>
+        <p>Lease, payment and private room-reference details stay inside your signed-in account.</p>
         <button onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening…' : 'Sign in with Google'}</button>
       </section> : null}
 
@@ -258,6 +259,15 @@ export default function RentalsPage() {
                   </button>) : <div className={styles.pickerEmpty}>No unused minted voxels yet. <Link href="/studio">Create one →</Link></div>}
                 </div> : null}
 
+                <RentalRoomPanel
+                  session={session}
+                  lease={lease}
+                  attachments={attached}
+                  voxelBySession={voxelBySession}
+                  editable={editable}
+                  onRefresh={() => refreshAll()}
+                />
+
                 {attached.length ? <div className={styles.attachedGrid}>
                   {attached.map((attachment) => {
                     const voxel = voxelBySession.get(attachment.voxel_session_id);
@@ -280,7 +290,7 @@ export default function RentalsPage() {
       </div>
 
       {message ? <div className={styles.message} role="status">{message}</div> : null}
-      <footer className={styles.truth}>A Rental Pass or voxel layer records digital access/status only. It is not the lease itself, does not replace landlord-tenant law, and cannot automatically evict a tenant.</footer>
+      <footer className={styles.truth}>Room photos and voxel placements are private renter decoration references. A Rental Pass or voxel layer is not the lease itself, does not replace landlord-tenant law, and cannot automatically evict a tenant.</footer>
     </section>
   </main>;
 }

--- a/lib/voxelpop-account.ts
+++ b/lib/voxelpop-account.ts
@@ -145,6 +145,7 @@ export function summarizeVoxel(record: AccountVoxel) {
     sessionId: normalized.sessionId,
     name: String(normalized.payload.asset?.name || 'Your voxel'),
     image: String(normalized.payload.asset?.dataUrl || ''),
+    modelUrl: String(normalized.payload.mesh?.modelUrl || ''),
     meshStatus: String(normalized.payload.mesh?.status || 'idle'),
     mint: normalized.payload.mint || null,
   };

--- a/scripts/test-global-rent-engine.mjs
+++ b/scripts/test-global-rent-engine.mjs
@@ -94,11 +94,16 @@ assert.equal(truth.latePaymentEndsTenancy, false, 'late payment cannot itself te
 assert.equal(truth.attachmentRequiresWalletOwnershipProof, true, 'permanent tenant placement must require current wallet ownership proof');
 assert.equal(truth.tenantKeepsOwnedVoxelAfterLease, true, 'renter keeps separately owned voxels after lease end');
 
-const [migration, tenantApi, adminApi, rentalPage, productMap, rentalDocs] = await Promise.all([
+const [migration, roomMigration, tenantApi, roomPhotoApi, adminApi, rentalPage, roomPanel, roomDecorator, voxelAccount, productMap, rentalDocs] = await Promise.all([
   source('../supabase/migrations/020_property_rentals.sql'),
+  source('../supabase/migrations/021_rental_room_references.sql'),
   source('../app/api/vault/rentals/[leaseId]/attachments/route.ts'),
+  source('../app/api/vault/rentals/[leaseId]/room-photo/route.ts'),
   source('../app/api/admin/rentals/route.ts'),
   source('../app/vault/rentals/page.js'),
+  source('../app/vault/rentals/RentalRoomPanel.js'),
+  source('../app/vault/rentals/BasicRoomDecorator.js'),
+  source('../lib/voxelpop-account.ts'),
   source('../lib/product-map.js'),
   source('../docs/PROPERTY_RENTALS.md'),
 ]);
@@ -107,11 +112,28 @@ assert.match(migration, /status <> 'ended'[\s\S]*termination_verified_at is not 
 assert.doesNotMatch(migration, /for insert to authenticated|for update to authenticated|for delete to authenticated/i, 'tenants must not self-verify or mutate authoritative lease/payment rows directly');
 assert.match(migration, /ownership_proof_hash/, 'tenant placement must retain a non-secret audit hash of wallet ownership proof');
 assert.match(migration, /ownership_verified_at/, 'tenant placement must record when wallet ownership was checked');
+assert.match(migration, /placed_transform jsonb/, 'tenant attachment schema must have a private placement transform');
+assert.match(roomMigration, /vault_rental_room_references/, 'room references must live in a separate private rental table');
+assert.match(roomMigration, /No authenticated client write policy/i, 'room-photo writes must stay behind signed-in server verification');
+assert.match(roomMigration, /not public property evidence|not.*verified floor plans/i, 'room photo schema must deny property/floor-plan truth semantics');
+
 assert.match(tenantApi, /loadAccountVoxel/, 'tenant attachment API must bind placement to the signed-in account voxel record');
 assert.match(tenantApi, /verifyMessage/, 'tenant attachment API must verify a wallet signature server-side');
 assert.match(tenantApi, /ownerOf/, 'tenant attachment API must check current on-chain token ownership');
 assert.match(tenantApi, /walletOwnershipVerified:\s*true/, 'permanent attachment may pass only after wallet and chain verification');
 assert.match(tenantApi, /ownershipVerifiedOnChain:\s*true/, 'successful attachment response must disclose that current chain ownership was verified');
+assert.match(tenantApi, /export async function PATCH/, 'tenant attachment API must support saving decoration placement');
+assert.match(tenantApi, /position:\s*\[clamp\([\s\S]*-3\.45, 3\.45\)[\s\S]*-2\.45, 2\.45\)/, 'room placement positions must be bounded server-side');
+assert.match(tenantApi, /scale:\s*\[uniformScale, uniformScale, uniformScale\]/, 'room placement scale must be normalized server-side');
+assert.match(tenantApi, /Canonical property geometry is unchanged/i, 'layout save must deny edits to canonical property truth');
+
+assert.match(roomPhotoApi, /requireVoxelVaultUser/, 'room photo upload must require the signed-in renter');
+assert.match(roomPhotoApi, /canTenantUseProperty/, 'room photo upload must require verified active tenant rights');
+assert.match(roomPhotoApi, /rightsConfirmed/, 'room photo upload must require explicit photo rights confirmation');
+assert.match(roomPhotoApi, /public:\s*false/, 'room photos must use private storage');
+assert.match(roomPhotoApi, /createSignedUrl/, 'room photo viewing must use temporary signed URLs');
+assert.match(roomPhotoApi, /not a verified floor plan or canonical property geometry/i, 'room photo API must label the upload as reference-only');
+
 assert.match(adminApi, /requireVoxelVaultAdmin/, 'lease/payment reconciliation must be owner/provider-gated');
 assert.match(adminApi, /automaticEviction:\s*false/, 'admin rental API must explicitly deny automatic eviction semantics');
 assert.match(adminApi, /status:\s*'archived'/, 'verified lease end archives tenant placements instead of deleting assets');
@@ -119,9 +141,25 @@ assert.match(rentalPage, /does not automatically evict/i, 'renter UI must explai
 assert.match(rentalPage, /getWallet/, 'renter must explicitly connect/sign with the current token-owning wallet before placement');
 assert.match(rentalPage, /On-chain ownership was checked/i, 'renter UI must disclose successful current-owner verification');
 assert.match(rentalPage, /PAY MONTHLY/, 'renter UI should keep the monthly payment flow simple and visible');
+assert.match(rentalPage, /UPLOAD ROOM/, 'renter flow must expose room photo upload before decoration');
+assert.match(rentalPage, /RentalRoomPanel/, 'rented property page must include the room decoration experience');
+
+assert.match(roomPanel, /Upload room photo/, 'room panel must offer a clear image upload action');
+assert.match(roomPanel, /image\/\*,\.heic,\.heif/, 'room upload picker should support iPhone photo selection');
+assert.match(roomPanel, /I took this photo or have permission to use it/, 'room upload must confirm user rights after preview');
+assert.match(roomPanel, /ROOM REFERENCE · NOT VERIFIED FLOOR PLAN/, 'room upload must visibly deny floor-plan verification');
+assert.match(roomPanel, /method:\s*'PATCH'/, 'room panel must persist selected voxel placement');
+assert.match(roomPanel, /only changes your renter decoration layer/i, 'room panel must explain saved layout is tenant-only');
+
+assert.match(roomDecorator, /BASIC ROOM · DECORATION LAYER/, 'decorator must label the approximate basic room');
+assert.match(roomDecorator, /Not a verified floor plan/, 'decorator must deny exact floor-plan truth');
+assert.match(roomDecorator, /Save layout/, 'decorator must provide an explicit touch-friendly persistence action');
+assert.match(roomDecorator, /DRAG TO TURN ROOM · PINCH TO ZOOM · TAP A VOXEL/, 'decorator must expose mobile 3D controls');
+assert.match(voxelAccount, /modelUrl:\s*String\(normalized\.payload\.mesh\?\.modelUrl/, 'rental room must receive ready VoxelPop GLB URLs when available');
+
 assert.match(productMap, /href: '\/vault\/rentals', label: 'Rented'/, 'Rented must be discoverable from the simple VoxelPop property dock');
 assert.match(productMap, /path === '\/vault\/rentals'/, 'Rented must stay inside the simplified property navigation mode');
 assert.match(rentalDocs, /does \*\*not\*\* yet provide:[\s\S]*production e-signature provider/i, 'docs must fail closed about legal lease execution');
 assert.match(rentalDocs, /late rent does not automatically end tenancy/i, 'docs must preserve lawful termination boundary');
 
-console.log('Global rent + legal tenant-layer safety checks passed: verified lease -> monthly status -> Rented Vault -> wallet-owned minted voxels -> lawful lease end/archive, never automatic eviction.');
+console.log('Global rent + room decorator safety checks passed: verified lease -> monthly status -> private room reference -> wallet-owned minted voxels -> bounded tenant layout -> lawful lease end/archive, never automatic eviction or fake floor-plan truth.');

--- a/supabase/migrations/021_rental_room_references.sql
+++ b/supabase/migrations/021_rental_room_references.sql
@@ -1,0 +1,27 @@
+-- Private renter-supplied room photos used only as visual decoration references.
+-- These images are not public property evidence, verified floor plans, lease documents,
+-- deed evidence, or canonical building geometry.
+
+create table if not exists public.vault_rental_room_references (
+  lease_id uuid primary key references public.vault_property_leases(id) on delete cascade,
+  tenant_user_id uuid not null references auth.users(id) on delete cascade,
+  storage_path text not null check (char_length(storage_path) between 1 and 600),
+  content_type text not null default 'image/jpeg' check (char_length(content_type) between 3 and 80),
+  file_digest text not null check (char_length(file_digest) = 64),
+  rights_confirmed_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.vault_rental_room_references enable row level security;
+
+create policy "tenants read own room reference"
+on public.vault_rental_room_references
+for select to authenticated
+using (tenant_user_id = auth.uid());
+
+-- No authenticated client write policy. Uploads and replacements go through the
+-- signed-in server route, which verifies the tenant and active lease state first.
+
+create index if not exists vault_rental_room_references_tenant_idx
+  on public.vault_rental_room_references(tenant_user_id, updated_at desc);


### PR DESCRIPTION
## What this adds

A simple VoxelPop-style renter interior flow inside **My Vault → Rented**:

`Lease → Pay monthly → Upload room → Decorate → Move out`

### Private room image upload
- Signed-in tenant can upload a room photo from iPhone or desktop.
- Picker accepts `image/*`, HEIC and HEIF; HEIC/HEIF gets a browser JPEG conversion attempt before upload.
- User previews the image first, then confirms they took it or have permission to use it.
- Original room reference is stored privately in the existing `voxel-system` bucket and opened with a temporary signed URL.
- New migration `021_rental_room_references.sql` keeps the room reference separate from public property evidence and canonical geometry.
- Room photo is visibly labeled **ROOM REFERENCE · NOT VERIFIED FLOOR PLAN**.

### Basic 3D room decorator
- Adds a lightweight iPhone-friendly Three.js room rather than inventing a full property floor plan.
- Attached renter voxels use their real VoxelPop GLB when a ready model exists; otherwise a placeholder is shown.
- Tap/select an item, then move left/right/forward/back, rotate, resize, reset, and **Save layout**.
- Existing `placed_transform` is now used for private position / rotation / scale persistence.
- Server clamps all saved transforms to the Basic Room bounds; the client cannot write arbitrary scene data.

### Rental + ownership safety preserved
- Only a verified active tenant layer can upload/replace a room reference or save placements.
- Permanent voxel attachment still requires the signed-in Creator Gallery mint, wallet signature, and current on-chain `ownerOf` verification.
- Late rent still does not automatically evict or end tenancy.
- Ending a lease archives the tenant layer; renter-owned voxels remain the renter's separate assets.
- Room photos and placements never modify the canonical property model, deed/title truth, or legal lease.

### Regression protection
The existing `test:global-rent` gate now asserts room-photo privacy, upload rights confirmation, iPhone picker support, floor-plan disclaimers, bounded transform persistence, mobile decorator controls, and canonical-geometry separation.