### PR TITLE
Finish VoxelPop generation-record persistence fix

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -11,6 +11,7 @@ export const dynamic = 'force-dynamic';
 const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_BYTES = 8 * 1024 * 1024;
 const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const SAVE_ATTEMPTS = 3;
 
 function clean(value: unknown, max = 240) {
   return String(value || '').trim().slice(0, max);
@@ -25,6 +26,17 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
     ...init,
     headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
   });
+}
+
+async function saveGenerationRecord(itemId: string, patch: Record<string, unknown>) {
+  for (let attempt = 0; attempt < SAVE_ATTEMPTS; attempt += 1) {
+    const saved = await saveCatalog3D(itemId, patch);
+    if (saved?.item_id) return saved;
+    if (attempt + 1 < SAVE_ATTEMPTS) {
+      await new Promise(resolve => setTimeout(resolve, 80 * (attempt + 1)));
+    }
+  }
+  return null;
 }
 
 export async function POST(request: Request) {
@@ -61,6 +73,37 @@ export async function POST(request: Request) {
     const digest = createHash('sha256').update(bytes).digest('hex');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
     const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
+    const sourceFingerprint = `inline-photo:${digest}`;
+    const startedAt = new Date().toISOString();
+    const baseRecord = {
+      source_image_url: sourceFingerprint,
+      source_image_urls: [sourceFingerprint],
+      provider: 'meshy-property-direct-photo-to-3d',
+      progress: 0,
+      model_url: null,
+      model_storage_path: null,
+      thumbnail_url: null,
+      exact_model_approved: false,
+      started_at: startedAt,
+      completed_at: null,
+      error: null,
+    };
+
+    // Reserve a durable, account-bound record before spending a Meshy job.
+    // If database + Storage persistence is unavailable, fail closed here so a
+    // provider task can never be started without a resumable ownership record.
+    const reservation = await saveGenerationRecord(itemId, {
+      ...baseRecord,
+      task_id: null,
+      status: 'PREPARING',
+    });
+    if (!reservation?.item_id) {
+      return privateJson({
+        ok: false,
+        error: 'VoxelPop cannot save generation records right now, so no 3D job was started. Please try again shortly.',
+        setupRequired: true,
+      }, { status: 503 });
+    }
 
     const response = await fetch(ENDPOINT, {
       method: 'POST',
@@ -79,30 +122,41 @@ export async function POST(request: Request) {
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+      const providerError = clean(data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.`, 800);
+      await saveGenerationRecord(itemId, {
+        ...baseRecord,
+        task_id: null,
+        status: 'FAILED',
+        completed_at: new Date().toISOString(),
+        error: providerError,
+      });
+      return privateJson({ ok: false, error: providerError }, { status: response.status });
     }
 
     const providerTaskId = clean(data?.result || data?.id, 240);
-    if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
+    if (!providerTaskId) {
+      await saveGenerationRecord(itemId, {
+        ...baseRecord,
+        task_id: null,
+        status: 'FAILED',
+        completed_at: new Date().toISOString(),
+        error: 'The 3D provider did not return a task ID.',
+      });
+      return privateJson({ ok: false, error: 'The 3D provider did not return a task ID.' }, { status: 502 });
+    }
+
     const taskId = taskKey(providerTaskId);
-    const sourceFingerprint = `inline-photo:${digest}`;
-    const saved = await saveCatalog3D(itemId, {
+    const saved = await saveGenerationRecord(itemId, {
+      ...baseRecord,
       task_id: taskId,
-      source_image_url: sourceFingerprint,
-      source_image_urls: [sourceFingerprint],
-      provider: 'meshy-property-direct-photo-to-3d',
       status: 'PENDING',
-      progress: 0,
-      model_url: null,
-      model_storage_path: null,
-      thumbnail_url: null,
-      exact_model_approved: false,
-      started_at: new Date().toISOString(),
-      completed_at: null,
-      error: null,
     });
     if (!saved?.task_id) {
-      throw new Error('VoxelPop started the 3D job, but the account generation record could not be saved. Please try again shortly.');
+      return privateJson({
+        ok: false,
+        error: 'VoxelPop started the 3D job but could not attach its task ID to your reserved account record after retrying. Please try again shortly.',
+        setupRequired: true,
+      }, { status: 503 });
     }
 
     const uploadedAt = new Date().toISOString();

--- a/lib/catalog3dStore.js
+++ b/lib/catalog3dStore.js
@@ -69,6 +69,39 @@ function legacyTablePayload(payload = {}) {
   return legacy;
 }
 
+function minimalIdentityPayload(payload = {}) {
+  return {
+    item_id: payload.item_id,
+    task_id: payload.task_id || null,
+  };
+}
+
+async function writeMinimalIdentityRow(admin, payload) {
+  const minimal = minimalIdentityPayload(payload);
+  if (!minimal.item_id) return null;
+
+  try {
+    const updated = await admin
+      .from('catalog_3d_media')
+      .update({ task_id: minimal.task_id })
+      .eq('item_id', minimal.item_id)
+      .select('*')
+      .maybeSingle();
+    if (!updated.error && updated.data) return normalizeRow(updated.data);
+  } catch {}
+
+  try {
+    const inserted = await admin
+      .from('catalog_3d_media')
+      .insert(minimal)
+      .select('*')
+      .single();
+    if (!inserted.error && inserted.data) return normalizeRow(inserted.data);
+  } catch {}
+
+  return null;
+}
+
 async function writeTableRow(admin, payload) {
   try {
     const full = await admin
@@ -88,7 +121,11 @@ async function writeTableRow(admin, payload) {
       .single();
     if (!legacy.error && legacy.data) return normalizeRow(legacy.data);
   } catch {}
-  return null;
+
+  // Absolute compatibility floor: if rich metadata/upsert handling is broken,
+  // retain the account-bound provider identity using only the original columns.
+  // Later provider status reads can recover the richer generation metadata.
+  return writeMinimalIdentityRow(admin, payload);
 }
 
 async function storageReadyFor(supabase) {
@@ -231,10 +268,9 @@ export async function saveCatalog3D(itemId, patch = {}) {
   if (!itemId) return null;
   const payload = normalizeRow({ item_id: itemId, ...patch, updated_at: new Date().toISOString() });
 
-  // Try every configured server credential. This avoids a stale/limited first
-  // credential hiding a valid service-role/secret-key candidate.
+  // Attempt the actual write with every configured server credential. A stale
+  // readiness/schema-cache read must not prevent a valid service-role write.
   for (const admin of adminCandidates()) {
-    if (!(await tableReadyFor(admin))) continue;
     const saved = await writeTableRow(admin, payload);
     if (saved) return saved;
   }

--- a/scripts/test-catalog3d-generation-record-compat.mjs
+++ b/scripts/test-catalog3d-generation-record-compat.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const store = read('lib/catalog3dStore.js');
+const directPhotoRoute = read('app/api/property-photo-upload/route.ts');
 const migration007 = read('supabase/migrations/007_catalog_3d_media.sql');
 const migration009 = read('supabase/migrations/009_catalog_3d_binary_storage.sql');
 
@@ -16,6 +17,12 @@ assert.match(store, /function legacyTablePayload/, 'store must provide a legacy-
 assert.match(store, /source_image_urls: _sourceImageUrls/, 'legacy retry must omit the 009 source-image list column');
 assert.match(store, /model_storage_path: _modelStoragePath/, 'legacy retry must omit the 009 private-model-path column');
 assert.match(store, /upsert\(legacyTablePayload\(payload\), \{ onConflict: 'item_id' \}\)/, 'failed full writes must retry against the valid 007/008 schema');
+assert.match(store, /function minimalIdentityPayload/, 'store must have an item/task-only compatibility floor');
+assert.match(store, /\.update\(\{ task_id: minimal\.task_id \}\)/, 'minimal fallback must update an existing account generation record without relying on upsert conflict handling');
+assert.match(store, /\.insert\(minimal\)/, 'minimal fallback must insert guaranteed item/task identity when no row exists');
+assert.match(store, /return writeMinimalIdentityRow\(admin, payload\)/, 'rich metadata failures must fall back to guaranteed task ownership persistence');
+assert.match(store, /const saved = await writeTableRow\(admin, payload\)/, 'generation writes must attempt the actual database write for each credential');
+assert.doesNotMatch(store, /if \(!\(await tableReadyFor\(admin\)\)\) continue;/, 'a stale readiness read must not block a valid generation-record write');
 assert.match(store, /async function storageReadyFor/, 'storage fallback must probe each configured backend independently');
 assert.match(store, /Bucket listing can be temporarily unavailable/, 'storage fallback must recover when bucket listing fails transiently');
 assert.match(store, /createBucket\(SYSTEM_BUCKET, \{ public: false, fileSizeLimit: '75MB' \}\)/, 'storage fallback must use idempotent bucket creation as a recovery probe');
@@ -24,4 +31,14 @@ assert.match(store, /for \(const supabase of adminCandidates\(\)\)/, 'storage wr
 assert.match(store, /storageReadyPromise = Promise\.resolve\(supabase\)/, 'a credential is cached only after a successful storage write');
 assert.match(store, /return writeStorageRow\(itemId, payload\)/, 'private storage remains a final fallback rather than a prerequisite for generation records');
 
-console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, retry recoverable Storage failures, and keep 009 private binary metadata optional.');
+const reservationIndex = directPhotoRoute.indexOf('const reservation = await saveGenerationRecord');
+const providerStartIndex = directPhotoRoute.indexOf('const response = await fetch(ENDPOINT');
+assert.ok(reservationIndex >= 0, 'direct photo generation must reserve an account record first');
+assert.ok(providerStartIndex > reservationIndex, 'VoxelPop must not start a Meshy 3D job until the account generation record is writable');
+assert.match(directPhotoRoute, /const SAVE_ATTEMPTS = 3;/, 'generation-record persistence must retry transient failures');
+assert.match(directPhotoRoute, /status: 'PREPARING'/, 'reserved generation records must have an explicit preparing state');
+assert.match(directPhotoRoute, /no 3D job was started/, 'preflight persistence failure must tell the user no provider job was started');
+assert.match(directPhotoRoute, /if \(!saved\?\.task_id\)/, 'the returned Meshy task id still must be attached to the reserved account record');
+assert.match(directPhotoRoute, /after retrying/, 'task-id attachment must retry before surfacing a persistence error');
+
+console.log('Catalog3D generation-record compatibility passed: VoxelPop reserves durable account persistence before Meshy, retries transient database/Storage failures, supports legacy 007/008 tables, and retains item/task ownership even when rich metadata writes are unavailable.');


### PR DESCRIPTION
Superseded by merged PR #398, which fixes the same runtime failure with a stronger signed, account-bound recovery path that keeps an already-accepted Meshy job usable even when catalog persistence is temporarily unavailable. #398 passed the web build, full Quality Gate, Mobile WebGL Guard, and contract checks. Closing this preflight alternative to avoid conflicting with the merged recovery implementation.