### PR TITLE
Finish automatic repair for corrupt cached Meshy GLBs

### DIFF
--- a/app/api/property-voxel-model/route.ts
+++ b/app/api/property-voxel-model/route.ts
@@ -19,12 +19,13 @@ async function fetchBytes(url: string) {
   return response;
 }
 
-function binaryResponse(response: Response, fallbackType: string) {
+function binaryResponse(response: Response, fallbackType: string, repaired = false) {
   return new Response(response.body, {
     status: 200,
     headers: {
       'Content-Type': response.headers.get('content-type') || fallbackType,
-      'Cache-Control': 'private, max-age=300',
+      'Cache-Control': repaired ? 'private, no-store, max-age=0' : 'private, max-age=300',
+      ...(repaired ? { 'X-Voxel-Vault-Model-Repaired': '1' } : {}),
     },
   });
 }
@@ -47,6 +48,7 @@ export async function GET(request: Request) {
     const taskId = clean(url.searchParams.get('taskId'));
     const token = clean(url.searchParams.get('token'), 128);
     const wantsPreview = url.searchParams.get('preview') === '1';
+    const forceProviderRepair = url.searchParams.has('previewRetry') || url.searchParams.get('repair') === '1';
     if (!verifyPropertyGenerationModelToken(apiKey, taskId, token)) {
       return NextResponse.json({ ok: false, error: 'Invalid or expired 3D model link.' }, { status: 403 });
     }
@@ -79,7 +81,11 @@ export async function GET(request: Request) {
       return binaryResponse(preview, 'image/webp');
     }
 
-    if (saved?.model_storage_path) {
+    // A GLB can return HTTP 200 and still contain stale/corrupt bytes that
+    // GLTFLoader cannot parse. The viewer adds previewRetry only after an actual
+    // parse/load failure, so treat that retry as a trusted signal to bypass the
+    // private object once and rebuild it from the already-completed Meshy task.
+    if (!forceProviderRepair && saved?.model_storage_path) {
       const signed = await createModelSignedUrl(saved.model_storage_path, 10 * 60);
       if (signed) {
         const cached = await fetchBytes(signed);
@@ -101,15 +107,16 @@ export async function GET(request: Request) {
     }
 
     // The provider task already exists and is complete. If the private cached GLB
-    // was missing or unreadable, overwrite that cache from the existing Meshy GLB.
-    // This repairs delivery without starting or charging for another generation.
+    // was missing, unreadable, or explicitly failed in GLTFLoader, overwrite that
+    // cache from the existing Meshy GLB. This never starts or charges for another
+    // generation.
     if (saved?.item_id) {
       const repairedPath = await persistModelBinary(saved.item_id, providerModelUrl);
       if (repairedPath) {
         const signed = await createModelSignedUrl(repairedPath, 10 * 60);
         if (signed) {
           const repaired = await fetchBytes(signed);
-          if (repaired) return binaryResponse(repaired, 'model/gltf-binary');
+          if (repaired) return binaryResponse(repaired, 'model/gltf-binary', forceProviderRepair);
         }
       }
     }
@@ -118,7 +125,7 @@ export async function GET(request: Request) {
     if (!providerModel) {
       return NextResponse.json({ ok: false, error: 'The refreshed 3D model could not be downloaded.' }, { status: 502 });
     }
-    return binaryResponse(providerModel, 'model/gltf-binary');
+    return binaryResponse(providerModel, 'model/gltf-binary', forceProviderRepair);
   } catch (error) {
     return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : '3D model delivery failed.' }, { status: 500 });
   }

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -50,17 +50,19 @@ assert.match(voxel3d, /displayUrlFor\(finalRow, apiKey\)/, 'persisted 3D polling
 assert.match(voxelModel, /verifyPropertyGenerationModelToken/, 'the model delivery endpoint must reject unsigned model requests');
 assert.match(voxelModel, /wantsPreview = url\.searchParams\.get\('preview'\) === '1'/, 'the signed model endpoint must expose a rendered 3D image mode');
 assert.match(voxelModel, /alpha_thumbnail_url \|\| refreshed\.task\?\.thumbnail_url/, 'thumbnail mode must use the Meshy rendered preview');
-assert.match(voxelModel, /model_storage_path/, 'the model delivery endpoint should prefer a durable cached GLB when one exists');
-assert.match(voxelModel, /model_urls\?\.glb/, 'the model delivery endpoint must refresh the current Meshy GLB when the cache is unavailable');
+assert.match(voxelModel, /forceProviderRepair = url\.searchParams\.has\('previewRetry'\)/, 'a viewer retry must explicitly enter provider-backed repair mode');
+assert.match(voxelModel, /!forceProviderRepair && saved\?\.model_storage_path/, 'a viewer retry must bypass a corrupt-but-present private GLB instead of serving the same bytes again');
+assert.match(voxelModel, /model_urls\?\.glb/, 'the model delivery endpoint must refresh the current Meshy GLB when cache repair is required');
 assert.match(voxelModel, /persistModelBinary\(saved\.item_id, providerModelUrl\)/, 'a broken private GLB cache must be overwritten from the completed provider task');
-assert.match(voxelModel, /without starting or charging for another generation/, 'cache repair must remain distinct from paid regeneration');
+assert.match(voxelModel, /X-Voxel-Vault-Model-Repaired/, 'repaired model responses must be explicitly marked and sent without reusable caching');
+assert.match(voxelModel, /never starts or charges for another/, 'cache repair must remain distinct from paid regeneration');
 
 assert.match(modelViewer, /url\.pathname === '\/api\/property-voxel-model'/, 'the viewer must recognize signed property-model delivery URLs');
 assert.match(modelViewer, /preview\.searchParams\.set\('preview', '1'\)/, 'the viewer must derive the rendered 3D image automatically');
 assert.match(modelViewer, /3D IMAGE · LOADING INTERACTIVE 3D/, 'the rendered 3D image must be visibly staged before interactive 3D');
 assert.match(modelViewer, /3D IMAGE → INTERACTIVE 3D/, 'the viewer must describe the image-to-interactive transition');
 assert.match(modelViewer, /attempt < 3/, 'the 3D viewer must retry temporary model-load failures before showing an error');
-assert.match(modelViewer, /previewRetry/, '3D viewer retries must bypass stale browser or edge caching');
+assert.match(modelViewer, /previewRetry/, '3D viewer retries must request provider-backed repair and bypass stale browser or edge caching');
 assert.match(modelViewer, /readyRef\.current/, 'interactive controls must unlock only after the GLB has actually loaded');
 assert.doesNotMatch(modelViewer, /cached Meshy GLB could not be loaded/i, 'the old non-recovering cached-GLB error must be removed');
 assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer must not tell users a temporary GLB failure is permanently stuck');
@@ -76,4 +78,4 @@ assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> final movable voxel 3D.');
+console.log('Property automatic journey regression passed: Meshy render shows before interactive 3D, and a corrupt cached GLB self-repairs from the completed provider job without starting another generation.');


### PR DESCRIPTION
## What is already on main

Current `main` shows the signed Meshy rendered image before interactive 3D, keeps that image visible until `GLTFLoader` succeeds, refreshes expired thumbnails, retries the GLB, and rebuilds a missing/unreadable private cache from the already-completed Meshy task.

## What this focused PR adds

One remaining edge case: a corrupt GLB can still return HTTP 200 from private Storage. In that case the server cannot know it is bad, but Three.js does. The viewer already adds `previewRetry` only after a real GLB load/parse failure.

This PR makes `previewRetry` enter provider-backed repair mode:

- bypass the existing private cached GLB even if Storage returns HTTP 200;
- fetch the GLB from the already-completed Meshy task;
- overwrite the private cached GLB when possible;
- serve the provider GLB directly if recaching is temporarily unavailable;
- mark repair responses `no-store` so bad bytes are not reused;
- never start or charge for another Meshy generation.

## Regression coverage

The photo-to-voxel regression explicitly requires corrupt-but-present cache bypass and provider-backed repair, while retaining the image-first `3D IMAGE → INTERACTIVE 3D` flow.