### PR TITLE
Fix Meshy GLB loading and 30% VoxelPop stall

### DIFF
--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -2,7 +2,6 @@ import { createHmac } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
 import {
-  createModelSignedUrl,
   persistModelBinary,
   readCatalog3D,
   readCatalog3DByTask,
@@ -21,6 +20,7 @@ import {
   propertyGenerationProviderTaskId,
   verifyPropertyGenerationRecoveryTaskId,
 } from '../../../lib/property-generation-task';
+import { propertyGenerationModelUrl } from '../../../lib/property-generation-model';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -58,16 +58,10 @@ function voxelImageTaskToken(apiKey: string, userId: string, taskId: string) {
   return createHmac('sha256', apiKey).update(`property-voxel-image-v1:${userId}:${taskId}`).digest('hex');
 }
 
-async function displayUrlFor(saved: any) {
-  // Active property generations should display Meshy's current provider URL first.
-  // The persisted private GLB remains the durable fallback for later sessions,
-  // but a stale/missing cache object must never hide a still-valid live model.
-  if (isHttpUrl(saved?.model_url)) return saved.model_url;
-  if (saved?.model_storage_path) {
-    const signed = await createModelSignedUrl(saved.model_storage_path, 60 * 60);
-    if (signed) return signed;
-  }
-  return null;
+function displayUrlFor(saved: any, apiKey: string) {
+  const taskId = clean(saved?.task_id, 420);
+  if (!taskId || !(saved?.model_storage_path || saved?.model_url)) return null;
+  return propertyGenerationModelUrl(apiKey, taskId);
 }
 
 function publicState(saved: any, displayModelUrl: string | null = null) {
@@ -148,7 +142,7 @@ export async function POST(request: Request) {
               ok: true,
               reused: true,
               directPhoto: true,
-              ...publicState(directJob, await displayUrlFor(directJob)),
+              ...publicState(directJob, displayUrlFor(directJob, apiKey)),
             });
           }
 
@@ -181,7 +175,7 @@ export async function POST(request: Request) {
     const existing = await readCatalog3D(itemId);
     const sameSourceImage = clean(existing?.source_image_url, 2200) === imageUrl;
     if (sameSourceImage && (existing?.model_url || existing?.model_storage_path)) {
-      return privateJson({ ok: true, reused: true, ...publicState(existing, await displayUrlFor(existing)), progress: 100 });
+      return privateJson({ ok: true, reused: true, ...publicState(existing, displayUrlFor(existing, apiKey)), progress: 100 });
     }
     if (sameSourceImage && existing?.task_id && ['PENDING', 'IN_PROGRESS'].includes(String(existing.status || '').toUpperCase())) {
       return privateJson({ ok: true, reused: true, ...publicState(existing) });
@@ -247,6 +241,7 @@ export async function GET(request: Request) {
   const phaseRaw = url.searchParams.get('phase') || '';
   const taskId = clean(url.searchParams.get('taskId'), 420);
   const resumeCached = url.searchParams.get('resume') === '1';
+  const apiKey = process.env.MESHY_API_KEY?.trim();
 
   try {
     if ((atlasIdRaw || draftIdRaw) && !taskId) {
@@ -263,11 +258,10 @@ export async function GET(request: Request) {
       }
       const saved = await readCatalog3D(itemId);
       if (!saved) return privateJson({ ok: true, exists: false, cachedResumeAvailable: false, status: 'NOT_STARTED', progress: 0, modelUrl: null });
-      return privateJson({ ok: true, exists: true, cachedResumeAvailable: true, ...publicState(saved, await displayUrlFor(saved)) });
+      return privateJson({ ok: true, exists: true, cachedResumeAvailable: true, ...publicState(saved, apiKey ? displayUrlFor(saved, apiKey) : null) });
     }
 
     if (!taskId) return privateJson({ ok: false, error: 'draftId, atlasId, or taskId is required.' }, { status: 400 });
-    const apiKey = process.env.MESHY_API_KEY?.trim();
     if (!apiKey) return privateJson({ ok: false, error: 'Property 3D generation is not configured on this deployment.' }, { status: 503 });
 
     const stored = await readCatalog3DByTask(taskId);
@@ -314,7 +308,12 @@ export async function GET(request: Request) {
         thumbnail_url: thumbnailUrl,
         error: data?.task_error?.message || null,
       };
-      return privateJson({ ok: true, exists: true, recoveryMode: true, ...publicState(finalRow, providerModelUrl) });
+      return privateJson({
+        ok: true,
+        exists: true,
+        recoveryMode: true,
+        ...publicState(finalRow, providerModelUrl ? propertyGenerationModelUrl(apiKey, taskId) : null),
+      });
     }
 
     let modelStoragePath = saved?.model_storage_path || null;
@@ -342,7 +341,7 @@ export async function GET(request: Request) {
       thumbnail_url: thumbnailUrl || updated?.thumbnail_url || null,
       error: data?.task_error?.message || null,
     };
-    return privateJson({ ok: true, exists: true, ...publicState(finalRow, await displayUrlFor(finalRow)) });
+    return privateJson({ ok: true, exists: true, ...publicState(finalRow, displayUrlFor(finalRow, apiKey)) });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Property 3D status failed.' }, { status: 500 });
   }

--- a/app/api/property-voxel-image/route.ts
+++ b/app/api/property-voxel-image/route.ts
@@ -1,9 +1,13 @@
+import { Buffer } from 'node:buffer';
 import { createHmac } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
 import { readCatalog3DByTask } from '../../../lib/catalog3dStore';
 import { normalizePropertyDraftId, propertyDraftItemId } from '../../../lib/property-generation-ids';
-import { verifyPropertyGenerationRecoveryTaskId } from '../../../lib/property-generation-task';
+import {
+  propertyGenerationProviderTaskId,
+  verifyPropertyGenerationRecoveryTaskId,
+} from '../../../lib/property-generation-task';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -11,6 +15,7 @@ export const dynamic = 'force-dynamic';
 
 const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-image';
 const THREE_D_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
+const MAX_REFERENCE_BYTES = 6 * 1024 * 1024;
 const ALLOWED_RIGHTS_BASES = new Set(['user-owned', 'open-licensed', 'licensed-derivative']);
 const BLOCKED_REFERENCE_HOSTS = /(^|\.)(google\.com|googleusercontent\.com|gstatic\.com|googleapis\.com|maps\.googleapis\.com|streetviewpixels-pa\.googleapis\.com|zillow\.com|zillowstatic\.com|redfin\.com|cdn-redfin\.com|apartments\.com)$/i;
 
@@ -56,10 +61,7 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
   });
 }
 
