### PR TITLE
Keep purchased VoxelPop models durable in the Vault

### DIFF
--- a/app/api/property-collectible/complete/route.ts
+++ b/app/api/property-collectible/complete/route.ts
@@ -7,6 +7,7 @@ import {
   secureStripePropertyCollectiblePurchase,
   verifyOwnedFinalVoxelModel,
 } from '../../../../lib/property-collectible-commerce';
+import { propertyCollectibleModelAccessPath } from '../../../../lib/property-collectible-model-access';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -36,6 +37,7 @@ export async function GET(request: Request) {
       draftId: purchase.draftId,
       modelTaskId: purchase.modelTaskId,
     });
+    const durableModelUrl = propertyCollectibleModelAccessPath(purchase.identityKey, purchase.modelTaskId);
 
     let building: any = {
       atlasId: purchase.atlasId,
@@ -72,8 +74,9 @@ export async function GET(request: Request) {
       model: {
         taskId: purchase.modelTaskId,
         itemId: verifiedModel.savedModel.item_id,
-        modelUrl: verifiedModel.modelUrl,
+        modelUrl: durableModelUrl,
         thumbnailUrl: verifiedModel.savedModel.thumbnail_url || null,
+        storage: verifiedModel.savedModel.model_storage_path ? 'private-persisted-glb' : 'provider-fallback',
       },
       next: {
         vault: '/vault/property-drafts',
@@ -81,7 +84,7 @@ export async function GET(request: Request) {
         world: '/world',
         verifyAndMint: '/vault/properties/claim',
       },
-      disclosure: 'Payment secured one digital VoxelPop collectible for this mapped World building identity. It does not transfer real property or create deed/title, rent, occupancy, investment or appreciation rights. Minting is optional and canonical property minting remains downstream of parcel verification.',
+      disclosure: 'Payment secured one digital VoxelPop collectible for this mapped World building identity. Its Vault model link re-issues short-lived access to the private persisted GLB instead of storing an expiring URL. It does not transfer real property or create deed/title, rent, occupancy, investment or appreciation rights. Minting is optional and canonical property minting remains downstream of parcel verification.',
     }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
   } catch (error) {
     const friendly = propertyCollectiblePaymentErrorMessage(error);

--- a/app/api/property-collectible/model/route.ts
+++ b/app/api/property-collectible/model/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { resolvePaidPropertyCollectibleModel } from '../../../../lib/property-collectible-model-access';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const resolved = await resolvePaidPropertyCollectibleModel({
+      identityKey: url.searchParams.get('identity'),
+      modelTaskId: url.searchParams.get('taskId'),
+      token: url.searchParams.get('token'),
+    });
+    return NextResponse.redirect(resolved.modelUrl, {
+      status: 307,
+      headers: {
+        'Cache-Control': 'private, no-store, max-age=0',
+        'Referrer-Policy': 'no-referrer',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Paid collectible model is unavailable.',
+    }, { status: 403, headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  }
+}

--- a/lib/property-collectible-model-access.ts
+++ b/lib/property-collectible-model-access.ts
@@ -1,0 +1,63 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createModelSignedUrl, readCatalog3DByTask } from './catalog3dStore';
+import { readPropertyCollectibleReservation } from './property-collectible-commerce';
+
+function clean(value: unknown, max = 300) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function signingSecret() {
+  const secret = process.env.STRIPE_SECRET_KEY?.trim();
+  if (!secret) throw new Error('Paid collectible model access is not configured on this deployment.');
+  return secret;
+}
+
+function payload(identityKey: string, modelTaskId: string) {
+  return `property-collectible-model-v1:${identityKey}:${modelTaskId}`;
+}
+
+export function createPropertyCollectibleModelToken(identityKeyRaw: unknown, modelTaskIdRaw: unknown) {
+  const identityKey = clean(identityKeyRaw, 100);
+  const modelTaskId = clean(modelTaskIdRaw, 260);
+  if (!identityKey || !modelTaskId) throw new Error('Paid collectible model identity is incomplete.');
+  return createHmac('sha256', signingSecret()).update(payload(identityKey, modelTaskId)).digest('hex');
+}
+
+export function propertyCollectibleModelAccessPath(identityKeyRaw: unknown, modelTaskIdRaw: unknown) {
+  const identityKey = clean(identityKeyRaw, 100);
+  const modelTaskId = clean(modelTaskIdRaw, 260);
+  const token = createPropertyCollectibleModelToken(identityKey, modelTaskId);
+  const query = new URLSearchParams({ identity: identityKey, taskId: modelTaskId, token });
+  return `/api/property-collectible/model?${query.toString()}`;
+}
+
+function tokenMatches(expected: string, suppliedRaw: unknown) {
+  const supplied = clean(suppliedRaw, 128);
+  if (!/^[a-f0-9]{64}$/i.test(supplied)) return false;
+  const expectedBytes = Buffer.from(expected, 'hex');
+  const suppliedBytes = Buffer.from(supplied, 'hex');
+  return expectedBytes.length === suppliedBytes.length && timingSafeEqual(expectedBytes, suppliedBytes);
+}
+
+export async function resolvePaidPropertyCollectibleModel(input: {
+  identityKey: unknown;
+  modelTaskId: unknown;
+  token: unknown;
+}) {
+  const identityKey = clean(input.identityKey, 100);
+  const modelTaskId = clean(input.modelTaskId, 260);
+  if (!identityKey || !modelTaskId) throw new Error('Paid collectible model identity is incomplete.');
+  const expected = createPropertyCollectibleModelToken(identityKey, modelTaskId);
+  if (!tokenMatches(expected, input.token)) throw new Error('Paid collectible model link is invalid.');
+
+  const reservation = await readPropertyCollectibleReservation(identityKey);
+  if (!reservation || !['paid', 'minted'].includes(reservation.state)) throw new Error('This digital collectible is not paid and available.');
+  if (reservation.modelTaskId !== modelTaskId) throw new Error('Paid collectible model does not match this purchase.');
+
+  const saved = await readCatalog3DByTask(modelTaskId);
+  if (!saved || (!saved.model_storage_path && !saved.model_url)) throw new Error('The persisted collectible model is unavailable.');
+  const signed = saved.model_storage_path ? await createModelSignedUrl(saved.model_storage_path, 5 * 60) : null;
+  const modelUrl = signed || saved.model_url || null;
+  if (!modelUrl) throw new Error('The persisted collectible model could not be opened.');
+  return { reservation, saved, modelUrl };
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:hyperreal-voxel": "node scripts/test-hyperreal-voxel-building.mjs",
     "test:buffalo-reference": "node scripts/test-buffalo-property-reference.mjs",
     "test:property-draft-funnel": "node scripts/test-property-draft-funnel.mjs",
-    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs",
+    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs",
     "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs && node scripts/test-fractional-property-bridge.mjs && node scripts/test-algorand-position-verifier.mjs && node scripts/test-geo-property-onboarding.mjs && node scripts/test-geo-finish-polish.mjs && node scripts/test-geo-map-context.mjs && node scripts/test-geo-map-explorer.mjs && node scripts/test-buffalo-property-reference.mjs && node scripts/test-financial-os-coherence.mjs && node scripts/test-hyperreal-voxel-building.mjs && npm run test:property-draft-funnel && npm run test:simple-property-world",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:first-real-erie-parcel": "node scripts/test-first-real-erie-parcel-live.mjs",

--- a/scripts/test-property-collectible-model-access.mjs
+++ b/scripts/test-property-collectible-model-access.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const access = fs.readFileSync(new URL('../lib/property-collectible-model-access.ts', import.meta.url), 'utf8');
+const route = fs.readFileSync(new URL('../app/api/property-collectible/model/route.ts', import.meta.url), 'utf8');
+const complete = fs.readFileSync(new URL('../app/api/property-collectible/complete/route.ts', import.meta.url), 'utf8');
+const success = fs.readFileSync(new URL('../app/property/success/page.js', import.meta.url), 'utf8');
+const store = fs.readFileSync(new URL('../lib/catalog3dStore.js', import.meta.url), 'utf8');
+
+assert.match(store, /public:\s*false/, 'persisted collectible GLBs must remain in the private system bucket');
+assert.match(store, /persistModelBinary/, 'generated GLBs must be persisted into owned storage');
+assert.match(store, /createModelSignedUrl/, 'private persisted GLBs must be opened through signed URLs');
+assert.match(access, /createHmac/, 'durable collectible model links must use an unguessable server HMAC');
+assert.match(access, /timingSafeEqual/, 'model access token comparison must be timing-safe');
+assert.match(access, /STRIPE_SECRET_KEY/, 'paid-model access token must derive from an existing server-only commerce secret');
+assert.match(access, /property-collectible-model-v1/, 'model access token must use a purpose-specific signing domain');
+assert.match(access, /readPropertyCollectibleReservation/, 'model access must re-check the durable paid reservation');
+assert.match(access, /\['paid', 'minted'\]\.includes\(reservation\.state\)/, 'unpaid reservations must never open collectible models');
+assert.match(access, /reservation\.modelTaskId !== modelTaskId/, 'model access must bind to the exact purchased model task');
+assert.match(access, /readCatalog3DByTask/, 'model access must resolve the persisted catalog row');
+assert.match(access, /createModelSignedUrl\(saved\.model_storage_path, 5 \* 60\)/, 'each open should issue a fresh short-lived private storage URL');
+assert.match(route, /resolvePaidPropertyCollectibleModel/, 'stable app model route must verify the opaque token and paid reservation');
+assert.match(route, /NextResponse\.redirect/, 'stable model URL should redirect to the freshly signed private GLB');
+assert.match(complete, /propertyCollectibleModelAccessPath/, 'post-payment delivery must return the durable opaque app model URL');
+assert.match(complete, /modelUrl: durableModelUrl/, 'success payload must not save an expiring storage URL as permanent Vault state');
+assert.match(success, /modelUrl: data\.model\.modelUrl/, 'Vault sync must preserve the durable paid model URL returned by completion');
+
+console.log('Paid collectible model access regression passed: private persisted GLB + durable opaque app link + paid reservation verification + fresh short-lived storage URL.');


### PR DESCRIPTION
## Fix purchased-model durability

PR #388 delivered the new photo → 3D → VoxelPop → World → buy & save journey. This small follow-up fixes one persistence detail found during post-merge hardening.

### Problem
The generated GLB is correctly persisted in the private `voxel-system` bucket, but purchase completion was saving a short-lived Supabase signed URL into Vault state. That URL can expire even though the purchased collectible still exists.

### Fix
- Add an opaque HMAC-signed paid-collectible model URL.
- The stable app URL re-verifies that the reservation is still `paid`/`minted` and that the model task matches the exact purchase.
- On every viewer open, the server issues a fresh 5-minute signed URL to the private persisted GLB and redirects the model loader to it.
- The storage bucket remains private.
- Purchase completion saves the durable opaque app URL instead of a one-hour storage URL.
- Add a regression test and run it inside the property-platform gate.

This changes model delivery only; it does not change the digital-only purchase rights boundary or optional downstream minting.