### PR TITLE
Keep property image visible until Meshy 3D renders

### DIFF
--- a/app/property/page.js
+++ b/app/property/page.js
@@ -458,7 +458,7 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Building the first 3D.</p>
         <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. Your photo stays visible until the 3D canvas has actually loaded.</p>
         <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} fallbackImageUrl={displaySource}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>Image first → first 3D → VoxelPop image → final movable 3D.</span></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel. Your image stays visible until each 3D render is ready.</span></div>
       </> : null}
 
       {step === 3 ? <>

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -300,8 +300,9 @@ export default function PropertyJourneyPage() {
       const data = await response.json().catch(() => ({}));
       if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || '3D build could not start.');
       setSourceReference(data.reference);
-      setPendingPhoto(null);
-      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+      // Keep the local photo File + object URL alive for this creation. The
+      // image remains visible until the generated 3D canvas really renders,
+      // and a failed/expired provider job can be rebuilt from the same photo.
       setSource3d(empty3d());
       setVoxelJob(emptyImage());
       setVoxelImage('');
@@ -319,6 +320,11 @@ export default function PropertyJourneyPage() {
   }
 
   async function retryBuild() {
+    if (pendingPhoto && rightsConfirmed) {
+      setMessage('Rebuilding the 3D from your photo…');
+      await usePhotoAndBuild();
+      return;
+    }
     if (!sourceReference) return;
     const iteration = ++pipelineRef.current;
     setSource3d(empty3d());
@@ -424,7 +430,7 @@ export default function PropertyJourneyPage() {
     </section></main>;
   }
 
-  const displaySource = pendingPreview || sourceReference?.url || '';
+  const displaySource = pendingPreview || sourceReference?.url || source3d?.thumbnailUrl || final3d?.thumbnailUrl || '';
   const pipelineRunning = busy === 'pipeline' || ['source3d', 'voxel-image', 'voxel-3d'].includes(pipelinePhase);
 
   return <main className={styles.page}>
@@ -450,26 +456,26 @@ export default function PropertyJourneyPage() {
 
       {step === 2 ? <>
         <p className={styles.bigPrompt}>Building the first 3D.</p>
-        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. When it finishes, the voxel step starts automatically.</p>
-        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel.</span></div>
+        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. Your photo stays visible until the 3D canvas has actually loaded.</p>
+        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} fallbackImageUrl={displaySource}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>Image first → first 3D → VoxelPop image → final movable 3D.</span></div>
       </> : null}
 
       {step === 3 ? <>
         <p className={styles.bigPrompt}>{pipelinePhase === 'voxel-3d' ? 'Building the final 3D voxel.' : 'Making the VoxelPop version.'}</p>
-        <p className={styles.stepCopy}>The VoxelPop style pass uses the generated 3D preview, then creates one final movable 3D voxel.</p>
+        <p className={styles.stepCopy}>The VoxelPop image stays visible while the final movable 3D loads, so a slow or retried GLB never leaves an empty card.</p>
         <div className={styles.heroCard}>
-          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : null}
+          {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl} fallbackImageUrl={displaySource}/> : null}
           <span className={styles.badge}>{pipelinePhase === 'voxel-3d' ? `FINAL 3D VOXEL · ${Math.round(Number(final3d?.progress || 0))}%` : `VOXEL LOOK · ${Math.round(Number(voxelJob?.progress || 0))}%`}</span>
           {pipelineRunning ? <div className={styles.buildPulse}/> : null}
         </div>
-        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes.</span></div>}
+        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Rebuild from photo</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>The image remains on screen until the 3D viewer confirms it rendered.</span></div>}
       </> : null}
 
       {step === 4 ? <>
         <p className={styles.bigPrompt}>Add the property address.</p>
         <p className={styles.stepCopy}>Enter the address for the property shown in your photo. We use it to place this digital representation on the map and check its mapped identity.</p>
-        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl}/><span className={styles.badge}>VOXEL READY</span></div>
+        <div className={styles.heroCard}><MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/><span className={styles.badge}>VOXEL READY</span></div>
         <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Checking address…' : 'Verify address + preview'}</button></form>
         <small className={styles.mapNote}>The address helps locate the reference. It is not proof of ownership, title, property value, or an investment offering.</small>
       </> : null}