-async function recoveredGenerated3DReference(apiKey: string, userId: string, sourceTaskId: string) {
-  const providerTaskId = verifyPropertyGenerationRecoveryTaskId(apiKey, userId, sourceTaskId);
-  if (!providerTaskId) return null;
-
+async function freshGenerated3DThumbnail(apiKey: string, providerTaskId: string) {
   const response = await fetch(`${THREE_D_ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
     headers: { Authorization: `Bearer ${apiKey}` },
     cache: 'no-store',
@@ -80,6 +82,34 @@ async function recoveredGenerated3DReference(apiKey: string, userId: string, sou
   return thumbnailUrl;
 }
 
+async function stableReferenceDataUri(referenceUrl: string) {
+  const response = await fetch(referenceUrl, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error('The generated 3D preview expired before VoxelPop could read it. Retry the build so the preview can be refreshed automatically.');
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!bytes.length || bytes.length > MAX_REFERENCE_BYTES) {
+    throw new Error('The generated 3D preview image is unavailable or too large to voxelize safely.');
+  }
+
+  const rawType = clean(response.headers.get('content-type'), 100).split(';')[0].toLowerCase();
+  let contentType = rawType === 'image/jpeg' || rawType === 'image/png' ? rawType : '';
+  if (!contentType) {
+    const isPng = bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47;
+    const isJpeg = bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+    contentType = isPng ? 'image/png' : isJpeg ? 'image/jpeg' : '';
+  }
+  if (!contentType) throw new Error('The generated 3D preview was not a supported PNG or JPEG image.');
+  return `data:${contentType};base64,${bytes.toString('base64')}`;
+}
+
+async function recoveredGenerated3DReference(apiKey: string, userId: string, sourceTaskId: string) {
+  const providerTaskId = verifyPropertyGenerationRecoveryTaskId(apiKey, userId, sourceTaskId);
+  if (!providerTaskId) return null;
+  return freshGenerated3DThumbnail(apiKey, providerTaskId);
+}
+
 async function generated3DReference(apiKey: string, userId: string, draftIdRaw: unknown, sourceTaskIdRaw: unknown) {
   const draftId = normalizePropertyDraftId(draftIdRaw);
   const sourceTaskId = clean(sourceTaskIdRaw, 420);
@@ -91,16 +121,27 @@ async function generated3DReference(apiKey: string, userId: string, draftIdRaw: 
   if (saved) {
     if (saved.item_id !== expectedItemId) throw new Error('That first 3D build does not belong to this signed-in creation.');
     const sourceReady = Boolean(saved.model_storage_path || saved.model_url);
-    thumbnailUrl = clean(saved.thumbnail_url, 2200);
     if (!sourceReady) throw new Error('Finish the first 3D build before making the voxel.');
+
+    const providerTaskId = propertyGenerationProviderTaskId(saved.task_id || sourceTaskId);
+    if (providerTaskId) {
+      try {
+        thumbnailUrl = await freshGenerated3DThumbnail(apiKey, providerTaskId);
+      } catch {
+        thumbnailUrl = clean(saved.thumbnail_url, 2200);
+      }
+    } else {
+      thumbnailUrl = clean(saved.thumbnail_url, 2200);
+    }
   } else {
     thumbnailUrl = await recoveredGenerated3DReference(apiKey, userId, sourceTaskId) || '';
     if (!thumbnailUrl) throw new Error('That first 3D build does not belong to this signed-in creation.');
   }
 
   if (!isHttpUrl(thumbnailUrl)) throw new Error('The first 3D build finished without a usable preview render. Retry the 3D build before voxelizing it.');
+  const stableReference = await stableReferenceDataUri(thumbnailUrl);
   return [{
-    url: thumbnailUrl,
+    url: stableReference,
     rightsBasis: 'licensed-derivative',
     rightsReference: 'Voxel Vault generated this 3D preview from the signed-in user-authorized source photo for this creation.',
     label: 'Generated 3D preview',
@@ -161,7 +202,7 @@ export async function POST(request: Request) {
       taskToken: taskToken(apiKey, auth.user.id, taskId),
       referenceCount: references.length,
       sourceLabels: references.map((item) => item.label),
-      note: draftId ? 'Voxel styling started from the signed-in user’s completed 3D preview.' : 'Voxel creation started from rights-cleared property imagery.',
+      note: draftId ? 'Voxel styling started from a fresh, account-verified 3D preview snapshot.' : 'Voxel creation started from rights-cleared property imagery.',
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Property voxel image generation failed.' }, { status: 400 });

--- a/app/api/property-voxel-model/route.ts
+++ b/app/api/property-voxel-model/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { createModelSignedUrl, readCatalog3DByTask } from '../../../lib/catalog3dStore';
+import { propertyGenerationProviderTaskId } from '../../../lib/property-generation-task';
+import { verifyPropertyGenerationModelToken } from '../../../lib/property-generation-model';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
+
+function clean(value: unknown, max = 520) {
+  return String(value || '').trim().slice(0, max);
+}
+
+async function fetchModelBytes(url: string) {
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok || !response.body) return null;
+  return response;
+}
+
+export async function GET(request: Request) {
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!apiKey) return NextResponse.json({ ok: false, error: '3D model delivery is not configured.' }, { status: 503 });
+
+  try {
+    const url = new URL(request.url);
+    const taskId = clean(url.searchParams.get('taskId'));
+    const token = clean(url.searchParams.get('token'), 128);
+    if (!verifyPropertyGenerationModelToken(apiKey, taskId, token)) {
+      return NextResponse.json({ ok: false, error: 'Invalid or expired 3D model link.' }, { status: 403 });
+    }
+
+    const saved = await readCatalog3DByTask(taskId);
+    if (saved?.model_storage_path) {
+      const signed = await createModelSignedUrl(saved.model_storage_path, 10 * 60);
+      if (signed) {
+        const cached = await fetchModelBytes(signed);
+        if (cached) {
+          return new Response(cached.body, {
+            status: 200,
+            headers: {
+              'Content-Type': cached.headers.get('content-type') || 'model/gltf-binary',
+              'Cache-Control': 'private, max-age=300',
+            },
+          });
+        }
+      }
+    }
+
+    const providerTaskId = propertyGenerationProviderTaskId(saved?.task_id || taskId);
+    if (!providerTaskId) {
+      return NextResponse.json({ ok: false, error: 'The 3D provider task reference is invalid.' }, { status: 404 });
+    }
+
+    const statusResponse = await fetch(`${ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
+    const task = await statusResponse.json().catch(() => ({}));
+    if (!statusResponse.ok) {
+      return NextResponse.json({ ok: false, error: task?.task_error?.message || task?.message || task?.error || 'The 3D provider could not refresh this model.' }, { status: statusResponse.status });
+    }
+
+    const providerModelUrl = clean(task?.model_urls?.glb, 2400);
+    if (!providerModelUrl) {
+      return NextResponse.json({ ok: false, error: 'The 3D model is not ready yet.' }, { status: 409 });
+    }
+
+    const providerModel = await fetchModelBytes(providerModelUrl);
+    if (!providerModel) {
+      return NextResponse.json({ ok: false, error: 'The refreshed 3D model could not be downloaded.' }, { status: 502 });
+    }
+
+    return new Response(providerModel.body, {
+      status: 200,
+      headers: {
+        'Content-Type': providerModel.headers.get('content-type') || 'model/gltf-binary',
+        'Cache-Control': 'private, max-age=300',
+      },
+    });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : '3D model delivery failed.' }, { status: 500 });
+  }
+}

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -2,6 +2,17 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+function retryUrl(modelUrl, attempt) {
+  if (!modelUrl || attempt <= 0) return modelUrl;
+  try {
+    const url = new URL(modelUrl, window.location.href);
+    url.searchParams.set('previewRetry', String(attempt));
+    return url.toString();
+  } catch {
+    return modelUrl;
+  }
+}
+
 export default function MeshyModelViewer({ modelUrl }) {
   const mountRef = useRef(null);
   const [error, setError] = useState('');
@@ -71,11 +82,9 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       const loader = new loaderModule.GLTFLoader();
       let model = null;
-      let loadAttempt = 0;
-      const loadModel = () => {
-        const separator = String(modelUrl).includes('?') ? '&' : '?';
-        const url = loadAttempt === 0 ? modelUrl : `${modelUrl}${separator}vv_reload=${Date.now()}`;
-        loader.load(url, (gltf) => {
+      let loadRetryTimer = 0;
+      const loadModel = (attempt = 0) => {
+        loader.load(retryUrl(modelUrl, attempt), (gltf) => {
           if (dead) return;
           model = gltf.scene;
           model.traverse((object) => {
@@ -101,15 +110,14 @@ export default function MeshyModelViewer({ modelUrl }) {
           setError('');
         }, undefined, () => {
           if (dead) return;
-          if (loadAttempt < 1) {
-            loadAttempt += 1;
-            setError('');
+          if (attempt < 3) {
             setLoading(true);
-            window.setTimeout(loadModel, 350);
+            setError('');
+            loadRetryTimer = window.setTimeout(() => loadModel(attempt + 1), 1200 * (attempt + 1));
             return;
           }
           setLoading(false);
-          setError('The 3D preview could not be loaded. Refresh the creation to request a fresh Meshy model link.');
+          setError('The 3D preview could not be loaded. The 3D job is still recoverable; use Try build again if it does not recover.');
         });
       };
       loadModel();
@@ -207,6 +215,7 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       cleanup = () => {
         cancelAnimationFrame(frame);
+        window.clearTimeout(loadRetryTimer);
         observer?.disconnect();
         document.removeEventListener('visibilitychange', visibility);
         window.removeEventListener('resize', resize);

--- a/lib/property-generation-model.ts
+++ b/lib/property-generation-model.ts
@@ -1,0 +1,33 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+function clean(value: unknown, max = 520) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function signaturesMatch(left: string, right: string) {
+  const a = Buffer.from(left, 'utf8');
+  const b = Buffer.from(right, 'utf8');
+  return a.length === b.length && a.length > 0 && timingSafeEqual(a, b);
+}
+
+export function propertyGenerationModelToken(secret: string, taskId: unknown) {
+  const canonicalTaskId = clean(taskId);
+  if (!canonicalTaskId) throw new Error('A 3D task ID is required.');
+  return createHmac('sha256', secret)
+    .update(`property-voxel-model-v1:${canonicalTaskId}`)
+    .digest('hex');
+}
+
+export function verifyPropertyGenerationModelToken(secret: string, taskId: unknown, token: unknown) {
+  const canonicalTaskId = clean(taskId);
+  const supplied = clean(token, 128);
+  if (!canonicalTaskId || !supplied) return false;
+  return signaturesMatch(supplied, propertyGenerationModelToken(secret, canonicalTaskId));
+}
+
+export function propertyGenerationModelUrl(secret: string, taskId: unknown) {
+  const canonicalTaskId = clean(taskId);
+  if (!canonicalTaskId) return null;
+  const token = propertyGenerationModelToken(secret, canonicalTaskId);
+  return `/api/property-voxel-model?taskId=${encodeURIComponent(canonicalTaskId)}&token=${encodeURIComponent(token)}`;
+}

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -5,8 +5,10 @@ const property = fs.readFileSync(new URL('../app/property/page.js', import.meta.
 const photoHandoff = fs.readFileSync(new URL('../app/api/property-photo-upload/route.ts', import.meta.url), 'utf8');
 const voxel3d = fs.readFileSync(new URL('../app/api/property-voxel-3d/route.ts', import.meta.url), 'utf8');
 const voxelImage = fs.readFileSync(new URL('../app/api/property-voxel-image/route.ts', import.meta.url), 'utf8');
-const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
+const voxelModel = fs.readFileSync(new URL('../app/api/property-voxel-model/route.ts', import.meta.url), 'utf8');
 const modelViewer = fs.readFileSync(new URL('../app/vault/earth/MeshyModelViewer.js', import.meta.url), 'utf8');
+const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
+const modelDelivery = fs.readFileSync(new URL('../lib/property-generation-model.ts', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
@@ -38,12 +40,21 @@ assert.match(taskRecovery, /createHmac\('sha256', secret\)/, 'recovery task refe
 assert.match(taskRecovery, /property-voxel-recovery-v1:\$\{userId\}:\$\{providerTaskId\}/, 'recovery signatures must bind the provider task to the signed-in account');
 assert.match(taskRecovery, /timingSafeEqual/, 'recovery signature verification must use constant-time comparison');
 
-assert.match(voxel3d, /if \(isHttpUrl\(saved\?\.model_url\)\) return saved\.model_url/, 'active 3D previews must prefer the current Meshy provider GLB over a potentially stale private cache object');
-assert.match(voxel3d, /createModelSignedUrl\(saved\.model_storage_path/, 'durable private GLB storage must remain available as a fallback when no provider URL is present');
-assert.match(modelViewer, /loadAttempt < 1/, '3D viewer must retry a failed GLB load automatically');
-assert.match(modelViewer, /vv_reload=/, '3D viewer retry must bypass a stale browser or edge cache');
-assert.match(modelViewer, /Loading live 3D model/, '3D viewer must show an explicit loading state while the generated model is being displayed');
-assert.doesNotMatch(modelViewer, /Regenerating is not automatic/, 'a failed cached GLB must not tell the user that the flow is permanently stuck');
+assert.match(voxelImage, /freshGenerated3DThumbnail/, 'voxel styling must refresh the provider thumbnail instead of trusting a cached signed URL');
+assert.match(voxelImage, /stableReferenceDataUri/, 'voxel styling must snapshot the refreshed thumbnail before creating the next provider task');
+assert.match(voxelImage, /data:\$\{contentType\};base64/, 'the voxel style provider must receive a stable data URI rather than a temporary Meshy thumbnail URL');
+assert.match(modelDelivery, /property-voxel-model-v1:/, '3D model delivery links must be server-signed');
+assert.match(modelDelivery, /timingSafeEqual/, '3D model delivery signatures must use constant-time comparison');
+assert.match(voxel3d, /propertyGenerationModelUrl\(apiKey, taskId\)/, '3D polling must return a same-origin model delivery URL for recovery jobs');
+assert.match(voxel3d, /displayUrlFor\(finalRow, apiKey\)/, 'persisted 3D polling must return the same-origin model delivery URL');
+assert.match(voxelModel, /verifyPropertyGenerationModelToken/, 'the model delivery endpoint must reject unsigned model requests');
+assert.match(voxelModel, /model_storage_path/, 'the model delivery endpoint should prefer a durable cached GLB when one exists');
+assert.match(voxelModel, /model_urls\?\.glb/, 'the model delivery endpoint must refresh the current Meshy GLB when the cache is unavailable');
+assert.match(modelViewer, /attempt < 3/, 'the 3D viewer must retry temporary model-load failures before showing an error');
+assert.match(modelViewer, /previewRetry/, '3D viewer retries must bypass stale browser or edge caching');
+assert.match(modelViewer, /Loading live 3D model/, '3D viewer must retain an explicit loading state while the live model is being delivered');
+assert.doesNotMatch(modelViewer, /cached Meshy GLB could not be loaded/i, 'the old non-recovering cached-GLB error must be removed');
+assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer must not tell users a temporary GLB failure is permanently stuck');
 
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
@@ -56,4 +67,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, including signed recovery and resilient live GLB display.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> refreshed/snapshotted VoxelPop style -> same-origin resilient GLB delivery -> final voxel 3D, including signed account-bound recovery and live loading/retry behavior.');


### PR DESCRIPTION
Fixes the live VoxelPop property flow where the browser reports `The cached Meshy GLB could not be loaded` and the automatic voxel pass can appear stuck around 30%.

Changes:
- Refresh the completed Meshy 3D thumbnail and snapshot it to a supported base64 Data URI before starting image-to-image, so the next job does not depend on an expiring signed Meshy URL.
- Add a signed same-origin `/api/property-voxel-model` delivery route that prefers the durable cached GLB and otherwise refreshes the current Meshy GLB server-side.
- Return the same-origin model delivery URL from property 3D polling, including recovery-mode jobs.
- Retry temporary GLB viewer load failures three times without starting a new paid generation.
- Remove the old non-recovering cached-GLB error copy.
- Extend the automatic-property regression test for refreshed thumbnails, signed model delivery, provider fallback, and viewer retries.

Meshy documents that Image-to-Image reference images may be supplied as base64 Data URIs, and its Image-to-3D result URLs are signed URLs with expiry parameters, which is why the pipeline now snapshots/proxies these assets instead of treating provider URLs as durable.