### PR TITLE
Fix VoxelPop 3D job persistence failure recovery

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -3,6 +3,10 @@ import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
 import { saveCatalog3D } from '../../../lib/catalog3dStore';
 import { normalizePropertyDraftId, propertyDraftItemId } from '../../../lib/property-generation-ids';
+import {
+  createPropertyGenerationRecoveryTaskId,
+  propertyGenerationCanonicalTaskId,
+} from '../../../lib/property-generation-task';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -14,10 +18,6 @@ const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
 function clean(value: unknown, max = 240) {
   return String(value || '').trim().slice(0, max);
-}
-
-function taskKey(raw: string) {
-  return raw.startsWith('property-voxel:task:') ? raw : `property-voxel:task:${raw}`;
 }
 
 function privateJson(body: unknown, init: ResponseInit = {}) {
@@ -84,10 +84,10 @@ export async function POST(request: Request) {
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
-    const taskId = taskKey(providerTaskId);
+    const canonicalTaskId = propertyGenerationCanonicalTaskId(providerTaskId);
     const sourceFingerprint = `inline-photo:${digest}`;
     const saved = await saveCatalog3D(itemId, {
-      task_id: taskId,
+      task_id: canonicalTaskId,
       source_image_url: sourceFingerprint,
       source_image_urls: [sourceFingerprint],
       provider: 'meshy-property-direct-photo-to-3d',
@@ -101,9 +101,12 @@ export async function POST(request: Request) {
       completed_at: null,
       error: null,
     });
-    if (!saved?.task_id) {
-      throw new Error('VoxelPop started the 3D job, but the account generation record could not be saved. Please try again shortly.');
-    }
+
+    // Do not orphan a provider job just because the account catalog table or
+    // private metadata bucket is temporarily unavailable. A signed recovery ID
+    // is scoped to this account and can be verified statelessly by later routes.
+    const taskId = saved?.task_id
+      || createPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, providerTaskId);
 
     const uploadedAt = new Date().toISOString();
     return privateJson({
@@ -121,10 +124,13 @@ export async function POST(request: Request) {
       },
       source3d: {
         taskId,
-        status: saved.status || 'PENDING',
-        progress: Number(saved.progress || 0),
+        status: saved?.status || 'PENDING',
+        progress: Number(saved?.progress || 0),
       },
-      privacy: 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider for this generation request; only a SHA-256 fingerprint and account-bound job record are retained by Voxel Vault.',
+      recoveryMode: !saved?.task_id,
+      privacy: saved?.task_id
+        ? 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider for this generation request; only a SHA-256 fingerprint and account-bound job record are retained by Voxel Vault.'
+        : 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider. Account job storage was temporarily unavailable, so Voxel Vault returned a signed account-bound recovery task reference and retained no copy of the original photo.',
     });
   } catch (error) {
     return privateJson({

--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -15,6 +15,12 @@ import {
   propertyGenerationItemBelongsToUser,
   propertyLegacyItemId,
 } from '../../../lib/property-generation-ids';
+import {
+  createPropertyGenerationRecoveryTaskId,
+  propertyGenerationCanonicalTaskId,
+  propertyGenerationProviderTaskId,
+  verifyPropertyGenerationRecoveryTaskId,
+} from '../../../lib/property-generation-task';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -50,14 +56,6 @@ function isHttpUrl(value: unknown) {
 
 function voxelImageTaskToken(apiKey: string, userId: string, taskId: string) {
   return createHmac('sha256', apiKey).update(`property-voxel-image-v1:${userId}:${taskId}`).digest('hex');
-}
-
-function taskKey(raw: string) {
-  return raw.startsWith('property-voxel:task:') ? raw : `property-voxel:task:${raw}`;
-}
-
-function rawTaskId(value: string) {
-  return value.replace(/^property-voxel:task:/, '');
 }
 
 async function displayUrlFor(saved: any) {
@@ -136,16 +134,30 @@ export async function POST(request: Request) {
       if (phase === 'source') {
         const sourceStoragePath = clean(body?.sourceStoragePath, 900);
         if (sourceStoragePath.startsWith('meshy-source:')) {
-          const taskId = clean(sourceStoragePath.slice('meshy-source:'.length), 260);
+          const taskId = clean(sourceStoragePath.slice('meshy-source:'.length), 420);
           const directJob = await readCatalog3DByTask(taskId);
-          if (!directJob?.item_id || directJob.item_id !== itemId) {
+          if (directJob?.item_id) {
+            if (directJob.item_id !== itemId) {
+              throw new Error('That direct photo 3D job does not belong to this signed-in creation.');
+            }
+            return privateJson({
+              ok: true,
+              reused: true,
+              directPhoto: true,
+              ...publicState(directJob, await displayUrlFor(directJob)),
+            });
+          }
+
+          const recoveryProviderTaskId = verifyPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, taskId);
+          if (!recoveryProviderTaskId) {
             throw new Error('That direct photo 3D job does not belong to this signed-in creation.');
           }
           return privateJson({
             ok: true,
             reused: true,
             directPhoto: true,
-            ...publicState(directJob, await displayUrlFor(directJob)),
+            recoveryMode: true,
+            ...publicState({ item_id: itemId, task_id: taskId, status: 'PENDING', progress: 0 }),
           });
         }
         imageUrl = await sourcePhotoUrl(auth, draftId, sourceStoragePath);
@@ -191,9 +203,9 @@ export async function POST(request: Request) {
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
-    const taskId = taskKey(providerTaskId);
+    const canonicalTaskId = propertyGenerationCanonicalTaskId(providerTaskId);
     const saved = await saveCatalog3D(itemId, {
-      task_id: taskId,
+      task_id: canonicalTaskId,
       source_image_url: imageUrl,
       source_image_urls: [imageUrl],
       provider,
@@ -207,8 +219,16 @@ export async function POST(request: Request) {
       completed_at: null,
       error: null,
     });
+    const taskId = saved?.task_id
+      || createPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, providerTaskId);
 
-    return privateJson({ ok: true, reused: false, sourceChanged: Boolean(existing && !sameSourceImage), ...publicState(saved || { item_id: itemId, task_id: taskId, status: 'PENDING' }) });
+    return privateJson({
+      ok: true,
+      reused: false,
+      sourceChanged: Boolean(existing && !sameSourceImage),
+      recoveryMode: !saved?.task_id,
+      ...publicState(saved || { item_id: itemId, task_id: taskId, status: 'PENDING' }),
+    });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Property 3D generation failed.' }, { status: 400 });
   }
@@ -221,7 +241,7 @@ export async function GET(request: Request) {
   const atlasIdRaw = url.searchParams.get('atlasId') || '';
   const draftIdRaw = url.searchParams.get('draftId') || '';
   const phaseRaw = url.searchParams.get('phase') || '';
-  const taskId = clean(url.searchParams.get('taskId'), 260);
+  const taskId = clean(url.searchParams.get('taskId'), 420);
   const resumeCached = url.searchParams.get('resume') === '1';
 
   try {
@@ -246,12 +266,28 @@ export async function GET(request: Request) {
     const apiKey = process.env.MESHY_API_KEY?.trim();
     if (!apiKey) return privateJson({ ok: false, error: 'Property 3D generation is not configured on this deployment.' }, { status: 503 });
 
-    const saved = await readCatalog3DByTask(taskId);
-    if (!saved?.item_id || !propertyGenerationItemBelongsToUser(auth.user.id, saved.item_id)) {
-      return privateJson({ ok: false, error: 'That 3D job does not belong to this signed-in account.' }, { status: 404 });
+    const stored = await readCatalog3DByTask(taskId);
+    let saved = stored;
+    let providerTaskId = '';
+    let recoveryMode = false;
+
+    if (saved?.item_id && propertyGenerationItemBelongsToUser(auth.user.id, saved.item_id)) {
+      providerTaskId = propertyGenerationProviderTaskId(saved.task_id || taskId);
+    } else {
+      const recoveredProviderTaskId = verifyPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, taskId);
+      if (!recoveredProviderTaskId) {
+        return privateJson({ ok: false, error: 'That 3D job does not belong to this signed-in account.' }, { status: 404 });
+      }
+      providerTaskId = recoveredProviderTaskId;
+      recoveryMode = true;
+      saved = null;
     }
 
-    const response = await fetch(`${ENDPOINT}/${encodeURIComponent(rawTaskId(taskId))}`, {
+    if (!providerTaskId) {
+      return privateJson({ ok: false, error: 'That 3D job has an invalid provider task reference.' }, { status: 400 });
+    }
+
+    const response = await fetch(`${ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       cache: 'no-store',
     });
@@ -262,11 +298,26 @@ export async function GET(request: Request) {
     const progress = Number(data?.progress || 0);
     const providerModelUrl = clean(data?.model_urls?.glb, 2200) || null;
     const thumbnailUrl = clean(data?.alpha_thumbnail_url || data?.thumbnail_url, 2200) || null;
+
+    if (recoveryMode || !saved?.item_id) {
+      const finalRow = {
+        item_id: null,
+        task_id: taskId,
+        status,
+        progress: providerModelUrl ? 100 : progress,
+        model_storage_path: null,
+        model_url: providerModelUrl,
+        thumbnail_url: thumbnailUrl,
+        error: data?.task_error?.message || null,
+      };
+      return privateJson({ ok: true, exists: true, recoveryMode: true, ...publicState(finalRow, providerModelUrl) });
+    }
+
     let modelStoragePath = saved?.model_storage_path || null;
     if (providerModelUrl && saved?.item_id && !modelStoragePath) modelStoragePath = await persistModelBinary(saved.item_id, providerModelUrl);
 
     const updated = await saveCatalog3D(saved.item_id, {
-      task_id: taskId,
+      task_id: saved.task_id || taskId,
       provider: saved.provider || 'meshy-property-generation',
       status,
       progress: providerModelUrl ? 100 : progress,

--- a/app/api/property-voxel-image/route.ts
+++ b/app/api/property-voxel-image/route.ts
@@ -3,12 +3,14 @@ import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
 import { readCatalog3DByTask } from '../../../lib/catalog3dStore';
 import { normalizePropertyDraftId, propertyDraftItemId } from '../../../lib/property-generation-ids';
+import { verifyPropertyGenerationRecoveryTaskId } from '../../../lib/property-generation-task';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
 const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-image';
+const THREE_D_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const ALLOWED_RIGHTS_BASES = new Set(['user-owned', 'open-licensed', 'licensed-derivative']);
 const BLOCKED_REFERENCE_HOSTS = /(^|\.)(google\.com|googleusercontent\.com|gstatic\.com|googleapis\.com|maps\.googleapis\.com|streetviewpixels-pa\.googleapis\.com|zillow\.com|zillowstatic\.com|redfin\.com|cdn-redfin\.com|apartments\.com)$/i;
 
@@ -54,16 +56,48 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
   });
 }
 
-async function generated3DReference(userId: string, draftIdRaw: unknown, sourceTaskIdRaw: unknown) {
+async function recoveredGenerated3DReference(apiKey: string, userId: string, sourceTaskId: string) {
+  const providerTaskId = verifyPropertyGenerationRecoveryTaskId(apiKey, userId, sourceTaskId);
+  if (!providerTaskId) return null;
+
+  const response = await fetch(`${THREE_D_ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: 'no-store',
+  });
+  const task = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(task?.task_error?.message || task?.message || task?.error || 'The first 3D build could not be verified.');
+
+  const status = clean(task?.status || '', 80).toUpperCase();
+  const modelUrl = clean(task?.model_urls?.glb, 2200);
+  if (status !== 'SUCCEEDED' || !isHttpUrl(modelUrl)) {
+    throw new Error('Finish the first 3D build before making the voxel.');
+  }
+
+  const thumbnailUrl = clean(task?.alpha_thumbnail_url || task?.thumbnail_url, 2200);
+  if (!isHttpUrl(thumbnailUrl)) {
+    throw new Error('The first 3D build finished without a usable preview render. Retry the 3D build before voxelizing it.');
+  }
+  return thumbnailUrl;
+}
+
+async function generated3DReference(apiKey: string, userId: string, draftIdRaw: unknown, sourceTaskIdRaw: unknown) {
   const draftId = normalizePropertyDraftId(draftIdRaw);
-  const sourceTaskId = clean(sourceTaskIdRaw, 260);
+  const sourceTaskId = clean(sourceTaskIdRaw, 420);
   if (!sourceTaskId) throw new Error('Finish the first 3D build before the voxel style pass.');
   const saved = await readCatalog3DByTask(sourceTaskId);
   const expectedItemId = propertyDraftItemId(userId, draftId, 'source');
-  if (!saved || saved.item_id !== expectedItemId) throw new Error('That first 3D build does not belong to this signed-in creation.');
-  const sourceReady = Boolean(saved.model_storage_path || saved.model_url);
-  const thumbnailUrl = clean(saved.thumbnail_url, 2200);
-  if (!sourceReady) throw new Error('Finish the first 3D build before making the voxel.');
+
+  let thumbnailUrl = '';
+  if (saved) {
+    if (saved.item_id !== expectedItemId) throw new Error('That first 3D build does not belong to this signed-in creation.');
+    const sourceReady = Boolean(saved.model_storage_path || saved.model_url);
+    thumbnailUrl = clean(saved.thumbnail_url, 2200);
+    if (!sourceReady) throw new Error('Finish the first 3D build before making the voxel.');
+  } else {
+    thumbnailUrl = await recoveredGenerated3DReference(apiKey, userId, sourceTaskId) || '';
+    if (!thumbnailUrl) throw new Error('That first 3D build does not belong to this signed-in creation.');
+  }
+
   if (!isHttpUrl(thumbnailUrl)) throw new Error('The first 3D build finished without a usable preview render. Retry the 3D build before voxelizing it.');
   return [{
     url: thumbnailUrl,
@@ -86,7 +120,7 @@ export async function POST(request: Request) {
     const address = clean(body?.address, 220);
     const atlasId = clean(body?.atlasId, 180);
     const references = draftId
-      ? await generated3DReference(auth.user.id, draftId, body?.source3dTaskId)
+      ? await generated3DReference(apiKey, auth.user.id, draftId, body?.source3dTaskId)
       : validateReferences(body?.references);
     if (!draftId && (!address || !atlasId)) return privateJson({ ok: false, error: 'A resolved property is required.' }, { status: 400 });
     if (!references.length) return privateJson({ ok: false, error: 'A rights-cleared visual reference is required before making the voxel.' }, { status: 400 });

--- a/lib/property-generation-task.ts
+++ b/lib/property-generation-task.ts
@@ -1,0 +1,63 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const TASK_PREFIX = 'property-voxel:task:';
+const RECOVERY_PREFIX = 'property-voxel:recovery:';
+
+function clean(value: unknown, max = 420) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function recoverySignature(secret: string, userId: string, providerTaskId: string) {
+  return createHmac('sha256', secret)
+    .update(`property-voxel-recovery-v1:${userId}:${providerTaskId}`)
+    .digest('hex');
+}
+
+function signaturesMatch(left: string, right: string) {
+  const a = Buffer.from(left, 'utf8');
+  const b = Buffer.from(right, 'utf8');
+  return a.length === b.length && a.length > 0 && timingSafeEqual(a, b);
+}
+
+export function propertyGenerationCanonicalTaskId(providerTaskId: string) {
+  const raw = clean(providerTaskId, 240);
+  if (!raw) throw new Error('The 3D provider did not return a task ID.');
+  return raw.startsWith(TASK_PREFIX) ? raw : `${TASK_PREFIX}${raw}`;
+}
+
+export function propertyGenerationProviderTaskId(taskId: unknown) {
+  const value = clean(taskId);
+  if (value.startsWith(TASK_PREFIX)) return clean(value.slice(TASK_PREFIX.length), 240);
+  if (!value.startsWith(RECOVERY_PREFIX)) return '';
+
+  const packed = value.slice(RECOVERY_PREFIX.length);
+  const separator = packed.indexOf('.');
+  if (separator <= 0) return '';
+  try {
+    return clean(Buffer.from(packed.slice(0, separator), 'base64url').toString('utf8'), 240);
+  } catch {
+    return '';
+  }
+}
+
+export function createPropertyGenerationRecoveryTaskId(secret: string, userId: string, providerTaskId: string) {
+  const canonical = propertyGenerationCanonicalTaskId(providerTaskId);
+  const raw = propertyGenerationProviderTaskId(canonical);
+  const encoded = Buffer.from(raw, 'utf8').toString('base64url');
+  return `${RECOVERY_PREFIX}${encoded}.${recoverySignature(secret, userId, raw)}`;
+}
+
+export function verifyPropertyGenerationRecoveryTaskId(secret: string, userId: string, taskId: unknown) {
+  const value = clean(taskId);
+  if (!value.startsWith(RECOVERY_PREFIX)) return null;
+
+  const packed = value.slice(RECOVERY_PREFIX.length);
+  const separator = packed.indexOf('.');
+  if (separator <= 0) return null;
+  const suppliedSignature = clean(packed.slice(separator + 1), 128);
+  const providerTaskId = propertyGenerationProviderTaskId(value);
+  if (!providerTaskId || !suppliedSignature) return null;
+
+  const expectedSignature = recoverySignature(secret, userId, providerTaskId);
+  return signaturesMatch(suppliedSignature, expectedSignature) ? providerTaskId : null;
+}

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 const property = fs.readFileSync(new URL('../app/property/page.js', import.meta.url), 'utf8');
 const photoHandoff = fs.readFileSync(new URL('../app/api/property-photo-upload/route.ts', import.meta.url), 'utf8');
 const voxel3d = fs.readFileSync(new URL('../app/api/property-voxel-3d/route.ts', import.meta.url), 'utf8');
+const voxelImage = fs.readFileSync(new URL('../app/api/property-voxel-image/route.ts', import.meta.url), 'utf8');
+const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
@@ -19,11 +21,21 @@ assert.doesNotMatch(photoHandoff, /storage\.from\(|createBucket\(|createSignedUr
 assert.match(property, /phase: 'source'/, 'automatic pipeline must continue through the first 3D source phase');
 assert.match(property, /sourceStoragePath: reference\.storagePath/, 'first 3D continuation must pass the opaque direct-job reference');
 assert.match(voxel3d, /sourceStoragePath\.startsWith\('meshy-source:'\)/, '3D route must recognize a pre-started direct photo job');
-assert.match(voxel3d, /directJob\.item_id !== itemId/, 'pre-started direct job must remain account and draft bound');
+assert.match(voxel3d, /directJob\.item_id !== itemId/, 'persisted pre-started direct jobs must remain account and draft bound');
 assert.match(property, /source3dTaskId: sourceDone\.taskId/, 'voxel style pass must start from the completed first 3D preview');
 assert.match(property, /voxelImageTaskId: voxelDone\.taskId/, 'final 3D must use the verified completed voxel-image job');
 assert.match(property, /voxelImageTaskToken: voxelDone\.taskToken/, 'final 3D must carry the account-bound voxel image task token');
 assert.match(property, /phase: 'voxel'/, 'automatic pipeline must build a distinct final voxel 3D phase');
+
+assert.doesNotMatch(photoHandoff, /account generation record could not be saved/, 'a started provider job must not be orphaned solely because catalog persistence is temporarily unavailable');
+assert.match(photoHandoff, /createPropertyGenerationRecoveryTaskId/, 'photo handoff must issue a signed recovery task reference when persistence fails');
+assert.match(voxel3d, /verifyPropertyGenerationRecoveryTaskId\(apiKey, auth\.user\.id, taskId\)/, '3D polling must verify account-bound recovery task references');
+assert.match(voxel3d, /recoveryMode: true/, '3D polling must expose a recoverable provider-backed path when storage is unavailable');
+assert.match(voxelImage, /recoveredGenerated3DReference/, 'voxel styling must accept a verified recovered source 3D job');
+assert.match(voxelImage, /verifyPropertyGenerationRecoveryTaskId\(apiKey, userId, sourceTaskId\)/, 'voxel styling must verify recovery ownership before using the generated preview');
+assert.match(taskRecovery, /createHmac\('sha256', secret\)/, 'recovery task references must be signed server-side');
+assert.match(taskRecovery, /property-voxel-recovery-v1:\$\{userId\}:\$\{providerTaskId\}/, 'recovery signatures must bind the provider task to the signed-in account');
+assert.match(taskRecovery, /timingSafeEqual/, 'recovery signature verification must use constant-time comparison');
 
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
@@ -36,4 +48,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, without requiring source-photo bucket storage.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, including signed account-bound recovery when generation-record persistence is temporarily unavailable.');


### PR DESCRIPTION
## What this fixes

VoxelPop can successfully start a Meshy image-to-3D job and then fail to persist the account generation record. Previously that orphaned an already-started provider job and surfaced: `VoxelPop started the 3D job, but the account generation record could not be saved.`

## Change

- Add signed, account-bound recovery task IDs for provider jobs when catalog persistence is temporarily unavailable.
- Continue the direct-photo 3D handoff without requiring a successful `catalog_3d_media` or Storage write.
- Verify recovery IDs server-side before status polling.
- Allow the voxel-image stage to verify and use a completed recovered Meshy 3D preview.
- Apply the same failover to final 3D creation if its persistence write fails.
- Keep the existing persisted-record ownership checks unchanged when storage is available.
- Extend the automatic property-creation regression test so this error cannot be reintroduced.

## Security / privacy

Recovery references are HMAC-SHA256 signed with server-only configuration and bind the Meshy provider task to the signed-in user. The original uploaded photo is still not retained in Voxel Vault Storage for this flow.

## Expected user behavior

If Supabase catalog persistence is unavailable after Meshy accepts a job, the user should no longer hit a dead end. The existing UI can continue polling the signed recovery task, voxelize the completed preview, and build the final movable 3D model without a client-side change.