### PR TITLE
Fix stale Meshy GLB preview and show image before 3D

### DIFF
--- a/app/property/page.js
+++ b/app/property/page.js
@@ -194,15 +194,27 @@ export default function PropertyJourneyPage() {
     } finally { setBusy(''); }
   }
 
+  async function read3D(taskId) {
+    if (!taskId) throw new Error('This 3D job has no recoverable task reference.');
+    const response = await fetch(`/api/property-voxel-3d?taskId=${encodeURIComponent(taskId)}`, {
+      cache: 'no-store', headers: authHeaders(),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data?.ok) throw new Error(data?.error || 'The 3D preview could not be refreshed.');
+    return data;
+  }
+
+  async function refresh3D(taskId, setter) {
+    const data = await read3D(taskId);
+    setter(data);
+    return data?.modelUrl || '';
+  }
+
   async function poll3D(taskId, setter, iteration, label) {
     for (let attempt = 0; attempt < 140; attempt += 1) {
       await wait(attempt === 0 ? 1500 : 3000);
       if (iteration !== pipelineRef.current) throw new Error('Creation changed.');
-      const response = await fetch(`/api/property-voxel-3d?taskId=${encodeURIComponent(taskId)}`, {
-        cache: 'no-store', headers: authHeaders(),
-      });
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.ok) throw new Error(data?.error || `${label} could not be read.`);
+      const data = await read3D(taskId);
       setter(data);
       if (data?.modelUrl) return data;
       if (terminal(data?.status)) throw new Error(data?.error || `${label} ended with ${data?.status}.`);
@@ -301,7 +313,9 @@ export default function PropertyJourneyPage() {
       if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || '3D build could not start.');
       setSourceReference(data.reference);
       setPendingPhoto(null);
-      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+      // Keep the local browser preview alive through the build. It is not uploaded
+      // to Voxel Vault storage, but it gives the user a stable visual reference
+      // until the generated image and interactive GLB are both ready.
       setSource3d(empty3d());
       setVoxelJob(emptyImage());
       setVoxelImage('');
@@ -437,7 +451,7 @@ export default function PropertyJourneyPage() {
 
       {step === 1 ? <>
         <p className={styles.bigPrompt}>{pendingPhoto ? 'Use this photo?' : 'Choose one photo.'}</p>
-        <p className={styles.flowHint}>Photo → first 3D → VoxelPop → final 3D voxel → address → My World → collect to Vault.</p>
+        <p className={styles.flowHint}>Photo → first 3D → VoxelPop image → final 3D voxel → address → My World → collect to Vault.</p>
         <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
         {displaySource ? <div className={styles.heroCard}><img src={displaySource} alt="Selected property reference"/><span className={styles.badge}>YOUR PHOTO</span></div> : <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>iPhone photos supported</span></div>}
         {pendingPhoto ? <div className={styles.choicePanel}>
@@ -450,26 +464,28 @@ export default function PropertyJourneyPage() {
 
       {step === 2 ? <>
         <p className={styles.bigPrompt}>Building the first 3D.</p>
-        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. When it finishes, the voxel step starts automatically.</p>
-        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel.</span></div>
+        <p className={styles.stepCopy}>Your source image stays visible while VoxelPop makes the first 3D interpretation. The interactive model only replaces the poster after the GLB really loads.</p>
+        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} posterUrl={displaySource} onRecover={() => refresh3D(source3d.taskId, setSource3d)} label="First property 3D preview"/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>Image stays visible → first 3D → VoxelPop image → final movable 3D.</span></div>
       </> : null}
 
       {step === 3 ? <>
-        <p className={styles.bigPrompt}>{pipelinePhase === 'voxel-3d' ? 'Building the final 3D voxel.' : 'Making the VoxelPop version.'}</p>
-        <p className={styles.stepCopy}>The VoxelPop style pass uses the generated 3D preview, then creates one final movable 3D voxel.</p>
+        <p className={styles.bigPrompt}>{pipelinePhase === 'voxel-3d' ? 'Your image first. Then the 3D.' : 'Making the VoxelPop version.'}</p>
+        <p className={styles.stepCopy}>The generated VoxelPop image remains visible as the trusted poster. Under it, the final interactive 3D loads and can refresh its GLB without starting a new paid generation.</p>
+        {voxelImage ? <div className={styles.heroCard}><img src={voxelImage} alt="VoxelPop property rendering"/><span className={styles.badge}>VOXELPOP IMAGE · READY</span></div> : null}
         <div className={styles.heroCard}>
-          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : null}
-          <span className={styles.badge}>{pipelinePhase === 'voxel-3d' ? `FINAL 3D VOXEL · ${Math.round(Number(final3d?.progress || 0))}%` : `VOXEL LOOK · ${Math.round(Number(voxelJob?.progress || 0))}%`}</span>
+          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl} posterUrl={voxelImage || displaySource} onRecover={() => refresh3D(final3d.taskId, setFinal3d)} label="Final VoxelPop interactive 3D"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} posterUrl={displaySource} onRecover={() => refresh3D(source3d.taskId, setSource3d)} label="Source 3D preview"/> : displaySource ? <img src={displaySource} alt="Property source preview"/> : null}
+          <span className={styles.badge}>{pipelinePhase === 'voxel-3d' ? `FINAL INTERACTIVE 3D · ${Math.round(Number(final3d?.progress || 0))}%` : `VOXEL LOOK · ${Math.round(Number(voxelJob?.progress || 0))}%`}</span>
           {pipelineRunning ? <div className={styles.buildPulse}/> : null}
         </div>
-        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes.</span></div>}
+        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes. A viewer refresh does not regenerate or spend another Meshy job.</span></div>}
       </> : null}
 
       {step === 4 ? <>
         <p className={styles.bigPrompt}>Add the property address.</p>
-        <p className={styles.stepCopy}>Enter the address for the property shown in your photo. We use it to place this digital representation on the map and check its mapped identity.</p>
-        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl}/><span className={styles.badge}>VOXEL READY</span></div>
+        <p className={styles.stepCopy}>The VoxelPop image is preserved, and the interactive 3D can recover a fresh model URL if its cached GLB becomes stale.</p>
+        {voxelImage ? <div className={styles.heroCard}><img src={voxelImage} alt="Final VoxelPop image"/><span className={styles.badge}>VOXELPOP IMAGE</span></div> : null}
+        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl} posterUrl={voxelImage || displaySource} onRecover={() => refresh3D(final3d.taskId, setFinal3d)} label="Final VoxelPop interactive 3D"/><span className={styles.badge}>INTERACTIVE 3D · READY</span></div>
         <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Checking address…' : 'Verify address + preview'}</button></form>
         <small className={styles.mapNote}>The address helps locate the reference. It is not proof of ownership, title, property value, or an investment offering.</small>
       </> : null}
