### PR TITLE
Fix VoxelPop generation record save failures

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -61,6 +61,34 @@ export async function POST(request: Request) {
     const digest = createHash('sha256').update(bytes).digest('hex');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
     const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
+    const sourceFingerprint = `inline-photo:${digest}`;
+    const startedAt = new Date().toISOString();
+
+    // Reserve the signed-in account record before spending a Meshy job. If the
+    // database/storage layer is not writable, fail here instead of starting a
+    // provider task that Voxel Vault cannot safely resume or associate with the user.
+    const reservation = await saveCatalog3D(itemId, {
+      task_id: null,
+      source_image_url: sourceFingerprint,
+      source_image_urls: [sourceFingerprint],
+      provider: 'meshy-property-direct-photo-to-3d',
+      status: 'PREPARING',
+      progress: 0,
+      model_url: null,
+      model_storage_path: null,
+      thumbnail_url: null,
+      exact_model_approved: false,
+      started_at: startedAt,
+      completed_at: null,
+      error: null,
+    });
+    if (!reservation?.item_id) {
+      return privateJson({
+        ok: false,
+        error: 'VoxelPop cannot save generation records on this deployment yet. No 3D job was started. Check the Supabase server write configuration and try again.',
+        setupRequired: true,
+      }, { status: 503 });
+    }
 
     const response = await fetch(ENDPOINT, {
       method: 'POST',
@@ -79,13 +107,22 @@ export async function POST(request: Request) {
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
+      await saveCatalog3D(itemId, {
+        task_id: null,
+        source_image_url: sourceFingerprint,
+        provider: 'meshy-property-direct-photo-to-3d',
+        status: 'FAILED',
+        progress: 0,
+        started_at: startedAt,
+        completed_at: new Date().toISOString(),
+        error: clean(data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.`, 800),
+      });
       return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
     }
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
     const taskId = taskKey(providerTaskId);
-    const sourceFingerprint = `inline-photo:${digest}`;
     const saved = await saveCatalog3D(itemId, {
       task_id: taskId,
       source_image_url: sourceFingerprint,
@@ -97,12 +134,12 @@ export async function POST(request: Request) {
       model_storage_path: null,
       thumbnail_url: null,
       exact_model_approved: false,
-      started_at: new Date().toISOString(),
+      started_at: startedAt,
       completed_at: null,
       error: null,
     });
     if (!saved?.task_id) {
-      throw new Error('VoxelPop started the 3D job, but the account generation record could not be saved. Please try again shortly.');
+      throw new Error('VoxelPop started the 3D job but could not attach its task ID to the reserved account record. The generation was not charged again; retry status after the deployment storage is repaired.');
     }
 
     const uploadedAt = new Date().toISOString();

--- a/lib/catalog3dStore.js
+++ b/lib/catalog3dStore.js
@@ -69,6 +69,39 @@ function legacyTablePayload(payload = {}) {
   return legacy;
 }
 
+function minimalIdentityPayload(payload = {}) {
+  return {
+    item_id: payload.item_id,
+    task_id: payload.task_id || null,
+  };
+}
+
+async function writeMinimalIdentityRow(admin, payload) {
+  const minimal = minimalIdentityPayload(payload);
+  if (!minimal.item_id) return null;
+
+  try {
+    const updated = await admin
+      .from('catalog_3d_media')
+      .update({ task_id: minimal.task_id })
+      .eq('item_id', minimal.item_id)
+      .select('*')
+      .maybeSingle();
+    if (!updated.error && updated.data) return normalizeRow(updated.data);
+  } catch {}
+
+  try {
+    const inserted = await admin
+      .from('catalog_3d_media')
+      .insert(minimal)
+      .select('*')
+      .single();
+    if (!inserted.error && inserted.data) return normalizeRow(inserted.data);
+  } catch {}
+
+  return null;
+}
+
 async function writeTableRow(admin, payload) {
   try {
     const full = await admin
@@ -88,7 +121,13 @@ async function writeTableRow(admin, payload) {
       .single();
     if (!legacy.error && legacy.data) return normalizeRow(legacy.data);
   } catch {}
-  return null;
+
+  // Absolute compatibility floor: tableReadyFor() only promises item_id and
+  // task_id. If a production table is partially migrated or PostgREST cannot
+  // use the expected upsert conflict target, retain account ownership of the
+  // provider task with those two guaranteed columns. Rich metadata can be
+  // recovered from the provider on later status reads.
+  return writeMinimalIdentityRow(admin, payload);
 }
 
 async function ensureStorageReady() {

--- a/scripts/test-catalog3d-generation-record-compat.mjs
+++ b/scripts/test-catalog3d-generation-record-compat.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const store = read('lib/catalog3dStore.js');
+const directPhotoRoute = read('app/api/property-photo-upload/route.ts');
 const migration007 = read('supabase/migrations/007_catalog_3d_media.sql');
 const migration009 = read('supabase/migrations/009_catalog_3d_binary_storage.sql');
 
@@ -16,7 +17,19 @@ assert.match(store, /function legacyTablePayload/, 'store must provide a legacy-
 assert.match(store, /source_image_urls: _sourceImageUrls/, 'legacy retry must omit the 009 source-image list column');
 assert.match(store, /model_storage_path: _modelStoragePath/, 'legacy retry must omit the 009 private-model-path column');
 assert.match(store, /upsert\(legacyTablePayload\(payload\), \{ onConflict: 'item_id' \}\)/, 'failed full writes must retry against the valid 007/008 schema');
+assert.match(store, /function minimalIdentityPayload/, 'store must have an item/task-only compatibility floor');
+assert.match(store, /\.update\(\{ task_id: minimal\.task_id \}\)/, 'minimal fallback must update an existing account generation record without relying on upsert conflict handling');
+assert.match(store, /\.insert\(minimal\)/, 'minimal fallback must insert the guaranteed item/task identity when no row exists');
+assert.match(store, /return writeMinimalIdentityRow\(admin, payload\)/, 'rich metadata failures must fall back to guaranteed task ownership persistence');
 assert.match(store, /for \(const admin of adminCandidates\(\)\)/, 'persistence must not stop at the first configured server credential');
 assert.match(store, /return writeStorageRow\(itemId, payload\)/, 'private storage remains a final fallback rather than a prerequisite for generation records');
 
-console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, while 009 private binary metadata remains optional.');
+const reservationIndex = directPhotoRoute.indexOf('const reservation = await saveCatalog3D');
+const providerStartIndex = directPhotoRoute.indexOf('const response = await fetch(ENDPOINT');
+assert.ok(reservationIndex >= 0, 'direct photo generation must reserve an account record first');
+assert.ok(providerStartIndex > reservationIndex, 'VoxelPop must not spend/start a Meshy 3D job until the account generation record is writable');
+assert.match(directPhotoRoute, /No 3D job was started/, 'preflight persistence failure must tell the user no provider job was started');
+assert.match(directPhotoRoute, /status: 'PREPARING'/, 'reserved generation records must have an explicit preparing state');
+assert.match(directPhotoRoute, /if \(!saved\?\.task_id\)/, 'the returned Meshy task id still must be attached to the reserved account record');
+
+console.log('Catalog3D generation-record compatibility passed: VoxelPop reserves a writable account record before Meshy, supports legacy 007/008 tables, and retains item/task ownership even when rich metadata writes are unavailable.');


### PR DESCRIPTION
Superseded by merged PR #398. #398 addresses the same VoxelPop generation-record failure without dead-ending an already-started provider job: it returns an HMAC-signed account-bound recovery task, verifies it on later 3D polling, and allows the voxel-image/final-3D pipeline to continue while catalog persistence recovers. The merged implementation passed the full repository Quality Gate and web build.