### PR TITLE
Fix Meshy generation record persistence on older production schemas

### DIFF
--- a/lib/catalog3dStore.js
+++ b/lib/catalog3dStore.js
@@ -1,4 +1,4 @@
-import { getSupabaseAdmin } from './supabase-admin';
+import { getSupabaseAdminCandidates } from './supabase-admin';
 
 const SYSTEM_BUCKET = 'voxel-system';
 const META_PREFIX = 'catalog-3d';
@@ -30,49 +30,107 @@ function metadataPath(itemId) {
   return `${META_PREFIX}/${encodeURIComponent(String(itemId))}.json`;
 }
 
-async function tableReady() {
+function adminCandidates() {
   try {
-    const { error } = await getSupabaseAdmin()
+    return getSupabaseAdminCandidates();
+  } catch {
+    return [];
+  }
+}
+
+async function tableReadyFor(admin) {
+  try {
+    const { error } = await admin
       .from('catalog_3d_media')
-      .select('item_id,source_image_urls,model_storage_path', { count: 'exact', head: true });
+      .select('item_id,task_id', { count: 'exact', head: true });
     return !error;
-  } catch { return false; }
+  } catch {
+    return false;
+  }
+}
+
+async function firstReadableTableClient() {
+  for (const admin of adminCandidates()) {
+    if (await tableReadyFor(admin)) return admin;
+  }
+  return null;
+}
+
+async function tableReady() {
+  return Boolean(await firstReadableTableClient());
+}
+
+function legacyTablePayload(payload = {}) {
+  const {
+    source_image_urls: _sourceImageUrls,
+    model_storage_path: _modelStoragePath,
+    ...legacy
+  } = payload;
+  return legacy;
+}
+
+async function writeTableRow(admin, payload) {
+  try {
+    const full = await admin
+      .from('catalog_3d_media')
+      .upsert(payload, { onConflict: 'item_id' })
+      .select('*')
+      .single();
+    if (!full.error && full.data) return normalizeRow(full.data);
+
+    // Production deployments may still have the original 007/008 schema.
+    // Those tables are valid for generation ownership/status records but do not
+    // yet have the optional 009 source_image_urls/model_storage_path columns.
+    const legacy = await admin
+      .from('catalog_3d_media')
+      .upsert(legacyTablePayload(payload), { onConflict: 'item_id' })
+      .select('*')
+      .single();
+    if (!legacy.error && legacy.data) return normalizeRow(legacy.data);
+  } catch {}
+  return null;
 }
 
 async function ensureStorageReady() {
   if (!storageReadyPromise) {
     storageReadyPromise = (async () => {
-      try {
-        const supabase = getSupabaseAdmin();
-        const { data, error } = await supabase.storage.listBuckets();
-        if (error) return false;
-        if (!data?.some(bucket => bucket.name === SYSTEM_BUCKET)) {
-          const created = await supabase.storage.createBucket(SYSTEM_BUCKET, { public: false, fileSizeLimit: '75MB' });
-          if (created.error && !/already exists/i.test(created.error.message || '')) return false;
-        }
-        return true;
-      } catch { return false; }
+      for (const supabase of adminCandidates()) {
+        try {
+          const { data, error } = await supabase.storage.listBuckets();
+          if (error) continue;
+          if (!data?.some(bucket => bucket.name === SYSTEM_BUCKET)) {
+            const created = await supabase.storage.createBucket(SYSTEM_BUCKET, { public: false, fileSizeLimit: '75MB' });
+            if (created.error && !/already exists/i.test(created.error.message || '')) continue;
+          }
+          return supabase;
+        } catch {}
+      }
+      return null;
     })();
   }
   return storageReadyPromise;
 }
 
 async function readStorageRow(itemId) {
-  if (!itemId || !(await ensureStorageReady())) return null;
+  if (!itemId) return null;
+  const supabase = await ensureStorageReady();
+  if (!supabase) return null;
   try {
-    const { data, error } = await getSupabaseAdmin().storage.from(SYSTEM_BUCKET).download(metadataPath(itemId));
+    const { data, error } = await supabase.storage.from(SYSTEM_BUCKET).download(metadataPath(itemId));
     if (error || !data) return null;
     return normalizeRow(JSON.parse(await data.text()));
   } catch { return null; }
 }
 
 async function writeStorageRow(itemId, patch = {}) {
-  if (!itemId || !(await ensureStorageReady())) return null;
+  if (!itemId) return null;
+  const supabase = await ensureStorageReady();
+  if (!supabase) return null;
   const previous = await readStorageRow(itemId);
   const payload = normalizeRow({ ...(previous || {}), item_id: itemId, ...patch, updated_at: new Date().toISOString() });
   try {
     const body = JSON.stringify(payload);
-    const { error } = await getSupabaseAdmin().storage.from(SYSTEM_BUCKET).upload(metadataPath(itemId), body, {
+    const { error } = await supabase.storage.from(SYSTEM_BUCKET).upload(metadataPath(itemId), body, {
       contentType: 'application/json',
       cacheControl: '0',
       upsert: true,
@@ -83,9 +141,10 @@ async function writeStorageRow(itemId, patch = {}) {
 }
 
 async function listStorageRows() {
-  if (!(await ensureStorageReady())) return [];
+  const supabase = await ensureStorageReady();
+  if (!supabase) return [];
   try {
-    const bucket = getSupabaseAdmin().storage.from(SYSTEM_BUCKET);
+    const bucket = supabase.storage.from(SYSTEM_BUCKET);
     const { data, error } = await bucket.list(META_PREFIX, { limit: 1000, sortBy: { column: 'name', order: 'asc' } });
     if (error) return [];
     const rows = await Promise.all((data || []).filter(file => file.name?.endsWith('.json')).map(async file => {
@@ -98,7 +157,7 @@ async function listStorageRows() {
 
 export async function catalog3DStoreHealth() {
   const table = await tableReady();
-  const storage = table ? true : await ensureStorageReady();
+  const storage = table ? true : Boolean(await ensureStorageReady());
   return { ready: table || storage, backend: table ? 'table' : storage ? 'storage' : 'unavailable', table, storage };
 }
 
@@ -108,9 +167,10 @@ export async function catalog3DStoreReady() {
 
 export async function readCatalog3D(itemId) {
   if (!itemId) return null;
-  if (await tableReady()) {
+  const admin = await firstReadableTableClient();
+  if (admin) {
     try {
-      const { data, error } = await getSupabaseAdmin().from('catalog_3d_media').select('*').eq('item_id', itemId).maybeSingle();
+      const { data, error } = await admin.from('catalog_3d_media').select('*').eq('item_id', itemId).maybeSingle();
       if (!error && data) return normalizeRow(data);
     } catch {}
   }
@@ -119,9 +179,10 @@ export async function readCatalog3D(itemId) {
 
 export async function readCatalog3DByTask(taskId) {
   if (!taskId) return null;
-  if (await tableReady()) {
+  const admin = await firstReadableTableClient();
+  if (admin) {
     try {
-      const { data, error } = await getSupabaseAdmin().from('catalog_3d_media').select('*').eq('task_id', taskId).maybeSingle();
+      const { data, error } = await admin.from('catalog_3d_media').select('*').eq('task_id', taskId).maybeSingle();
       if (!error && data) return normalizeRow(data);
     } catch {}
   }
@@ -130,9 +191,10 @@ export async function readCatalog3DByTask(taskId) {
 }
 
 export async function listCatalog3D() {
-  if (await tableReady()) {
+  const admin = await firstReadableTableClient();
+  if (admin) {
     try {
-      const { data, error } = await getSupabaseAdmin().from('catalog_3d_media').select('*');
+      const { data, error } = await admin.from('catalog_3d_media').select('*');
       if (!error) return (data || []).map(normalizeRow).filter(Boolean);
     } catch {}
   }
@@ -142,24 +204,29 @@ export async function listCatalog3D() {
 export async function saveCatalog3D(itemId, patch = {}) {
   if (!itemId) return null;
   const payload = normalizeRow({ item_id: itemId, ...patch, updated_at: new Date().toISOString() });
-  if (await tableReady()) {
-    try {
-      const { data, error } = await getSupabaseAdmin().from('catalog_3d_media').upsert(payload, { onConflict: 'item_id' }).select('*').single();
-      if (!error && data) return normalizeRow(data);
-    } catch {}
+
+  // Try every configured server credential. This avoids a stale/limited first
+  // credential hiding a valid service-role/secret-key candidate.
+  for (const admin of adminCandidates()) {
+    if (!(await tableReadyFor(admin))) continue;
+    const saved = await writeTableRow(admin, payload);
+    if (saved) return saved;
   }
+
   return writeStorageRow(itemId, payload);
 }
 
 export async function persistModelBinary(itemId, remoteUrl) {
-  if (!itemId || !remoteUrl || !(await ensureStorageReady())) return null;
+  if (!itemId || !remoteUrl) return null;
+  const supabase = await ensureStorageReady();
+  if (!supabase) return null;
   try {
     const response = await fetch(remoteUrl, { cache: 'no-store' });
     if (!response.ok) return null;
     const contentType = response.headers.get('content-type') || 'model/gltf-binary';
     const bytes = await response.arrayBuffer();
     const path = `models/${encodeURIComponent(String(itemId))}.glb`;
-    const { error } = await getSupabaseAdmin().storage.from(SYSTEM_BUCKET).upload(path, bytes, {
+    const { error } = await supabase.storage.from(SYSTEM_BUCKET).upload(path, bytes, {
       contentType,
       cacheControl: '31536000',
       upsert: true,
@@ -170,9 +237,11 @@ export async function persistModelBinary(itemId, remoteUrl) {
 }
 
 export async function createModelSignedUrl(storagePath, expiresIn = 3600) {
-  if (!storagePath || !(await ensureStorageReady())) return null;
+  if (!storagePath) return null;
+  const supabase = await ensureStorageReady();
+  if (!supabase) return null;
   try {
-    const { data, error } = await getSupabaseAdmin().storage.from(SYSTEM_BUCKET).createSignedUrl(storagePath, expiresIn);
+    const { data, error } = await supabase.storage.from(SYSTEM_BUCKET).createSignedUrl(storagePath, expiresIn);
     if (error) return null;
     return data?.signedUrl || null;
   } catch { return null; }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:hyperreal-voxel": "node scripts/test-hyperreal-voxel-building.mjs",
     "test:buffalo-reference": "node scripts/test-buffalo-property-reference.mjs",
     "test:property-draft-funnel": "node scripts/test-property-draft-funnel.mjs",
-    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs && node scripts/test-meshy-polycount-limit.mjs",
+    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs && node scripts/test-meshy-polycount-limit.mjs && node scripts/test-catalog3d-generation-record-compat.mjs",
     "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs && node scripts/test-fractional-property-bridge.mjs && node scripts/test-algorand-position-verifier.mjs && node scripts/test-geo-property-onboarding.mjs && node scripts/test-geo-finish-polish.mjs && node scripts/test-geo-map-context.mjs && node scripts/test-geo-map-explorer.mjs && node scripts/test-buffalo-property-reference.mjs && node scripts/test-financial-os-coherence.mjs && node scripts/test-hyperreal-voxel-building.mjs && npm run test:property-draft-funnel && npm run test:simple-property-world",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:first-real-erie-parcel": "node scripts/test-first-real-erie-parcel-live.mjs",

--- a/scripts/test-catalog3d-generation-record-compat.mjs
+++ b/scripts/test-catalog3d-generation-record-compat.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+const store = read('lib/catalog3dStore.js');
+const migration007 = read('supabase/migrations/007_catalog_3d_media.sql');
+const migration009 = read('supabase/migrations/009_catalog_3d_binary_storage.sql');
+
+assert.match(store, /getSupabaseAdminCandidates/, '3D persistence must try every configured Supabase server credential');
+assert.match(store, /select\('item_id,task_id', \{ count: 'exact', head: true \}\)/, 'table readiness must only require the original generation-record columns');
+assert.match(migration007, /task_id text unique/, 'original catalog table must provide account-bound task identity');
+assert.match(migration007, /model_url text/, 'original catalog table must be able to retain provider model URLs');
+assert.match(migration009, /source_image_urls jsonb/, 'newer binary-storage columns remain optional enhancements');
+assert.match(migration009, /model_storage_path text/, 'private GLB persistence remains an optional newer enhancement');
+assert.match(store, /function legacyTablePayload/, 'store must provide a legacy-schema payload');
+assert.match(store, /source_image_urls: _sourceImageUrls/, 'legacy retry must omit the 009 source-image list column');
+assert.match(store, /model_storage_path: _modelStoragePath/, 'legacy retry must omit the 009 private-model-path column');
+assert.match(store, /upsert\(legacyTablePayload\(payload\), \{ onConflict: 'item_id' \}\)/, 'failed full writes must retry against the valid 007/008 schema');
+assert.match(store, /for \(const admin of adminCandidates\(\)\)/, 'persistence must not stop at the first configured server credential');
+assert.match(store, /return writeStorageRow\(itemId, payload\)/, 'private storage remains a final fallback rather than a prerequisite for generation records');
+
+console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, while 009 private binary metadata remains optional.');


### PR DESCRIPTION
Fixes the next live VoxelPop property-creator blocker: Meshy successfully starts the 3D job, but Voxel Vault can fail to save the account-bound generation record when production still has the valid 007/008 `catalog_3d_media` schema without the optional 009 binary-storage columns.

Changes:
- table readiness now checks only the original `item_id` / `task_id` generation-record columns
- full 009 payload is attempted first, then automatically retried without `source_image_urls` / `model_storage_path` on older schemas
- all configured Supabase server credentials are tried instead of only the first one
- private `voxel-system` Storage remains a fallback, not a prerequisite for the task record
- adds a regression test wired into the property CI path

This does not weaken account binding, property truth boundaries, checkout verification, or optional minting semantics. The newer private GLB persistence columns remain supported whenever migration 009/storage are available.