### PR TITLE
Make Meshy property 3D image-first and self-recovering

### DIFF
--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -58,16 +58,16 @@ function voxelImageTaskToken(apiKey: string, userId: string, taskId: string) {
   return createHmac('sha256', apiKey).update(`property-voxel-image-v1:${userId}:${taskId}`).digest('hex');
 }
 
+async function cachedBinaryUrl(saved: any) {
+  if (!saved?.model_storage_path) return null;
+  return createModelSignedUrl(saved.model_storage_path, 60 * 60);
+}
+
 async function displayUrlFor(saved: any) {
-  // Active property generations should display Meshy's current provider URL first.
-  // The persisted private GLB remains the durable fallback for later sessions,
-  // but a stale/missing cache object must never hide a still-valid live model.
+  // Prefer the current provider URL for an active preview. A private persisted
+  // GLB remains the durable fallback for an older/expired provider task.
   if (isHttpUrl(saved?.model_url)) return saved.model_url;
-  if (saved?.model_storage_path) {
-    const signed = await createModelSignedUrl(saved.model_storage_path, 60 * 60);
-    if (signed) return signed;
-  }
-  return null;
+  return cachedBinaryUrl(saved);
 }
 
 function publicState(saved: any, displayModelUrl: string | null = null) {
@@ -87,6 +87,88 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
     ...init,
     headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
   });
