### PR TITLE
Prevent Meshy credit exhaustion from stranding VoxelPop builds

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -7,6 +7,14 @@ import {
   createPropertyGenerationRecoveryTaskId,
   propertyGenerationCanonicalTaskId,
 } from '../../../lib/property-generation-task';
+import {
+  MESHY_PROPERTY_CREDITS,
+  meshyClientStatus,
+  meshyCreditError,
+  meshyCreditsSufficient,
+  meshyProviderFailure,
+  readMeshyCreditBalance,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -57,6 +65,18 @@ export async function POST(request: Request) {
       return privateJson({ ok: false, error: 'Property photos must be smaller than 8 MB after preparation.' }, { status: 413 });
     }
 
+    // The automatic Property journey is three paid Meshy calls: 15 credits for
+    // this textured Smart Topology source 3D, 3 for nano-banana image-to-image,
+    // and 15 for the final textured Smart Topology 3D. Do not burn the first 15
+    // unless the provider account can afford the complete automatic journey.
+    const balance = await readMeshyCreditBalance(apiKey);
+    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.fullPipeline)) {
+      return privateJson(
+        meshyCreditError('starting the complete property build', MESHY_PROPERTY_CREDITS.fullPipeline),
+        { status: 503 },
+      );
+    }
+
     const bytes = Buffer.from(await photo.arrayBuffer());
     const digest = createHash('sha256').update(bytes).digest('hex');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
@@ -79,7 +99,16 @@ export async function POST(request: Request) {
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+      return privateJson(
+        meshyProviderFailure(
+          response.status,
+          data,
+          `3D provider returned ${response.status}.`,
+          'starting the first property 3D build',
+          MESHY_PROPERTY_CREDITS.source3d,
+        ),
+        { status: meshyClientStatus(response.status) },
+      );
     }
 
     const providerTaskId = clean(data?.result || data?.id, 240);

--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -21,6 +21,14 @@ import {
   verifyPropertyGenerationRecoveryTaskId,
 } from '../../../lib/property-generation-task';
 import { propertyGenerationModelUrl } from '../../../lib/property-generation-model';
+import {
+  MESHY_PROPERTY_CREDITS,
+  meshyClientStatus,
+  meshyCreditError,
+  meshyCreditsSufficient,
+  meshyProviderFailure,
+  readMeshyCreditBalance,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -104,7 +112,10 @@ async function verifiedVoxelImageUrl(apiKey: string, userId: string, taskIdRaw: 
     cache: 'no-store',
   });
   const task = await response.json().catch(() => ({}));
-  if (!response.ok) throw new Error(task?.message || task?.error || 'The voxel image job could not be verified.');
+  if (!response.ok) {
+    if (response.status === 402) throw new Error(meshyCreditError('reading the completed VoxelPop image', 0).error);
+    throw new Error(task?.message || task?.error || 'The voxel image job could not be verified.');
+  }
   if (String(task?.status || '').toUpperCase() !== 'SUCCEEDED') throw new Error('Finish the voxel image before building the final 3D collectible.');
   const imageUrl = Array.isArray(task?.image_urls) ? clean(task.image_urls[0], 2200) : '';
   if (!isHttpUrl(imageUrl)) throw new Error('The completed voxel image is unavailable.');
@@ -181,6 +192,20 @@ export async function POST(request: Request) {
       return privateJson({ ok: true, reused: true, ...publicState(existing) });
     }
 
+    // Every new Image-to-3D task created by this route currently uses textured
+    // Smart Topology at 2K, which costs 15 Meshy credits. Preflight immediately
+    // before task creation so old/retried jobs also cannot surface raw 402 copy.
+    const balance = await readMeshyCreditBalance(apiKey);
+    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.final3d)) {
+      return privateJson(
+        meshyCreditError(
+          provider === 'meshy-property-voxel-style-to-3d' ? 'starting the final VoxelPop 3D' : 'starting a property 3D build',
+          MESHY_PROPERTY_CREDITS.final3d,
+        ),
+        { status: 503 },
+      );
+    }
+
     const response = await fetch(ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -197,7 +222,18 @@ export async function POST(request: Request) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+    if (!response.ok) {
+      return privateJson(
+        meshyProviderFailure(
+          response.status,
+          data,
+          `3D provider returned ${response.status}.`,
+          provider === 'meshy-property-voxel-style-to-3d' ? 'starting the final VoxelPop 3D' : 'starting a property 3D build',
+          MESHY_PROPERTY_CREDITS.final3d,
+        ),
+        { status: meshyClientStatus(response.status) },
+      );
+    }
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
@@ -290,7 +326,12 @@ export async function GET(request: Request) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || 'Could not read property 3D status.' }, { status: response.status });
+    if (!response.ok) {
+      return privateJson(
+        meshyProviderFailure(response.status, data, 'Could not read property 3D status.', 'reading the property 3D job'),
+        { status: meshyClientStatus(response.status) },
+      );
+    }
 
     const status = clean(data?.status || 'PENDING', 80);
     const progress = Number(data?.progress || 0);

