### PR TITLE
Remove source-photo storage blocker from VoxelPop property creation

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -1,168 +1,135 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
-import { getSupabaseAdminCandidates } from '../../../lib/supabase-admin';
-import { normalizePropertyDraftId } from '../../../lib/property-generation-ids';
+import { saveCatalog3D } from '../../../lib/catalog3dStore';
+import { normalizePropertyDraftId, propertyDraftItemId } from '../../../lib/property-generation-ids';
 
 export const runtime = 'nodejs';
-export const maxDuration = 60;
+export const maxDuration = 120;
 export const dynamic = 'force-dynamic';
 
-const BUCKET = 'voxel-system';
+const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_BYTES = 8 * 1024 * 1024;
-const ALLOWED_TYPES = new Map([
-  ['image/jpeg', 'jpg'],
-  ['image/png', 'png'],
-  ['image/webp', 'webp'],
-]);
-
-class PrivateStorageError extends Error {}
+const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
 function clean(value: unknown, max = 240) {
   return String(value || '').trim().slice(0, max);
 }
 
-function safeSegment(value: unknown, fallback = 'property') {
-  const text = clean(value, 180).replace(/[^a-zA-Z0-9_.:-]+/g, '-').replace(/^-+|-+$/g, '');
-  return text || fallback;
+function taskKey(raw: string) {
+  return raw.startsWith('property-voxel:task:') ? raw : `property-voxel:task:${raw}`;
 }
 
-function storageMessage(error: any) {
-  return String(error?.message || error?.error || error || '').slice(0, 500);
-}
-
-async function ensureBucket(admin: any) {
-  const { data, error } = await admin.storage.listBuckets();
-  if (error) {
-    console.error('Voxel Vault private storage bucket list failed', { message: storageMessage(error) });
-    throw new PrivateStorageError('Private photo storage is temporarily unavailable. Please try again in a moment.');
-  }
-  if (data?.some((bucket: any) => bucket.name === BUCKET)) return;
-
-  const created = await admin.storage.createBucket(BUCKET, { public: false, fileSizeLimit: '75MB' });
-  if (created.error && !/already exists|duplicate/i.test(storageMessage(created.error))) {
-    console.error('Voxel Vault private storage bucket creation failed', { message: storageMessage(created.error) });
-    throw new PrivateStorageError('Private photo storage needs server setup before uploads can continue.');
-  }
-}
-
-async function uploadPrivatePhoto(admin: any, path: string, bytes: Buffer, contentType: string) {
-  let lastError: any = null;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    await ensureBucket(admin);
-    const uploaded = await admin.storage.from(BUCKET).upload(path, bytes, {
-      contentType,
-      cacheControl: '0',
-      upsert: false,
-    });
-    if (!uploaded.error) return;
-    lastError = uploaded.error;
-    console.error('Voxel Vault private property photo upload failed', {
-      attempt: attempt + 1,
-      message: storageMessage(uploaded.error),
-    });
-    if (attempt === 0) await new Promise((resolve) => setTimeout(resolve, 180));
-  }
-  throw new PrivateStorageError(`Private photo storage could not save this upload. ${storageMessage(lastError) ? 'The storage service rejected the write.' : 'Please try again.'}`);
-}
-
-async function storeWithConfiguredServerCredential(path: string, bytes: Buffer, contentType: string) {
-  const candidates = getSupabaseAdminCandidates();
-  let lastError: unknown = null;
-  for (let index = 0; index < candidates.length; index += 1) {
-    try {
-      await uploadPrivatePhoto(candidates[index], path, bytes, contentType);
-      return { admin: candidates[index], candidates };
-    } catch (error) {
-      lastError = error;
-      console.error('Voxel Vault storage credential attempt failed', {
-        credentialIndex: index,
-        message: storageMessage(error),
-      });
-    }
-  }
-  throw lastError instanceof Error ? lastError : new PrivateStorageError('Private photo storage is unavailable on this deployment.');
-}
-
-async function createTemporaryPhotoUrl(path: string, preferredAdmin: any, candidates: any[]) {
-  const ordered = [preferredAdmin, ...candidates.filter((candidate) => candidate !== preferredAdmin)];
-  for (const admin of ordered) {
-    const signed = await admin.storage.from(BUCKET).createSignedUrl(path, 6 * 60 * 60);
-    if (!signed.error && signed.data?.signedUrl) return signed.data.signedUrl;
-    console.error('Voxel Vault property photo signed URL failed', { message: storageMessage(signed.error) });
-  }
-  throw new PrivateStorageError('Your photo was saved, but it could not be opened for generation yet. Please try again shortly.');
+function privateJson(body: unknown, init: ResponseInit = {}) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
+  });
 }
 
 export async function POST(request: Request) {
   const auth = await requireVoxelVaultUser(request);
   if (auth.ok === false) {
-    return NextResponse.json({ ok: false, error: auth.error, setupRequired: auth.setupRequired === true }, { status: auth.status });
+    return privateJson({ ok: false, error: auth.error, setupRequired: auth.setupRequired === true }, { status: auth.status });
+  }
+
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!apiKey) {
+    return privateJson({ ok: false, error: 'VoxelPop 3D generation is not configured on this deployment.' }, { status: 503 });
   }
 
   try {
     const form = await request.formData();
     const photo = form.get('photo');
-    const draftIdRaw = clean(form.get('draftId'), 100);
-    const draftId = draftIdRaw ? normalizePropertyDraftId(draftIdRaw) : '';
-    const atlasId = clean(form.get('atlasId'), 180);
-    const address = clean(form.get('address'), 220);
+    const draftId = normalizePropertyDraftId(clean(form.get('draftId'), 100));
     const rightsConfirmed = clean(form.get('rightsConfirmed'), 16) === 'true';
 
     if (!(photo instanceof File)) {
-      return NextResponse.json({ ok: false, error: 'Choose a property photo first.' }, { status: 400 });
-    }
-    if (!draftId && (!atlasId || !address)) {
-      return NextResponse.json({ ok: false, error: 'Start a photo creation or resolve the property before uploading.' }, { status: 400 });
+      return privateJson({ ok: false, error: 'Choose a property photo first.' }, { status: 400 });
     }
     if (!rightsConfirmed) {
-      return NextResponse.json({ ok: false, error: 'Confirm that you took this photo or have permission to use it.' }, { status: 400 });
+      return privateJson({ ok: false, error: 'Confirm that you took this photo or have permission to use it.' }, { status: 400 });
     }
-    const extension = ALLOWED_TYPES.get(String(photo.type || '').toLowerCase());
-    if (!extension) {
-      return NextResponse.json({ ok: false, error: 'Use a JPG, PNG, or WebP property photo.' }, { status: 415 });
+    if (!ALLOWED_TYPES.has(String(photo.type || '').toLowerCase())) {
+      return privateJson({ ok: false, error: 'Use a JPG, PNG, or WebP property photo.' }, { status: 415 });
     }
     if (photo.size <= 0 || photo.size > MAX_BYTES) {
-      return NextResponse.json({ ok: false, error: 'Property photos must be smaller than 8 MB.' }, { status: 413 });
+      return privateJson({ ok: false, error: 'Property photos must be smaller than 8 MB after preparation.' }, { status: 413 });
     }
 
     const bytes = Buffer.from(await photo.arrayBuffer());
     const digest = createHash('sha256').update(bytes).digest('hex');
-    const userId = safeSegment(auth.user.id, 'user');
-    const subjectId = safeSegment(draftId || atlasId);
-    const objectId = `${digest.slice(0, 20)}-${randomUUID().slice(0, 12)}`;
-    const path = `property-references/${userId}/${subjectId}/${objectId}.${extension}`;
+    const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
+    const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
 
-    const stored = await storeWithConfiguredServerCredential(path, bytes, photo.type);
-    const signedUrl = await createTemporaryPhotoUrl(path, stored.admin, stored.candidates);
+    const response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        image_url: dataUri,
+        model_type: 'smart-topology',
+        ai_model: 'meshy-t2',
+        target_polycount: 18000,
+        should_texture: true,
+        enable_pbr: true,
+        texture_resolution: '2k',
+        target_formats: ['glb'],
+      }),
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+    }
+
+    const providerTaskId = clean(data?.result || data?.id, 240);
+    if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
+    const taskId = taskKey(providerTaskId);
+    const sourceFingerprint = `inline-photo:${digest}`;
+    const saved = await saveCatalog3D(itemId, {
+      task_id: taskId,
+      source_image_url: sourceFingerprint,
+      source_image_urls: [sourceFingerprint],
+      provider: 'meshy-property-direct-photo-to-3d',
+      status: 'PENDING',
+      progress: 0,
+      model_url: null,
+      model_storage_path: null,
+      thumbnail_url: null,
+      exact_model_approved: false,
+      started_at: new Date().toISOString(),
+      completed_at: null,
+      error: null,
+    });
+    if (!saved?.task_id) {
+      throw new Error('VoxelPop started the 3D job, but the account generation record could not be saved. Please try again shortly.');
+    }
 
     const uploadedAt = new Date().toISOString();