+}
+
+function providerErrorMessage(data: any, fallback: string) {
+  return clean(data?.task_error?.message || data?.message || data?.error || fallback, 600);
+}
+
+async function refreshPersistedModel(apiKey: string, saved: any, clientTaskId: string | null = null) {
+  const providerTaskId = propertyGenerationProviderTaskId(saved?.task_id || clientTaskId || '');
+  if (!providerTaskId) {
+    const fallbackUrl = await cachedBinaryUrl(saved);
+    return {
+      providerRefreshed: false,
+      cachedBinaryFallback: Boolean(fallbackUrl),
+      ...publicState(saved, fallbackUrl),
+    };
+  }
+
+  const response = await fetch(`${ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: 'no-store',
+  });
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const fallbackUrl = await cachedBinaryUrl(saved);
+    if (fallbackUrl) {
+      return {
+        providerRefreshed: false,
+        providerRefreshFailed: true,
+        cachedBinaryFallback: true,
+        ...publicState(saved, fallbackUrl),
+      };
+    }
+    const stale = {
+      ...saved,
+      model_url: null,
+      error: providerErrorMessage(data, 'The saved 3D link expired. Rebuild it from the original photo.'),
+    };
+    return {
+      providerRefreshed: false,
+      providerRefreshFailed: true,
+      needsRebuild: true,
+      ...publicState(stale, null),
+    };
+  }
+
+  const status = clean(data?.status || saved?.status || 'PENDING', 80);
+  const progress = Number(data?.progress || 0);
+  const providerModelUrl = clean(data?.model_urls?.glb, 2200) || null;
+  const thumbnailUrl = clean(data?.alpha_thumbnail_url || data?.thumbnail_url, 2200) || null;
+  let modelStoragePath = saved?.model_storage_path || null;
+
+  if (providerModelUrl && saved?.item_id && !modelStoragePath) {
+    modelStoragePath = await persistModelBinary(saved.item_id, providerModelUrl);
+  }
+
+  const patch = {
+    task_id: saved?.task_id || clientTaskId,
+    provider: saved?.provider || 'meshy-property-generation',
+    status,
+    progress: providerModelUrl ? 100 : progress,
+    model_url: providerModelUrl || null,
+    model_storage_path: modelStoragePath || null,
+    thumbnail_url: thumbnailUrl || saved?.thumbnail_url || null,
+    completed_at: providerModelUrl ? new Date().toISOString() : saved?.completed_at || null,
+    error: data?.task_error?.message || null,
+  };
+  const updated = saved?.item_id
+    ? (await saveCatalog3D(saved.item_id, patch) || { ...saved, ...patch })
+    : { ...saved, ...patch };
+  const finalRow = {
+    ...updated,
+    task_id: clientTaskId || updated?.task_id || saved?.task_id || null,
+  };
+  const fallbackUrl = providerModelUrl ? null : await cachedBinaryUrl(finalRow);
+
+  return {
+    providerRefreshed: true,
+    cachedBinaryReady: Boolean(modelStoragePath),
+    cachedBinaryFallback: Boolean(!providerModelUrl && fallbackUrl),
+    ...publicState(finalRow, providerModelUrl || fallbackUrl),
+  };
 }
 
 async function sourcePhotoUrl(auth: any, draftId: string, storagePathRaw: unknown) {
@@ -144,11 +226,14 @@ export async function POST(request: Request) {
             if (directJob.item_id !== itemId) {
               throw new Error('That direct photo 3D job does not belong to this signed-in creation.');
             }
+            const refreshed = (directJob.model_url || directJob.model_storage_path)
+              ? await refreshPersistedModel(apiKey, directJob, taskId)
+              : publicState(directJob);
             return privateJson({
               ok: true,
               reused: true,
               directPhoto: true,
-              ...publicState(directJob, await displayUrlFor(directJob)),
+              ...refreshed,
             });
           }
 
@@ -181,7 +266,8 @@ export async function POST(request: Request) {
     const existing = await readCatalog3D(itemId);
     const sameSourceImage = clean(existing?.source_image_url, 2200) === imageUrl;
     if (sameSourceImage && (existing?.model_url || existing?.model_storage_path)) {
-      return privateJson({ ok: true, reused: true, ...publicState(existing, await displayUrlFor(existing)), progress: 100 });
+      const refreshed = await refreshPersistedModel(apiKey, existing, existing?.task_id || null);
+      return privateJson({ ok: true, reused: true, ...refreshed, progress: refreshed.modelUrl ? 100 : refreshed.progress });
     }
     if (sameSourceImage && existing?.task_id && ['PENDING', 'IN_PROGRESS'].includes(String(existing.status || '').toUpperCase())) {
       return privateJson({ ok: true, reused: true, ...publicState(existing) });
@@ -203,7 +289,7 @@ export async function POST(request: Request) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+    if (!response.ok) return privateJson({ ok: false, error: providerErrorMessage(data, `3D provider returned ${response.status}.`) }, { status: response.status });
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
@@ -247,6 +333,7 @@ export async function GET(request: Request) {
   const phaseRaw = url.searchParams.get('phase') || '';
   const taskId = clean(url.searchParams.get('taskId'), 420);
   const resumeCached = url.searchParams.get('resume') === '1';
+  const apiKey = process.env.MESHY_API_KEY?.trim();
 
   try {
     if ((atlasIdRaw || draftIdRaw) && !taskId) {
@@ -263,11 +350,22 @@ export async function GET(request: Request) {
       }
       const saved = await readCatalog3D(itemId);
       if (!saved) return privateJson({ ok: true, exists: false, cachedResumeAvailable: false, status: 'NOT_STARTED', progress: 0, modelUrl: null });
-      return privateJson({ ok: true, exists: true, cachedResumeAvailable: true, ...publicState(saved, await displayUrlFor(saved)) });
+      if (apiKey && (saved.model_url || saved.model_storage_path)) {
+        const refreshed = await refreshPersistedModel(apiKey, saved, saved.task_id || null);
+        return privateJson({ ok: true, exists: true, cachedResumeAvailable: true, ...refreshed });
+      }
+      const fallbackUrl = await cachedBinaryUrl(saved);
+      return privateJson({
+        ok: true,
+        exists: true,
+        cachedResumeAvailable: true,
+        cachedBinaryFallback: Boolean(fallbackUrl),
+        needsRebuild: !fallbackUrl,
+        ...publicState({ ...saved, model_url: null }, fallbackUrl),
+      });
     }
 
     if (!taskId) return privateJson({ ok: false, error: 'draftId, atlasId, or taskId is required.' }, { status: 400 });
-    const apiKey = process.env.MESHY_API_KEY?.trim();
     if (!apiKey) return privateJson({ ok: false, error: 'Property 3D generation is not configured on this deployment.' }, { status: 503 });
 
     const stored = await readCatalog3DByTask(taskId);
@@ -296,7 +394,19 @@ export async function GET(request: Request) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || 'Could not read property 3D status.' }, { status: response.status });
+    if (!response.ok) {
+      const fallbackUrl = await cachedBinaryUrl(saved);
+      if (fallbackUrl) {
+        return privateJson({
+          ok: true,
+          exists: true,
+          providerRefreshFailed: true,
+          cachedBinaryFallback: true,
+          ...publicState(saved, fallbackUrl),
+        });
+      }
+      return privateJson({ ok: false, error: providerErrorMessage(data, 'Could not refresh the property 3D model. Rebuild it from the original photo.') }, { status: response.status });
+    }
 
     const status = clean(data?.status || 'PENDING', 80);
     const progress = Number(data?.progress || 0);
@@ -314,7 +424,7 @@ export async function GET(request: Request) {
         thumbnail_url: thumbnailUrl,
         error: data?.task_error?.message || null,
       };
-      return privateJson({ ok: true, exists: true, recoveryMode: true, ...publicState(finalRow, providerModelUrl) });
+      return privateJson({ ok: true, exists: true, recoveryMode: true, providerRefreshed: true, ...publicState(finalRow, providerModelUrl) });
     }
 
     let modelStoragePath = saved?.model_storage_path || null;
@@ -325,7 +435,7 @@ export async function GET(request: Request) {
       provider: saved.provider || 'meshy-property-generation',
       status,
       progress: providerModelUrl ? 100 : progress,
-      model_url: providerModelUrl || saved.model_url || null,
+      model_url: providerModelUrl || null,
       model_storage_path: modelStoragePath || null,
       thumbnail_url: thumbnailUrl || saved.thumbnail_url || null,
       completed_at: providerModelUrl ? new Date().toISOString() : saved.completed_at || null,
@@ -338,11 +448,19 @@ export async function GET(request: Request) {
       status,
       progress: providerModelUrl ? 100 : progress,
       model_storage_path: modelStoragePath,
-      model_url: providerModelUrl || updated?.model_url || null,
+      model_url: providerModelUrl || null,
       thumbnail_url: thumbnailUrl || updated?.thumbnail_url || null,
       error: data?.task_error?.message || null,
     };
-    return privateJson({ ok: true, exists: true, ...publicState(finalRow, await displayUrlFor(finalRow)) });
+    const fallbackUrl = providerModelUrl ? null : await cachedBinaryUrl(finalRow);
+    return privateJson({
+      ok: true,
+      exists: true,
+      providerRefreshed: true,
+      cachedBinaryReady: Boolean(modelStoragePath),
+      cachedBinaryFallback: Boolean(!providerModelUrl && fallbackUrl),
+      ...publicState(finalRow, providerModelUrl || fallbackUrl),
+    });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Property 3D status failed.' }, { status: 500 });
   }

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -300,8 +300,9 @@ export default function PropertyJourneyPage() {
       const data = await response.json().catch(() => ({}));
       if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || '3D build could not start.');
       setSourceReference(data.reference);
-      setPendingPhoto(null);
-      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+      // Keep the local photo File + object URL alive for this creation. The
+      // image remains visible until the generated 3D canvas really renders,
+      // and a failed/expired provider job can be rebuilt from the same photo.
       setSource3d(empty3d());
       setVoxelJob(emptyImage());
       setVoxelImage('');
@@ -319,6 +320,11 @@ export default function PropertyJourneyPage() {
   }
 
   async function retryBuild() {
+    if (pendingPhoto && rightsConfirmed) {
+      setMessage('Rebuilding the 3D from your photo…');
+      await usePhotoAndBuild();
+      return;
+    }
     if (!sourceReference) return;
     const iteration = ++pipelineRef.current;
     setSource3d(empty3d());
@@ -424,7 +430,7 @@ export default function PropertyJourneyPage() {
     </section></main>;
   }
 
-  const displaySource = pendingPreview || sourceReference?.url || '';
+  const displaySource = pendingPreview || sourceReference?.url || source3d?.thumbnailUrl || final3d?.thumbnailUrl || '';
   const pipelineRunning = busy === 'pipeline' || ['source3d', 'voxel-image', 'voxel-3d'].includes(pipelinePhase);
 
   return <main className={styles.page}>
@@ -450,26 +456,26 @@ export default function PropertyJourneyPage() {
 
       {step === 2 ? <>
         <p className={styles.bigPrompt}>Building the first 3D.</p>
-        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. When it finishes, the voxel step starts automatically.</p>
-        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel.</span></div>
+        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. Your photo stays visible until the 3D canvas has actually loaded.</p>
+        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} fallbackImageUrl={displaySource}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>Image first → first 3D → VoxelPop image → final movable 3D.</span></div>
       </> : null}
 
       {step === 3 ? <>
         <p className={styles.bigPrompt}>{pipelinePhase === 'voxel-3d' ? 'Building the final 3D voxel.' : 'Making the VoxelPop version.'}</p>
-        <p className={styles.stepCopy}>The VoxelPop style pass uses the generated 3D preview, then creates one final movable 3D voxel.</p>
+        <p className={styles.stepCopy}>The VoxelPop image stays visible while the final movable 3D loads, so a slow or retried GLB never leaves an empty card.</p>
         <div className={styles.heroCard}>
-          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : null}
+          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} fallbackImageUrl={displaySource}/> : null}
           <span className={styles.badge}>{pipelinePhase === 'voxel-3d' ? `FINAL 3D VOXEL · ${Math.round(Number(final3d?.progress || 0))}%` : `VOXEL LOOK · ${Math.round(Number(voxelJob?.progress || 0))}%`}</span>
           {pipelineRunning ? <div className={styles.buildPulse}/> : null}
         </div>
-        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes.</span></div>}
+        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Rebuild from photo</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>The image remains on screen until the 3D viewer confirms it rendered.</span></div>}
       </> : null}
 
       {step === 4 ? <>
         <p className={styles.bigPrompt}>Add the property address.</p>
         <p className={styles.stepCopy}>Enter the address for the property shown in your photo. We use it to place this digital representation on the map and check its mapped identity.</p>
-        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl}/><span className={styles.badge}>VOXEL READY</span></div>
+        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/><span className={styles.badge}>VOXEL READY</span></div>
         <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Checking address…' : 'Verify address + preview'}</button></form>
         <small className={styles.mapNote}>The address helps locate the reference. It is not proof of ownership, title, property value, or an investment offering.</small>
       </> : null}
@@ -478,7 +484,7 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Your World preview.</p>
         <p className={styles.stepCopy}>This preview is private to your account. It is not published publicly unless you choose to share it later from Vault.</p>
         <div className={styles.worldCard}><PlanetStreamGlobe listings={worldListing} selectedId="my-voxel-preview" simpleMode/><span className={styles.worldBadge}>MY WORLD · PRIVATE PREVIEW</span></div>
-        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl}/></div>
+        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/></div>
         <div className={styles.priceCard}>
           <div><small>DIGITAL VOXEL</small><b>{quote?.label || 'World preview'}</b><span>{mappedAddress}</span></div>
           <strong>{quote ? dollars(quote.priceCents) : '—'}</strong>

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -2,17 +2,40 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-export default function MeshyModelViewer({ modelUrl }) {
+function retryableUrl(value, retryCount) {
+  if (!value || retryCount <= 0 || typeof window === 'undefined') return value;
+  try {
+    const url = new URL(value, window.location.href);
+    url.searchParams.set('vv_reload', `${Date.now()}-${retryCount}`);
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+export default function MeshyModelViewer({
+  modelUrl,
+  fallbackImageUrl = '',
+  label = 'Interactive Meshy 3D model',
+}) {
   const mountRef = useRef(null);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(Boolean(modelUrl));
+  const [loaded, setLoaded] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    setError('');
+    setLoaded(false);
+    setRetryCount(0);
+  }, [modelUrl]);
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
     let dead = false;
+    let retryTimer = 0;
     let cleanup = () => {};
     setError('');
-    setLoading(true);
+    setLoaded(false);
 
     Promise.all([
       import('three'),
@@ -24,8 +47,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       try {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
-        setLoading(false);
-        setError('3D model preview is unavailable in this browser.');
+        setError('3D preview is unavailable in this browser. Your image is still shown.');
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -40,6 +62,8 @@ export default function MeshyModelViewer({ modelUrl }) {
       renderer.shadowMap.enabled = !compact;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       renderer.domElement.style.touchAction = 'none';
+      renderer.domElement.style.opacity = '0';
+      renderer.domElement.style.transition = 'opacity 220ms ease';
       mount.innerHTML = '';
       mount.appendChild(renderer.domElement);
 
@@ -71,48 +95,45 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       const loader = new loaderModule.GLTFLoader();
       let model = null;
-      let loadAttempt = 0;
-      const loadModel = () => {
-        const separator = String(modelUrl).includes('?') ? '&' : '?';
-        const url = loadAttempt === 0 ? modelUrl : `${modelUrl}${separator}vv_reload=${Date.now()}`;
-        loader.load(url, (gltf) => {
-          if (dead) return;
-          model = gltf.scene;
-          model.traverse((object) => {
-            if (!object?.isMesh) return;
-            object.castShadow = !compact;
-            object.receiveShadow = !compact;
-            if (object.material) {
-              object.material.envMapIntensity = 0.75;
-              object.material.needsUpdate = true;
-            }
+      const requestedUrl = retryableUrl(modelUrl, retryCount);
+      loader.load(requestedUrl, (gltf) => {
+        if (dead) return;
+        model = gltf.scene;
+        model.traverse((object) => {
+          if (!object?.isMesh) return;
+          object.castShadow = !compact;
+          object.receiveShadow = !compact;
+          const materials = Array.isArray(object.material) ? object.material : [object.material];
+          materials.forEach((material) => {
+            if (!material) return;
+            material.envMapIntensity = 0.75;
+            material.needsUpdate = true;
           });
-          const box = new THREE.Box3().setFromObject(model);
-          const size = new THREE.Vector3();
-          const center = new THREE.Vector3();
-          box.getSize(size);
-          box.getCenter(center);
-          const largest = Math.max(size.x, size.y, size.z, 0.001);
-          const scale = 5.7 / largest;
-          model.scale.setScalar(scale);
-          model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
-          root.add(model);
-          setLoading(false);
-          setError('');
-        }, undefined, () => {
-          if (dead) return;
-          if (loadAttempt < 1) {
-            loadAttempt += 1;
-            setError('');
-            setLoading(true);
-            window.setTimeout(loadModel, 350);
-            return;
-          }
-          setLoading(false);
-          setError('The 3D preview could not be loaded. Refresh the creation to request a fresh Meshy model link.');
         });
-      };
-      loadModel();
+        const box = new THREE.Box3().setFromObject(model);
+        const size = new THREE.Vector3();
+        const center = new THREE.Vector3();
+        box.getSize(size);
+        box.getCenter(center);
+        const largest = Math.max(size.x, size.y, size.z, 0.001);
+        const scale = 5.7 / largest;
+        model.scale.setScalar(scale);
+        model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
+        root.add(model);
+        renderer.domElement.style.opacity = '1';
+        setLoaded(true);
+        setError('');
+      }, undefined, () => {
+        if (dead) return;
+        if (retryCount === 0) {
+          setError('Refreshing the saved 3D model…');
+          retryTimer = window.setTimeout(() => {
+            if (!dead) setRetryCount(1);
+          }, 550);
+          return;
+        }
+        setError('3D preview could not open. Tap Reload 3D to retry the saved model.');
+      });
 
       const pointers = new Map();
       let moved = false;
@@ -206,6 +227,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       window.addEventListener('resize', resize);
 
       cleanup = () => {
+        if (retryTimer) window.clearTimeout(retryTimer);
         cancelAnimationFrame(frame);
         observer?.disconnect();
         document.removeEventListener('visibilitychange', visibility);
@@ -218,8 +240,8 @@ export default function MeshyModelViewer({ modelUrl }) {
         root.traverse((object) => {
           if (!object?.isMesh) return;
           object.geometry?.dispose?.();
-          const mats = Array.isArray(object.material) ? object.material : [object.material];
-          mats.forEach((material) => material?.dispose?.());
+          const materials = Array.isArray(object.material) ? object.material : [object.material];
+          materials.forEach((material) => material?.dispose?.());
         });
         floorGeometry.dispose();
         floorMaterial.dispose();
@@ -227,20 +249,28 @@ export default function MeshyModelViewer({ modelUrl }) {
         mount.innerHTML = '';
       };
     }).catch(() => {
-      if (!dead) {
-        setLoading(false);
-        setError('The 3D model viewer could not start.');
-      }
+      if (!dead) setError('The 3D viewer could not start. Your image is still shown.');
     });
 
-    return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+    return () => {
+      dead = true;
+      if (retryTimer) window.clearTimeout(retryTimer);
+      cleanup();
+    };
+  }, [modelUrl, retryCount]);
+
+  function reloadModel() {
+    setError('');
+    setLoaded(false);
+    setRetryCount((current) => current + 1);
+  }
 
   return <div className="viewerShell">
-    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {loading && !error ? <div className="viewerLoading">Loading live 3D model…</div> : null}
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · LIVE 3D</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerLoading{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    {fallbackImageUrl ? <img className={`viewerFallback ${loaded ? 'viewerFallbackHidden' : ''}`} src={fallbackImageUrl} alt="3D source preview"/> : null}
+    <div ref={mountRef} className="viewer" aria-label={label}/>
+    {!loaded && !fallbackImageUrl ? <div className="viewerLoading">LOADING 3D…</div> : null}
+    {error ? <div className="viewerError" role="status"><span>{error}</span>{retryCount > 0 ? <button type="button" onClick={reloadModel}>Reload 3D</button> : null}</div> : null}
+    <div className="viewerHint">{loaded ? 'DRAG · PINCH TO ZOOM · 3D READY' : 'IMAGE FIRST · LOADING 3D'}</div>
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewerFallback{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:opacity .22s ease}.viewerFallbackHidden{opacity:0}.viewer{position:absolute;inset:0;z-index:2}.viewerLoading{position:absolute;inset:0;display:grid;place-items:center;color:#a8b6b1;font-size:10px;letter-spacing:.12em;font-weight:900}.viewerError{position:absolute;z-index:4;left:14px;right:14px;bottom:34px;display:flex;align-items:center;justify-content:center;gap:9px;flex-wrap:wrap;padding:10px 12px;text-align:center;color:#e7efec;font-size:10px;line-height:1.4;background:rgba(9,16,15,.82);border:1px solid rgba(255,255,255,.1);border-radius:14px;backdrop-filter:blur(10px)}.viewerError button{min-height:36px;border:0;border-radius:12px;padding:0 13px;background:#c9ff54;color:#24310e;font:900 10px inherit;cursor:pointer}.viewerHint{position:absolute;z-index:3;left:12px;right:12px;bottom:10px;text-align:center;color:#9aa9a4;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
   </div>;
 }

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -38,22 +38,36 @@ assert.match(taskRecovery, /createHmac\('sha256', secret\)/, 'recovery task refe
 assert.match(taskRecovery, /property-voxel-recovery-v1:\$\{userId\}:\$\{providerTaskId\}/, 'recovery signatures must bind the provider task to the signed-in account');
 assert.match(taskRecovery, /timingSafeEqual/, 'recovery signature verification must use constant-time comparison');
 
-assert.match(voxel3d, /if \(isHttpUrl\(saved\?\.model_url\)\) return saved\.model_url/, 'active 3D previews must prefer the current Meshy provider GLB over a potentially stale private cache object');
-assert.match(voxel3d, /createModelSignedUrl\(saved\.model_storage_path/, 'durable private GLB storage must remain available as a fallback when no provider URL is present');
-assert.match(modelViewer, /loadAttempt < 1/, '3D viewer must retry a failed GLB load automatically');
-assert.match(modelViewer, /vv_reload=/, '3D viewer retry must bypass a stale browser or edge cache');
-assert.match(modelViewer, /Loading live 3D model/, '3D viewer must show an explicit loading state while the generated model is being displayed');
-assert.doesNotMatch(modelViewer, /Regenerating is not automatic/, 'a failed cached GLB must not tell the user that the flow is permanently stuck');
+assert.match(voxel3d, /async function refreshPersistedModel/, 'saved 3D jobs must refresh their Meshy provider state before reuse');
+assert.match(voxel3d, /await refreshPersistedModel\(apiKey, directJob, taskId\)/, 'direct-photo jobs must refresh an old provider GLB before reuse');
+assert.match(voxel3d, /await refreshPersistedModel\(apiKey, existing, existing\?\.task_id \|\| null\)/, 'same-source generated jobs must refresh an old provider GLB before reuse');
+assert.match(voxel3d, /cachedBinaryFallback: true/, 'durable private GLB storage must remain a fallback if Meshy can no longer refresh a job');
+assert.match(voxel3d, /needsRebuild: true/, 'an expired provider URL without a durable GLB must fail closed into a rebuild path rather than returning a dead URL');
+assert.match(voxel3d, /persistModelBinary\(saved\.item_id, providerModelUrl\)/, 'fresh provider GLBs should be persisted when durable storage is available');
+
+assert.match(modelViewer, /fallbackImageUrl = ''/, '3D viewer must support an image-first fallback');
+assert.match(modelViewer, /Refreshing the saved 3D model/, 'viewer must retry a failed GLB load automatically');
+assert.match(modelViewer, /vv_reload/, 'viewer retry must bypass a stale browser or edge cache');
+assert.match(modelViewer, /Reload 3D/, 'viewer must offer an explicit reload control after its automatic retry');
+assert.match(modelViewer, /viewerFallbackHidden/, 'the fallback image must disappear only after the GLB actually renders');
+assert.match(modelViewer, /IMAGE FIRST · LOADING 3D/, 'viewer must clearly communicate image-first loading');
+assert.doesNotMatch(modelViewer, /Regenerating is not automatic/, 'the old dead-end cached GLB message must not return');
+
+assert.match(property, /Keep the local photo File \+ object URL alive for this creation/, 'the selected source image must stay available during the complete creation flow');
+assert.match(property, /fallbackImageUrl=\{displaySource\}/, 'the first 3D must keep the selected photo visible until rendering succeeds');
+assert.match(property, /fallbackImageUrl=\{voxelImage \|\| displaySource\}/, 'the final 3D must keep the VoxelPop image visible until rendering succeeds');
+assert.doesNotMatch(property, /setSourceReference\(data\.reference\);\s*setPendingPhoto\(null\);\s*setPendingPreview/, 'starting generation must not immediately throw away the visible source image');
+assert.match(property, /if \(pendingPhoto && rightsConfirmed\)/, 'a paused build must be able to start a fresh provider job from the retained photo');
+assert.match(property, /await usePhotoAndBuild\(\)/, 'the paused build retry must re-upload the retained photo when needed');
 
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
 assert.match(property, /setPipelinePhase\('paused'\)/, 'provider failure must move the automatic chain to a recoverable paused state');
-assert.match(property, /async function retryBuild\(\)/, 'paused automatic chain must preserve a retry path');
-assert.match(property, /Try build again/, 'paused voxel stage must expose a clear retry action');
-assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3D voxel\./, 'visible copy must make the automatic handoff obvious');
+assert.match(property, /Rebuild from photo/, 'paused generation must expose the fresh-photo rebuild action');
+assert.match(property, /Image first → first 3D → VoxelPop image → final movable 3D\./, 'visible copy must explain the image-first handoff into final 3D');
 
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> generated-3D voxel style -> final voxel 3D, including signed recovery and resilient live GLB display.');
+console.log('Property automatic journey regression passed: source image stays visible -> fresh Meshy source 3D -> VoxelPop image -> final movable 3D, with provider-link refresh, durable GLB fallback, and rebuild recovery.');


### PR DESCRIPTION
Superseded because PR #405 merged a newer same-origin GLB proxy and Meshy refresh/30%-stall fix while this branch was being built. I moved the non-overlapping image-first UI improvements onto a clean branch based on that newer main so the backend fix is preserved.