--- a/app/api/property-voxel-image/route.ts
+++ b/app/api/property-voxel-image/route.ts
@@ -8,6 +8,14 @@ import {
   propertyGenerationProviderTaskId,
   verifyPropertyGenerationRecoveryTaskId,
 } from '../../../lib/property-generation-task';
+import {
+  MESHY_PROPERTY_CREDITS,
+  meshyClientStatus,
+  meshyCreditError,
+  meshyCreditsSufficient,
+  meshyProviderFailure,
+  readMeshyCreditBalance,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -160,6 +168,18 @@ export async function POST(request: Request) {
     const draftId = clean(body?.draftId, 100);
     const address = clean(body?.address, 220);
     const atlasId = clean(body?.atlasId, 180);
+    const requiredCredits = draftId ? MESHY_PROPERTY_CREDITS.afterSource : MESHY_PROPERTY_CREDITS.voxelImage;
+    const balance = await readMeshyCreditBalance(apiKey);
+    if (!meshyCreditsSufficient(balance, requiredCredits)) {
+      return privateJson(
+        meshyCreditError(
+          draftId ? 'starting the VoxelPop style pass and final 3D' : 'starting the VoxelPop image pass',
+          requiredCredits,
+        ),
+        { status: 503 },
+      );
+    }
+
     const references = draftId
       ? await generated3DReference(apiKey, auth.user.id, draftId, body?.source3dTaskId)
       : validateReferences(body?.references);
@@ -190,7 +210,18 @@ export async function POST(request: Request) {
       cache: 'no-store',
     });
     const created = await create.json().catch(() => ({}));
-    if (!create.ok) return privateJson({ ok: false, error: created?.message || created?.error || `Voxel image provider returned ${create.status}.` }, { status: create.status });
+    if (!create.ok) {
+      return privateJson(
+        meshyProviderFailure(
+          create.status,
+          created,
+          `Voxel image provider returned ${create.status}.`,
+          'starting the VoxelPop image pass',
+          MESHY_PROPERTY_CREDITS.voxelImage,
+        ),
+        { status: meshyClientStatus(create.status) },
+      );
+    }
 
     const taskId = clean(created?.result || created?.id, 240);
     if (!taskId) throw new Error('The voxel image provider did not return a task ID.');
@@ -229,7 +260,12 @@ export async function GET(request: Request) {
       cache: 'no-store',
     });
     const task = await statusResponse.json().catch(() => ({}));
