### PR TITLE
Fix Meshy cached GLB recovery and image-first 3D loading

### DIFF
--- a/app/api/world-atlas/mesh/route.ts
+++ b/app/api/world-atlas/mesh/route.ts
@@ -84,6 +84,88 @@ function safeMeshState(saved: any, displayModelUrl: string | null = null) {
   };
 }
 
+async function recoverCachedDisplay(saved: any) {
+  if (!saved) return { saved, displayModelUrl: null, recovered: false };
+
+  if (saved?.model_storage_path) {
+    const signed = await createModelSignedUrl(saved.model_storage_path, 60 * 60);
+    if (signed) return { saved, displayModelUrl: signed, recovered: false };
+  }
+
+  let updated = saved;
+  let modelStoragePath: string | null = null;
+  let providerModelUrl = saved?.model_url || null;
+
+  if (saved?.item_id && providerModelUrl) {
+    modelStoragePath = await persistModelBinary(saved.item_id, providerModelUrl);
+    if (modelStoragePath) {
+      updated = await saveCatalog3D(saved.item_id, {
+        ...saved,
+        model_storage_path: modelStoragePath,
+        error: null,
+      }) || { ...saved, model_storage_path: modelStoragePath, error: null };
+      const signed = await createModelSignedUrl(modelStoragePath, 60 * 60);
+      if (signed) return { saved: updated, displayModelUrl: signed, recovered: true };
+    }
+  }
+
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!saved?.task_id || !apiKey) {
+    return { saved: updated, displayModelUrl: await displayUrlFor(updated), recovered: false };
+  }
+
+  try {
+    const response = await fetch(`${ENDPOINT}/${encodeURIComponent(rawTaskId(saved.task_id))}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) return { saved: updated, displayModelUrl: await displayUrlFor(updated), recovered: false };
+
+    const refreshedModelUrl = data?.model_urls?.glb || providerModelUrl || null;
+    const refreshedThumbnailUrl = data?.thumbnail_url || saved?.thumbnail_url || null;
+    const refreshedStatus = String(data?.status || saved?.status || 'PENDING');
+    const refreshedProgress = Number(data?.progress ?? saved?.progress ?? 0);
+    let refreshedStoragePath = modelStoragePath || null;
+
+    if (saved?.item_id && refreshedModelUrl) {
+      refreshedStoragePath = await persistModelBinary(saved.item_id, refreshedModelUrl) || refreshedStoragePath;
+      updated = await saveCatalog3D(saved.item_id, {
+        ...saved,
+        task_id: saved.task_id,
+        provider: saved.provider || `meshy-world-atlas:${WORLD_ATLAS_MESH_POLICY.aiModel}`,
+        status: refreshedStatus,
+        progress: refreshedModelUrl ? 100 : refreshedProgress,
+        model_url: refreshedModelUrl,
+        model_storage_path: refreshedStoragePath,
+        thumbnail_url: refreshedThumbnailUrl,
+        completed_at: refreshedModelUrl ? (saved.completed_at || new Date().toISOString()) : saved.completed_at || null,
+        error: data?.task_error?.message || null,
+      }) || {
+        ...saved,
+        status: refreshedStatus,
+        progress: refreshedModelUrl ? 100 : refreshedProgress,
+        model_url: refreshedModelUrl,
+        model_storage_path: refreshedStoragePath,
+        thumbnail_url: refreshedThumbnailUrl,
+        error: data?.task_error?.message || null,
+      };
+    }
+
+    return {
+      saved: updated,
+      displayModelUrl: await displayUrlFor({
+        ...updated,
+        model_url: refreshedModelUrl || updated?.model_url || null,
+        model_storage_path: refreshedStoragePath || updated?.model_storage_path || null,
+      }),
+      recovered: Boolean(refreshedModelUrl || refreshedStoragePath),
+    };
+  } catch {
+    return { saved: updated, displayModelUrl: await displayUrlFor(updated), recovered: false };
+  }
+}
+
 export async function POST(request: Request) {
   const admin = await requireVoxelVaultAdmin(request);
   if (admin.ok === false) return NextResponse.json({ configured: false, error: admin.error }, { status: admin.status });
@@ -99,7 +181,8 @@ export async function POST(request: Request) {
     if (!forceRestart) {
       const saved = await readCatalog3D(itemId);
       if (saved?.model_url || saved?.model_storage_path) {
-        return NextResponse.json({ configured: true, reused: true, ...safeMeshState(saved, await displayUrlFor(saved)), progress: 100 });
+        const recovered = await recoverCachedDisplay(saved);
+        return NextResponse.json({ configured: true, reused: true, recovered: recovered.recovered, ...safeMeshState(recovered.saved, recovered.displayModelUrl), progress: 100 });
       }
       if (saved?.task_id && ['PENDING', 'IN_PROGRESS'].includes(String(saved.status || '').toUpperCase())) {
         return NextResponse.json({ configured: true, reused: true, ...safeMeshState(saved) });
@@ -183,7 +266,8 @@ export async function GET(request: Request) {
       const atlasId = cleanAtlasId(atlasIdRaw);
       const saved = await readCatalog3D(`world-atlas:${atlasId}`);
       if (!saved) return NextResponse.json({ configured: true, exists: false, status: 'NOT_STARTED', progress: 0, displayModelUrl: null, meshPolicy: WORLD_ATLAS_MESH_POLICY });
-      return NextResponse.json({ configured: true, exists: true, ...safeMeshState(saved, await displayUrlFor(saved)) });
+      const recovered = await recoverCachedDisplay(saved);
+      return NextResponse.json({ configured: true, exists: true, recovered: recovered.recovered, ...safeMeshState(recovered.saved, recovered.displayModelUrl) });
     } catch (error) {
       return NextResponse.json({ error: error instanceof Error ? error.message : 'Unable to read cached world model.' }, { status: 400 });
     }

--- a/app/vault/earth/MeshyHeroPanel.js
+++ b/app/vault/earth/MeshyHeroPanel.js
@@ -85,7 +85,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
   const [session, setSession] = useState(null);
   const [ownerState, setOwnerState] = useState('checking');
   const [status, setStatus] = useState('Checking Meshy 7 cache…');
-  const [mesh, setMesh] = useState({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+  const [mesh, setMesh] = useState({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
   const [references, setReferences] = useState([blankReference(), blankReference()]);
   const [busy, setBusy] = useState('');
   const clientRef = useRef(null);
@@ -123,13 +123,13 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
       if (!atlasId) {
         setOwnerState('idle');
         setStatus('Select a mapped building first.');
-        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
         return;
       }
       if (!session?.access_token) {
         setOwnerState('signed-out');
         setStatus('Owner sign-in unlocks private Meshy 7 reconstruction and cached hero models.');
-        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null });
+        setMesh({ status: 'NOT_STARTED', progress: 0, displayModelUrl: null, taskId: null, thumbnailUrl: null });
         return;
       }
       setOwnerState('checking');
@@ -149,7 +149,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
         if (!response.ok) throw new Error(data?.error || 'Owner Meshy status is unavailable.');
         setOwnerState('ready');
         setMesh(data);
-        if (data?.displayModelUrl) setStatus('Cached Meshy 7 property model loaded. No new credits were spent.');
+        if (data?.displayModelUrl) setStatus(data?.recovered ? 'Saved Meshy model repaired from the existing task. Showing its image first, then interactive 3D. No new credits were spent.' : 'Saved Meshy model ready. Showing its image first, then interactive 3D. No new credits were spent.');
         else if (data?.taskId && !terminalStatus(data?.status)) setStatus(`Meshy 7 generation ${Math.round(Number(data?.progress || 0))}% complete…`);
         else setStatus('No Meshy 7 hero model is cached for this building yet.');
       } catch (error) {
@@ -320,7 +320,7 @@ export default function MeshyHeroPanel({ building, listing = null, openReference
     {openStreetReferences.length >= 2 ? <button className="openFeed" type="button" onClick={useOpenStreetReferences}>USE {openStreetReferences.length} FREE OPEN KARTAVIEW VIEW{openStreetReferences.length === 1 ? '' : 'S'} · CC BY-SA</button> : null}
     {feedReferences.length ? <button className="licensedFeed" type="button" onClick={useLicensedFeedReferences}>USE {feedReferences.length} DERIVATIVE-LICENSED PROVIDER VIEW{feedReferences.length === 1 ? '' : 'S'}</button> : null}
 
-    {mesh?.displayModelUrl ? <MeshyModelViewer modelUrl={mesh.displayModelUrl} /> : null}
+    {mesh?.displayModelUrl ? <MeshyModelViewer modelUrl={mesh.displayModelUrl} posterUrl={mesh.thumbnailUrl || listing?.imageUrl || openStreetReferences[0]?.url || ''} /> : null}
 
     {!mesh?.displayModelUrl && ownerState === 'signed-out' ? <button className="ownerButton" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'OPENING SIGN-IN…' : 'OWNER SIGN-IN FOR MESHY 7'}</button> : null}
     {!mesh?.displayModelUrl && ownerState === 'locked' ? <div className="locked">OWNER TOOLS LOCKED FOR THIS ACCOUNT</div> : null}

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -9,10 +9,10 @@ function loadErrorMessage(error) {
   return 'The interactive 3D model could not be loaded right now.';
 }
 
-async function fetchModelBlob(modelUrl, deadRef) {
+async function fetchModelBlob(modelUrl, isDead) {
   let lastError = null;
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    if (deadRef.current) throw new Error('Viewer closed.');
+    if (isDead()) throw new Error('Viewer closed.');
     try {
       const response = await fetch(modelUrl, { cache: 'no-store' });
       if (!response.ok) {
@@ -25,7 +25,7 @@ async function fetchModelBlob(modelUrl, deadRef) {
       return URL.createObjectURL(bytes);
     } catch (error) {
       lastError = error;
-      if (attempt === 0 && !deadRef.current) await new Promise((resolve) => window.setTimeout(resolve, 650));
+      if (attempt === 0 && !isDead()) await new Promise((resolve) => window.setTimeout(resolve, 650));
     }
   }
   throw lastError || new Error('3D file request failed.');
@@ -33,7 +33,6 @@ async function fetchModelBlob(modelUrl, deadRef) {
 
 export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
   const mountRef = useRef(null);
-  const deadRef = useRef(false);
   const [error, setError] = useState('');
   const [phase, setPhase] = useState('loading');
   const [retryKey, setRetryKey] = useState(0);
@@ -52,7 +51,8 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
-    deadRef.current = false;
+    let dead = false;
+    let failed = false;
     let cleanup = () => {};
     let objectUrl = '';
     setError('');
@@ -61,9 +61,9 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
     Promise.all([
       import('three'),
       import('three/examples/jsm/loaders/GLTFLoader.js'),
-      fetchModelBlob(modelUrl, deadRef),
+      fetchModelBlob(modelUrl, () => dead),
     ]).then(([THREE, loaderModule, localModelUrl]) => {
-      if (deadRef.current || !mountRef.current) {
+      if (dead || !mountRef.current) {
         URL.revokeObjectURL(localModelUrl);
         return;
       }
@@ -73,6 +73,7 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
+        failed = true;
         setError('Interactive 3D is unavailable in this browser, so the property image is staying visible.');
         setPhase('error');
         URL.revokeObjectURL(objectUrl);
@@ -123,10 +124,9 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
       scene.add(floor);
 
       const loader = new loaderModule.GLTFLoader();
-      let model = null;
       loader.load(localModelUrl, (gltf) => {
-        if (deadRef.current) return;
-        model = gltf.scene;
+        if (dead) return;
+        const model = gltf.scene;
         model.traverse((object) => {
           if (!object?.isMesh) return;
           object.castShadow = !compact;
@@ -152,7 +152,8 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
         renderer.domElement.style.opacity = '1';
         setPhase('ready');
       }, undefined, (loadError) => {
-        if (!deadRef.current) {
+        if (!dead) {
+          failed = true;
           setError(loadErrorMessage(loadError));
           setPhase('error');
         }
@@ -229,7 +230,7 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
       let lastRender = 0;
       const animate = (time = 0) => {
         frame = requestAnimationFrame(animate);
-        if (!visible || !pageVisible || phase === 'error') return;
+        if (!visible || !pageVisible || failed) return;
         if (compact && time - lastRender < 33) return;
         lastRender = time;
         if (!reducedMotion && pointers.size === 0 && !moved) targetY += 0.00065;
@@ -272,7 +273,8 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
         if (objectUrl) URL.revokeObjectURL(objectUrl);
       };
     }).catch((loadError) => {
-      if (!deadRef.current) {
+      if (!dead) {
+        failed = true;
         setError(loadErrorMessage(loadError));
         setPhase('error');
       }
@@ -280,7 +282,7 @@ export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
     });
 
     return () => {
-      deadRef.current = true;
+      dead = true;
       cleanup();
     };
   }, [modelUrl, retryKey]);

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -2,27 +2,81 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-export default function MeshyModelViewer({ modelUrl }) {
+function loadErrorMessage(error) {
+  const status = Number(error?.status || 0);
+  if (status === 401 || status === 403) return 'The saved 3D link expired before the model finished loading.';
+  if (status === 404) return 'The saved 3D file is temporarily unavailable.';
+  return 'The interactive 3D model could not be loaded right now.';
+}
+
+async function fetchModelBlob(modelUrl, deadRef) {
+  let lastError = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (deadRef.current) throw new Error('Viewer closed.');
+    try {
+      const response = await fetch(modelUrl, { cache: 'no-store' });
+      if (!response.ok) {
+        const error = new Error(`3D file request failed (${response.status}).`);
+        error.status = response.status;
+        throw error;
+      }
+      const bytes = await response.blob();
+      if (!bytes.size) throw new Error('The 3D file was empty.');
+      return URL.createObjectURL(bytes);
+    } catch (error) {
+      lastError = error;
+      if (attempt === 0 && !deadRef.current) await new Promise((resolve) => window.setTimeout(resolve, 650));
+    }
+  }
+  throw lastError || new Error('3D file request failed.');
+}
+
+export default function MeshyModelViewer({ modelUrl, posterUrl = '' }) {
   const mountRef = useRef(null);
+  const deadRef = useRef(false);
   const [error, setError] = useState('');
+  const [phase, setPhase] = useState('loading');
+  const [retryKey, setRetryKey] = useState(0);
+  const [poster, setPoster] = useState(posterUrl || '');
+
+  useEffect(() => {
+    if (posterUrl) {
+      setPoster(posterUrl);
+      return;
+    }
+    const shell = mountRef.current?.closest?.('.meshPanel');
+    const image = shell?.querySelector?.('.displayOnly img');
+    const discovered = image?.currentSrc || image?.src || '';
+    if (discovered) setPoster(discovered);
+  }, [posterUrl, modelUrl]);
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
-    let dead = false;
+    deadRef.current = false;
     let cleanup = () => {};
+    let objectUrl = '';
     setError('');
+    setPhase('loading');
 
     Promise.all([
       import('three'),
       import('three/examples/jsm/loaders/GLTFLoader.js'),
-    ]).then(([THREE, loaderModule]) => {
-      if (dead || !mountRef.current) return;
+      fetchModelBlob(modelUrl, deadRef),
+    ]).then(([THREE, loaderModule, localModelUrl]) => {
+      if (deadRef.current || !mountRef.current) {
+        URL.revokeObjectURL(localModelUrl);
+        return;
+      }
+      objectUrl = localModelUrl;
       const mount = mountRef.current;
       let renderer;
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
-        setError('3D model preview is unavailable in this browser.');
+        setError('Interactive 3D is unavailable in this browser, so the property image is staying visible.');
+        setPhase('error');
+        URL.revokeObjectURL(objectUrl);
+        objectUrl = '';
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -37,6 +91,8 @@ export default function MeshyModelViewer({ modelUrl }) {
       renderer.shadowMap.enabled = !compact;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       renderer.domElement.style.touchAction = 'none';
+      renderer.domElement.style.opacity = '0';
+      renderer.domElement.style.transition = reducedMotion ? 'none' : 'opacity 280ms ease';
       mount.innerHTML = '';
       mount.appendChild(renderer.domElement);
 
@@ -68,17 +124,19 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       const loader = new loaderModule.GLTFLoader();
       let model = null;
-      loader.load(modelUrl, (gltf) => {
-        if (dead) return;
+      loader.load(localModelUrl, (gltf) => {
+        if (deadRef.current) return;
         model = gltf.scene;
         model.traverse((object) => {
           if (!object?.isMesh) return;
           object.castShadow = !compact;
           object.receiveShadow = !compact;
-          if (object.material) {
-            object.material.envMapIntensity = 0.75;
-            object.material.needsUpdate = true;
-          }
+          const materials = Array.isArray(object.material) ? object.material : [object.material];
+          materials.forEach((material) => {
+            if (!material) return;
+            material.envMapIntensity = 0.75;
+            material.needsUpdate = true;
+          });
         });
         const box = new THREE.Box3().setFromObject(model);
         const size = new THREE.Vector3();
@@ -90,8 +148,14 @@ export default function MeshyModelViewer({ modelUrl }) {
         model.scale.setScalar(scale);
         model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
         root.add(model);
-      }, undefined, () => {
-        if (!dead) setError('The cached Meshy GLB could not be loaded. Regenerating is not automatic.');
+        renderer.render(scene, camera);
+        renderer.domElement.style.opacity = '1';
+        setPhase('ready');
+      }, undefined, (loadError) => {
+        if (!deadRef.current) {
+          setError(loadErrorMessage(loadError));
+          setPhase('error');
+        }
       });
 
       const pointers = new Map();
@@ -165,7 +229,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       let lastRender = 0;
       const animate = (time = 0) => {
         frame = requestAnimationFrame(animate);
-        if (!visible || !pageVisible) return;
+        if (!visible || !pageVisible || phase === 'error') return;
         if (compact && time - lastRender < 33) return;
         lastRender = time;
         if (!reducedMotion && pointers.size === 0 && !moved) targetY += 0.00065;
@@ -205,18 +269,34 @@ export default function MeshyModelViewer({ modelUrl }) {
         floorMaterial.dispose();
         renderer.dispose();
         mount.innerHTML = '';
+        if (objectUrl) URL.revokeObjectURL(objectUrl);
       };
-    }).catch(() => {
-      if (!dead) setError('The 3D model viewer could not start.');
+    }).catch((loadError) => {
+      if (!deadRef.current) {
+        setError(loadErrorMessage(loadError));
+        setPhase('error');
+      }
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
     });
 
-    return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+    return () => {
+      deadRef.current = true;
+      cleanup();
+    };
+  }, [modelUrl, retryKey]);
 
-  return <div className="viewerShell">
-    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · CACHED GLB</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+  const retry = () => {
+    setError('');
+    setPhase('loading');
+    setRetryKey((value) => value + 1);
+  };
+
+  return <div className={`viewerShell ${phase}`}>
+    {poster ? <img className="poster" src={poster} alt="Property reference while interactive 3D loads" referrerPolicy="no-referrer" /> : <div className="posterFallback" aria-hidden="true"><div className="fallbackHouse"><i/><b/><span/></div></div>}
+    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" aria-busy={phase === 'loading'} />
+    {phase === 'loading' ? <div className="loadingCard"><i/><div><b>PHOTO → 3D</b><span>Preparing the interactive model…</span></div></div> : null}
+    {phase === 'error' ? <div className="recoveryCard"><div><b>Property image kept visible</b><span>{error} Retry the saved 3D file without creating a new paid Meshy job.</span></div><button type="button" onClick={retry}>RETRY 3D</button></div> : null}
+    {phase === 'ready' ? <div className="viewerHint">DRAG · PINCH TO ZOOM · 3D READY</div> : null}
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:22px;overflow:hidden;background:#0b1210;border:1px solid rgba(255,255,255,.08)}.poster,.posterFallback{position:absolute;inset:0;width:100%;height:100%}.poster{object-fit:cover;filter:saturate(.92) contrast(1.02)}.posterFallback{display:grid;place-items:center;background:radial-gradient(circle at 50% 35%,rgba(121,239,188,.15),transparent 42%),linear-gradient(160deg,#14231d,#07100e)}.fallbackHouse{position:relative;width:110px;height:82px;border-radius:12px;background:#d7f6e6;box-shadow:inset 0 -28px 0 #a4d8bd;transform:perspective(300px) rotateX(4deg) rotateY(-8deg)}.fallbackHouse:before{content:'';position:absolute;left:7px;right:7px;top:-42px;border-left:48px solid transparent;border-right:48px solid transparent;border-bottom:44px solid #8cbba4}.fallbackHouse i,.fallbackHouse b,.fallbackHouse span{position:absolute;bottom:0;background:#173a2f}.fallbackHouse i{left:18px;width:23px;height:28px}.fallbackHouse b{right:18px;width:25px;height:22px;bottom:30px}.fallbackHouse span{right:18px;width:25px;height:22px}.viewer{position:absolute;inset:0}.loadingCard{position:absolute;left:14px;right:14px;bottom:14px;display:flex;gap:10px;align-items:center;padding:10px 12px;border-radius:14px;background:rgba(7,13,12,.78);backdrop-filter:blur(12px);border:1px solid rgba(255,255,255,.1)}.loadingCard>i{width:10px;height:10px;border-radius:50%;border:2px solid rgba(255,255,255,.24);border-top-color:#d8fff0;animation:spin .8s linear infinite}.loadingCard div,.recoveryCard div{display:grid;gap:2px}.loadingCard b,.recoveryCard b{font-size:8px;letter-spacing:.09em}.loadingCard span,.recoveryCard span{font-size:8px;color:#9ba9a3;line-height:1.4}.recoveryCard{position:absolute;left:12px;right:12px;bottom:12px;display:flex;gap:12px;justify-content:space-between;align-items:center;padding:11px;border-radius:15px;background:rgba(7,13,12,.9);backdrop-filter:blur(14px);border:1px solid rgba(255,255,255,.11)}.recoveryCard button{flex:0 0 auto;min-height:38px;border:0;border-radius:11px;padding:0 12px;background:#fff;color:#07100e;font-size:7px;font-weight:950;letter-spacing:.09em}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#b4c4bd;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none;text-shadow:0 1px 8px #000}.ready .poster{opacity:0;transition:opacity 280ms ease}.error .viewer{opacity:0;pointer-events:none}@keyframes spin{to{transform:rotate(360deg)}}@media(prefers-reduced-motion:reduce){.loadingCard>i{animation:none}.ready .poster{transition:none}}@media(max-width:520px){.viewerShell{min-height:360px}.recoveryCard{align-items:stretch;flex-direction:column}.recoveryCard button{width:100%}}`}</style>
   </div>;
 }

