### PR TITLE
Preflight Meshy credits before VoxelPop property generation

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -7,6 +7,12 @@ import {
   createPropertyGenerationRecoveryTaskId,
   propertyGenerationCanonicalTaskId,
 } from '../../../lib/property-generation-task';
+import {
+  ensureMeshyCredits,
+  isMeshyCreditFailure,
+  MESHY_PROPERTY_CREDITS,
+  meshyCreditFailure,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -15,6 +21,7 @@ export const dynamic = 'force-dynamic';
 const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_BYTES = 8 * 1024 * 1024;
 const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const FULL_BUILD_STAGE = 'the complete Photo → 3D → VoxelPop → final 3D build';
 
 function clean(value: unknown, max = 240) {
   return String(value || '').trim().slice(0, max);
@@ -57,6 +64,12 @@ export async function POST(request: Request) {
       return privateJson({ ok: false, error: 'Property photos must be smaller than 8 MB after preparation.' }, { status: 413 });
     }
 
+    // Fail before any paid Meshy task starts. The current VoxelPop property chain
+    // uses two textured Smart Topology image-to-3D calls (15 + 15 credits) plus
+    // one nano-banana image-to-image style pass (3 credits) = 33 credits total.
+    const creditGate = await ensureMeshyCredits(apiKey, MESHY_PROPERTY_CREDITS.fullPipeline, FULL_BUILD_STAGE);
+    if (!creditGate.ok) return privateJson(creditGate, { status: creditGate.status });
+
     const bytes = Buffer.from(await photo.arrayBuffer());
     const digest = createHash('sha256').update(bytes).digest('hex');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
@@ -79,6 +92,9 @@ export async function POST(request: Request) {
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
+      if (isMeshyCreditFailure(response.status, data)) {
+        return privateJson(meshyCreditFailure(MESHY_PROPERTY_CREDITS.fullPipeline, null, FULL_BUILD_STAGE), { status: 402 });
+      }
       return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
     }
 

--- a/app/api/property-voxel-3d/route.ts
+++ b/app/api/property-voxel-3d/route.ts
@@ -21,6 +21,12 @@ import {
   verifyPropertyGenerationRecoveryTaskId,
 } from '../../../lib/property-generation-task';
 import { propertyGenerationModelUrl } from '../../../lib/property-generation-model';
+import {
+  ensureMeshyCredits,
+  isMeshyCreditFailure,
+  MESHY_PROPERTY_CREDITS,
+  meshyCreditFailure,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -124,10 +130,12 @@ export async function POST(request: Request) {
     let itemId = '';
     let imageUrl = '';
     let provider = 'meshy-property-voxel-image-to-3d';
+    let generationStage = 'the property 3D';
 
     if (draftIdRaw) {
       const draftId = normalizePropertyDraftId(draftIdRaw);
       const phase = normalizePropertyGenerationPhase(body?.phase);
+      generationStage = phase === 'voxel' ? 'the final movable VoxelPop 3D' : 'the first property 3D';
       itemId = propertyDraftItemId(auth.user.id, draftId, phase);
       if (phase === 'source') {
         const sourceStoragePath = clean(body?.sourceStoragePath, 900);
@@ -181,6 +189,10 @@ export async function POST(request: Request) {
       return privateJson({ ok: true, reused: true, ...publicState(existing) });
     }
 
+    // Only a genuinely new textured image-to-3D call reaches this point.
+    const creditGate = await ensureMeshyCredits(apiKey, MESHY_PROPERTY_CREDITS.final3d, generationStage);
+    if (!creditGate.ok) return privateJson(creditGate, { status: creditGate.status });
+
     const response = await fetch(ENDPOINT, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
@@ -197,7 +209,12 @@ export async function POST(request: Request) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok) return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+    if (!response.ok) {
+      if (isMeshyCreditFailure(response.status, data)) {
+        return privateJson(meshyCreditFailure(MESHY_PROPERTY_CREDITS.final3d, null, generationStage), { status: 402 });
+      }
+      return privateJson({ ok: false, error: data?.task_error?.message || data?.message || data?.error || `3D provider returned ${response.status}.` }, { status: response.status });
+    }
 
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');

--- a/app/api/property-voxel-image/route.ts
+++ b/app/api/property-voxel-image/route.ts
@@ -8,6 +8,12 @@ import {
   propertyGenerationProviderTaskId,
   verifyPropertyGenerationRecoveryTaskId,
 } from '../../../lib/property-generation-task';
+import {
+  ensureMeshyCredits,
+  isMeshyCreditFailure,
+  MESHY_PROPERTY_CREDITS,
+  meshyCreditFailure,
+} from '../../../lib/meshy-credits';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -18,6 +24,7 @@ const THREE_D_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_REFERENCE_BYTES = 6 * 1024 * 1024;
 const ALLOWED_RIGHTS_BASES = new Set(['user-owned', 'open-licensed', 'licensed-derivative']);
 const BLOCKED_REFERENCE_HOSTS = /(^|\.)(google\.com|googleusercontent\.com|gstatic\.com|googleapis\.com|maps\.googleapis\.com|streetviewpixels-pa\.googleapis\.com|zillow\.com|zillowstatic\.com|redfin\.com|cdn-redfin\.com|apartments\.com)$/i;
+const REMAINING_BUILD_STAGE = 'the VoxelPop style pass and final movable 3D';
 
 function clean(value: unknown, max = 500) {
   return String(value || '').trim().slice(0, max);
@@ -166,6 +173,11 @@ export async function POST(request: Request) {
     if (!draftId && (!address || !atlasId)) return privateJson({ ok: false, error: 'A resolved property is required.' }, { status: 400 });
     if (!references.length) return privateJson({ ok: false, error: 'A rights-cleared visual reference is required before making the voxel.' }, { status: 400 });
 
+    // Once the first 3D exists, do not spend the 3-credit styling call unless
+    // the account can also afford the following 15-credit final 3D stage.
+    const creditGate = await ensureMeshyCredits(apiKey, MESHY_PROPERTY_CREDITS.afterSource, REMAINING_BUILD_STAGE);
+    if (!creditGate.ok) return privateJson(creditGate, { status: creditGate.status });
+
     const subject = draftId ? 'the exact building shown in the generated 3D reference render' : `the exact property shown in the supplied reference photo${references.length > 1 ? 's' : ''}: ${address}`;
     const prompt = [
       `Create a faithful VoxelPop-style voxel architectural rendering of ${subject}.`,
@@ -190,7 +202,12 @@ export async function POST(request: Request) {
       cache: 'no-store',
     });
     const created = await create.json().catch(() => ({}));
-    if (!create.ok) return privateJson({ ok: false, error: created?.message || created?.error || `Voxel image provider returned ${create.status}.` }, { status: create.status });
+    if (!create.ok) {
+      if (isMeshyCreditFailure(create.status, created)) {
+        return privateJson(meshyCreditFailure(MESHY_PROPERTY_CREDITS.afterSource, null, REMAINING_BUILD_STAGE), { status: 402 });
+      }
+      return privateJson({ ok: false, error: created?.message || created?.error || `Voxel image provider returned ${create.status}.` }, { status: create.status });
+    }
 
     const taskId = clean(created?.result || created?.id, 240);
     if (!taskId) throw new Error('The voxel image provider did not return a task ID.');

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -57,7 +57,7 @@ export async function readMeshyCreditBalance(apiKey: string) {
 export async function ensureMeshyCredits(apiKey: string, requiredCredits: number, stage: string) {
   const balance = await readMeshyCreditBalance(apiKey);
   if (balance === null || balance >= requiredCredits) {
-    return { ok: true as const, availableCredits: balance, requiredCredits, stage };
+    return { ok: true as const, status: 200 as const, availableCredits: balance, requiredCredits, stage };
   }
   return {
     ...meshyCreditFailure(requiredCredits, balance, stage),

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -28,10 +28,10 @@ export function meshyCreditFailure(requiredCredits: number, availableCredits: nu
   const available = numericBalance(availableCredits);
   const balanceCopy = available === null ? '' : ` The connected Meshy API account currently has ${available} credit${available === 1 ? '' : 's'}.`;
   return {
-    ok: false,
-    code: 'MESHY_CREDITS_REQUIRED',
-    creditRequired: true,
-    provider: 'meshy',
+    ok: false as const,
+    code: 'MESHY_CREDITS_REQUIRED' as const,
+    creditRequired: true as const,
+    provider: 'meshy' as const,
     stage,
     requiredCredits,
     availableCredits: available,
@@ -60,8 +60,8 @@ export async function ensureMeshyCredits(apiKey: string, requiredCredits: number
     return { ok: true as const, availableCredits: balance, requiredCredits, stage };
   }
   return {
-    ok: false as const,
-    status: 402,
     ...meshyCreditFailure(requiredCredits, balance, stage),
+    ok: false as const,
+    status: 402 as const,
   };
 }

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -35,7 +35,7 @@ export function meshyCreditFailure(requiredCredits: number, availableCredits: nu
     stage,
     requiredCredits,
     availableCredits: available,
-    error: `VoxelPop 3D credits are currently unavailable for ${stage}. ${requiredCredits} Meshy API credits are needed before this stage starts.${balanceCopy} This is the Meshy generation balance, not your Voxel Vault USD, crypto, or property balance. Nothing new was generated for this stage.`,
+    error: `VoxelPop 3D credits are currently unavailable for ${stage}. ${requiredCredits} Meshy API credits are needed before this stage starts.${balanceCopy} This is the Meshy credit balance, not your Voxel Vault USD, crypto, or property balance. Nothing new was generated for this stage.`,
   };
 }
 

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -1,0 +1,61 @@
+const BALANCE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/balance';
+
+export const MESHY_PROPERTY_CREDITS = Object.freeze({
+  source3d: 15,
+  voxelImage: 3,
+  final3d: 15,
+  afterSource: 18,
+  fullPipeline: 33,
+});
+
+function messageFrom(payload: any) {
+  return String(payload?.task_error?.message || payload?.message || payload?.error || '').trim();
+}
+
+export function isMeshyCreditFailure(status: unknown, payload: any = {}) {
+  const code = Number(status || 0);
+  const message = messageFrom(payload);
+  return code === 402 || /insufficient\s+(?:credits|funds)|payment\s+required/i.test(message);
+}
+
+export function meshyCreditFailure(requiredCredits: number, availableCredits: number | null, stage: string) {
+  const available = Number.isFinite(Number(availableCredits)) ? Math.max(0, Number(availableCredits)) : null;
+  const balanceCopy = available === null ? '' : ` The connected Meshy API account currently has ${available} credit${available === 1 ? '' : 's'}.`;
+  return {
+    ok: false,
+    code: 'MESHY_CREDITS_REQUIRED',
+    creditRequired: true,
+    provider: 'meshy',
+    stage,
+    requiredCredits,
+    availableCredits: available,
+    error: `VoxelPop 3D credits are currently unavailable for ${stage}. ${requiredCredits} Meshy API credits are needed before this stage starts.${balanceCopy} Nothing new was generated for this stage.`,
+  };
+}
+
+export async function readMeshyCreditBalance(apiKey: string) {
+  try {
+    const response = await fetch(BALANCE_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    const balance = Number(data?.balance);
+    if (!response.ok || !Number.isFinite(balance)) return null;
+    return Math.max(0, balance);
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureMeshyCredits(apiKey: string, requiredCredits: number, stage: string) {
+  const balance = await readMeshyCreditBalance(apiKey);
+  if (balance === null || balance >= requiredCredits) {
+    return { ok: true as const, availableCredits: balance, requiredCredits, stage };
+  }
+  return {
+    ok: false as const,
+    status: 402,
+    ...meshyCreditFailure(requiredCredits, balance, stage),
+  };
+}

--- a/lib/meshy-credits.ts
+++ b/lib/meshy-credits.ts
@@ -12,6 +12,12 @@ function messageFrom(payload: any) {
   return String(payload?.task_error?.message || payload?.message || payload?.error || '').trim();
 }
 
+function numericBalance(value: unknown) {
+  if (value === null || value === undefined || value === '') return null;
+  const balance = Number(value);
+  return Number.isFinite(balance) ? Math.max(0, balance) : null;
+}
+
 export function isMeshyCreditFailure(status: unknown, payload: any = {}) {
   const code = Number(status || 0);
   const message = messageFrom(payload);
@@ -19,7 +25,7 @@ export function isMeshyCreditFailure(status: unknown, payload: any = {}) {
 }
 
 export function meshyCreditFailure(requiredCredits: number, availableCredits: number | null, stage: string) {
-  const available = Number.isFinite(Number(availableCredits)) ? Math.max(0, Number(availableCredits)) : null;
+  const available = numericBalance(availableCredits);
   const balanceCopy = available === null ? '' : ` The connected Meshy API account currently has ${available} credit${available === 1 ? '' : 's'}.`;
   return {
     ok: false,
@@ -29,7 +35,7 @@ export function meshyCreditFailure(requiredCredits: number, availableCredits: nu
     stage,
     requiredCredits,
     availableCredits: available,
-    error: `VoxelPop 3D credits are currently unavailable for ${stage}. ${requiredCredits} Meshy API credits are needed before this stage starts.${balanceCopy} Nothing new was generated for this stage.`,
+    error: `VoxelPop 3D credits are currently unavailable for ${stage}. ${requiredCredits} Meshy API credits are needed before this stage starts.${balanceCopy} This is the Meshy generation balance, not your Voxel Vault USD, crypto, or property balance. Nothing new was generated for this stage.`,
   };
 }
 
@@ -40,9 +46,9 @@ export async function readMeshyCreditBalance(apiKey: string) {
       cache: 'no-store',
     });
     const data = await response.json().catch(() => ({}));
-    const balance = Number(data?.balance);
-    if (!response.ok || !Number.isFinite(balance)) return null;
-    return Math.max(0, balance);
+    const balance = numericBalance(data?.balance);
+    if (!response.ok || balance === null) return null;
+    return balance;
   } catch {
     return null;
   }

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -9,6 +9,7 @@ const voxelModel = fs.readFileSync(new URL('../app/api/property-voxel-model/rout
 const modelViewer = fs.readFileSync(new URL('../app/vault/earth/MeshyModelViewer.js', import.meta.url), 'utf8');
 const taskRecovery = fs.readFileSync(new URL('../lib/property-generation-task.ts', import.meta.url), 'utf8');
 const modelDelivery = fs.readFileSync(new URL('../lib/property-generation-model.ts', import.meta.url), 'utf8');
+const meshyCredits = fs.readFileSync(new URL('../lib/meshy-credits.ts', import.meta.url), 'utf8');
 
 assert.match(property, /async function usePhotoAndBuild\(\)/, 'photo approval must own the automatic generation handoff');
 assert.match(property, /form\.append\('draftId', draftId\)/, 'approved photo must be tied to an account-scoped creation before generation');
@@ -20,6 +21,29 @@ assert.match(photoHandoff, /meshy-property-direct-photo-to-3d/, 'direct source g
 assert.match(photoHandoff, /inline-photo:\$\{digest\}/, 'Voxel Vault should retain only a source-photo fingerprint in the generation record');
 assert.match(photoHandoff, /storagePath: `meshy-source:\$\{taskId\}`/, 'the UI handoff should carry an opaque account-bound provider job reference');
 assert.doesNotMatch(photoHandoff, /storage\.from\(|createBucket\(|createSignedUrl\(/, 'normal VoxelPop photo creation must not require Supabase Storage');
+
+assert.match(meshyCredits, /openapi\/v1\/balance/, 'VoxelPop must use Meshy Balance API before paid generation');
+assert.match(meshyCredits, /source3d:\s*15/, 'first textured Smart Topology 3D cost must stay explicit');
+assert.match(meshyCredits, /voxelImage:\s*3/, 'nano-banana voxel style cost must stay explicit');
+assert.match(meshyCredits, /final3d:\s*15/, 'final textured Smart Topology 3D cost must stay explicit');
+assert.match(meshyCredits, /afterSource:\s*18/, 'remaining style + final 3D budget must be guarded together');
+assert.match(meshyCredits, /fullPipeline:\s*33/, 'full automatic property build must preflight its complete current Meshy cost');
+assert.match(meshyCredits, /code:\s*'MESHY_CREDITS_REQUIRED'/, 'credit exhaustion must have a structured provider-specific error code');
+assert.match(meshyCredits, /Meshy credit balance, not your Voxel Vault USD, crypto, or property balance/, 'credit errors must not look like a Voxel Vault wallet or property-funds failure');
+assert.match(meshyCredits, /code === 402/, 'Meshy HTTP 402 must be recognized as provider credit exhaustion');
+assert.match(photoHandoff, /ensureMeshyCredits\(apiKey, MESHY_PROPERTY_CREDITS\.fullPipeline/, 'photo handoff must preflight the full 33-credit automatic chain');
+assert.match(voxelImage, /ensureMeshyCredits\(apiKey, MESHY_PROPERTY_CREDITS\.afterSource/, 'voxel styling must require enough balance to finish style plus final 3D');
+assert.match(voxel3d, /ensureMeshyCredits\(apiKey, MESHY_PROPERTY_CREDITS\.final3d/, 'each genuinely new textured 3D call must preflight its 15-credit cost');
+
+const photoGate = photoHandoff.indexOf('const creditGate = await ensureMeshyCredits');
+const photoPaidCall = photoHandoff.indexOf('const response = await fetch(ENDPOINT, {');
+assert.ok(photoGate >= 0 && photoPaidCall >= 0 && photoGate < photoPaidCall, 'full-pipeline balance check must happen before the first paid Meshy 3D request');
+const styleGate = voxelImage.indexOf('const creditGate = await ensureMeshyCredits');
+const stylePaidCall = voxelImage.indexOf('const create = await fetch(ENDPOINT, {');
+assert.ok(styleGate >= 0 && stylePaidCall >= 0 && styleGate < stylePaidCall, 'remaining-balance check must happen before the paid voxel style request');
+const finalGate = voxel3d.indexOf('const creditGate = await ensureMeshyCredits');
+const finalPaidCall = voxel3d.indexOf('const response = await fetch(ENDPOINT, {');
+assert.ok(finalGate >= 0 && finalPaidCall >= 0 && finalGate < finalPaidCall, '3D balance check must happen before a new paid Meshy 3D request');
 
 assert.match(property, /phase: 'source'/, 'automatic pipeline must continue through the first 3D source phase');
 assert.match(property, /sourceStoragePath: reference\.storagePath/, 'first 3D continuation must pass the opaque direct-job reference');
@@ -86,4 +110,4 @@ assert.match(property, /Your finished VoxelPop image is preserved on this page/,
 assert.doesNotMatch(property, /Use this street photo/, 'photo-first journey must not branch back into the old street-photo chooser');
 assert.doesNotMatch(property, /autoCreateAfterPhoto/, 'old photo-to-image auto-start state should be removed in favor of the full automatic pipeline');
 
-console.log('Property automatic journey regression passed: authorized photo -> direct provider source 3D -> rendered 3D image -> same-origin self-repairing interactive GLB -> VoxelPop style -> resumable final movable voxel 3D without re-spending completed stages.');
+console.log('Property automatic journey regression passed: authorized photo -> 33-credit preflight -> direct provider source 3D -> rendered 3D image -> 18-credit remaining-stage preflight -> VoxelPop style -> 15-credit final-3D preflight -> resumable final movable voxel 3D without re-spending completed stages.');


### PR DESCRIPTION
Superseded by merged PR #413, which fixes the same Meshy `insufficient funds` failure on current `main` with provider-balance preflights, safe 402→service-availability mapping, the 33 / 18 / 15 credit guards, and resumable final-3D behavior. #413 passed the full Voxel Vault web build, Quality Gate, Mobile WebGL Guard, and contract checks. Closing this duplicate branch to avoid overwriting the newer merged implementation.