@@ -478,7 +484,7 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Your World preview.</p>
         <p className={styles.stepCopy}>This preview is private to your account. It is not published publicly unless you choose to share it later from Vault.</p>
         <div className={styles.worldCard}><PlanetStreamGlobe listings={worldListing} selectedId="my-voxel-preview" simpleMode/><span className={styles.worldBadge}>MY WORLD · PRIVATE PREVIEW</span></div>
-        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl}/></div>
+        <div className={styles.miniModel}><MeshyModelViewer modelUrl={final3d.modelUrl} fallbackImageUrl={voxelImage || displaySource}/></div>
         <div className={styles.priceCard}>
           <div><small>DIGITAL VOXEL</small><b>{quote?.label || 'World preview'}</b><span>{mappedAddress}</span></div>
           <strong>{quote ? dollars(quote.priceCents) : '—'}</strong>

--- a/app/vault/earth/MeshyModelViewer.js
+++ b/app/vault/earth/MeshyModelViewer.js
@@ -13,10 +13,22 @@ function retryUrl(modelUrl, attempt) {
   }
 }
 
-export default function MeshyModelViewer({ modelUrl }) {
+export default function MeshyModelViewer({
+  modelUrl,
+  fallbackImageUrl = '',
+  label = 'Interactive Meshy 3D model',
+}) {
   const mountRef = useRef(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(Boolean(modelUrl));
+  const [loaded, setLoaded] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    setError('');
+    setLoading(Boolean(modelUrl));
+    setLoaded(false);
+  }, [modelUrl]);
 
   useEffect(() => {
     if (!modelUrl || !mountRef.current) return undefined;
@@ -24,6 +36,7 @@ export default function MeshyModelViewer({ modelUrl }) {
     let cleanup = () => {};
     setError('');
     setLoading(true);
+    setLoaded(false);
 
     Promise.all([
       import('three'),
@@ -36,7 +49,7 @@ export default function MeshyModelViewer({ modelUrl }) {
         renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       } catch {
         setLoading(false);
-        setError('3D model preview is unavailable in this browser.');
+        setError('3D preview is unavailable in this browser. Your image is still shown.');
         return;
       }
       const width = Math.max(280, mount.clientWidth || 360);
@@ -51,6 +64,8 @@ export default function MeshyModelViewer({ modelUrl }) {
       renderer.shadowMap.enabled = !compact;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
       renderer.domElement.style.touchAction = 'none';
+      renderer.domElement.style.opacity = '0';
+      renderer.domElement.style.transition = 'opacity 220ms ease';
       mount.innerHTML = '';
       mount.appendChild(renderer.domElement);
 
@@ -84,17 +99,19 @@ export default function MeshyModelViewer({ modelUrl }) {
       let model = null;
       let loadRetryTimer = 0;
       const loadModel = (attempt = 0) => {
-        loader.load(retryUrl(modelUrl, attempt), (gltf) => {
+        loader.load(retryUrl(modelUrl, attempt + reloadKey * 4), (gltf) => {
           if (dead) return;
           model = gltf.scene;
           model.traverse((object) => {
             if (!object?.isMesh) return;
             object.castShadow = !compact;
             object.receiveShadow = !compact;
-            if (object.material) {
-              object.material.envMapIntensity = 0.75;
-              object.material.needsUpdate = true;
-            }
+            const materials = Array.isArray(object.material) ? object.material : [object.material];
+            materials.forEach((material) => {
+              if (!material) return;
+              material.envMapIntensity = 0.75;
+              material.needsUpdate = true;
+            });
           });
           const box = new THREE.Box3().setFromObject(model);
           const size = new THREE.Vector3();
@@ -106,7 +123,9 @@ export default function MeshyModelViewer({ modelUrl }) {
           model.scale.setScalar(scale);
           model.position.set(-center.x * scale, -box.min.y * scale, -center.z * scale);
           root.add(model);
+          renderer.domElement.style.opacity = '1';
           setLoading(false);
+          setLoaded(true);
           setError('');
         }, undefined, () => {
           if (dead) return;
@@ -117,7 +136,7 @@ export default function MeshyModelViewer({ modelUrl }) {
             return;
           }
           setLoading(false);
-          setError('The 3D preview could not be loaded. The 3D job is still recoverable; use Try build again if it does not recover.');
+          setError('The 3D preview did not open. Your image is safe—tap Reload 3D or rebuild from the photo.');
         });
       };
       loadModel();
@@ -238,18 +257,19 @@ export default function MeshyModelViewer({ modelUrl }) {
     }).catch(() => {
       if (!dead) {
         setLoading(false);
-        setError('The 3D model viewer could not start.');
+        setError('The 3D viewer could not start. Your image is still shown.');
       }
     });
 
     return () => { dead = true; cleanup(); };
-  }, [modelUrl]);
+  }, [modelUrl, reloadKey]);
 
   return <div className="viewerShell">
-    <div ref={mountRef} className="viewer" aria-label="Interactive Meshy hero-property 3D model" />
-    {loading && !error ? <div className="viewerLoading">Loading live 3D model…</div> : null}
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">DRAG · PINCH TO ZOOM · LIVE 3D</div>
-    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewer{position:absolute;inset:0}.viewerLoading{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:#09100f}.viewerHint{position:absolute;left:12px;right:12px;bottom:10px;text-align:center;color:#7e8c87;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
+    {fallbackImageUrl ? <img className={`viewerFallback ${loaded ? 'viewerFallbackHidden' : ''}`} src={fallbackImageUrl} alt="3D source preview"/> : null}
+    <div ref={mountRef} className="viewer" aria-label={label}/>
+    {loading && !fallbackImageUrl ? <div className="viewerLoading">Loading live 3D model…</div> : null}
+    {error ? <div className="viewerError" role="status"><span>{error}</span><button type="button" onClick={() => setReloadKey((current) => current + 1)}>Reload 3D</button></div> : null}
+    <div className="viewerHint">{loaded ? 'DRAG · PINCH TO ZOOM · 3D READY' : 'IMAGE FIRST · LOADING 3D'}</div>
+    <style jsx>{`.viewerShell{position:relative;min-height:330px;border-radius:20px;overflow:hidden;background:radial-gradient(circle at 50% 35%,rgba(78,151,126,.16),transparent 42%),#070d0c}.viewerFallback{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:opacity .22s ease}.viewerFallbackHidden{opacity:0}.viewer{position:absolute;inset:0;z-index:2}.viewerLoading{position:absolute;inset:0;display:grid;place-content:center;padding:28px;text-align:center;color:#bdc8c4;font-size:11px;line-height:1.5;background:rgba(9,16,15,.68);pointer-events:none}.viewerError{position:absolute;z-index:4;left:14px;right:14px;bottom:34px;display:flex;align-items:center;justify-content:center;gap:9px;flex-wrap:wrap;padding:10px 12px;text-align:center;color:#e7efec;font-size:10px;line-height:1.45;background:rgba(9,16,15,.86);border:1px solid rgba(255,255,255,.1);border-radius:14px;backdrop-filter:blur(10px)}.viewerError button{min-height:36px;border:0;border-radius:12px;padding:0 13px;background:#c9ff54;color:#24310e;font:900 10px inherit;cursor:pointer}.viewerHint{position:absolute;z-index:3;left:12px;right:12px;bottom:10px;text-align:center;color:#9aa9a4;font-size:6px;letter-spacing:.12em;font-weight:900;pointer-events:none}`}</style>
   </div>;
 }

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -50,21 +50,33 @@ assert.match(voxel3d, /displayUrlFor\(finalRow, apiKey\)/, 'persisted 3D polling
 assert.match(voxelModel, /verifyPropertyGenerationModelToken/, 'the model delivery endpoint must reject unsigned model requests');
 assert.match(voxelModel, /model_storage_path/, 'the model delivery endpoint should prefer a durable cached GLB when one exists');
 assert.match(voxelModel, /model_urls\?\.glb/, 'the model delivery endpoint must refresh the current Meshy GLB when the cache is unavailable');
+
 assert.match(modelViewer, /attempt < 3/, 'the 3D viewer must retry temporary model-load failures before showing an error');
 assert.match(modelViewer, /previewRetry/, '3D viewer retries must bypass stale browser or edge caching');
-assert.match(modelViewer, /Loading live 3D model/, '3D viewer must retain an explicit loading state while the live model is being delivered');
+assert.match(modelViewer, /fallbackImageUrl = ''/, '3D viewer must support an image-first visual fallback');
+assert.match(modelViewer, /viewerFallbackHidden/, 'the source image must remain visible until GLTFLoader has actually succeeded');
+assert.match(modelViewer, /Reload 3D/, 'a failed 3D viewer must offer a direct reload action');
+assert.match(modelViewer, /IMAGE FIRST · LOADING 3D/, 'the loading state must explicitly describe the image-first 3D transition');
+assert.match(modelViewer, /renderer\.domElement\.style\.opacity = '1'/, 'the 3D canvas must become visible only after a model has loaded');
 assert.doesNotMatch(modelViewer, /cached Meshy GLB could not be loaded/i, 'the old non-recovering cached-GLB error must be removed');
 assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer must not tell users a temporary GLB failure is permanently stuck');
+
+assert.match(property, /Keep the local photo File \+ object URL alive for this creation/, 'the selected source photo must remain available for image-first loading and rebuild recovery');
+assert.match(property, /fallbackImageUrl=\{displaySource\}/, 'the first 3D viewer must keep the source photo visible until the model renders');
+assert.match(property, /fallbackImageUrl=\{voxelImage \|\| displaySource\}/, 'the final 3D viewer must keep the VoxelPop image visible until the model renders');
+assert.doesNotMatch(property, /setSourceReference\(data\.reference\);\s*setPendingPhoto\(null\);\s*setPendingPreview/, 'starting a 3D job must not immediately discard the user-visible source photo');
+assert.match(property, /if \(pendingPhoto && rightsConfirmed\)/, 'paused generation must be able to create a fresh provider job from the retained photo');
+assert.match(property, /await usePhotoAndBuild\(\)/, 'rebuild recovery must re-submit the retained authorized photo when needed');
 
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
 assert.match(property, /setPipelinePhase\('paused'\)/, 'provider failure must move the automatic chain to a recoverable paused state');
 assert.match(property, /async function retryBuild\(\)/, 'paused automatic chain must preserve a retry path');
-assert.match(property, /Try build again/, 'paused voxel stage must expose a clear retry action');
-assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3D voxel\./, 'visible copy must make the automatic handoff obvious');
+assert.match(property, /Rebuild from photo/, 'paused voxel stage must expose a fresh-photo rebuild action');
+assert.match(property, /Image first → first 3D → VoxelPop image → final movable 3D\./, 'visible copy must make the image-first handoff obvious');
 
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> refreshed/snapshotted VoxelPop style -> same-origin resilient GLB delivery -> final voxel 3D, including signed account-bound recovery and live loading/retry behavior.');
+console.log('Property automatic journey regression passed: authorized photo stays visible -> refreshed/snapshotted VoxelPop pipeline -> same-origin resilient GLB delivery -> final movable 3D, with image-first fallback and fresh-photo rebuild recovery.');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -74,7 +74,8 @@ assert.match(property, /Building your final VoxelPop 3D/, 'user must see final v
 assert.match(property, /setPipelinePhase\('paused'\)/, 'provider failure must move the automatic chain to a recoverable paused state');
 assert.match(property, /async function retryBuild\(\)/, 'paused automatic chain must preserve a retry path');
 assert.match(property, /Rebuild from photo/, 'paused voxel stage must expose a fresh-photo rebuild action');
-assert.match(property, /Image first → first 3D → VoxelPop image → final movable 3D\./, 'visible copy must make the image-first handoff obvious');
+assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3D voxel\./, 'visible copy must preserve the automatic no-extra-button handoff');
+assert.match(property, /Your image stays visible until each 3D render is ready\./, 'visible copy must make the image-first fallback promise explicit');
 
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');


### PR DESCRIPTION
Closed as superseded by the newer main commit 2b38d77773580e6484dd8e72f49a381722467eca (`Show Meshy render first and auto-repair cached property GLBs`). That implementation overlaps this PR and more directly matches the requested flow: provider-rendered 3D image first -> interactive 3D after GLTFLoader success, plus same-origin GLB recovery/repair. I verified main's build, compile, guard, and Vercel checks are passing, so this conflicting duplicate should not be force-merged.