--- a/scripts/check-mobile-webgl.mjs
+++ b/scripts/check-mobile-webgl.mjs
@@ -54,6 +54,11 @@ assert.match(meshyViewer, /time - lastRender < 33/, 'Meshy GLB viewer must cap c
 assert.match(meshyViewer, /pointers\.size >= 2/, 'Meshy GLB viewer must retain two-finger pinch zoom');
 assert.match(meshyViewer, /IntersectionObserver/, 'Meshy GLB viewer must pause offscreen');
 assert.match(meshyViewer, /prefers-reduced-motion/, 'Meshy GLB viewer must respect reduced motion');
+assert.match(meshyViewer, /fetch\(modelUrl, \{ cache: 'no-store' \}\)/, 'Meshy viewer must bypass stale browser GLB cache before decoding');
+assert.match(meshyViewer, /PHOTO → 3D/, 'Meshy viewer must visibly preserve the image-first transition');
+assert.match(meshyViewer, /RETRY 3D/, 'Meshy viewer must offer in-place GLB recovery without forcing regeneration');
+assert.match(meshyViewer, /\.displayOnly img/, 'Meshy viewer must reuse visible property evidence as its loading/error poster when available');
+assert.doesNotMatch(meshyViewer, /Regenerating is not automatic/, 'Meshy viewer must not strand the user on the old dead-end cached-GLB error');
 assert.match(meshyPanel, /maxSide = 2048/, 'iPhone reference photos must normalize to bounded Meshy upload size');
 assert.match(meshyPanel, /image\/jpeg/, 'iPhone reference normalization must output Meshy-compatible JPEG');
 assert.match(meshyPanel, /FREE OPEN KARTAVIEW VIEW/, 'open-licensed street imagery must be loadable into Meshy from a phone');
@@ -62,4 +67,4 @@ assert.match(realEstateCss, /mobileTabBar/, 'Real estate homepage must expose mo
 assert.match(realEstateCss, /safe-area-inset-bottom/, 'Real estate homepage must account for iPhone safe area');
 assert.match(realEstateCss, /calc\(100% - 22px\)/, 'Real estate mobile shell width must use valid CSS math');
 
-console.log('Mobile WebGL source guard passed: Voxel, GEO, streaming Globe, free open street Compare, Meshy GLB and iPhone reference-photo flows retain touch-safe mobile fallbacks, bounded caches and rendering limits.');
+console.log('Mobile WebGL source guard passed: Voxel, GEO, streaming Globe, free open street Compare, Meshy image-first GLB recovery and iPhone reference-photo flows retain touch-safe mobile fallbacks, bounded caches and rendering limits.');

--- a/scripts/check-mobile-webgl.mjs
+++ b/scripts/check-mobile-webgl.mjs
@@ -59,6 +59,7 @@ assert.match(meshyViewer, /PHOTO → 3D/, 'Meshy viewer must visibly preserve th
 assert.match(meshyViewer, /RETRY 3D/, 'Meshy viewer must offer in-place GLB recovery without forcing regeneration');
 assert.match(meshyViewer, /\.displayOnly img/, 'Meshy viewer must reuse visible property evidence as its loading/error poster when available');
 assert.doesNotMatch(meshyViewer, /Regenerating is not automatic/, 'Meshy viewer must not strand the user on the old dead-end cached-GLB error');
+assert.match(meshyPanel, /posterUrl=\{mesh\.thumbnailUrl \|\| listing\?\.imageUrl \|\| openStreetReferences\[0\]\?\.url \|\| ''\}/, 'Meshy panel must prefer the generated thumbnail, then real property imagery, before revealing interactive 3D');
 assert.match(meshyPanel, /maxSide = 2048/, 'iPhone reference photos must normalize to bounded Meshy upload size');
 assert.match(meshyPanel, /image\/jpeg/, 'iPhone reference normalization must output Meshy-compatible JPEG');
 assert.match(meshyPanel, /FREE OPEN KARTAVIEW VIEW/, 'open-licensed street imagery must be loadable into Meshy from a phone');

--- a/scripts/test-catalog3d-generation-record-compat.mjs
+++ b/scripts/test-catalog3d-generation-record-compat.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const store = read('lib/catalog3dStore.js');
+const meshRoute = read('app/api/world-atlas/mesh/route.ts');
 const migration007 = read('supabase/migrations/007_catalog_3d_media.sql');
 const migration009 = read('supabase/migrations/009_catalog_3d_binary_storage.sql');
 
@@ -24,4 +25,10 @@ assert.match(store, /for \(const supabase of adminCandidates\(\)\)/, 'storage wr
 assert.match(store, /storageReadyPromise = Promise\.resolve\(supabase\)/, 'a credential is cached only after a successful storage write');
 assert.match(store, /return writeStorageRow\(itemId, payload\)/, 'private storage remains a final fallback rather than a prerequisite for generation records');
 
-console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, retry recoverable Storage failures, and keep 009 private binary metadata optional.');
+assert.match(meshRoute, /async function recoverCachedDisplay/, 'world-atlas Meshy must have an explicit stale-cache recovery path');
+assert.match(meshRoute, /persistModelBinary\(saved\.item_id, providerModelUrl\)/, 'old provider URLs must be re-cached into private storage when still valid');
+assert.match(meshRoute, /fetch\(`\$\{ENDPOINT\}\/\$\{encodeURIComponent\(rawTaskId\(saved\.task_id\)\)\}`/, 'expired provider URLs must be refreshable from the existing Meshy task');
+assert.match(meshRoute, /recovered: recovered\.recovered/, 'cache repair state must be surfaced to callers');
+assert.doesNotMatch(meshRoute, /forceRestart: true/, 'cache recovery must not silently start a new paid Meshy generation');
+
+console.log('Catalog3D generation-record compatibility passed: VoxelPop can save Meshy task ownership/status on the original 007/008 table schema, retry recoverable Storage failures, repair stale completed-model URLs from the existing task, and keep 009 private binary metadata optional.');


### PR DESCRIPTION
## What this fixes

- Keeps the property / Meshy thumbnail visible while the GLB is loading instead of clearing the preview to a black error state.
- Fades into interactive 3D only after the GLB has actually downloaded and decoded.
- Fetches the GLB with `cache: no-store` and automatically retries a transient download failure once.
- Adds an in-place **Retry 3D** action that retries the saved model without starting a new paid Meshy generation.
- Prefers the generated Meshy thumbnail as the poster, then the listing photo, then open KartaView imagery.
- Repairs stale legacy Meshy model URLs server-side: first tries to re-cache the existing GLB into private storage, then refreshes the existing Meshy task result if the old CDN URL expired.
- Cache repair never sets `forceRestart` and does not create a new generation job.
- Adds source guards for the image-first transition and stale-cache recovery path.

## Expected UX

`property image / 3D thumbnail -> Preparing interactive 3D -> interactive draggable GLB`

If the GLB still cannot load, the image stays visible and the user gets a clear retry control instead of the old dead-end “cached Meshy GLB could not be loaded” screen.