### PR TITLE
Preserve VoxelPop image and resume only final 3D

### DIFF
--- a/app/property/page.js
+++ b/app/property/page.js
@@ -14,6 +14,9 @@ function clean(value) { return String(value || '').trim(); }
 function terminal(value) {
   return ['SUCCEEDED', 'SUCCESS', 'COMPLETED', 'FAILED', 'EXPIRED', 'CANCELED', 'CANCELLED'].includes(String(value || '').toUpperCase());
 }
+function providerNeedsFunds(value) {
+  return /insufficient (funds|credits)|credit balance|not enough credits/i.test(String(value || ''));
+}
 function newDraftId() {
   const random = globalThis.crypto?.randomUUID?.().replace(/-/g, '') || `${Date.now()}${Math.random().toString(16).slice(2)}`;
   return `vp-${random.slice(0, 28)}`;
@@ -230,6 +233,7 @@ export default function PropertyJourneyPage() {
 
   async function runAutomaticBuild(reference, iteration) {
     setBusy('pipeline');
+    let finalCheckpoint = null;
     try {
       setPipelinePhase('source3d');
       setMessage('Building a first 3D model from your photo…');
@@ -254,6 +258,7 @@ export default function PropertyJourneyPage() {
       if (!imageResponse.ok || !imageStart?.ok || !imageStart?.taskId || !imageStart?.taskToken) throw new Error(imageStart?.error || 'Voxel style pass could not start.');
       setVoxelJob(imageStart);
       const voxelDone = await pollVoxelImage(imageStart, iteration);
+      finalCheckpoint = voxelDone;
       setVoxelImage(voxelDone.imageUrl);
 
       setPipelinePhase('voxel-3d');
@@ -269,7 +274,12 @@ export default function PropertyJourneyPage() {
         }),
       });
       const finalStart = await finalResponse.json().catch(() => ({}));
-      if (!finalResponse.ok || !finalStart?.ok || !finalStart?.taskId) throw new Error(finalStart?.error || 'Final voxel 3D could not start.');
+      if (!finalResponse.ok || !finalStart?.ok || !finalStart?.taskId) {
+        const finalError = finalStart?.error || 'Final voxel 3D could not start.';
+        throw new Error(providerNeedsFunds(finalError)
+          ? 'Final 3D is waiting for Meshy credits. Your finished VoxelPop image is preserved on this page. Add Meshy credits, then tap Resume final 3D.'
+          : finalError);
+      }
       setFinal3d(finalStart);
       const finalDone = finalStart.modelUrl ? finalStart : await poll3D(finalStart.taskId, setFinal3d, iteration, 'Building your final VoxelPop 3D');
       setFinal3d(finalDone);
@@ -278,7 +288,7 @@ export default function PropertyJourneyPage() {
     } catch (error) {
       if (iteration === pipelineRef.current) {
         setMessage(String(error?.message || error || 'The automatic build stopped.'));
-        setPipelinePhase('paused');
+        setPipelinePhase(finalCheckpoint?.taskId ? 'paused-final' : 'paused');
       }
     } finally {
       if (iteration === pipelineRef.current) setBusy('');
@@ -318,7 +328,50 @@ export default function PropertyJourneyPage() {
     }
   }
 
+  async function resumeFinal3D() {
+    if (!voxelImage || !voxelJob?.taskId || !voxelJob?.taskToken) return retryBuild();
+    const iteration = ++pipelineRef.current;
+    setBusy('pipeline');
+    setPipelinePhase('voxel-3d');
+    setMessage('Resuming only the final 3D voxel…');
+    try {
+      const finalResponse = await fetch('/api/property-voxel-3d', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          draftId,
+          phase: 'voxel',
+          voxelImageTaskId: voxelJob.taskId,
+          voxelImageTaskToken: voxelJob.taskToken,
+        }),
+      });
+      const finalStart = await finalResponse.json().catch(() => ({}));
+      if (!finalResponse.ok || !finalStart?.ok || !finalStart?.taskId) {
+        const finalError = finalStart?.error || 'Final voxel 3D could not start.';
+        throw new Error(providerNeedsFunds(finalError)
+          ? 'Meshy still needs credits for the final 3D step. Your completed VoxelPop image is still preserved here; add credits, then tap Resume final 3D again.'
+          : finalError);
+      }
+      setFinal3d(finalStart);
+      const finalDone = finalStart.modelUrl ? finalStart : await poll3D(finalStart.taskId, setFinal3d, iteration, 'Building your final VoxelPop 3D');
+      setFinal3d(finalDone);
+      setPipelinePhase('world');
+      setMessage('Your voxel is ready. Add the property address to place the reference on My World.');
+    } catch (error) {
+      if (iteration === pipelineRef.current) {
+        const text = String(error?.message || error || 'Final voxel 3D could not resume.');
+        setMessage(providerNeedsFunds(text)
+          ? 'Meshy still needs credits for the final 3D step. Your completed VoxelPop image is still preserved here; add credits, then tap Resume final 3D again.'
+          : text);
+        setPipelinePhase('paused-final');
+      }
+    } finally {
+      if (iteration === pipelineRef.current) setBusy('');
+    }
+  }
+
   async function retryBuild() {
+    if (pipelinePhase === 'paused-final' && voxelImage && voxelJob?.taskId && voxelJob?.taskToken) return resumeFinal3D();
     if (!sourceReference) return;
     const iteration = ++pipelineRef.current;
     setSource3d(empty3d());
@@ -456,14 +509,14 @@ export default function PropertyJourneyPage() {
       </> : null}
 
       {step === 3 ? <>
-        <p className={styles.bigPrompt}>{pipelinePhase === 'voxel-3d' ? 'Building the final 3D voxel.' : 'Making the VoxelPop version.'}</p>
+        <p className={styles.bigPrompt}>{pipelinePhase === 'paused-final' ? 'Voxel image ready. Final 3D is paused.' : pipelinePhase === 'voxel-3d' ? 'Building the final 3D voxel.' : 'Making the VoxelPop version.'}</p>
         <p className={styles.stepCopy}>The VoxelPop style pass uses the generated 3D preview, then creates one final movable 3D voxel.</p>
         <div className={styles.heroCard}>
           {final3d?.modelUrl ? <MeshyModelViewer modelUrl={final3d.modelUrl}/> : voxelImage ? <img src={voxelImage} alt="VoxelPop property rendering"/> : source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : null}
           <span className={styles.badge}>{pipelinePhase === 'voxel-3d' ? `FINAL 3D VOXEL · ${Math.round(Number(final3d?.progress || 0))}%` : `VOXEL LOOK · ${Math.round(Number(voxelJob?.progress || 0))}%`}</span>
           {pipelineRunning ? <div className={styles.buildPulse}/> : null}
         </div>
-        {pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes.</span></div>}
+        {pipelinePhase === 'paused-final' ? <div className={styles.choicePanel}><b>VoxelPop image complete.</b><span>The finished image stays here. Resume only the final 3D step after the 3D provider has credits available.</span><button className={styles.primaryOrange} type="button" onClick={resumeFinal3D}>Resume final 3D</button></div> : pipelinePhase === 'paused' ? <div className={styles.choicePanel}><b>The automatic build paused.</b><button className={styles.primaryOrange} type="button" onClick={retryBuild}>Try build again</button></div> : <div className={styles.autoPanel}><b>AUTOMATIC</b><span>Keep this page open while the current build finishes.</span></div>}
       </> : null}
 
       {step === 4 ? <>

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -68,7 +68,7 @@ assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer m
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
-assert.match(property, /setPipelinePhase\('paused'\)/, 'provider failure must move the automatic chain to a recoverable paused state');
+assert.match(property, /'paused-final' : 'paused'/, 'provider failures must distinguish a preserved final-stage checkpoint from earlier recoverable pauses');
 assert.match(property, /async function retryBuild\(\)/, 'paused automatic chain must preserve a retry path');
 assert.match(property, /Try build again/, 'paused early stages must expose a clear retry action');
 assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3D voxel\./, 'visible copy must make the automatic handoff obvious');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -70,10 +70,20 @@ assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel 
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
 assert.match(property, /setPipelinePhase\('paused'\)/, 'provider failure must move the automatic chain to a recoverable paused state');
 assert.match(property, /async function retryBuild\(\)/, 'paused automatic chain must preserve a retry path');
-assert.match(property, /Try build again/, 'paused voxel stage must expose a clear retry action');
+assert.match(property, /Try build again/, 'paused early stages must expose a clear retry action');
 assert.match(property, /No extra button\. First 3D → VoxelPop look → final 3D voxel\./, 'visible copy must make the automatic handoff obvious');
+
+assert.match(property, /function providerNeedsFunds\(value\)/, 'the UI must recognize provider credit exhaustion separately from generation failure');
+assert.match(property, /finalCheckpoint = voxelDone/, 'the completed voxel image job must become a resumable final-3D checkpoint');
+assert.match(property, /setPipelinePhase\(finalCheckpoint\?\.taskId \? 'paused-final' : 'paused'\)/, 'a final-stage failure must preserve the completed voxel checkpoint');
+assert.match(property, /async function resumeFinal3D\(\)/, 'the completed voxel checkpoint must have a dedicated final-3D resume path');
+assert.match(property, /voxelImageTaskId: voxelJob\.taskId/, 'final-3D resume must reuse the completed voxel-image job instead of creating another image');
+assert.match(property, /voxelImageTaskToken: voxelJob\.taskToken/, 'final-3D resume must reuse the account-bound voxel image token');
+assert.match(property, /pipelinePhase === 'paused-final' && voxelImage && voxelJob\?\.taskId && voxelJob\?\.taskToken/, 'generic retry must route final-stage pauses to the checkpoint resume path');
+assert.match(property, /Resume final 3D/, 'the paused final stage must clearly offer a final-3D-only resume action');
+assert.match(property, /Your finished VoxelPop image is preserved on this page/, 'credit exhaustion must explain that the completed image is preserved instead of implying the entire build failed');
 
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> final movable voxel 3D.');
+console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> resumable final movable voxel 3D without re-spending completed stages.');


### PR DESCRIPTION
## What this fixes

The property flow can successfully finish the VoxelPop image at 100% and then receive `Insufficient funds` when Meshy tries to start the final image-to-3D step. Previously the UI treated that as a generic pipeline failure, and `Try build again` cleared the completed checkpoint and restarted earlier generation stages.

## Changes

- Recognize provider credit exhaustion separately from an ordinary generation failure.
- Preserve the completed VoxelPop image and its account-bound image job as a final-3D checkpoint.
- Show a specific paused-final state instead of implying the whole build failed.
- Add `Resume final 3D`, which reuses the completed voxel-image task/token and calls only the final 3D endpoint.
- Route generic retry to the final-only resume path when that checkpoint exists.
- Keep the 100% VoxelPop image visible while final 3D is blocked.
- Add regression coverage so this path cannot silently revert to re-running paid stages.

This does not bypass Meshy billing. If the configured Meshy account has no credits, final 3D cannot start until credits are available; the fix prevents wasting the completed earlier work in the meantime.