### PR TITLE
Fix Meshy t2 polycount limit in property builds

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
         image_url: dataUri,
         model_type: 'smart-topology',
         ai_model: 'meshy-t2',
-        target_polycount: 18000,
+        target_polycount: 15000,
         should_texture: true,
         enable_pbr: true,
         texture_resolution: '2k',

--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -178,7 +178,7 @@ export async function POST(request: Request) {
         image_url: imageUrl,
         model_type: 'smart-topology',
         ai_model: 'meshy-t2',
-        target_polycount: 18000,
+        target_polycount: 15000,
         should_texture: true,
         enable_pbr: true,
         texture_resolution: '2k',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:hyperreal-voxel": "node scripts/test-hyperreal-voxel-building.mjs",
     "test:buffalo-reference": "node scripts/test-buffalo-property-reference.mjs",
     "test:property-draft-funnel": "node scripts/test-property-draft-funnel.mjs",
-    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs",
+    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs && node scripts/test-meshy-polycount-limit.mjs",
     "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs && node scripts/test-fractional-property-bridge.mjs && node scripts/test-algorand-position-verifier.mjs && node scripts/test-geo-property-onboarding.mjs && node scripts/test-geo-finish-polish.mjs && node scripts/test-geo-map-context.mjs && node scripts/test-geo-map-explorer.mjs && node scripts/test-buffalo-property-reference.mjs && node scripts/test-financial-os-coherence.mjs && node scripts/test-hyperreal-voxel-building.mjs && npm run test:property-draft-funnel && npm run test:simple-property-world",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:first-real-erie-parcel": "node scripts/test-first-real-erie-parcel-live.mjs",

--- a/scripts/test-meshy-polycount-limit.mjs
+++ b/scripts/test-meshy-polycount-limit.mjs
@@ -11,8 +11,12 @@ for (const [name, source] of [
   ['voxel image -> final 3D', property3dRoute],
 ]) {
   assert.match(source, /ai_model:\s*'meshy-t2'/, `${name} must keep the intended Meshy model explicit`);
-  assert.match(source, /target_polycount:\s*15000/, `${name} must stay within the meshy-t2 maximum polycount`);
-  assert.doesNotMatch(source, /target_polycount:\s*(?:1[5-9]\d{3}|[2-9]\d{4,})/, `${name} must never request more than 15000 polygons from meshy-t2`);
+  const polycounts = [...source.matchAll(/target_polycount:\s*(\d+)/g)].map((match) => Number(match[1]));
+  assert.ok(polycounts.length > 0, `${name} must declare a target polycount`);
+  for (const value of polycounts) {
+    assert.ok(value >= 100 && value <= 15000, `${name} target_polycount ${value} must stay within the meshy-t2 100..15000 range`);
+  }
+  assert.ok(polycounts.includes(15000), `${name} should use the supported meshy-t2 maximum of 15000`);
 }
 
-console.log('Meshy property polycount checks passed: source and final 3D requests stay at the meshy-t2 maximum of 15000.');
+console.log('Meshy property polycount checks passed: source and final 3D requests stay within the meshy-t2 100..15000 range.');

--- a/scripts/test-meshy-polycount-limit.mjs
+++ b/scripts/test-meshy-polycount-limit.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const directPhotoRoute = read('app/api/property-photo-upload/route.ts');
+const property3dRoute = read('app/api/property-voxel-3d/route.ts');
+
+for (const [name, source] of [
+  ['direct photo -> 3D', directPhotoRoute],
+  ['voxel image -> final 3D', property3dRoute],
+]) {
+  assert.match(source, /ai_model:\s*'meshy-t2'/, `${name} must keep the intended Meshy model explicit`);
+  assert.match(source, /target_polycount:\s*15000/, `${name} must stay within the meshy-t2 maximum polycount`);
+  assert.doesNotMatch(source, /target_polycount:\s*(?:1[5-9]\d{3}|[2-9]\d{4,})/, `${name} must never request more than 15000 polygons from meshy-t2`);
+}
+
+console.log('Meshy property polycount checks passed: source and final 3D requests stay at the meshy-t2 maximum of 15000.');


### PR DESCRIPTION
Fixes the production-blocking Meshy validation error reported in the VoxelPop property creator.

Changes:
- lower direct photo → 3D `target_polycount` from 18000 to the `meshy-t2` maximum of 15000
- lower final voxel image → 3D `target_polycount` from 18000 to 15000
- add a focused regression test that rejects any future `meshy-t2` property request above 15000
- wire the regression into the existing property-platform CI path

No property-rights, checkout, minting, or storage semantics are changed.