-    if (!statusResponse.ok) return privateJson({ ok: false, error: task?.message || task?.error || `Could not read voxel image task (${statusResponse.status}).` }, { status: statusResponse.status });
+    if (!statusResponse.ok) {
+      return privateJson(
+        meshyProviderFailure(statusResponse.status, task, `Could not read voxel image task (${statusResponse.status}).`, 'reading the VoxelPop image task'),
+        { status: meshyClientStatus(statusResponse.status) },
+      );
+    }
 
     const status = clean(task?.status || 'PENDING', 80).toUpperCase();
     const progress = Math.max(0, Math.min(100, Number(task?.progress || 0)));

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -1,0 +1,64 @@
+const BALANCE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/balance';
+
+export const MESHY_PROPERTY_CREDITS = Object.freeze({
+  source3d: 15,
+  voxelImage: 3,
+  final3d: 15,
+  fullPipeline: 33,
+  afterSource: 18,
+});
+
+function clean(value: unknown, max = 600) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function providerMessage(data: any) {
+  return clean(data?.task_error?.message || data?.message || data?.error, 600);
+}
+
+export async function readMeshyCreditBalance(apiKey: string) {
+  try {
+    const response = await fetch(BALANCE_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
+    if (!response.ok) return null;
+    const data = await response.json().catch(() => ({}));
+    const balance = Number(data?.balance);
+    return Number.isFinite(balance) && balance >= 0 ? balance : null;
+  } catch {
+    return null;
+  }
+}
+
+export function meshyCreditsSufficient(balance: number | null, required: number) {
+  // Fail open if Meshy's non-billable balance endpoint is temporarily unavailable.
+  // The paid endpoint still has explicit 402 mapping below, so users never see a
+  // provider billing message as if it came from their own wallet or card.
+  return balance === null || balance >= required;
+}
+
+export function meshyCreditError(stage: string, requiredProviderCredits: number) {
+  return {
+    ok: false,
+    code: 'VOXELPOP_PROVIDER_CREDITS_LOW',
+    providerCreditIssue: true,
+    retryable: true,
+    stage,
+    requiredProviderCredits,
+    error: "There are not enough credits in Voxel Vault's Meshy provider account to continue VoxelPop's 3D generation service. This is not your wallet, bank account, card, or crypto balance. No payment was attempted from your account. Please retry after the service credits are replenished.",
+  };
+}
+
+export function meshyProviderFailure(status: number, data: any, fallback: string, stage: string, requiredProviderCredits = 0) {
+  const message = providerMessage(data);
+  const insufficient = status === 402 || /insufficient\s+(funds|credits)|payment\s+required/i.test(message);
+  if (insufficient) return meshyCreditError(stage, requiredProviderCredits);
+  return { ok: false, error: message || fallback, providerStatus: status };
+}
+
+export function meshyClientStatus(status: number) {
+  // A Meshy 402 is a backend-provider availability problem for Voxel Vault,
+  // not a payment request to the signed-in user.
+  return status === 402 ? 503 : status;
+}

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -9,6 +9,7 @@ const voxelModel = fs.readFileSync(new URL('../app/api/property-voxel-model/rout
 const modelViewer = fs.readFileSync(new URL('../app/vault/earth/MeshyModelViewer.js', import.meta.url), 'utf8');
 const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
 const modelDelivery = fs.readFileSync(new URL('../lib/property-generation-model.ts', import.meta.url), 'utf8');
+const meshyCredits = fs.readFileSync(new URL('../lib/meshy-credits.ts', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
@@ -65,6 +66,20 @@ assert.match(modelViewer, /readyRef\.current/, 'interactive controls must unlock
 assert.doesNotMatch(modelViewer, /cached Meshy GLB could not be loaded/i, 'the old non-recovering cached-GLB error must be removed');
 assert.doesNotMatch(modelViewer, /Regenerating is not automatic/i, 'the viewer must not tell users a temporary GLB failure is permanently stuck');
 
+assert.match(meshyCredits, /fullPipeline: 33/, 'the automatic property budget must reserve all three paid Meshy stages before starting');
+assert.match(meshyCredits, /afterSource: 18/, 'the voxel style stage must reserve enough credits for itself plus the final 3D');
+assert.match(meshyCredits, /final3d: 15/, 'the final textured Smart Topology 3D budget must match current Meshy pricing');
+assert.match(meshyCredits, /openapi\/v1\/balance/, 'provider credit preflight must use Meshy’s balance API');
+assert.match(meshyCredits, /status === 402/, 'Meshy 402 responses must be recognized as provider-credit exhaustion');
+assert.match(meshyCredits, /not your wallet, bank account, card, or crypto balance/, 'credit exhaustion copy must not imply the signed-in user lacks funds');
+assert.match(meshyCredits, /return status === 402 \? 503 : status/, 'provider 402 must surface as service availability rather than a user payment request');
+assert.match(photoHandoff, /MESHY_PROPERTY_CREDITS\.fullPipeline/, 'photo upload must preflight the complete 33-credit automatic pipeline');
+assert.match(voxelImage, /MESHY_PROPERTY_CREDITS\.afterSource/, 'voxel image creation must preflight the remaining 18-credit automatic pipeline');
+assert.match(voxel3d, /MESHY_PROPERTY_CREDITS\.final3d/, 'every new textured property 3D task must preflight its 15-credit cost');
+assert.match(photoHandoff, /meshyProviderFailure/, 'source 3D must translate provider credit errors to VoxelPop service errors');
+assert.match(voxelImage, /meshyProviderFailure/, 'voxel styling must translate provider credit errors to VoxelPop service errors');
+assert.match(voxel3d, /meshyProviderFailure/, 'final 3D must translate provider credit errors to VoxelPop service errors');
+
 assert.match(property, /Building a first 3D model from your photo/, 'user must see the first automatic 3D processing state');
 assert.match(property, /Turning the 3D into VoxelPop/, 'user must see the voxel processing state');
 assert.match(property, /Building your final VoxelPop 3D/, 'user must see final voxel 3D progress');
@@ -86,4 +101,4 @@ assert.match(property, /Your finished VoxelPop image is preserved on this page/,
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> resumable final movable voxel 3D without re-spending completed stages.');
+console.log('Property automatic journey regression passed: authorized photo -> full Meshy credit preflight -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> resumable final movable voxel 3D without re-spending completed stages, with provider-credit failures separated from user funds.');


### PR DESCRIPTION
Fixes the VoxelPop Property flow surfacing Meshy `insufficient funds` as though the signed-in user lacked money.

Changes:
- Adds an official Meshy Balance API preflight helper.
- Reserves the current full automatic Property pipeline budget before starting: 15 credits source textured Smart Topology 3D + 3 credits nano-banana image-to-image + 15 credits final textured Smart Topology 3D = 33 credits.
- Requires 18 credits before the style + final-3D handoff and 15 before any newly-created textured property 3D task, so retries/older jobs fail before another paid request.
- Maps Meshy HTTP 402 to a VoxelPop service-availability error (HTTP 503) that explicitly says this is Voxel Vault's provider balance, not the customer's wallet, bank, card, or crypto balance.
- Fails open only if Meshy's non-billable balance endpoint itself is temporarily unreadable; the paid calls still map any 402 safely.
- Extends the photo-to-voxel regression guard for the 33/18/15 credit budgets and provider-error translation.

This does not fabricate provider credits: when the Meshy API account is actually below the required budget, generation will pause safely until those service credits are replenished instead of partially spending credits and failing later.