### PR TITLE
Fix VoxelPop cached Meshy GLB display recovery

### DIFF
--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -59,11 +59,15 @@ function voxelImageTaskToken(apiKey: string, userId: string, taskId: string) {
 }
 
 async function displayUrlFor(saved: any) {
+  // Active property generations should display Meshy's current provider URL first.
+  // The persisted private GLB remains the durable fallback for later sessions,
+  // but a stale/missing cache object must never hide a still-valid live model.
+  if (isHttpUrl(saved?.model_url)) return saved.model_url;
   if (saved?.model_storage_path) {
     const signed = await createModelSignedUrl(saved.model_storage_path, 60 * 60);
     if (signed) return signed;
   }
-  return saved?.model_url || null;
+  return null;
 }
 
 function publicState(saved: any, displayModelUrl: string | null = null) {

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -5,12 +5,14 @@ import { useEffect, useRef, useState } from 'react';
 export default function MeshyModelViewer({ modelUrl }) {
   const mountRef = useRef(null);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(Boolean(modelUrl));
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
     let dead = false;
     let cleanup = () => {};
     setError('');
+    setLoading(true);
 
     Promise.all([
       import('three'),
@@ -22,6 +24,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
+        setLoading(false);
         setError('3D model preview is unavailable in this browser.');
         return;
       }
@@ -68,31 +71,48 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       const loader = new loaderModule.GLTFLoader();
       let model = null;
-      loader.load(modelUrl, (gltf) => {
-        if (dead) return;
-        model = gltf.scene;
-        model.traverse((object) => {
-          if (!object?.isMesh) return;
-          object.castShadow = !compact;
-          object.receiveShadow = !compact;
-          if (object.material) {
-            object.material.envMapIntensity = 0.75;
-            object.material.needsUpdate = true;
+      let loadAttempt = 0;
+      const loadModel = () => {
+        const separator = String(modelUrl).includes('?') ? '&' : '?';
+        const url = loadAttempt === 0 ? modelUrl : `${modelUrl}${separator}vv_reload=${Date.now()}`;
+        loader.load(url, (gltf) => {
+          if (dead) return;
+          model = gltf.scene;
+          model.traverse((object) => {
+            if (!object?.isMesh) return;
+            object.castShadow = !compact;
+            object.receiveShadow = !compact;
+            if (object.material) {
+              object.material.envMapIntensity = 0.75;
+              object.material.needsUpdate = true;
+            }
+          });
+          const box = new THREE.Box3().setFromObject(model);
+          const size = new THREE.Vector3();
+          const center = new THREE.Vector3();
+          box.getSize(size);
+          box.getCenter(center);
+          const largest = Math.max(size.x, size.y, size.z, 0.001);
+          const scale = 5.7 / largest;
+          model.scale.setScalar(scale);
+          model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
+          root.add(model);
+          setLoading(false);
+          setError('');
+        }, undefined, () => {
+          if (dead) return;
+          if (loadAttempt < 1) {
+            loadAttempt += 1;
+            setError('');
+            setLoading(true);
+            window.setTimeout(loadModel, 350);
+            return;
           }
+          setLoading(false);
+          setError('The 3D preview could not be loaded. Refresh the creation to request a fresh Meshy model link.');
         });
-        const box = new THREE.Box3().setFromObject(model);
-        const size = new THREE.Vector3();
-        const center = new THREE.Vector3();
-        box.getSize(size);
-        box.getCenter(center);
-        const largest = Math.max(size.x, size.y, size.z, 0.001);
-        const scale = 5.7 / largest;
-        model.scale.setScalar(scale);
-        model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
-        root.add(model);
-      }, undefined, () => {
-        if (!dead) setError('The cached Meshy GLB could not be loaded. Regenerating is not automatic.');
-      });
+      };
+      loadModel();
 
       const pointers = new Map();
       let moved = false;
@@ -207,7 +227,10 @@ export default function MeshyModelViewer({ modelUrl }) {
         mount.innerHTML = '';
       };
     }).catch(() => {
-      if (!dead) setError('The 3D model viewer could not start.');
+      if (!dead) {
+        setLoading(false);
+        setError('The 3D model viewer could not start.');
+      }
     });
 
     return () => { dead = true; cleanup(); };
@@ -215,8 +238,9 @@ export default function MeshyModelViewer({ modelUrl }) {
 
   return <div className="viewerShell">
     <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
+    {loading && !error ? <div className="viewerLoading">Loading live 3D model…</div> : null}
     {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · CACHED GLB</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    <div className="viewerHint">DRAG · PINCH TO ZOOM · LIVE 3D</div>
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerLoading{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
   </div>;
 }

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -6,6 +6,7 @@ const photoHandoff = fs.readFileSync(new URL('../app/api/property-photo-upload/r
 const voxel3d = fs.readFileSync(new URL('../app/api/property-voxel-3d/route.ts', import.meta.url), 'utf8');
 const voxelImage = fs.readFileSync(new URL('../app/api/property-voxel-image/route.ts', import.meta.url), 'utf8');
 const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
+const modelViewer = fs.readFileSync(new URL('../app/vault/earth/MeshyModelViewer.js', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
@@ -37,6 +38,13 @@ assert.match(taskRecovery, /createHmac\('sha256', secret\)/, 'recovery task refe
 assert.match(taskRecovery, /property-voxel-recovery-v1:\$\{userId\}:\$\{providerTaskId\}/, 'recovery signatures must bind the provider task to the signed-in account');
 assert.match(taskRecovery, /timingSafeEqual/, 'recovery signature verification must use constant-time comparison');
 
+assert.match(voxel3d, /if \(isHttpUrl\(saved\?\.model_url\)\) return saved\.model_url/, 'active 3D previews must prefer the current Meshy provider GLB over a potentially stale private cache object');
+assert.match(voxel3d, /createModelSignedUrl\(saved\.model_storage_path/, 'durable private GLB storage must remain available as a fallback when no provider URL is present');
+assert.match(modelViewer, /loadAttempt < 1/, '3D viewer must retry a failed GLB load automatically');
+assert.match(modelViewer, /vv_reload=/, '3D viewer retry must bypass a stale browser or edge cache');
+assert.match(modelViewer, /Loading live 3D model/, '3D viewer must show an explicit loading state while the generated model is being displayed');
+assert.doesNotMatch(modelViewer, /Regenerating is not automatic/, 'a failed cached GLB must not tell the user that the flow is permanently stuck');
+
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
@@ -48,4 +56,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, including signed account-bound recovery when generation-record persistence is temporarily unavailable.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, including signed recovery and resilient live GLB display.');


### PR DESCRIPTION
## What this fixes

VoxelPop could finish a Meshy 3D job but display `The cached Meshy GLB could not be loaded. Regenerating is not automatic.` even while Meshy still had a valid live GLB for the same task.

## Changes

- Prefer the current Meshy provider GLB for active property previews instead of allowing a stale/missing private cached object to hide it.
- Keep the private persisted GLB as the durable fallback when no provider URL is available.
- Add an explicit 3D loading state in the viewer.
- Automatically retry a failed GLB request once with a cache-busting query before showing an error.
- Remove the dead-end `Regenerating is not automatic` message.
- Extend the existing photo → first 3D → VoxelPop image → final 3D regression guard for this exact display failure.

This keeps the intended visible sequence intact: first generated 3D preview → VoxelPop image → final movable 3D voxel.