-    return NextResponse.json({
+    return privateJson({
       ok: true,
-      draftId: draftId || null,
+      draftId,
       reference: {
-        url: signedUrl,
+        url: null,
         rightsBasis: 'user-owned',
-        rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital property creation.',
-        label: 'Uploaded property photo',
+        rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital creation.',
+        label: 'Selected property photo',
         sourcePhotoId: `upload:${digest.slice(0, 20)}`,
-        provider: 'user-upload',
-        storagePath: path,
+        provider: 'user-photo-direct-generation',
+        storagePath: `meshy-source:${taskId}`,
         uploadedAt,
       },
-      privacy: 'The original upload is stored privately. Generation receives short-lived signed access only.',
-    }, {
-      headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+      source3d: {
+        taskId,
+        status: saved.status || 'PENDING',
+        progress: Number(saved.progress || 0),
+      },
+      privacy: 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider for this generation request; only a SHA-256 fingerprint and account-bound job record are retained by Voxel Vault.',
     });
   } catch (error) {
-    const setupRequired = error instanceof PrivateStorageError;
-    return NextResponse.json({
+    return privateJson({
       ok: false,
-      setupRequired,
-      error: error instanceof Error ? error.message : 'Property photo upload failed.',
-    }, {
-      status: setupRequired ? 503 : 400,
-      headers: { 'Cache-Control': 'private, no-store, max-age=0' },
-    });
+      error: error instanceof Error ? error.message : 'Property photo generation handoff failed.',
+    }, { status: 400 });
   }
 }