@@ -478,7 +494,8 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Your World preview.</p>
         <p className={styles.stepCopy}>This preview is private to your account. It is not published publicly unless you choose to share it later from Vault.</p>
         <div className={styles.worldCard}><PlanetStreamGlobe listings={worldListing} selectedId="my-voxel-preview" simpleMode/><span className={styles.worldBadge}>MY WORLD · PRIVATE PREVIEW</span></div>
-        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl}/></div>
+        {voxelImage ? <div className={styles.heroCard}><img src={voxelImage} alt="VoxelPop image saved with this 3D"/><span className={styles.badge}>IMAGE</span></div> : null}
+        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl} posterUrl={voxelImage || displaySource} onRecover={() => refresh3D(final3d.taskId, setFinal3d)} label="Saved VoxelPop interactive 3D"/></div>
         <div className={styles.priceCard}>
           <div><small>DIGITAL VOXEL</small><b>{quote?.label || 'World preview'}</b><span>{mappedAddress}</span></div>
           <strong>{quote ? dollars(quote.priceCents) : '—'}</strong>

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -466,7 +466,7 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Building the first 3D.</p>
         <p className={styles.stepCopy}>Your source image stays visible while VoxelPop makes the first 3D interpretation. The interactive model only replaces the poster after the GLB really loads.</p>
         <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} posterUrl={displaySource} onRecover={() => refresh3D(source3d.taskId, setSource3d)} label="First property 3D preview"/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>Image stays visible → first 3D → VoxelPop image → final movable 3D.</span></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel. The source image stays visible while every handoff finishes.</span></div>
       </> : null}
 
       {step === 3 ? <>

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -2,12 +2,55 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-export default function MeshyModelViewer({ modelUrl }) {
+function cacheBust(url) {
+  try {
+    const next = new URL(String(url || ''), window.location.href);
+    next.searchParams.set('vv_retry', String(Date.now()));
+    return next.toString();
+  } catch {
+    const joiner = String(url || '').includes('?') ? '&' : '?';
+    return `${url}${joiner}vv_retry=${Date.now()}`;
+  }
+}
+
+export default function MeshyModelViewer({ modelUrl, posterUrl = '', onRecover = null, label = 'Interactive VoxelPop 3D model' }) {
   const mountRef = useRef(null);
+  const recoveryRef = useRef(0);
+  const [activeUrl, setActiveUrl] = useState(modelUrl || '');
   const [error, setError] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const [recovering, setRecovering] = useState(false);
 
   useEffect(() => {
-    if (!modelUrl || !mountRef.current) return undefined;
+    recoveryRef.current = 0;
+    setActiveUrl(modelUrl || '');
+    setLoaded(false);
+    setError('');
+    setRecovering(false);
+  }, [modelUrl]);
+
+  async function recover({ manual = false } = {}) {
+    if (!modelUrl || recovering) return;
+    setRecovering(true);
+    setError('');
+    try {
+      let nextUrl = '';
+      if (typeof onRecover === 'function') {
+        nextUrl = String(await onRecover() || '').trim();
+      }
+      recoveryRef.current += 1;
+      setLoaded(false);
+      setActiveUrl(nextUrl || cacheBust(modelUrl));
+      if (manual) setError('');
+    } catch {
+      setError('The 3D preview could not be refreshed. Your generated image is still available.');
+    } finally {
+      setRecovering(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!activeUrl || !mountRef.current) return undefined;
     let dead = false;
     let cleanup = () => {};
     setError('');
@@ -22,7 +65,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
-        setError('3D model preview is unavailable in this browser.');
+        setError('3D preview is unavailable in this browser. The generated image is still shown.');
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -67,10 +110,9 @@ export default function MeshyModelViewer({ modelUrl }) {
       scene.add(floor);
 
       const loader = new loaderModule.GLTFLoader();
-      let model = null;
-      loader.load(modelUrl, (gltf) => {
+      loader.load(activeUrl, (gltf) => {
         if (dead) return;
-        model = gltf.scene;
+        const model = gltf.scene;
         model.traverse((object) => {
           if (!object?.isMesh) return;
           object.castShadow = !compact;
@@ -90,8 +132,16 @@ export default function MeshyModelViewer({ modelUrl }) {
         model.scale.setScalar(scale);
         model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
         root.add(model);
+        setLoaded(true);
+        setError('');
       }, undefined, () => {
-        if (!dead) setError('The cached Meshy GLB could not be loaded. Regenerating is not automatic.');
+        if (dead) return;
+        setLoaded(false);
+        if (recoveryRef.current < 1) {
+          recover();
+        } else {
+          setError('The 3D preview could not load. Your generated image is safe; try the 3D preview again.');
+        }
       });
 
       const pointers = new Map();
@@ -207,16 +257,18 @@ export default function MeshyModelViewer({ modelUrl }) {
         mount.innerHTML = '';
       };
     }).catch(() => {
-      if (!dead) setError('The 3D model viewer could not start.');
+      if (!dead) setError('The 3D viewer could not start. Your generated image is still available.');
     });
 
     return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+  }, [activeUrl]);
 
   return <div className="viewerShell">
-    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · CACHED GLB</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    {posterUrl && !loaded ? <img className="viewerPoster" src={posterUrl} alt="Generated VoxelPop preview"/> : null}
+    <div ref={mountRef} className={`viewer ${loaded ? 'viewerLoaded' : ''}`} aria-label={label} />
+    {!loaded && !error ? <div className="viewerStatus">{recovering ? 'Refreshing 3D preview…' : 'Loading interactive 3D…'}</div> : null}
+    {error ? <div className="viewerError"><span>{error}</span><button type="button" onClick={() => recover({ manual: true })} disabled={recovering}>{recovering ? 'Refreshing…' : 'Try 3D again'}</button></div> : null}
+    {loaded ? <div className="viewerHint">DRAG · PINCH TO ZOOM · 3D READY</div> : null}
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0;opacity:0;transition:opacity .18s ease}.viewerLoaded{opacity:1}.viewerPoster{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#0b1210}.viewerStatus{position:absolute;left:50%;bottom:18px;transform:translateX(-50%);padding:8px 11px;border-radius:999px;background:rgba(9,16,15,.78);color:#e7efec;font-size:9px;font-weight:850;letter-spacing:.04em;backdrop-filter:blur(12px);white-space:nowrap}.viewerError{position:absolute;left:14px;right:14px;bottom:14px;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:11px 12px;border:1px solid rgba(255,255,255,.12);border-radius:14px;color:#eef4f1;font-size:10px;line-height:1.35;background:rgba(9,16,15,.9);backdrop-filter:blur(15px)}.viewerError span{min-width:0}.viewerError button{flex:0 0 auto;min-height:36px;padding:0 12px;border:0;border-radius:11px;background:#c9ff54;color:#26330c;font-size:9px;font-weight:950}.viewerError button:disabled{opacity:.65}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#9aa8a3;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}@media(max-width:520px){.viewerError{align-items:stretch;flex-direction:column}.viewerError button{width:100%;min-height:42px}}`}</style>
   </div>;
 }


### PR DESCRIPTION
## Fix

This removes the dead-end cached-GLB experience and makes the property creation flow visibly progress from image to interactive 3D.

### Viewer recovery
- Replaces the terminal `The cached Meshy GLB could not be loaded. Regenerating is not automatic.` state.
- Automatically retries one failed GLB load without starting a new Meshy generation.
- Supports asking the existing authenticated property task for a fresh model URL/signed URL before falling back to a cache-busted retry.
- Adds a real `Try 3D again` control if the refreshed preview still cannot load.
- Keeps a generated poster image visible while WebGL/GLB is loading or recovering instead of showing a blank/broken viewer.

### Property creator sequence
- Keeps the local authorized source-photo preview alive in the browser while the initial 3D is generated.
- Makes the VoxelPop generated image a first-class visible stage.
- Shows the final sequence as **VoxelPop image → interactive 3D**, rather than instantly replacing the image as soon as a model URL exists.
- Uses the existing account-bound Meshy task to refresh stale final 3D URLs; viewer recovery does not create a new paid generation.
- Keeps the image visible in the address and World stages as a stable fallback/reference.

No property-rights, checkout, minting, custody or legal boundaries are changed.