### PR TITLE
Start voxel creation immediately after property photo approval

### DIFF
--- a/app/property/page.js
+++ b/app/property/page.js
@@ -85,6 +85,7 @@ export default function SimplePropertyPage() {
   const [pendingPhoto, setPendingPhoto] = useState(null);
   const [pendingPreview, setPendingPreview] = useState('');
   const [uploadRightsConfirmed, setUploadRightsConfirmed] = useState(false);
+  const [autoCreateAfterPhoto, setAutoCreateAfterPhoto] = useState(false);
   const [voxelImage, setVoxelImage] = useState('');
   const [model, setModel] = useState(emptyModel);
   const [busy, setBusy] = useState('');
@@ -162,6 +163,12 @@ export default function SimplePropertyPage() {
   }, []);
 
   useEffect(() => {
+    if (!autoCreateAfterPhoto || !building?.atlasId || !activeReference || !session?.access_token) return;
+    setAutoCreateAfterPhoto(false);
+    void createImage();
+  }, [autoCreateAfterPhoto, building?.atlasId, activeReference, session?.access_token]);
+
+  useEffect(() => {
     if (!model?.taskId || model?.modelUrl || terminal(model?.status) || !session?.access_token) return undefined;
     let active = true;
     let timer = null;
@@ -220,6 +227,7 @@ export default function SimplePropertyPage() {
     const address = clean(value);
     if (!address) return;
     imageIterationRef.current += 1;
+    setAutoCreateAfterPhoto(false);
     setBusy('search');
     clearPendingPhoto();
     setBuilding(null);
@@ -305,7 +313,8 @@ export default function SimplePropertyPage() {
       setVoxelImage('');
       setModel(emptyModel());
       setSaved(null);
-      setMessage('Photo locked in. Now make the voxel first.');
+      setAutoCreateAfterPhoto(true);
+      setMessage('Photo saved. Making your voxel now…');
     } catch (error) { setMessage(String(error?.message || error)); }
     finally { setBusy(''); }
   }
@@ -319,7 +328,8 @@ export default function SimplePropertyPage() {
     setVoxelImage('');
     setModel(emptyModel());
     setSaved(null);
-    setMessage('Photo locked in. Now make the voxel first.');
+    setAutoCreateAfterPhoto(true);
+    setMessage('Street photo selected. Making your voxel now…');
   }
 
   async function createImage() {
@@ -397,6 +407,7 @@ export default function SimplePropertyPage() {
 
   function changePhoto() {
     imageIterationRef.current += 1;
+    setAutoCreateAfterPhoto(false);
     clearPendingPhoto();
     setStreetPhotoChosen(false);
     setUploadedReference(null);
@@ -408,6 +419,7 @@ export default function SimplePropertyPage() {
 
   function changeProperty() {
     imageIterationRef.current += 1;
+    setAutoCreateAfterPhoto(false);
     clearPendingPhoto();
     setBuilding(null);
     setResolvedQuery('');
@@ -423,6 +435,7 @@ export default function SimplePropertyPage() {
 
   const modelRunning = Boolean(model?.taskId && !model?.modelUrl && !terminal(model?.status));
   const photoChosen = Boolean(uploadedReference || streetPhotoChosen);
+  const imageStarting = autoCreateAfterPhoto || busy === 'image';
   const stage = !building ? 1 : model?.modelUrl ? (saved ? 6 : 5) : modelRunning ? 4 : (pendingPhoto || !photoChosen) ? 2 : !voxelImage ? 3 : 4;
   const displayImage = model?.modelUrl ? '' : voxelImage || pendingPreview || activePhoto?.imageUrl || '';
   const photoDate = readableDate(activePhoto?.shotDate);
@@ -488,7 +501,7 @@ export default function SimplePropertyPage() {
           <p className={styles.bigPrompt}>Pick the clearest photo.</p>
           <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectLocalPhoto}/>
           <button className={styles.primaryPurple} type="button" onClick={chooseUpload} disabled={busy === 'prepare-photo'}>{busy === 'prepare-photo' ? 'Preparing photo…' : 'Upload your photo'}</button>
-          {activeReference ? <button className={styles.secondaryButton} type="button" onClick={useStreetPhoto}>Use this street photo</button> : null}
+          {activeReference ? <button className={styles.secondaryButton} type="button" onClick={useStreetPhoto}>Use this street photo → make voxel</button> : null}
           <small>iPhone photos supported · JPG, PNG, WebP, HEIC/HEIF</small>
         </div> : null}
 
@@ -498,15 +511,15 @@ export default function SimplePropertyPage() {
             <input type="checkbox" checked={uploadRightsConfirmed} onChange={(event) => setUploadRightsConfirmed(event.target.checked)}/>
             <span>I took this photo or have permission to use it.</span>
           </label>
-          <button className={styles.primaryPurple} type="button" onClick={usePendingPhoto} disabled={!uploadRightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Saving photo…' : 'Use this photo'}</button>
+          <button className={styles.primaryPurple} type="button" onClick={usePendingPhoto} disabled={!uploadRightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Saving photo…' : 'Use this photo → make voxel'}</button>
           <button className={styles.textButton} type="button" onClick={chooseUpload}>Choose another</button>
         </div> : null}
 
         {stage === 3 ? <div className={styles.choicePanel}>
-          <p className={styles.bigPrompt}>Make the voxel first.</p>
-          <p className={styles.stepCopy}>We process the exact photo you chose into the VoxelPop image before 3D unlocks.</p>
-          <button className={styles.primaryOrange} type="button" onClick={createImage} disabled={busy === 'image'}>{busy === 'image' ? 'Making your voxel…' : 'Make my voxel'}</button>
-          <button className={styles.textButton} type="button" onClick={changePhoto} disabled={busy === 'image'}>Change photo</button>
+          <p className={styles.bigPrompt}>{imageStarting ? 'Making your voxel…' : 'Make the voxel first.'}</p>
+          <p className={styles.stepCopy}>{imageStarting ? 'Your photo is saved. VoxelPop is processing it now; the voxel image will appear here when it is ready.' : 'The automatic image step paused. Your photo is still saved—tap below to try the voxel again.'}</p>
+          <button className={styles.primaryOrange} type="button" onClick={createImage} disabled={imageStarting}>{imageStarting ? 'Making your voxel…' : 'Make my voxel'}</button>
+          <button className={styles.textButton} type="button" onClick={changePhoto} disabled={imageStarting}>Change photo</button>
         </div> : null}
 
         {stage === 4 ? <div className={styles.choicePanel}>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:hyperreal-voxel": "node scripts/test-hyperreal-voxel-building.mjs",
     "test:buffalo-reference": "node scripts/test-buffalo-property-reference.mjs",
     "test:property-draft-funnel": "node scripts/test-property-draft-funnel.mjs",
-    "test:simple-property-world": "node scripts/test-simple-property-world.mjs",
+    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs",
     "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs && node scripts/test-fractional-property-bridge.mjs && node scripts/test-algorand-position-verifier.mjs && node scripts/test-geo-property-onboarding.mjs && node scripts/test-geo-finish-polish.mjs && node scripts/test-geo-map-context.mjs && node scripts/test-geo-map-explorer.mjs && node scripts/test-buffalo-property-reference.mjs && node scripts/test-financial-os-coherence.mjs && node scripts/test-hyperreal-voxel-building.mjs && npm run test:property-draft-funnel && npm run test:simple-property-world",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:first-real-erie-parcel": "node scripts/test-first-real-erie-parcel-live.mjs",

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const property = fs.readFileSync(new URL('../app/property/page.js', import.meta.url), 'utf8');
+
+assert.match(property, /const \[autoCreateAfterPhoto, setAutoCreateAfterPhoto\] = useState\(false\)/, 'property flow must track automatic voxel start after photo approval');
+assert.match(property, /if \(!autoCreateAfterPhoto \|\| !building\?\.atlasId \|\| !activeReference \|\| !session\?\.access_token\) return;/, 'auto-start must wait for a signed-in account, property and exact selected reference');
+assert.match(property, /setAutoCreateAfterPhoto\(false\);\s*void createImage\(\);/, 'automatic photo handoff must invoke voxel image generation exactly once');
+assert.match(property, /setUploadedReference\(data\.reference\)[\s\S]{0,260}setAutoCreateAfterPhoto\(true\)/, 'approved uploaded photos must immediately schedule voxel generation');
+assert.match(property, /setStreetPhotoChosen\(true\)[\s\S]{0,220}setAutoCreateAfterPhoto\(true\)/, 'approved street references must immediately schedule voxel generation');
+assert.match(property, /Use this photo → make voxel/, 'uploaded-photo action must tell the user it starts the voxel step');
+assert.match(property, /Use this street photo → make voxel/, 'street-photo action must tell the user it starts the voxel step');
+assert.match(property, /Your photo is saved\. VoxelPop is processing it now/, 'the automatic transition must show a visible processing state');
+assert.match(property, /The automatic image step paused\. Your photo is still saved/, 'a failed auto-start must leave a clear manual retry path instead of a dead end');
+
+console.log('Property photo handoff regression passed: approving a photo immediately starts the signed-in voxel-image job with visible progress and a safe retry path.');


### PR DESCRIPTION
## Fix the dead-stop after “Use this photo”

The property maker previously saved the approved photo and then waited for a second manual tap on **Make my voxel**. On iPhone that looked like nothing happened.

### New flow
`Sign in → Address → Photo → Use this photo → voxel processing starts automatically → approve voxel → Make it 3D → Vault`

### Changes
- Approved uploaded photos immediately schedule the voxel-image job after the private upload succeeds.
- Rights-cleared street photos do the same.
- The UI switches directly to **Making your voxel…** and disables duplicate generation while the async image task runs.
- If automatic generation fails or pauses, the uploaded photo stays selected and a clear **Make my voxel** retry remains available.
- Existing account checks, rights confirmation, private storage, provider polling, voxel-before-3D ordering, and property truth boundaries remain unchanged.

### Regression protection
Adds a focused property-photo handoff test and runs it inside `test:simple-property-world`, which is already part of the property-platform quality gate.