### PR TITLE
Show Meshy render first and auto-repair cached property GLBs

### DIFF
--- a/app/api/property-voxel-model/route.ts
+++ b/app/api/property-voxel-model/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createModelSignedUrl, readCatalog3DByTask } from '../../../lib/catalog3dStore';
+import { createModelSignedUrl, persistModelBinary, readCatalog3DByTask } from '../../../lib/catalog3dStore';
 import { propertyGenerationProviderTaskId } from '../../../lib/property-generation-task';
 import { verifyPropertyGenerationModelToken } from '../../../lib/property-generation-model';
 
@@ -13,10 +13,29 @@ function clean(value: unknown, max = 520) {
   return String(value || '').trim().slice(0, max);
 }
 
-async function fetchModelBytes(url: string) {
+async function fetchBytes(url: string) {
   const response = await fetch(url, { cache: 'no-store' });
   if (!response.ok || !response.body) return null;
   return response;
+}
+
+function binaryResponse(response: Response, fallbackType: string) {
+  return new Response(response.body, {
+    status: 200,
+    headers: {
+      'Content-Type': response.headers.get('content-type') || fallbackType,
+      'Cache-Control': 'private, max-age=300',
+    },
+  });
+}
+
+async function providerTask(apiKey: string, taskId: string) {
+  const response = await fetch(`${ENDPOINT}/${encodeURIComponent(taskId)}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    cache: 'no-store',
+  });
+  const task = await response.json().catch(() => ({}));
+  return { response, task };
 }
 
 export async function GET(request: Request) {
@@ -27,58 +46,75 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const taskId = clean(url.searchParams.get('taskId'));
     const token = clean(url.searchParams.get('token'), 128);
+    const wantsPreview = url.searchParams.get('preview') === '1';
     if (!verifyPropertyGenerationModelToken(apiKey, taskId, token)) {
       return NextResponse.json({ ok: false, error: 'Invalid or expired 3D model link.' }, { status: 403 });
     }
 
     const saved = await readCatalog3DByTask(taskId);
-    if (saved?.model_storage_path) {
-      const signed = await createModelSignedUrl(saved.model_storage_path, 10 * 60);
-      if (signed) {
-        const cached = await fetchModelBytes(signed);
-        if (cached) {
-          return new Response(cached.body, {
-            status: 200,
-            headers: {
-              'Content-Type': cached.headers.get('content-type') || 'model/gltf-binary',
-              'Cache-Control': 'private, max-age=300',
-            },
-          });
-        }
-      }
-    }
-
     const providerTaskId = propertyGenerationProviderTaskId(saved?.task_id || taskId);
     if (!providerTaskId) {
       return NextResponse.json({ ok: false, error: 'The 3D provider task reference is invalid.' }, { status: 404 });
     }
 
-    const statusResponse = await fetch(`${ENDPOINT}/${encodeURIComponent(providerTaskId)}`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      cache: 'no-store',
-    });
-    const task = await statusResponse.json().catch(() => ({}));
-    if (!statusResponse.ok) {
-      return NextResponse.json({ ok: false, error: task?.task_error?.message || task?.message || task?.error || 'The 3D provider could not refresh this model.' }, { status: statusResponse.status });
+    if (wantsPreview) {
+      let thumbnailUrl = clean(saved?.thumbnail_url, 2400);
+      if (!thumbnailUrl) {
+        const refreshed = await providerTask(apiKey, providerTaskId);
+        if (!refreshed.response.ok) {
+          return NextResponse.json({
+            ok: false,
+            error: refreshed.task?.task_error?.message || refreshed.task?.message || refreshed.task?.error || 'The 3D provider could not refresh this preview.',
+          }, { status: refreshed.response.status });
+        }
+        thumbnailUrl = clean(refreshed.task?.alpha_thumbnail_url || refreshed.task?.thumbnail_url, 2400);
+      }
+      if (!thumbnailUrl) return NextResponse.json({ ok: false, error: 'The rendered 3D image is not ready yet.' }, { status: 409 });
+      const preview = await fetchBytes(thumbnailUrl);
+      if (!preview) return NextResponse.json({ ok: false, error: 'The rendered 3D image could not be loaded.' }, { status: 502 });
+      return binaryResponse(preview, 'image/webp');
     }
 
-    const providerModelUrl = clean(task?.model_urls?.glb, 2400);
+    if (saved?.model_storage_path) {
+      const signed = await createModelSignedUrl(saved.model_storage_path, 10 * 60);
+      if (signed) {
+        const cached = await fetchBytes(signed);
+        if (cached) return binaryResponse(cached, 'model/gltf-binary');
+      }
+    }
+
+    const refreshed = await providerTask(apiKey, providerTaskId);
+    if (!refreshed.response.ok) {
+      return NextResponse.json({
+        ok: false,
+        error: refreshed.task?.task_error?.message || refreshed.task?.message || refreshed.task?.error || 'The 3D provider could not refresh this model.',
+      }, { status: refreshed.response.status });
+    }
+
+    const providerModelUrl = clean(refreshed.task?.model_urls?.glb, 2400);
     if (!providerModelUrl) {
       return NextResponse.json({ ok: false, error: 'The 3D model is not ready yet.' }, { status: 409 });
     }
 
-    const providerModel = await fetchModelBytes(providerModelUrl);
+    // The provider task already exists and is complete. If the private cached GLB
+    // was missing or unreadable, overwrite that cache from the existing Meshy GLB.
+    // This repairs delivery without starting or charging for another generation.
+    if (saved?.item_id) {
+      const repairedPath = await persistModelBinary(saved.item_id, providerModelUrl);
+      if (repairedPath) {
+        const signed = await createModelSignedUrl(repairedPath, 10 * 60);
+        if (signed) {
+          const repaired = await fetchBytes(signed);
+          if (repaired) return binaryResponse(repaired, 'model/gltf-binary');
+        }
+      }
+    }
+
+    const providerModel = await fetchBytes(providerModelUrl);
     if (!providerModel) {
       return NextResponse.json({ ok: false, error: 'The refreshed 3D model could not be downloaded.' }, { status: 502 });
     }
-
-    return new Response(providerModel.body, {
-      status: 200,
-      headers: {
-        'Content-Type': providerModel.headers.get('content-type') || 'model/gltf-binary',
-        'Cache-Control': 'private, max-age=300',
-      },
-    });
+    return binaryResponse(providerModel, 'model/gltf-binary');
   } catch (error) {
     return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : '3D model delivery failed.' }, { status: 500 });
   }

--- a/app/api/property-voxel-model/route.ts
+++ b/app/api/property-voxel-model/route.ts
@@ -58,8 +58,12 @@ export async function GET(request: Request) {
     }
 
     if (wantsPreview) {
-      let thumbnailUrl = clean(saved?.thumbnail_url, 2400);
-      if (!thumbnailUrl) {
+      // Prefer the saved Meshy render, but provider thumbnail URLs can expire.
+      // If it no longer loads, refresh the already-completed task for the current
+      // render URL. This never starts a new generation.
+      const savedThumbnailUrl = clean(saved?.thumbnail_url, 2400);
+      let preview = savedThumbnailUrl ? await fetchBytes(savedThumbnailUrl) : null;
+      if (!preview) {
         const refreshed = await providerTask(apiKey, providerTaskId);
         if (!refreshed.response.ok) {
           return NextResponse.json({
@@ -67,10 +71,10 @@ export async function GET(request: Request) {
             error: refreshed.task?.task_error?.message || refreshed.task?.message || refreshed.task?.error || 'The 3D provider could not refresh this preview.',
           }, { status: refreshed.response.status });
         }
-        thumbnailUrl = clean(refreshed.task?.alpha_thumbnail_url || refreshed.task?.thumbnail_url, 2400);
+        const freshThumbnailUrl = clean(refreshed.task?.alpha_thumbnail_url || refreshed.task?.thumbnail_url, 2400);
+        if (!freshThumbnailUrl) return NextResponse.json({ ok: false, error: 'The rendered 3D image is not ready yet.' }, { status: 409 });
+        preview = await fetchBytes(freshThumbnailUrl);
       }
-      if (!thumbnailUrl) return NextResponse.json({ ok: false, error: 'The rendered 3D image is not ready yet.' }, { status: 409 });
-      const preview = await fetchBytes(thumbnailUrl);
       if (!preview) return NextResponse.json({ ok: false, error: 'The rendered 3D image could not be loaded.' }, { status: 502 });
       return binaryResponse(preview, 'image/webp');
     }

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -1,12 +1,28 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+function modelPresentation(modelUrl) {
+  const raw = String(modelUrl || '').trim();
+  if (!raw) return { assetUrl: '', previewImageUrl: '' };
+  try {
+    const url = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'https://voxelvault.local');
+    const metadata = new URLSearchParams(url.hash.replace(/^#/, ''));
+    const previewImageUrl = String(metadata.get('vvPreview') || '').trim();
+    url.hash = '';
+    const assetUrl = raw.startsWith('/') ? `${url.pathname}${url.search}` : url.toString();
+    return { assetUrl, previewImageUrl };
+  } catch {
+    return { assetUrl: raw, previewImageUrl: '' };
+  }
+}
 
 function retryUrl(modelUrl, attempt) {
   if (!modelUrl || attempt <= 0) return modelUrl;
   try {
     const url = new URL(modelUrl, window.location.href);
     url.searchParams.set('previewRetry', String(attempt));
+    url.hash = '';
     return url.toString();
   } catch {
     return modelUrl;
@@ -15,15 +31,21 @@ function retryUrl(modelUrl, attempt) {
 
 export default function MeshyModelViewer({ modelUrl }) {
   const mountRef = useRef(null);
+  const presentation = useMemo(() => modelPresentation(modelUrl), [modelUrl]);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(Boolean(modelUrl));
+  const [loading, setLoading] = useState(Boolean(presentation.assetUrl));
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    if (!modelUrl || !mountRef.current) return undefined;
+    if (!presentation.assetUrl || !mountRef.current) return undefined;
     let dead = false;
     let cleanup = () => {};
+    let loadRetryTimer = 0;
+    let revealTimer = 0;
     setError('');
     setLoading(true);
+    setReady(false);
+    const startedAt = Date.now();
 
     Promise.all([
       import('three'),
@@ -36,7 +58,9 @@ export default function MeshyModelViewer({ modelUrl }) {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
         setLoading(false);
-        setError('3D model preview is unavailable in this browser.');
+        setError(presentation.previewImageUrl
+          ? 'Interactive 3D is unavailable in this browser. The rendered 3D image is still shown.'
+          : '3D model preview is unavailable in this browser.');
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -51,6 +75,8 @@ export default function MeshyModelViewer({ modelUrl }) {
       renderer.shadowMap.enabled = !compact;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       renderer.domElement.style.touchAction = 'none';
+      renderer.domElement.style.opacity = presentation.previewImageUrl ? '0' : '1';
+      renderer.domElement.style.transition = 'opacity .38s ease';
       mount.innerHTML = '';
       mount.appendChild(renderer.domElement);
 
@@ -82,9 +108,8 @@ export default function MeshyModelViewer({ modelUrl }) {
 
       const loader = new loaderModule.GLTFLoader();
       let model = null;
-      let loadRetryTimer = 0;
       const loadModel = (attempt = 0) => {
-        loader.load(retryUrl(modelUrl, attempt), (gltf) => {
+        loader.load(retryUrl(presentation.assetUrl, attempt), (gltf) => {
           if (dead) return;
           model = gltf.scene;
           model.traverse((object) => {
@@ -106,18 +131,27 @@ export default function MeshyModelViewer({ modelUrl }) {
           model.scale.setScalar(scale);
           model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
           root.add(model);
-          setLoading(false);
           setError('');
+          const previewDelay = presentation.previewImageUrl ? Math.max(0, 650 - (Date.now() - startedAt)) : 0;
+          revealTimer = window.setTimeout(() => {
+            if (dead) return;
+            renderer.domElement.style.opacity = '1';
+            setLoading(false);
+            setReady(true);
+          }, previewDelay);
         }, undefined, () => {
           if (dead) return;
           if (attempt < 3) {
             setLoading(true);
             setError('');
-            loadRetryTimer = window.setTimeout(() => loadModel(attempt + 1), 1200 * (attempt + 1));
+            loadRetryTimer = window.setTimeout(() => loadModel(attempt + 1), 900 * (attempt + 1));
             return;
           }
           setLoading(false);
-          setError('The 3D preview could not be loaded. The 3D job is still recoverable; use Try build again if it does not recover.');
+          setReady(false);
+          setError(presentation.previewImageUrl
+            ? 'Interactive 3D is reconnecting. The rendered 3D image stays visible.'
+            : 'The 3D preview could not be loaded. The completed job is still recoverable; try again shortly.');
         });
       };
       loadModel();
@@ -138,6 +172,7 @@ export default function MeshyModelViewer({ modelUrl }) {
         camera.lookAt(0, 1.25, 0);
       };
       const down = (event) => {
+        if (!ready) return;
         pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
         renderer.domElement.setPointerCapture?.(event.pointerId);
         moved = false;
@@ -170,6 +205,7 @@ export default function MeshyModelViewer({ modelUrl }) {
         if (pointers.size < 2) pinch = 0;
       };
       const wheel = (event) => {
+        if (!ready) return;
         event.preventDefault();
         cameraDistance = Math.max(6.5, Math.min(13.5, cameraDistance + Math.sign(event.deltaY) * 0.5));
         updateCamera();
@@ -216,6 +252,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       cleanup = () => {
         cancelAnimationFrame(frame);
         window.clearTimeout(loadRetryTimer);
+        window.clearTimeout(revealTimer);
         observer?.disconnect();
         document.removeEventListener('visibilitychange', visibility);
         window.removeEventListener('resize', resize);
@@ -238,18 +275,22 @@ export default function MeshyModelViewer({ modelUrl }) {
     }).catch(() => {
       if (!dead) {
         setLoading(false);
-        setError('The 3D model viewer could not start.');
+        setError(presentation.previewImageUrl
+          ? 'Interactive 3D viewer could not start. The rendered 3D image is still shown.'
+          : 'The 3D model viewer could not start.');
       }
     });
 
     return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+  }, [presentation.assetUrl, presentation.previewImageUrl]);
 
   return <div className="viewerShell">
+    {presentation.previewImageUrl ? <img className={`viewerPreview ${ready ? 'viewerPreviewHidden' : ''}`} src={presentation.previewImageUrl} alt="Rendered Meshy 3D preview" referrerPolicy="no-referrer"/> : null}
     <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {loading && !error ? <div className="viewerLoading">Loading live 3D model…</div> : null}
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · LIVE 3D</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerLoading{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    {loading && presentation.previewImageUrl ? <div className="viewerStage">3D IMAGE · LOADING INTERACTIVE 3D</div> : null}
+    {loading && !presentation.previewImageUrl && !error ? <div className="viewerLoading">Loading interactive 3D…</div> : null}
+    {error ? <div className={`viewerError ${presentation.previewImageUrl ? 'viewerErrorSoft' : ''}`}>{error}</div> : null}
+    <div className="viewerHint">{ready ? 'DRAG · PINCH TO ZOOM · INTERACTIVE 3D' : presentation.previewImageUrl ? '3D IMAGE → INTERACTIVE 3D' : 'PREPARING INTERACTIVE 3D'}</div>
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewerPreview{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:1;opacity:1;transition:opacity .38s ease}.viewerPreviewHidden{opacity:0;pointer-events:none}.viewer{position:absolute;inset:0;z-index:2}.viewerStage{position:absolute;z-index:4;top:12px;left:12px;padding:7px 9px;border-radius:999px;background:rgba(7,13,12,.76);backdrop-filter:blur(8px);color:#d8e7e1;font-size:7px;letter-spacing:.12em;font-weight:900}.viewerLoading{position:absolute;inset:0;z-index:3;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;inset:0;z-index:5;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerErrorSoft{inset:auto 12px 36px 12px;display:block;padding:9px 11px;border-radius:12px;background:rgba(7,13,12,.82);backdrop-filter:blur(8px);font-size:9px}.viewerHint{position:absolute;z-index:6;left:12px;right:12px;bottom:10px;text-align:center;color:#9aaaa4;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
   </div>;
 }

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -8,9 +8,18 @@ function modelPresentation(modelUrl) {
   try {
     const url = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'https://voxelvault.local');
     const metadata = new URLSearchParams(url.hash.replace(/^#/, ''));
-    const previewImageUrl = String(metadata.get('vvPreview') || '').trim();
+    let previewImageUrl = String(metadata.get('vvPreview') || '').trim();
     url.hash = '';
     const assetUrl = raw.startsWith('/') ? `${url.pathname}${url.search}` : url.toString();
+
+    // Signed property model links can also serve the provider's rendered
+    // thumbnail. This gives every Property/Vault viewer an image-first stage
+    // without changing every caller or exposing the original uploaded photo.
+    if (!previewImageUrl && url.pathname === '/api/property-voxel-model') {
+      const preview = new URL(url.toString());
+      preview.searchParams.set('preview', '1');
+      previewImageUrl = raw.startsWith('/') ? `${preview.pathname}${preview.search}` : preview.toString();
+    }
     return { assetUrl, previewImageUrl };
   } catch {
     return { assetUrl: raw, previewImageUrl: '' };

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -31,6 +31,7 @@ function retryUrl(modelUrl, attempt) {
 
 export default function MeshyModelViewer({ modelUrl }) {
   const mountRef = useRef(null);
+  const readyRef = useRef(false);
   const presentation = useMemo(() => modelPresentation(modelUrl), [modelUrl]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(Boolean(presentation.assetUrl));
@@ -42,6 +43,7 @@ export default function MeshyModelViewer({ modelUrl }) {
     let cleanup = () => {};
     let loadRetryTimer = 0;
     let revealTimer = 0;
+    readyRef.current = false;
     setError('');
     setLoading(true);
     setReady(false);
@@ -135,6 +137,7 @@ export default function MeshyModelViewer({ modelUrl }) {
           const previewDelay = presentation.previewImageUrl ? Math.max(0, 650 - (Date.now() - startedAt)) : 0;
           revealTimer = window.setTimeout(() => {
             if (dead) return;
+            readyRef.current = true;
             renderer.domElement.style.opacity = '1';
             setLoading(false);
             setReady(true);
@@ -147,6 +150,7 @@ export default function MeshyModelViewer({ modelUrl }) {
             loadRetryTimer = window.setTimeout(() => loadModel(attempt + 1), 900 * (attempt + 1));
             return;
           }
+          readyRef.current = false;
           setLoading(false);
           setReady(false);
           setError(presentation.previewImageUrl
@@ -172,7 +176,7 @@ export default function MeshyModelViewer({ modelUrl }) {
         camera.lookAt(0, 1.25, 0);
       };
       const down = (event) => {
-        if (!ready) return;
+        if (!readyRef.current) return;
         pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
         renderer.domElement.setPointerCapture?.(event.pointerId);
         moved = false;
@@ -205,7 +209,7 @@ export default function MeshyModelViewer({ modelUrl }) {
         if (pointers.size < 2) pinch = 0;
       };
       const wheel = (event) => {
-        if (!ready) return;
+        if (!readyRef.current) return;
         event.preventDefault();
         cameraDistance = Math.max(6.5, Math.min(13.5, cameraDistance + Math.sign(event.deltaY) * 0.5));
         updateCamera();
@@ -250,6 +254,7 @@ export default function MeshyModelViewer({ modelUrl }) {
       window.addEventListener('resize', resize);
 
       cleanup = () => {
+        readyRef.current = false;
         cancelAnimationFrame(frame);
         window.clearTimeout(loadRetryTimer);
         window.clearTimeout(revealTimer);

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -48,11 +48,20 @@ assert.match(modelDelivery, /timingSafeEqual/, '3D model delivery signatures mus
 assert.match(voxel3d, /propertyGenerationModelUrl\(apiKey, taskId\)/, '3D polling must return a same-origin model delivery URL for recovery jobs');
 assert.match(voxel3d, /displayUrlFor\(finalRow, apiKey\)/, 'persisted 3D polling must return the same-origin model delivery URL');
 assert.match(voxelModel, /verifyPropertyGenerationModelToken/, 'the model delivery endpoint must reject unsigned model requests');
+assert.match(voxelModel, /wantsPreview = url\.searchParams\.get\('preview'\) === '1'/, 'the signed model endpoint must expose a rendered 3D image mode');
+assert.match(voxelModel, /alpha_thumbnail_url \|\| refreshed\.task\?\.thumbnail_url/, 'thumbnail mode must use the Meshy rendered preview');
 assert.match(voxelModel, /model_storage_path/, 'the model delivery endpoint should prefer a durable cached GLB when one exists');
 assert.match(voxelModel, /model_urls\?\.glb/, 'the model delivery endpoint must refresh the current Meshy GLB when the cache is unavailable');
+assert.match(voxelModel, /persistModelBinary\(saved\.item_id, providerModelUrl\)/, 'a broken private GLB cache must be overwritten from the completed provider task');
+assert.match(voxelModel, /without starting or charging for another generation/, 'cache repair must remain distinct from paid regeneration');
+
+assert.match(modelViewer, /url\.pathname === '\/api\/property-voxel-model'/, 'the viewer must recognize signed property-model delivery URLs');
+assert.match(modelViewer, /preview\.searchParams\.set\('preview', '1'\)/, 'the viewer must derive the rendered 3D image automatically');
+assert.match(modelViewer, /3D IMAGE · LOADING INTERACTIVE 3D/, 'the rendered 3D image must be visibly staged before interactive 3D');
+assert.match(modelViewer, /3D IMAGE → INTERACTIVE 3D/, 'the viewer must describe the image-to-interactive transition');
 assert.match(modelViewer, /attempt < 3/, 'the 3D viewer must retry temporary model-load failures before showing an error');
 assert.match(modelViewer, /previewRetry/, '3D viewer retries must bypass stale browser or edge caching');
-assert.match(modelViewer, /Loading live 3D model/, '3D viewer must retain an explicit loading state while the live model is being delivered');
+assert.match(modelViewer, /readyRef\.current/, 'interactive controls must unlock only after the GLB has actually loaded');
 assert.doesNotMatch(modelViewer, /cached Meshy GLB could not be loaded/i, 'the old non-recovering cached-GLB error must be removed');
 assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer must not tell users a temporary GLB failure is permanently stuck');
 
@@ -67,4 +76,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> refreshed/snapshotted VoxelPop style -> same-origin resilient GLB delivery -> final voxel 3D, including signed account-bound recovery and live loading/retry behavior.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> final movable voxel 3D.');


### PR DESCRIPTION
Fixes the VoxelPop 3D display failure where a cached Meshy GLB could fail to load and leave the user at a dead end.

### New display flow
`photo → Meshy rendered 3D image → interactive 3D → VoxelPop style → final movable voxel 3D`

### What changes
- signed property-model URLs now automatically expose a `preview=1` rendered-image mode
- the shared Meshy viewer detects those property model links and shows the real Meshy render before the interactive GLB is ready
- the 3D canvas only fades in after GLTFLoader successfully finishes
- GLB loading keeps the existing bounded cache-busting retries
- when a private cached GLB is missing or unreadable, the signed model-delivery route polls the already-completed Meshy task, overwrites the private cache from that existing GLB, and serves the repaired copy
- if cache repair itself fails, delivery still falls back to the provider GLB
- no new image-to-3D generation request is started by cache repair
- interactive drag/pinch controls remain locked until the GLB is actually loaded

### Regression protection
The existing property automatic-journey test now requires image-first display, self-repairing GLB delivery, cache-busting retries, and removal of the old non-recovering cached-GLB error.

This is based on the current `main` and preserves the recently merged signed model-delivery/recovery architecture.