### PR TITLE
Make Meshy preview image-first and repair failed GLB cache

### DIFF
--- a/app/api/world-atlas/mesh/route.ts
+++ b/app/api/world-atlas/mesh/route.ts
@@ -177,6 +177,7 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const atlasIdRaw = url.searchParams.get('atlasId') || '';
   const taskId = url.searchParams.get('taskId') || '';
+  const repairCachedModel = url.searchParams.get('repair') === '1';
 
   if (atlasIdRaw && !taskId) {
     try {
@@ -208,7 +209,10 @@ export async function GET(request: Request) {
     const saved = await readCatalog3DByTask(taskId);
     let modelStoragePath = saved?.model_storage_path || null;
 
-    if (providerModelUrl && saved?.item_id && !modelStoragePath) modelStoragePath = await persistModelBinary(saved.item_id, providerModelUrl);
+    if (providerModelUrl && saved?.item_id && (repairCachedModel || !modelStoragePath)) {
+      const repairedStoragePath = await persistModelBinary(saved.item_id, providerModelUrl);
+      if (repairedStoragePath) modelStoragePath = repairedStoragePath;
+    }
     let updated = saved;
     if (saved?.item_id) {
       updated = await saveCatalog3D(saved.item_id, {
@@ -227,6 +231,7 @@ export async function GET(request: Request) {
     return NextResponse.json({
       configured: true,
       exists: true,
+      repaired: repairCachedModel && Boolean(providerModelUrl),
       aiModel: WORLD_ATLAS_MESH_POLICY.aiModel,
       ...safeMeshState({
         ...(updated || {}),

--- a/app/vault/earth/MeshyHeroPanel.js
+++ b/app/vault/earth/MeshyHeroPanel.js
@@ -85,7 +85,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
   const [session, setSession] = useState(null);
   const [ownerState, setOwnerState] = useState('checking');
   const [status, setStatus] = useState('Checking Meshy 7 cache…');
-  const [mesh, setMesh] = useState({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+  const [mesh, setMesh] = useState({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
   const [references, setReferences] = useState([blankReference(), blankReference()]);
   const [busy, setBusy] = useState('');
   const clientRef = useRef(null);
@@ -123,13 +123,13 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
       if (!atlasId) {
         setOwnerState('idle');
         setStatus('Select a mapped building first.');
-        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
         return;
       }
       if (!session?.access_token) {
         setOwnerState('signed-out');
         setStatus('Owner sign-in unlocks private Meshy 7 reconstruction and cached hero models.');
-        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
         return;
       }
       setOwnerState('checking');
@@ -149,7 +149,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
         if (!response.ok) throw new Error(data?.error || 'Owner Meshy status is unavailable.');
         setOwnerState('ready');
         setMesh(data);
-        if (data?.displayModelUrl) setStatus('Cached Meshy 7 property model loaded. No new credits were spent.');
+        if (data?.displayModelUrl) setStatus('Meshy preview ready. Loading the interactive 3D from the private cache…');
         else if (data?.taskId && !terminalStatus(data?.status)) setStatus(`Meshy 7 generation ${Math.round(Number(data?.progress || 0))}% complete…`);
         else setStatus('No Meshy 7 hero model is cached for this building yet.');
       } catch (error) {
@@ -177,7 +177,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
         if (!response.ok) throw new Error(data?.error || 'Could not read Meshy progress.');
         setMesh(data);
         if (data?.displayModelUrl) {
-          setStatus('Meshy 7 model complete, cached privately, and ready to inspect.');
+          setStatus('Meshy preview ready. Loading the interactive 3D…');
           return;
         }
         if (terminalStatus(data?.status)) {
@@ -193,6 +193,21 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
     timer = window.setTimeout(poll, 2000);
     return () => { active = false; if (timer) window.clearTimeout(timer); };
   }, [mesh?.taskId, mesh?.displayModelUrl, mesh?.status, session?.access_token]);
+
+  async function refreshModelAfterViewerError() {
+    if (!session?.access_token || !mesh?.taskId) return;
+    setStatus('The cached GLB did not open. Keeping the Meshy preview visible while Voxel Vault refreshes this same 3D task…');
+    const response = await fetch(`/api/world-atlas/mesh?taskId=${encodeURIComponent(mesh.taskId)}&repair=1&t=${Date.now()}`, {
+      cache: 'no-store',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(data?.error || 'The existing Meshy 3D could not be refreshed.');
+    setMesh(data);
+    setStatus(data?.displayModelUrl
+      ? 'Meshy preview kept visible. Refreshed the existing 3D model without starting a new paid generation.'
+      : 'The existing Meshy task was refreshed, but its 3D file is not available yet.');
+  }
 
   async function signIn() {
     setBusy('signin');
@@ -297,7 +312,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
       const data = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(data?.error || 'Meshy generation could not start.');
       setMesh(data);
-      if (data?.displayModelUrl) setStatus('Existing cached property model reused. No new Meshy credits were spent.');
+      if (data?.displayModelUrl) setStatus('Existing Meshy preview found. Loading the interactive 3D without spending new credits.');
       else setStatus(data?.reused ? 'Existing Meshy 7 job resumed.' : 'Meshy 7 reconstruction started. Normal Atlas browsing still spends zero Meshy credits.');
     } catch (error) {
       setStatus(text(error));
@@ -310,6 +325,8 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
     return <div className="meshPanel empty"><b>MESHY 7 PROPERTY MODEL</b><span>Select a source-backed building first. Browsing never triggers paid generation automatically.</span><style jsx>{styles}</style></div>;
   }
 
+  const previewImageUrl = mesh?.thumbnailUrl || listing?.imageUrl || '';
+
   return <section className="meshPanel">
     <div className="meshTop">
       <div><small>OPTIONAL HIGH-FIDELITY LAYER</small><h3>Meshy 7 property reconstruction</h3><p>{status}</p></div>
@@ -320,7 +337,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
     {openStreetReferences.length >= 2 ? <button className="openFeed" type="button" onClick={useOpenStreetReferences}>USE {openStreetReferences.length} FREE OPEN KARTAVIEW VIEW{openStreetReferences.length === 1 ? '' : 'S'} · CC BY-SA</button> : null}
     {feedReferences.length ? <button className="licensedFeed" type="button" onClick={useLicensedFeedReferences}>USE {feedReferences.length} DERIVATIVE-LICENSED PROVIDER VIEW{feedReferences.length === 1 ? '' : 'S'}</button> : null}
 
-    {mesh?.displayModelUrl ? <MeshyModelViewer modelUrl={mesh.displayModelUrl} /> : null}
+    {mesh?.displayModelUrl ? <MeshyModelViewer modelUrl={mesh.displayModelUrl} previewImageUrl={previewImageUrl} previewAlt="Meshy-generated property 3D preview" onModelError={refreshModelAfterViewerError} /> : null}
 
     {!mesh?.displayModelUrl && ownerState === 'signed-out' ? <button className="ownerButton" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'OPENING SIGN-IN…' : 'OWNER SIGN-IN FOR MESHY 7'}</button> : null}
     {!mesh?.displayModelUrl && ownerState === 'locked' ? <div className="locked">OWNER TOOLS LOCKED FOR THIS ACCOUNT</div> : null}

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -2,15 +2,28 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-export default function MeshyModelViewer({ modelUrl }) {
+export default function MeshyModelViewer({
+  modelUrl,
+  previewImageUrl = '',
+  previewAlt = 'Generated 3D preview image',
+  onModelError = null,
+}) {
   const mountRef = useRef(null);
+  const onModelErrorRef = useRef(onModelError);
+  const repairAttemptRef = useRef('');
   const [error, setError] = useState('');
+  const [modelReady, setModelReady] = useState(false);
+  const [repairing, setRepairing] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+
+  onModelErrorRef.current = onModelError;
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
     let dead = false;
     let cleanup = () => {};
     setError('');
+    setModelReady(false);
 
     Promise.all([
       import('three'),
@@ -22,7 +35,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
-        setError('3D model preview is unavailable in this browser.');
+        setError('Interactive 3D is unavailable in this browser. The generated preview image is still shown when available.');
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -90,8 +103,23 @@ export default function MeshyModelViewer({ modelUrl }) {
         model.scale.setScalar(scale);
         model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
         root.add(model);
-      }, undefined, () => {
-        if (!dead) setError('The cached Meshy GLB could not be loaded. Regenerating is not automatic.');
+        repairAttemptRef.current = '';
+        setRepairing(false);
+        setError('');
+        setModelReady(true);
+      }, undefined, async () => {
+        if (dead) return;
+        setModelReady(false);
+        setError('Interactive 3D could not load from the cached GLB. Keeping the generated preview visible while Voxel Vault refreshes the model.');
+        const repairKey = String(modelUrl || '');
+        if (onModelErrorRef.current && repairAttemptRef.current !== repairKey) {
+          repairAttemptRef.current = repairKey;
+          setRepairing(true);
+          try {
+            await onModelErrorRef.current();
+          } catch {}
+          if (!dead) setRepairing(false);
+        }
       });
 
       const pointers = new Map();
@@ -207,16 +235,29 @@ export default function MeshyModelViewer({ modelUrl }) {
         mount.innerHTML = '';
       };
     }).catch(() => {
-      if (!dead) setError('The 3D model viewer could not start.');
+      if (!dead) {
+        setModelReady(false);
+        setError('The interactive 3D viewer could not start. The generated preview image is still available when provided.');
+      }
     });
 
     return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+  }, [modelUrl, retryKey]);
+
+  function retry3D() {
+    repairAttemptRef.current = '';
+    setError('');
+    setRepairing(false);
+    setModelReady(false);
+    setRetryKey((value) => value + 1);
+  }
 
   return <div className="viewerShell">
-    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · CACHED GLB</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    {previewImageUrl ? <img className={`viewerPreview${modelReady ? ' ready' : ''}`} src={previewImageUrl} alt={previewAlt} referrerPolicy="no-referrer"/> : null}
+    <div ref={mountRef} className={`viewer${modelReady ? ' ready' : ''}`} aria-label="Interactive Meshy hero-property 3D model" />
+    {!modelReady && previewImageUrl ? <div className="viewerPhase">3D PREVIEW IMAGE</div> : null}
+    {error ? <div className="viewerError" role="status"><span>{error}</span><button type="button" onClick={retry3D} disabled={repairing}>{repairing ? 'REFRESHING 3D…' : 'TRY 3D AGAIN'}</button></div> : null}
+    <div className="viewerHint">{modelReady ? 'DRAG · PINCH TO ZOOM · INTERACTIVE 3D' : previewImageUrl ? 'PREVIEW → INTERACTIVE 3D' : 'LOADING INTERACTIVE 3D…'}</div>
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewerPreview{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:1;transform:scale(1.01);transition:opacity .32s ease,transform .45s ease}.viewerPreview.ready{opacity:0;transform:scale(1.025);pointer-events:none}.viewer{position:absolute;inset:0;opacity:0;transition:opacity .3s ease}.viewer.ready{opacity:1}.viewerPhase{position:absolute;z-index:3;left:12px;top:12px;padding:7px 9px;border-radius:999px;background:rgba(255,255,255,.9);color:#18211e;font-size:7px;letter-spacing:.1em;font-weight:950}.viewerError{position:absolute;z-index:4;left:12px;right:12px;bottom:34px;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 11px;border-radius:13px;color:#dbe5e1;font-size:9px;line-height:1.4;background:rgba(9,16,15,.9);backdrop-filter:blur(8px)}.viewerError span{min-width:0}.viewerError button{flex:0 0 auto;border:0;border-radius:9px;padding:9px 10px;background:#fff;color:#0b110f;font-size:7px;font-weight:950;letter-spacing:.08em}.viewerError button:disabled{opacity:.55}.viewerHint{position:absolute;z-index:3;left:12px;right:12px;bottom:10px;text-align:center;color:#a8b3af;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none;text-shadow:0 1px 8px rgba(0,0,0,.75)}@media(max-width:520px){.viewerError{align-items:flex-start;flex-direction:column}.viewerError button{width:100%;min-height:42px}}`}</style>
   </div>;
 }


### PR DESCRIPTION
Superseded by newer work already merged to `main`.

Current `main` now has the more complete image-first/recoverable delivery flow:
- Meshy rendered thumbnail is served as the first frame for property model links.
- The interactive GLB fades in only after it loads.
- Failed GLB delivery retries without starting another paid generation.
- The model-delivery route refreshes the existing Meshy task and repairs an unreadable private GLB cache.
- The VoxelPop image is preserved if final 3D is paused so only the final stage needs to resume.

Closing this older conflicting implementation to avoid overwriting the newer recovery/resume work.