--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -134,7 +134,21 @@ export async function POST(request: Request) {
       const phase = normalizePropertyGenerationPhase(body?.phase);
       itemId = propertyDraftItemId(auth.user.id, draftId, phase);
       if (phase === 'source') {
-        imageUrl = await sourcePhotoUrl(auth, draftId, body?.sourceStoragePath);
+        const sourceStoragePath = clean(body?.sourceStoragePath, 900);
+        if (sourceStoragePath.startsWith('meshy-source:')) {
+          const taskId = clean(sourceStoragePath.slice('meshy-source:'.length), 260);
+          const directJob = await readCatalog3DByTask(taskId);
+          if (!directJob?.item_id || directJob.item_id !== itemId) {
+            throw new Error('That direct photo 3D job does not belong to this signed-in creation.');
+          }
+          return privateJson({
+            ok: true,
+            reused: true,
+            directPhoto: true,
+            ...publicState(directJob, await displayUrlFor(directJob)),
+          });
+        }
+        imageUrl = await sourcePhotoUrl(auth, draftId, sourceStoragePath);
         provider = 'meshy-property-photo-to-3d';
       } else {
         imageUrl = await verifiedVoxelImageUrl(apiKey, auth.user.id, body?.voxelImageTaskId, body?.voxelImageTaskToken);

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -290,7 +290,7 @@ export default function PropertyJourneyPage() {
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
     const iteration = ++pipelineRef.current;
     setBusy('upload');
-    setMessage('Saving your photo privately…');
+    setMessage('Starting your private 3D build…');
     try {
       const form = new FormData();
       form.append('photo', pendingPhoto);
@@ -298,7 +298,7 @@ export default function PropertyJourneyPage() {
       form.append('rightsConfirmed', 'true');
       const response = await fetch('/api/property-photo-upload', { method: 'POST', headers: authHeaders(), body: form });
       const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || 'Photo upload failed.');
+      if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || '3D build could not start.');
       setSourceReference(data.reference);
       setPendingPhoto(null);
       setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
@@ -442,10 +442,10 @@ export default function PropertyJourneyPage() {
         {displaySource ? <div className={styles.heroCard}><img src={displaySource} alt="Selected property reference"/><span className={styles.badge}>YOUR PHOTO</span></div> : <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>iPhone photos supported</span></div>}
         {pendingPhoto ? <div className={styles.choicePanel}>
           <label className={styles.rightsCheck}><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
-          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Saving photo…' : 'Use photo → start build'}</button>
+          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Starting 3D…' : 'Use photo → start build'}</button>
           <button className={styles.textButton} type="button" onClick={choosePhoto}>Choose another</button>
         </div> : <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>}
-        <p className={styles.truth}>The photo guides visible appearance only. One photo cannot verify unseen sides, roof details, exact dimensions, or legal property facts.</p>
+        <p className={styles.truth}>The photo guides visible appearance only. One photo cannot verify unseen sides, roof details, exact dimensions, or legal property facts. Voxel Vault does not need to retain the original source photo in its Storage bucket for this build.</p>
       </> : null}
 
       {step === 2 ? <>

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -2,14 +2,24 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const property = fs.readFileSync(new URL('../app/property/page.js', import.meta.url), 'utf8');
+const photoHandoff = fs.readFileSync(new URL('../app/api/property-photo-upload/route.ts', import.meta.url), 'utf8');
+const voxel3d = fs.readFileSync(new URL('../app/api/property-voxel-3d/route.ts', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
-assert.match(property, /setSourceReference\(data\.reference\)/, 'private uploaded reference must become the source for the automatic pipeline');
-assert.match(property, /await runAutomaticBuild\(data\.reference, iteration\)/, 'approving the photo must immediately start the automatic build pipeline');
+assert.match(property, /setSourceReference\(data\.reference\)/, 'direct generation reference must become the source for the automatic pipeline');
+assert.match(property, /await runAutomaticBuild\(data\.reference, iteration\)/, 'approving the photo must immediately continue the automatic build pipeline');
 
-assert.match(property, /phase: 'source'/, 'automatic pipeline must build a first 3D from the authorized photo');
-assert.match(property, /sourceStoragePath: reference\.storagePath/, 'first 3D must use the private source-photo storage path rather than an arbitrary browser URL');
+assert.match(photoHandoff, /data:\$\{photo\.type\};base64/, 'source photo must be handed directly to the 3D provider as an inline data URI');
+assert.match(photoHandoff, /meshy-property-direct-photo-to-3d/, 'direct source generation must have an explicit provider marker');
+assert.match(photoHandoff, /inline-photo:\$\{digest\}/, 'Voxel Vault should retain only a source-photo fingerprint in the generation record');
+assert.match(photoHandoff, /storagePath: `meshy-source:\$\{taskId\}`/, 'the UI handoff should carry an opaque account-bound provider job reference');
+assert.doesNotMatch(photoHandoff, /storage\.from\(|createBucket\(|createSignedUrl\(/, 'normal VoxelPop photo creation must not require Supabase Storage');
+
+assert.match(property, /phase: 'source'/, 'automatic pipeline must continue through the first 3D source phase');
+assert.match(property, /sourceStoragePath: reference\.storagePath/, 'first 3D continuation must pass the opaque direct-job reference');
+assert.match(voxel3d, /sourceStoragePath\.startsWith\('meshy-source:'\)/, '3D route must recognize a pre-started direct photo job');
+assert.match(voxel3d, /directJob\.item_id !== itemId/, 'pre-started direct job must remain account and draft bound');
 assert.match(property, /source3dTaskId: sourceDone\.taskId/, 'voxel style pass must start from the completed first 3D preview');
 assert.match(property, /voxelImageTaskId: voxelDone\.taskId/, 'final 3D must use the verified completed voxel-image job');
 assert.match(property, /voxelImageTaskToken: voxelDone\.taskToken/, 'final 3D must carry the account-bound voxel image task token');
@@ -26,4 +36,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: approved private photo -> source 3D -> generated-3D voxel style -> final voxel 3D, with visible progress, clear automatic wording, and a safe retry path.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, without requiring source-photo bucket storage.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -9,8 +9,6 @@ const property = read('app/property/page.js');
 const propertyCss = read('app/property/property.module.css');
 const success = read('app/property/success/page.js');
 const photoUploadRoute = read('app/api/property-photo-upload/route.ts');
-const supabaseAdmin = read('lib/supabase-admin.ts');
-const storageMigration = read('supabase/migrations/022_voxel_system_storage_bucket.sql');
 const voxelImageRoute = read('app/api/property-voxel-image/route.ts');
 const voxel3dRoute = read('app/api/property-voxel-3d/route.ts');
 const generationIds = read('lib/property-generation-ids.ts');
@@ -56,13 +54,27 @@ assert.match(property, /Choose one photo\./, 'first signed-in step must be photo
 assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC/HEIF selection remains supported');
 assert.match(property, /normalizeIphonePhoto/, 'iPhone HEIC preparation remains automatic');
 assert.match(property, /I took this photo or have permission to use it\./, 'source photo must require rights confirmation');
-assert.match(property, /form\.append\('draftId', draftId\)/, 'photo-first upload must use an account-bound creation ID before map placement');
+assert.match(property, /form\.append\('draftId', draftId\)/, 'photo-first handoff must use an account-bound creation ID before map placement');
 assert.match(property, /Use photo → start build/, 'one photo approval must start the automatic generation journey');
 assert.doesNotMatch(property, /Use this street photo/, 'simple journey should not branch into a street-photo chooser');
 
+// Normal source-photo creation goes directly to the provider and must not depend on Supabase Storage.
+assert.match(photoUploadRoute, /requireVoxelVaultUser/, 'photo handoff requires a verified account');
+assert.match(photoUploadRoute, /rightsConfirmed/, 'server enforces source-photo rights confirmation');
+assert.match(photoUploadRoute, /data:\$\{photo\.type\};base64/, 'authorized source photo must become an inline provider input');
+assert.match(photoUploadRoute, /createHash\('sha256'\)/, 'source photo must receive a non-reversible fingerprint');
+assert.match(photoUploadRoute, /source_image_url: sourceFingerprint/, 'account generation records retain the fingerprint rather than source photo bytes');
+assert.match(photoUploadRoute, /meshy-property-direct-photo-to-3d/, 'direct photo source generation must have an explicit provider marker');
+assert.match(photoUploadRoute, /storagePath: `meshy-source:\$\{taskId\}`/, 'UI handoff uses an opaque account-bound direct-job reference');
+assert.match(photoUploadRoute, /does not store the original source photo in its Storage bucket/, 'privacy disclosure must accurately describe the storage-free source path');
+assert.doesNotMatch(photoUploadRoute, /storage\.from\(|createBucket\(|createSignedUrl\(|PrivateStorageError|getSupabaseAdminCandidates/, 'normal VoxelPop source creation must not require Supabase Storage administration');
+
 // Automatic source 3D -> voxel style -> final 3D.
-assert.match(property, /phase: 'source'/, 'original authorized photo must create the first 3D phase');
-assert.match(property, /sourceStoragePath: reference\.storagePath/, 'source 3D must use the private account-owned upload path');
+assert.match(property, /phase: 'source'/, 'automatic pipeline must continue through the first 3D source phase');
+assert.match(property, /sourceStoragePath: reference\.storagePath/, 'source continuation passes the opaque account-bound direct-job reference');
+assert.match(voxel3dRoute, /sourceStoragePath\.startsWith\('meshy-source:'\)/, '3D route must recognize a pre-started direct-photo job');
+assert.match(voxel3dRoute, /directJob\.item_id !== itemId/, 'pre-started source job must remain bound to the signed-in user and draft');
+assert.match(voxel3dRoute, /directPhoto: true/, 'direct-photo continuation must be explicit in the server response');
 assert.match(property, /source3dTaskId: sourceDone\.taskId/, 'voxel styling must use the completed 3D preview');
 assert.match(property, /voxelImageTaskId: voxelDone\.taskId/, 'final 3D must use the verified voxel-image task');
 assert.match(property, /phase: 'voxel'/, 'final 3D must have a distinct voxel phase');
@@ -70,31 +82,13 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.match(property, /MeshyModelViewer/, 'generated source/final models must be viewable interactively');
 assert.doesNotMatch(property, /eth_requestAccounts|mintVoxelFlip/, 'wallet/mint execution must not block the guided maker');
 
-// Private upload must fail clearly and recover from storage races/credential configuration.
-assert.match(photoUploadRoute, /requireVoxelVaultUser/, 'photo upload requires a verified account');
-assert.match(photoUploadRoute, /draftId/, 'photo upload must support creation-before-location');
-assert.match(photoUploadRoute, /public:\s*false/, 'source-photo bucket creation stays private');
-assert.match(photoUploadRoute, /createSignedUrl/, 'providers receive short-lived source-photo access');
-assert.match(photoUploadRoute, /rightsConfirmed/, 'server enforces source-photo rights confirmation');
-assert.match(photoUploadRoute, /PrivateStorageError/, 'storage infrastructure failures must be distinguishable from bad user input');
-assert.match(photoUploadRoute, /randomUUID/, 'retries must use a unique private object name instead of overwriting one deterministic path');
-assert.match(photoUploadRoute, /upsert:\s*false/, 'property photo uploads should be insert-only');
-assert.match(photoUploadRoute, /attempt < 2/, 'private photo upload must retry once after re-checking storage');
-assert.match(photoUploadRoute, /setupRequired/, 'storage setup failures must be surfaced explicitly');
-assert.match(photoUploadRoute, /getSupabaseAdminCandidates/, 'private storage should try every configured supported server credential');
-assert.match(supabaseAdmin, /getSupabaseAdminCandidates/, 'Supabase server helper must expose credential candidates');
-assert.match(supabaseAdmin, /SUPABASE_SECRET_KEY/, 'new Supabase server secret must remain supported');
-assert.match(supabaseAdmin, /SUPABASE_SERVICE_ROLE_KEY/, 'legacy service-role credential must remain supported');
-assert.match(storageMigration, /'voxel-system', 'voxel-system', false, 78643200/, 'migration must guarantee the private voxel-system bucket');
-assert.match(storageMigration, /on conflict \(id\) do update/, 'storage bucket migration must be idempotent');
-
 assert.match(generationIds, /property-create:/, 'photo-first phases use separate account-scoped creation IDs');
 assert.match(generationIds, /propertyGenerationUserScope/, 'generation IDs must hash/scope by user');
 assert.match(voxel3dRoute, /phase === 'source'/, '3D route must support the source-photo 3D phase');
 assert.match(voxel3dRoute, /propertyDraftItemId\(auth\.user\.id, draftId, phase\)/, '3D phase records must be user- and draft-bound');
 assert.match(voxel3dRoute, /propertyGenerationItemBelongsToUser/, '3D polling must reject other users jobs');
 assert.match(voxel3dRoute, /verifiedVoxelImageUrl/, 'final voxel 3D must verify the account-bound voxel-image task');
-assert.match(voxel3dRoute, /persistModelBinary/, 'completed GLBs must be persisted');
+assert.match(voxel3dRoute, /persistModelBinary/, 'completed GLBs should still attempt durable persistence while retaining provider URL fallback');
 assert.match(voxelImageRoute, /generated3DReference/, 'voxel style pass must reference the completed source 3D');
 assert.match(voxelImageRoute, /propertyDraftItemId\(userId, draftId, 'source'\)/, 'voxelizer must verify the exact source-3D creation record');
 assert.match(voxelImageRoute, /licensed-derivative/, 'generated 3D preview must carry explicit derivative-rights classification');
@@ -167,4 +161,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /if \(pathname === '\/property'\) return null;/, 'fixed app dock stays out of the guided maker');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> photo -> first 3D -> automatic voxel styling -> final 3D voxel -> address verification -> private My World preview -> server-priced digital collection -> Vault -> optional verified mint, with resilient private storage and real-property rights kept separate.');
+console.log('Guided VoxelPop property checks passed: sign in -> authorized photo -> direct source 3D -> automatic voxel styling -> final 3D voxel -> address verification -> private My World preview -> server-priced digital collection -> Vault -> optional verified mint, without requiring source-photo bucket storage and with real-property rights kept separate.');


### PR DESCRIPTION
## What this fixes
The normal VoxelPop property flow could stop at `Private photo storage needs server setup before uploads can continue` when the deployment could authenticate users but could not administratively create/use the private Supabase Storage bucket.

This PR removes that bucket dependency from the normal source-photo creation path.

## New source-photo flow
`Sign in → choose authorized photo → direct provider source 3D → VoxelPop style → final movable 3D voxel → address/World → collect → Vault → optional Verify & Mint`

- the authorized JPG/PNG/WebP bytes are sent directly from the signed-in server route to Meshy Image-to-3D as a supported base64 data URI
- Voxel Vault does **not** write the original source photo into `voxel-system` for this normal flow
- Voxel Vault retains only a SHA-256 source fingerprint plus the account/draft-bound provider job record
- the existing Property page continues using its current automatic pipeline; the 3D route recognizes the pre-started `meshy-source:` job and continues polling it
- legacy/admin storage-based reference flows remain available separately

## UX copy
The Property screen now says `Starting your private 3D build…` / `Starting 3D…` instead of claiming the photo is being saved to Storage.

## Safety preserved
- sign-in required
- explicit photo-rights confirmation required
- provider job remains tied to the signed-in user + draft
- voxel style pass must come from the verified completed source-3D job
- final voxel job remains account-bound
- address/map/payment/mint still do not create deed/title, rent, occupancy, investment or appreciation rights
- fractional investing remains a separate verified-offering rail

## Regression protection
Updates the automatic-journey and simple-property tests so normal VoxelPop source creation is explicitly forbidden from depending on Supabase Storage bucket creation/signing.