### PR TITLE
Harden VoxelPop generation persistence fallback

### DIFF
--- a/lib/catalog3dStore.js
+++ b/lib/catalog3dStore.js
@@ -91,24 +91,41 @@ async function writeTableRow(admin, payload) {
   return null;
 }
 
-async function ensureStorageReady() {
-  if (!storageReadyPromise) {
-    storageReadyPromise = (async () => {
-      for (const supabase of adminCandidates()) {
-        try {
-          const { data, error } = await supabase.storage.listBuckets();
-          if (error) continue;
-          if (!data?.some(bucket => bucket.name === SYSTEM_BUCKET)) {
-            const created = await supabase.storage.createBucket(SYSTEM_BUCKET, { public: false, fileSizeLimit: '75MB' });
-            if (created.error && !/already exists/i.test(created.error.message || '')) continue;
-          }
-          return supabase;
-        } catch {}
-      }
-      return null;
-    })();
+async function storageReadyFor(supabase) {
+  try {
+    const { data, error } = await supabase.storage.listBuckets();
+    if (!error) {
+      if (data?.some(bucket => bucket.name === SYSTEM_BUCKET)) return true;
+      const created = await supabase.storage.createBucket(SYSTEM_BUCKET, { public: false, fileSizeLimit: '75MB' });
+      return !created.error || /already exists/i.test(created.error?.message || '');
+    }
+  } catch {}
+
+  // Bucket listing can be temporarily unavailable even when object access works.
+  // Try idempotent creation anyway; an "already exists" response proves the
+  // target bucket is present and avoids turning a transient list failure into a
+  // permanent generation-record failure.
+  try {
+    const created = await supabase.storage.createBucket(SYSTEM_BUCKET, { public: false, fileSizeLimit: '75MB' });
+    return !created.error || /already exists/i.test(created.error?.message || '');
+  } catch {
+    return false;
   }
-  return storageReadyPromise;
+}
+
+async function discoverStorageClient() {
+  for (const supabase of adminCandidates()) {
+    if (await storageReadyFor(supabase)) return supabase;
+  }
+  return null;
+}
+
+async function ensureStorageReady() {
+  if (!storageReadyPromise) storageReadyPromise = discoverStorageClient();
+  const ready = await storageReadyPromise;
+  // Never pin a transient failure for the lifetime of a warm server instance.
+  if (!ready) storageReadyPromise = null;
+  return ready;
 }
 
 async function readStorageRow(itemId) {
@@ -124,20 +141,29 @@ async function readStorageRow(itemId) {
 
 async function writeStorageRow(itemId, patch = {}) {
   if (!itemId) return null;
-  const supabase = await ensureStorageReady();
-  if (!supabase) return null;
   const previous = await readStorageRow(itemId);
   const payload = normalizeRow({ ...(previous || {}), item_id: itemId, ...patch, updated_at: new Date().toISOString() });
-  try {
-    const body = JSON.stringify(payload);
-    const { error } = await supabase.storage.from(SYSTEM_BUCKET).upload(metadataPath(itemId), body, {
-      contentType: 'application/json',
-      cacheControl: '0',
-      upsert: true,
-    });
-    if (error) return null;
-    return payload;
-  } catch { return null; }
+  const body = JSON.stringify(payload);
+
+  // A credential that can inspect Storage is not necessarily the one that can
+  // write objects. Try every configured backend credential, just as table
+  // persistence does, and only cache a client after a successful upload.
+  for (const supabase of adminCandidates()) {
+    if (!(await storageReadyFor(supabase))) continue;
+    try {
+      const { error } = await supabase.storage.from(SYSTEM_BUCKET).upload(metadataPath(itemId), body, {
+        contentType: 'application/json',
+        cacheControl: '0',
+        upsert: true,
+      });
+      if (error) continue;
+      storageReadyPromise = Promise.resolve(supabase);
+      return payload;
+    } catch {}
+  }
+
+  storageReadyPromise = null;
+  return null;
 }
 
 async function listStorageRows() {
@@ -231,9 +257,15 @@ export async function persistModelBinary(itemId, remoteUrl) {
       cacheControl: '31536000',
       upsert: true,
     });
-    if (error) return null;
+    if (error) {
+      storageReadyPromise = null;
+      return null;
+    }
     return path;
-  } catch { return null; }
+  } catch {
+    storageReadyPromise = null;
+    return null;
+  }
 }
 
 export async function createModelSignedUrl(storagePath, expiresIn = 3600) {

--- a/scripts/test-catalog3d-generation-record-compat.mjs
+++ b/scripts/test-catalog3d-generation-record-compat.mjs
@@ -16,7 +16,12 @@ assert.match(store, /function legacyTablePayload/, 'store must provide a legacy-
 assert.match(store, /source_image_urls: _sourceImageUrls/, 'legacy retry must omit the 009 source-image list column');
 assert.match(store, /model_storage_path: _modelStoragePath/, 'legacy retry must omit the 009 private-model-path column');
 assert.match(store, /upsert\(legacyTablePayload\(payload\), \{ onConflict: 'item_id' \}\)/, 'failed full writes must retry against the valid 007/008 schema');
-assert.match(store, /for \(const admin of adminCandidates\(\)\)/, 'persistence must not stop at the first configured server credential');
+assert.match(store, /async function storageReadyFor/, 'storage fallback must probe each configured backend independently');
+assert.match(store, /Bucket listing can be temporarily unavailable/, 'storage fallback must recover when bucket listing fails transiently');
+assert.match(store, /createBucket\(SYSTEM_BUCKET, \{ public: false, fileSizeLimit: '75MB' \}\)/, 'storage fallback must use idempotent bucket creation as a recovery probe');
+assert.match(store, /if \(!ready\) storageReadyPromise = null/, 'transient storage readiness failures must not stay cached for a warm server lifetime');
+assert.match(store, /for \(const supabase of adminCandidates\(\)\)/, 'storage writes must try every configured server credential');
+assert.match(store, /storageReadyPromise = Promise\.resolve\(supabase\)/, 'a credential is cached only after a successful storage write');
 assert.match(store, /return writeStorageRow\(itemId, payload\)/, 'private storage remains a final fallback rather than a prerequisite for generation records');
 
-console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, while 009 private binary metadata remains optional.');
+console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, retry recoverable Storage failures, and keep 009 private binary metadata optional.');


### PR DESCRIPTION
Fixes the runtime case behind “VoxelPop started the 3D job, but the account generation record could not be saved.”

Changes:
- keep the legacy catalog_3d_media schema compatibility already on main
- recover when Supabase bucket listing fails but bucket/object access is still usable
- do not cache a transient Storage readiness failure for the lifetime of a warm server instance
- try every configured Supabase server credential for Storage writes
- cache the Storage client only after a successful write
- add regression guards for these persistence fallback cases

This preserves account-bound generation records while making transient/credential-specific Storage failures recoverable.