### PR TITLE
Require $4.99 payment before VoxelPop property generation

### DIFF
--- a/app/api/property-generation/checkout/route.ts
+++ b/app/api/property-generation/checkout/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '../../../../lib/stripe-server';
+import { requireVoxelVaultUser } from '../../../../lib/user-auth';
+import {
+  PROPERTY_VOXEL_GENERATION_KIND,
+  PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+  PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+  deleteStagedPropertyPhoto,
+  stagePaidPropertyPhoto,
+} from '../../../../lib/property-generation-payment';
+import {
+  MESHY_PROPERTY_CREDITS,
+  meshyCreditError,
+  meshyCreditsSufficient,
+  readMeshyCreditBalance,
+} from '../../../../lib/meshy-credits';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+function clean(value: unknown, max = 500) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function privateJson(body: unknown, init: ResponseInit = {}) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
+  });
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!apiKey) return privateJson({ ok: false, error: 'VoxelPop 3D generation is not configured on this deployment.' }, { status: 503 });
+
+  let stagedDraftId = '';
+  try {
+    const form = await request.formData();
+    const photo = form.get('photo');
+    const draftId = clean(form.get('draftId'), 100);
+    const rightsConfirmed = clean(form.get('rightsConfirmed'), 16) === 'true';
+    if (!(photo instanceof File)) return privateJson({ ok: false, error: 'Choose a property photo first.' }, { status: 400 });
+    if (!rightsConfirmed) return privateJson({ ok: false, error: 'Confirm that you took this photo or have permission to use it.' }, { status: 400 });
+
+    // Do not charge a customer unless the backend currently has enough Meshy
+    // capacity for the complete automatic source-3D -> voxel-image -> final-3D flow.
+    const balance = await readMeshyCreditBalance(apiKey);
+    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.fullPipeline)) {
+      return privateJson(meshyCreditError('opening VoxelPop checkout', MESHY_PROPERTY_CREDITS.fullPipeline), { status: 503 });
+    }
+
+    const staged = await stagePaidPropertyPhoto(auth, draftId, photo);
+    stagedDraftId = staged.draftId;
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const email = typeof auth.user.email === 'string' && auth.user.email.includes('@') ? auth.user.email : undefined;
+
+    const checkout = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{
+        quantity: 1,
+        price_data: {
+          currency: 'usd',
+          unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+          product_data: {
+            name: 'VoxelPop 3D Voxel Creation',
+            description: 'One custom digital VoxelPop creation: source 3D, voxel-style render, and final interactive 3D GLB. Digital creation only; no rights in physical real estate.',
+          },
+        },
+      }],
+      client_reference_id: auth.user.id,
+      ...(email ? { customer_email: email } : {}),
+      metadata: {
+        kind: PROPERTY_VOXEL_GENERATION_KIND,
+        voxelpop_user_id: auth.user.id,
+        draft_id: staged.draftId,
+        source_storage_path: staged.storagePath,
+        source_sha256: staged.digest,
+        source_content_type: staged.contentType,
+        source_name: staged.fileName,
+        rights_confirmed: 'true',
+        price_cents: String(PROPERTY_VOXEL_GENERATION_PRICE_CENTS),
+      },
+      success_url: `${origin}/property?generation_session={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/property?generation_checkout=cancelled&draftId=${encodeURIComponent(staged.draftId)}`,
+    });
+
+    if (!checkout.url) throw new Error('Stripe did not return a checkout URL.');
+    return privateJson({
+      ok: true,
+      url: checkout.url,
+      priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+      priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+      draftId: staged.draftId,
+      staged: true,
+    });
+  } catch (error) {
+    if (stagedDraftId) await deleteStagedPropertyPhoto(auth, stagedDraftId);
+    return privateJson({
+      ok: false,
+      error: error instanceof Error ? error.message : 'VoxelPop checkout could not be opened.',
+    }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+  try {
+    const url = new URL(request.url);
+    const draftId = clean(url.searchParams.get('draftId'), 100);
+    if (!draftId) return privateJson({ ok: false, error: 'draftId is required.' }, { status: 400 });
+    await deleteStagedPropertyPhoto(auth, draftId);
+    return privateJson({ ok: true, deleted: true });
+  } catch (error) {
+    return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Checkout staging cleanup failed.' }, { status: 400 });
+  }
+}

--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -79,7 +79,7 @@ function generationResult(input: {
       progress: Number(input.progress || 0),
     },
     recoveryMode: input.recoveryMode === true,
-    privacy: 'The authorized source photo was staged privately only for checkout and the paid Meshy handoff. Voxel Vault removes that staged source after generation starts; the account keeps the SHA-256 fingerprint and account-bound generation record rather than the original photo.',
+    privacy: 'After the paid provider handoff, Voxel Vault does not store the original source photo in its Storage bucket. Checkout temporarily stages the authorized photo privately, then removes that staged source when generation starts; the account keeps the SHA-256 fingerprint and account-bound generation record rather than the original photo.',
   };
 }
 

--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -54,6 +54,7 @@ function generationResult(input: {
   paymentSessionId: string;
 }) {
   const uploadedAt = new Date().toISOString();
+  const taskId = input.taskId;
   return {
     ok: true,
     paid: true,
@@ -70,11 +71,11 @@ function generationResult(input: {
       label: 'Selected property photo',
       sourcePhotoId: `upload:${input.digest.slice(0, 20)}`,
       provider: 'user-photo-direct-generation',
-      storagePath: `meshy-source:${input.taskId}`,
+      storagePath: `meshy-source:${taskId}`,
       uploadedAt,
     },
     source3d: {
-      taskId: input.taskId,
+      taskId,
       status: input.status || 'PENDING',
       progress: Number(input.progress || 0),
     },

--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -1,12 +1,20 @@
 import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
+import { stripe } from '../../../lib/stripe-server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
-import { saveCatalog3D } from '../../../lib/catalog3dStore';
-import { normalizePropertyDraftId, propertyDraftItemId } from '../../../lib/property-generation-ids';
+import { readCatalog3D, saveCatalog3D } from '../../../lib/catalog3dStore';
+import { propertyDraftItemId } from '../../../lib/property-generation-ids';
 import {
   createPropertyGenerationRecoveryTaskId,
   propertyGenerationCanonicalTaskId,
 } from '../../../lib/property-generation-task';
+import {
+  PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+  PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+  deleteStagedPropertyPhoto,
+  loadPaidPropertyGenerationPhoto,
+  paidPropertyGenerationReceipt,
+} from '../../../lib/property-generation-payment';
 import {
   MESHY_PROPERTY_CREDITS,
   meshyClientStatus,
@@ -24,7 +32,7 @@ const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MAX_BYTES = 8 * 1024 * 1024;
 const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
-function clean(value: unknown, max = 240) {
+function clean(value: unknown, max = 260) {
   return String(value || '').trim().slice(0, max);
 }
 
@@ -33,6 +41,46 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
     ...init,
     headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
   });
+}
+
+function generationResult(input: {
+  draftId: string;
+  digest: string;
+  taskId: string;
+  status?: string | null;
+  progress?: number | null;
+  recoveryMode?: boolean;
+  reused?: boolean;
+  paymentSessionId: string;
+}) {
+  const uploadedAt = new Date().toISOString();
+  return {
+    ok: true,
+    paid: true,
+    reused: input.reused === true,
+    priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+    priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+    paymentSessionId: input.paymentSessionId,
+    draftId: input.draftId,
+    reference: {
+      url: null,
+      draftId: input.draftId,
+      rightsBasis: 'user-owned',
+      rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital creation.',
+      label: 'Selected property photo',
+      sourcePhotoId: `upload:${input.digest.slice(0, 20)}`,
+      provider: 'user-photo-direct-generation',
+      storagePath: `meshy-source:${input.taskId}`,
+      uploadedAt,
+    },
+    source3d: {
+      taskId: input.taskId,
+      status: input.status || 'PENDING',
+      progress: Number(input.progress || 0),
+    },
+    recoveryMode: input.recoveryMode === true,
+    privacy: 'The authorized source photo was staged privately only for checkout and the paid Meshy handoff. Voxel Vault removes that staged source after generation starts; the account keeps the SHA-256 fingerprint and account-bound generation record rather than the original photo.',
+  };
 }
 
 export async function POST(request: Request) {
@@ -48,9 +96,42 @@ export async function POST(request: Request) {
 
   try {
     const form = await request.formData();
-    const photo = form.get('photo');
-    const draftId = normalizePropertyDraftId(clean(form.get('draftId'), 100));
-    const rightsConfirmed = clean(form.get('rightsConfirmed'), 16) === 'true';
+    const generationSessionId = clean(form.get('generationSessionId'), 260);
+    if (!generationSessionId) {
+      return privateJson({
+        ok: false,
+        paymentRequired: true,
+        priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+        priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+        checkoutEndpoint: '/api/property-generation/checkout',
+        error: `Pay ${PROPERTY_VOXEL_GENERATION_PRICE_LABEL} before VoxelPop starts paid 3D generation.`,
+      }, { status: 402 });
+    }
+
+    const receipt = await paidPropertyGenerationReceipt(auth, stripe, generationSessionId);
+    const draftId = receipt.draftId;
+    const rightsConfirmed = true;
+    const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
+    const sourceFingerprint = `inline-photo:${receipt.digest}`;
+
+    // A Stripe success page can be refreshed. Reuse the exact account/draft job
+    // instead of spending Meshy credits a second time for the same paid source.
+    const existing = await readCatalog3D(itemId);
+    if (existing?.task_id && existing?.source_image_url === sourceFingerprint) {
+      await deleteStagedPropertyPhoto(auth, draftId);
+      return privateJson(generationResult({
+        draftId,
+        digest: receipt.digest,
+        taskId: existing.task_id,
+        status: existing.status,
+        progress: existing.progress,
+        reused: true,
+        paymentSessionId: generationSessionId,
+      }));
+    }
+
+    const paidInput = await loadPaidPropertyGenerationPhoto(auth, receipt);
+    const photo = new File([paidInput.bytes], paidInput.fileName, { type: paidInput.contentType });
 
     if (!(photo instanceof File)) {
       return privateJson({ ok: false, error: 'Choose a property photo first.' }, { status: 400 });
@@ -67,20 +148,20 @@ export async function POST(request: Request) {
 
     // The automatic Property journey is three paid Meshy calls: 15 credits for
     // this textured Smart Topology source 3D, 3 for nano-banana image-to-image,
-    // and 15 for the final textured Smart Topology 3D. Do not burn the first 15
-    // unless the provider account can afford the complete automatic journey.
+    // and 15 for the final textured Smart Topology 3D. Check again after Stripe
+    // so a paid user is never sent into a knowingly underfunded provider flow.
     const balance = await readMeshyCreditBalance(apiKey);
     if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.fullPipeline)) {
       return privateJson(
-        meshyCreditError('starting the complete property build', MESHY_PROPERTY_CREDITS.fullPipeline),
+        meshyCreditError('starting the complete paid property build', MESHY_PROPERTY_CREDITS.fullPipeline),
         { status: 503 },
       );
     }
 
     const bytes = Buffer.from(await photo.arrayBuffer());
     const digest = createHash('sha256').update(bytes).digest('hex');
+    if (digest !== receipt.digest) throw new Error('The paid source photo fingerprint no longer matches checkout.');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
-    const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
 
     const response = await fetch(ENDPOINT, {
       method: 'POST',
@@ -104,7 +185,7 @@ export async function POST(request: Request) {
           response.status,
           data,
           `3D provider returned ${response.status}.`,
-          'starting the first property 3D build',
+          'starting the first paid property 3D build',
           MESHY_PROPERTY_CREDITS.source3d,
         ),
         { status: meshyClientStatus(response.status) },
@@ -114,7 +195,6 @@ export async function POST(request: Request) {
     const providerTaskId = clean(data?.result || data?.id, 240);
     if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
     const canonicalTaskId = propertyGenerationCanonicalTaskId(providerTaskId);
-    const sourceFingerprint = `inline-photo:${digest}`;
     const saved = await saveCatalog3D(itemId, {
       task_id: canonicalTaskId,
       source_image_url: sourceFingerprint,
@@ -131,36 +211,21 @@ export async function POST(request: Request) {
       error: null,
     });
 
-    // Do not orphan a provider job just because the account catalog table or
-    // private metadata bucket is temporarily unavailable. A signed recovery ID
-    // is scoped to this account and can be verified statelessly by later routes.
+    // Do not orphan a provider job just because account catalog persistence is
+    // temporarily unavailable. The signed recovery ID remains account-bound.
     const taskId = saved?.task_id
       || createPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, providerTaskId);
 
-    const uploadedAt = new Date().toISOString();
-    return privateJson({
-      ok: true,
+    await deleteStagedPropertyPhoto(auth, draftId);
+    return privateJson(generationResult({
       draftId,
-      reference: {
-        url: null,
-        rightsBasis: 'user-owned',
-        rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital creation.',
-        label: 'Selected property photo',
-        sourcePhotoId: `upload:${digest.slice(0, 20)}`,
-        provider: 'user-photo-direct-generation',
-        storagePath: `meshy-source:${taskId}`,
-        uploadedAt,
-      },
-      source3d: {
-        taskId,
-        status: saved?.status || 'PENDING',
-        progress: Number(saved?.progress || 0),
-      },
+      digest,
+      taskId,
+      status: saved?.status || 'PENDING',
+      progress: Number(saved?.progress || 0),
       recoveryMode: !saved?.task_id,
-      privacy: saved?.task_id
-        ? 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider for this generation request; only a SHA-256 fingerprint and account-bound job record are retained by Voxel Vault.'
-        : 'Voxel Vault does not store the original source photo in its Storage bucket for this flow. The authorized photo is sent directly to the 3D provider. Account job storage was temporarily unavailable, so Voxel Vault returned a signed account-bound recovery task reference and retained no copy of the original photo.',
-    });
+      paymentSessionId: generationSessionId,
+    }));
   } catch (error) {
     return privateJson({
       ok: false,

--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -111,9 +111,10 @@ export async function POST(request: Request) {
 
     const receipt = await paidPropertyGenerationReceipt(auth, stripe, generationSessionId);
     const draftId = receipt.draftId;
+    const digest = receipt.digest;
     const rightsConfirmed = true;
     const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
-    const sourceFingerprint = `inline-photo:${receipt.digest}`;
+    const sourceFingerprint = `inline-photo:${digest}`;
 
     // A Stripe success page can be refreshed. Reuse the exact account/draft job
     // instead of spending Meshy credits a second time for the same paid source.
@@ -122,7 +123,7 @@ export async function POST(request: Request) {
       await deleteStagedPropertyPhoto(auth, draftId);
       return privateJson(generationResult({
         draftId,
-        digest: receipt.digest,
+        digest,
         taskId: existing.task_id,
         status: existing.status,
         progress: existing.progress,
@@ -160,8 +161,8 @@ export async function POST(request: Request) {
     }
 
     const bytes = Buffer.from(await photo.arrayBuffer());
-    const digest = createHash('sha256').update(bytes).digest('hex');
-    if (digest !== receipt.digest) throw new Error('The paid source photo fingerprint no longer matches checkout.');
+    const verifiedDigest = createHash('sha256').update(bytes).digest('hex');
+    if (verifiedDigest !== digest) throw new Error('The paid source photo fingerprint no longer matches checkout.');
     const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
 
     const response = await fetch(ENDPOINT, {

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -9,6 +9,7 @@ import styles from './property.module.css';
 const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
 const empty3d = () => ({ status: 'NOT_STARTED', progress: 0, modelUrl: null, thumbnailUrl: null, taskId: null });
 const emptyImage = () => ({ status: 'NOT_STARTED', progress: 0, imageUrl: null, taskId: null, taskToken: null });
+const CREATION_PRICE_LABEL = '$4.99';
 
 function clean(value) { return String(value || '').trim(); }
 function terminal(value) {
@@ -97,6 +98,7 @@ export default function PropertyJourneyPage() {
   const clientRef = useRef(null);
   const uploadInputRef = useRef(null);
   const pipelineRef = useRef(0);
+  const checkoutHandledRef = useRef('');
 
   const finalReady = Boolean(final3d?.modelUrl);
   const sourceReady = Boolean(source3d?.modelUrl);
@@ -154,6 +156,74 @@ export default function PropertyJourneyPage() {
     return () => { active = false; subscription?.unsubscribe?.(); };
   }, []);
 
+  useEffect(() => {
+    if (!session?.access_token || typeof window === 'undefined') return undefined;
+    const params = new URLSearchParams(window.location.search);
+    const canceled = params.get('generation_checkout') === 'cancelled';
+    const canceledDraftId = clean(params.get('draftId'));
+    if (canceled && canceledDraftId) {
+      const cancelKey = `cancel:${canceledDraftId}`;
+      if (checkoutHandledRef.current === cancelKey) return undefined;
+      checkoutHandledRef.current = cancelKey;
+      setBusy('');
+      setMessage('Checkout canceled. No paid 3D generation was started.');
+      fetch(`/api/property-generation/checkout?draftId=${encodeURIComponent(canceledDraftId)}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      }).catch(() => {});
+      window.history.replaceState({}, '', '/property');
+      return undefined;
+    }
+
+    const generationSessionId = clean(params.get('generation_session'));
+    if (!generationSessionId || checkoutHandledRef.current === generationSessionId) return undefined;
+    checkoutHandledRef.current = generationSessionId;
+    let active = true;
+    const iteration = ++pipelineRef.current;
+    setBusy('payment-return');
+    setMessage('Payment received. Starting your VoxelPop 3D creation…');
+
+    (async () => {
+      try {
+        const form = new FormData();
+        form.append('generationSessionId', generationSessionId);
+        const response = await fetch('/api/property-photo-upload', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: form,
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || !data?.ok || !data?.reference?.storagePath) {
+          throw new Error(data?.error || 'Your paid 3D creation could not start.');
+        }
+        if (!active) return;
+        setDraftId(data.draftId);
+        setSourceReference(data.reference);
+        setPendingPhoto(null);
+        setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+        setRightsConfirmed(false);
+        setSource3d(data.source3d || empty3d());
+        setVoxelJob(emptyImage());
+        setVoxelImage('');
+        setFinal3d(empty3d());
+        setBuilding(null);
+        setMappedAddress('');
+        setQuote(null);
+        setAvailability('');
+        window.history.replaceState({}, '', '/property');
+        await runAutomaticBuild(data.reference, iteration);
+      } catch (error) {
+        if (active && iteration === pipelineRef.current) {
+          setBusy('');
+          setPipelinePhase('photo');
+          setMessage(String(error?.message || error || 'Your paid VoxelPop creation could not start.'));
+        }
+      }
+    })();
+
+    return () => { active = false; };
+  }, [session?.access_token]);
+
   function authHeaders(extra = {}) {
     return { Authorization: `Bearer ${session?.access_token || ''}`, ...extra };
   }
@@ -191,7 +261,7 @@ export default function PropertyJourneyPage() {
       setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return URL.createObjectURL(photo); });
       setPendingPhoto(photo);
       setRightsConfirmed(false);
-      setMessage('Photo ready. Confirm you can use it, then VoxelPop starts the build automatically.');
+      setMessage(`Photo ready. Confirm you can use it, then pay ${CREATION_PRICE_LABEL} to create the complete 3D voxel.`);
     } catch (error) {
       setMessage(String(error?.message || error || 'This photo could not be prepared.'));
     } finally { setBusy(''); }
@@ -232,6 +302,8 @@ export default function PropertyJourneyPage() {
   }
 
   async function runAutomaticBuild(reference, iteration) {
+    const activeDraftId = reference?.draftId || draftId;
+    if (!activeDraftId) throw new Error('The paid VoxelPop creation ID is missing.');
     setBusy('pipeline');
     let finalCheckpoint = null;
     try {
@@ -240,7 +312,7 @@ export default function PropertyJourneyPage() {
       const sourceResponse = await fetch('/api/property-voxel-3d', {
         method: 'POST',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ draftId, phase: 'source', sourceStoragePath: reference.storagePath }),
+        body: JSON.stringify({ draftId: activeDraftId, phase: 'source', sourceStoragePath: reference.storagePath }),
       });
       const sourceStart = await sourceResponse.json().catch(() => ({}));
       if (!sourceResponse.ok || !sourceStart?.ok || !sourceStart?.taskId) throw new Error(sourceStart?.error || 'The first 3D build could not start.');
@@ -252,7 +324,7 @@ export default function PropertyJourneyPage() {
       const imageResponse = await fetch('/api/property-voxel-image', {
         method: 'POST',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ draftId, source3dTaskId: sourceDone.taskId }),
+        body: JSON.stringify({ draftId: activeDraftId, source3dTaskId: sourceDone.taskId }),
       });
       const imageStart = await imageResponse.json().catch(() => ({}));
       if (!imageResponse.ok || !imageStart?.ok || !imageStart?.taskId || !imageStart?.taskToken) throw new Error(imageStart?.error || 'Voxel style pass could not start.');
@@ -267,7 +339,7 @@ export default function PropertyJourneyPage() {
         method: 'POST',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({
-          draftId,
+          draftId: activeDraftId,
           phase: 'voxel',
           voxelImageTaskId: voxelDone.taskId,
           voxelImageTaskToken: voxelDone.taskToken,
@@ -284,7 +356,7 @@ export default function PropertyJourneyPage() {
       const finalDone = finalStart.modelUrl ? finalStart : await poll3D(finalStart.taskId, setFinal3d, iteration, 'Building your final VoxelPop 3D');
       setFinal3d(finalDone);
       setPipelinePhase('world');
-      setMessage('Your voxel is ready. Add the property address to place the reference on My World.');
+      setMessage('Your paid voxel is ready. Add the property address to place the reference on My World.');
     } catch (error) {
       if (iteration === pipelineRef.current) {
         setMessage(String(error?.message || error || 'The automatic build stopped.'));
@@ -298,33 +370,20 @@ export default function PropertyJourneyPage() {
   async function usePhotoAndBuild() {
     if (!pendingPhoto || !session?.access_token || !draftId) return;
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
-    const iteration = ++pipelineRef.current;
-    setBusy('upload');
-    setMessage('Starting your private 3D build…');
+    setBusy('generation-checkout');
+    setMessage(`Securing your photo and opening ${CREATION_PRICE_LABEL} checkout…`);
     try {
       const form = new FormData();
       form.append('photo', pendingPhoto);
       form.append('draftId', draftId);
       form.append('rightsConfirmed', 'true');
-      const response = await fetch('/api/property-photo-upload', { method: 'POST', headers: authHeaders(), body: form });
+      const response = await fetch('/api/property-generation/checkout', { method: 'POST', headers: authHeaders(), body: form });
       const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.ok || !data?.reference?.storagePath) throw new Error(data?.error || '3D build could not start.');
-      setSourceReference(data.reference);
-      setPendingPhoto(null);
-      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
-      setSource3d(empty3d());
-      setVoxelJob(emptyImage());
-      setVoxelImage('');
-      setFinal3d(empty3d());
-      setBuilding(null);
-      setMappedAddress('');
-      setQuote(null);
-      setAvailability('');
-      await runAutomaticBuild(data.reference, iteration);
+      if (!response.ok || !data?.ok || !data?.url) throw new Error(data?.error || 'Secure 3D creation checkout could not open.');
+      window.location.assign(data.url);
     } catch (error) {
-      if (iteration === pipelineRef.current) setMessage(String(error?.message || error || 'Could not start this creation.'));
-    } finally {
-      if (iteration === pipelineRef.current && busy !== 'pipeline') setBusy('');
+      setMessage(String(error?.message || error || 'Secure 3D creation checkout could not open.'));
+      setBusy('');
     }
   }
 
@@ -356,7 +415,7 @@ export default function PropertyJourneyPage() {
       const finalDone = finalStart.modelUrl ? finalStart : await poll3D(finalStart.taskId, setFinal3d, iteration, 'Building your final VoxelPop 3D');
       setFinal3d(finalDone);
       setPipelinePhase('world');
-      setMessage('Your voxel is ready. Add the property address to place the reference on My World.');
+      setMessage('Your paid voxel is ready. Add the property address to place the reference on My World.');
     } catch (error) {
       if (iteration === pipelineRef.current) {
         const text = String(error?.message || error || 'Final voxel 3D could not resume.');
@@ -489,22 +548,23 @@ export default function PropertyJourneyPage() {
       <p className={styles.stageLabel}>STEP {step} OF 5 · {labels[step - 1]}</p>
 
       {step === 1 ? <>
-        <p className={styles.bigPrompt}>{pendingPhoto ? 'Use this photo?' : 'Choose one photo.'}</p>
-        <p className={styles.flowHint}>Photo → first 3D → VoxelPop → final 3D voxel → address → My World → collect to Vault.</p>
+        <p className={styles.bigPrompt}>{pendingPhoto ? 'Ready to voxel it?' : 'Choose one photo.'}</p>
+        <p className={styles.flowHint}>Photo → {CREATION_PRICE_LABEL} checkout → first 3D → VoxelPop image → final movable 3D → My World.</p>
         <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
         {displaySource ? <div className={styles.heroCard}><img src={displaySource} alt="Selected property reference"/><span className={styles.badge}>YOUR PHOTO</span></div> : <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>iPhone photos supported</span></div>}
         {pendingPhoto ? <div className={styles.choicePanel}>
           <label className={styles.rightsCheck}><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
-          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'upload'}>{busy === 'upload' ? 'Starting 3D…' : 'Use photo → start build'}</button>
+          <span>One-time creation · {CREATION_PRICE_LABEL} · secure Stripe checkout · wallet not required.</span>
+          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'generation-checkout'}>{busy === 'generation-checkout' ? 'Opening $4.99 checkout…' : 'Pay $4.99 · Use photo → start build'}</button>
           <button className={styles.textButton} type="button" onClick={choosePhoto}>Choose another</button>
         </div> : <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>}
-        <p className={styles.truth}>The photo guides visible appearance only. One photo cannot verify unseen sides, roof details, exact dimensions, or legal property facts. Voxel Vault does not need to retain the original source photo in its Storage bucket for this build.</p>
+        <p className={styles.truth}>The {CREATION_PRICE_LABEL} charge is for one digital VoxelPop creation, including the generated 3D stages; it does not buy or value the physical property. The authorized photo is staged privately for checkout, then removed from that staging area when the paid provider handoff starts. One photo still cannot verify unseen sides, roof details, exact dimensions, or legal property facts.</p>
       </> : null}
 
       {step === 2 ? <>
         <p className={styles.bigPrompt}>Building the first 3D.</p>
-        <p className={styles.stepCopy}>VoxelPop is making a 3D interpretation from your authorized photo. When it finishes, the voxel step starts automatically.</p>
-        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
+        <p className={styles.stepCopy}>Payment is verified. VoxelPop is making a 3D interpretation from your authorized photo. When it finishes, the voxel step starts automatically.</p>
+        <div className={styles.heroCard}>{source3d?.modelUrl ? <MeshyModelViewer modelUrl={source3d.modelUrl}/> : displaySource ? <img src={displaySource} alt="Source being turned into 3D"/> : null}<span className={styles.badge}>PAID 3D BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
         <div className={styles.autoPanel}><b>AUTOMATIC BUILD</b><span>No extra button. First 3D → VoxelPop look → final 3D voxel.</span></div>
       </> : null}
 
@@ -541,7 +601,7 @@ export default function PropertyJourneyPage() {
           {quote && availability !== 'SOLD' ? <button className={styles.primaryOrange} type="button" onClick={collectAndSave} disabled={busy === 'checkout'}>{busy === 'checkout' ? 'Opening secure checkout…' : `Collect voxel · ${dollars(quote.priceCents)}`}</button> : null}
           <button className={styles.textButton} type="button" onClick={() => { setBuilding(null); setMappedAddress(''); setQuote(null); setAvailability(''); setMessage('Enter the correct property address.'); }}>Change address</button>
         </div>
-        <p className={styles.truth}>This checkout collects the generated digital VoxelPop item only. The address, map, payment, or optional later mint does not create deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property. Real-property investing can only appear through a separately verified offering.</p>
+        <p className={styles.truth}>The {CREATION_PRICE_LABEL} generation payment covers creating the digital VoxelPop model. Any later collection price shown here is a separate digital-collectible purchase and is not the market value of the physical property. Neither payment nor optional minting creates deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property. Real-property investing can only appear through a separately verified offering.</p>
       </> : null}
 
       {step > 1 && !pipelineRunning ? <button className={styles.change} type="button" onClick={resetCreation}>Start over with another photo</button> : null}

--- a/lib/property-generation-payment.ts
+++ b/lib/property-generation-payment.ts
@@ -68,7 +68,7 @@ export async function deleteStagedPropertyPhoto(auth: any, draftIdRaw: unknown) 
   return storagePath;
 }
 
-export async function paidPropertyGenerationInput(auth: any, stripe: any, sessionIdRaw: unknown) {
+export async function paidPropertyGenerationReceipt(auth: any, stripe: any, sessionIdRaw: unknown) {
   const sessionId = clean(sessionIdRaw, 260);
   if (!sessionId) throw new Error('The VoxelPop payment session is missing.');
   const session = await stripe.checkout.sessions.retrieve(sessionId);
@@ -91,14 +91,9 @@ export async function paidPropertyGenerationInput(auth: any, stripe: any, sessio
   const storagePath = clean(metadata.source_storage_path, 900);
   if (storagePath !== expectedPath) throw new Error('The paid source photo does not match this creation.');
 
-  const { data, error } = await auth.admin.storage.from(BUCKET).download(storagePath);
-  if (error || !data) throw new Error('The paid source photo is no longer available.');
-  const bytes = Buffer.from(await data.arrayBuffer());
-  if (!bytes.length || bytes.length > MAX_BYTES) throw new Error('The paid source photo is invalid.');
-  const digest = createHash('sha256').update(bytes).digest('hex');
-  if (digest !== clean(metadata.source_sha256, 80)) throw new Error('The paid source photo changed after checkout started.');
-
+  const digest = clean(metadata.source_sha256, 80);
   const contentType = clean(metadata.source_content_type, 80).toLowerCase();
+  if (!/^[a-f0-9]{64}$/i.test(digest)) throw new Error('The paid source photo fingerprint is invalid.');
   if (!ALLOWED_TYPES.has(contentType)) throw new Error('The paid source photo format is unsupported.');
 
   return {
@@ -106,8 +101,22 @@ export async function paidPropertyGenerationInput(auth: any, stripe: any, sessio
     draftId,
     storagePath,
     digest,
-    bytes,
     contentType,
     fileName: clean(metadata.source_name, 120) || 'property-photo',
   };
+}
+
+export async function loadPaidPropertyGenerationPhoto(auth: any, receipt: any) {
+  const { data, error } = await auth.admin.storage.from(BUCKET).download(receipt.storagePath);
+  if (error || !data) throw new Error('The paid source photo is no longer available.');
+  const bytes = Buffer.from(await data.arrayBuffer());
+  if (!bytes.length || bytes.length > MAX_BYTES) throw new Error('The paid source photo is invalid.');
+  const digest = createHash('sha256').update(bytes).digest('hex');
+  if (digest !== receipt.digest) throw new Error('The paid source photo changed after checkout started.');
+  return { ...receipt, bytes };
+}
+
+export async function paidPropertyGenerationInput(auth: any, stripe: any, sessionIdRaw: unknown) {
+  const receipt = await paidPropertyGenerationReceipt(auth, stripe, sessionIdRaw);
+  return loadPaidPropertyGenerationPhoto(auth, receipt);
 }

--- a/lib/property-generation-payment.ts
+++ b/lib/property-generation-payment.ts
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto';
+import { normalizePropertyDraftId } from './property-generation-ids';
+
+export const PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499;
+export const PROPERTY_VOXEL_GENERATION_PRICE_LABEL = '$4.99';
+export const PROPERTY_VOXEL_GENERATION_KIND = 'property_voxel_generation_v1';
+
+const BUCKET = 'voxel-system';
+const MAX_BYTES = 8 * 1024 * 1024;
+const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+function clean(value: unknown, max = 500) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function safeSegment(value: unknown, fallback = 'item') {
+  const text = clean(value, 180).replace(/[^a-zA-Z0-9_.:-]+/g, '-').replace(/^-+|-+$/g, '');
+  return text || fallback;
+}
+
+async function ensureBucket(admin: any) {
+  const { data, error } = await admin.storage.listBuckets();
+  if (!error && data?.some((bucket: any) => bucket.name === BUCKET)) return;
+  const created = await admin.storage.createBucket(BUCKET, { public: false, fileSizeLimit: '75MB' });
+  if (created.error && !/already exists/i.test(created.error.message || '')) {
+    throw new Error('Private VoxelPop checkout storage could not be prepared.');
+  }
+}
+
+export function propertyGenerationStagePath(userId: unknown, draftIdRaw: unknown) {
+  const draftId = normalizePropertyDraftId(clean(draftIdRaw, 100));
+  return `property-paid-inputs/${safeSegment(userId, 'user')}/${safeSegment(draftId, 'draft')}/source`;
+}
+
+export async function stagePaidPropertyPhoto(auth: any, draftIdRaw: unknown, photo: File) {
+  const draftId = normalizePropertyDraftId(clean(draftIdRaw, 100));
+  if (!(photo instanceof File)) throw new Error('Choose a property photo first.');
+  const contentType = String(photo.type || '').toLowerCase();
+  if (!ALLOWED_TYPES.has(contentType)) throw new Error('Use a JPG, PNG, or WebP property photo.');
+  if (photo.size <= 0 || photo.size > MAX_BYTES) throw new Error('Property photos must be smaller than 8 MB after preparation.');
+
+  const bytes = Buffer.from(await photo.arrayBuffer());
+  const digest = createHash('sha256').update(bytes).digest('hex');
+  const storagePath = propertyGenerationStagePath(auth.user.id, draftId);
+  await ensureBucket(auth.admin);
+  const { error } = await auth.admin.storage.from(BUCKET).upload(storagePath, bytes, {
+    contentType,
+    cacheControl: '0',
+    upsert: true,
+  });
+  if (error) throw new Error('Your photo could not be staged securely for checkout.');
+
+  return {
+    draftId,
+    storagePath,
+    digest,
+    contentType,
+    fileName: clean(photo.name || 'property-photo', 120) || 'property-photo',
+    sizeBytes: bytes.length,
+  };
+}
+
+export async function deleteStagedPropertyPhoto(auth: any, draftIdRaw: unknown) {
+  const storagePath = propertyGenerationStagePath(auth.user.id, draftIdRaw);
+  try {
+    await auth.admin.storage.from(BUCKET).remove([storagePath]);
+  } catch {}
+  return storagePath;
+}
+
+export async function paidPropertyGenerationInput(auth: any, stripe: any, sessionIdRaw: unknown) {
+  const sessionId = clean(sessionIdRaw, 260);
+  if (!sessionId) throw new Error('The VoxelPop payment session is missing.');
+  const session = await stripe.checkout.sessions.retrieve(sessionId);
+  const metadata = session?.metadata || {};
+  const draftId = normalizePropertyDraftId(clean(metadata.draft_id, 100));
+
+  if (metadata.kind !== PROPERTY_VOXEL_GENERATION_KIND) throw new Error('This payment is not for a VoxelPop 3D creation.');
+  if (session.payment_status !== 'paid') throw new Error('Payment has not completed yet.');
+  if (session.client_reference_id !== auth.user.id || metadata.voxelpop_user_id !== auth.user.id) {
+    throw new Error('This VoxelPop purchase belongs to a different account.');
+  }
+  if (session.currency !== 'usd' || Number(session.amount_total || 0) !== PROPERTY_VOXEL_GENERATION_PRICE_CENTS) {
+    throw new Error('The VoxelPop payment amount could not be verified.');
+  }
+  if (metadata.price_cents !== String(PROPERTY_VOXEL_GENERATION_PRICE_CENTS) || metadata.rights_confirmed !== 'true') {
+    throw new Error('The VoxelPop creation authorization is incomplete.');
+  }
+
+  const expectedPath = propertyGenerationStagePath(auth.user.id, draftId);
+  const storagePath = clean(metadata.source_storage_path, 900);
+  if (storagePath !== expectedPath) throw new Error('The paid source photo does not match this creation.');
+
+  const { data, error } = await auth.admin.storage.from(BUCKET).download(storagePath);
+  if (error || !data) throw new Error('The paid source photo is no longer available.');
+  const bytes = Buffer.from(await data.arrayBuffer());
+  if (!bytes.length || bytes.length > MAX_BYTES) throw new Error('The paid source photo is invalid.');
+  const digest = createHash('sha256').update(bytes).digest('hex');
+  if (digest !== clean(metadata.source_sha256, 80)) throw new Error('The paid source photo changed after checkout started.');
+
+  const contentType = clean(metadata.source_content_type, 80).toLowerCase();
+  if (!ALLOWED_TYPES.has(contentType)) throw new Error('The paid source photo format is unsupported.');
+
+  return {
+    session,
+    draftId,
+    storagePath,
+    digest,
+    bytes,
+    contentType,
+    fileName: clean(metadata.source_name, 120) || 'property-photo',
+  };
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:hyperreal-voxel": "node scripts/test-hyperreal-voxel-building.mjs",
     "test:buffalo-reference": "node scripts/test-buffalo-property-reference.mjs",
     "test:property-draft-funnel": "node scripts/test-property-draft-funnel.mjs",
-    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs && node scripts/test-meshy-polycount-limit.mjs && node scripts/test-catalog3d-generation-record-compat.mjs",
+    "test:simple-property-world": "node scripts/test-simple-property-world.mjs && node scripts/test-photo-to-voxel-autostart.mjs && node scripts/test-property-collectible-model-access.mjs && node scripts/test-meshy-polycount-limit.mjs && node scripts/test-catalog3d-generation-record-compat.mjs && node scripts/test-paid-property-generation.mjs",
     "test:property-platform": "node scripts/test-property-platform-safety.mjs && node scripts/test-erie-county-spatial-intake.mjs && node scripts/test-fractional-property-bridge.mjs && node scripts/test-algorand-position-verifier.mjs && node scripts/test-geo-property-onboarding.mjs && node scripts/test-geo-finish-polish.mjs && node scripts/test-geo-map-context.mjs && node scripts/test-geo-map-explorer.mjs && node scripts/test-buffalo-property-reference.mjs && node scripts/test-financial-os-coherence.mjs && node scripts/test-hyperreal-voxel-building.mjs && npm run test:property-draft-funnel && npm run test:simple-property-world",
     "test:property-twin": "node scripts/test-property-twin-truth.mjs",
     "test:first-real-erie-parcel": "node scripts/test-first-real-erie-parcel-live.mjs",

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const property = read('app/property/page.js');
+const checkout = read('app/api/property-generation/checkout/route.ts');
+const photoHandoff = read('app/api/property-photo-upload/route.ts');
+const payment = read('lib/property-generation-payment.ts');
+
+assert.match(payment, /PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499/, 'server-authoritative VoxelPop creation price must be $4.99');
+assert.match(payment, /PROPERTY_VOXEL_GENERATION_KIND = 'property_voxel_generation_v1'/, 'paid property creation must have its own Stripe product rail');
+assert.match(payment, /session\.payment_status !== 'paid'/, 'generation unlock must require a paid Stripe session');
+assert.match(payment, /session\.client_reference_id !== auth\.user\.id/, 'paid generation must remain bound to the signed-in buyer');
+assert.match(payment, /metadata\.voxelpop_user_id !== auth\.user\.id/, 'Stripe metadata must independently bind the payment to the account');
+assert.match(payment, /Number\(session\.amount_total \|\| 0\) !== PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'the server must verify the exact paid amount');
+assert.match(payment, /source_sha256/, 'the staged source must be cryptographically bound to the checkout');
+assert.match(payment, /digest !== receipt\.digest/, 'source bytes must be re-verified after returning from Stripe');
+
+assert.match(checkout, /requireVoxelVaultUser/, 'checkout must require a signed-in Voxel Vault account');
+assert.match(checkout, /MESHY_PROPERTY_CREDITS\.fullPipeline/, 'provider capacity must be checked before charging');
+assert.match(checkout, /readMeshyCreditBalance\(apiKey\)/, 'checkout must read the live Meshy service-credit balance before Stripe');
+assert.match(checkout, /stagePaidPropertyPhoto/, 'the authorized source photo must be staged privately across Stripe checkout');
+assert.match(checkout, /stripe\.checkout\.sessions\.create/, 'the generation paywall must use server-created Stripe Checkout');
+assert.match(checkout, /unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'the client cannot choose the generation price');
+assert.match(checkout, /VoxelPop 3D Voxel Creation/, 'Stripe must identify exactly what is being purchased');
+assert.match(checkout, /Digital creation only; no rights in physical real estate/, 'checkout copy must preserve the real-property boundary');
+assert.match(checkout, /generation_session=\{CHECKOUT_SESSION_ID\}/, 'successful payment must return through the paid generation resume path');
+assert.match(checkout, /generation_checkout=cancelled/, 'canceled checkout must return without starting generation');
+assert.match(checkout, /deleteStagedPropertyPhoto/, 'canceled or failed checkout staging must have cleanup support');
+
+assert.match(photoHandoff, /if \(!generationSessionId\)/, 'direct source generation must reject calls without a payment session');
+assert.match(photoHandoff, /paymentRequired: true/, 'unpaid direct calls must expose an explicit payment-required response');
+assert.match(photoHandoff, /status: 402/, 'unpaid source-generation calls must fail closed');
+assert.match(photoHandoff, /paidPropertyGenerationReceipt\(auth, stripe, generationSessionId\)/, 'the paid Stripe receipt must be verified before any Meshy task starts');
+assert.match(photoHandoff, /readCatalog3D\(itemId\)/, 'Stripe-return refreshes must check for an existing generation before spending credits again');
+assert.match(photoHandoff, /existing\?\.source_image_url === sourceFingerprint/, 'idempotency must be tied to the exact paid source photo');
+assert.match(photoHandoff, /deleteStagedPropertyPhoto\(auth, draftId\)/, 'the private checkout source must be removed after provider handoff');
+
+assert.match(property, /CREATION_PRICE_LABEL = '\$4\.99'/, 'the maker must show the $4.99 creation price');
+assert.match(property, /\/api\/property-generation\/checkout/, 'photo approval must open paid generation checkout instead of calling Meshy directly');
+assert.match(property, /Pay \$4\.99 · Use photo → start build/, 'the primary CTA must clearly disclose the creation charge');
+assert.match(property, /generation_session/, 'the maker must resume a successfully paid creation after Stripe');
+assert.match(property, /form\.append\('generationSessionId', generationSessionId\)/, 'Stripe return must pass the verified session into the source-generation gate');
+assert.match(property, /generation_checkout.*cancelled/, 'the maker must recognize canceled creation checkout');
+assert.match(property, /method: 'DELETE'/, 'canceled checkout must request cleanup of the staged source photo');
+assert.match(property, /The \{CREATION_PRICE_LABEL\} charge is for one digital VoxelPop creation/, 'UI copy must explain that $4.99 buys digital generation rather than real estate');
+
+console.log('Paid VoxelPop property-generation regression passed: signed-in photo -> private staging -> Meshy capacity preflight -> server-authoritative $4.99 Stripe checkout -> paid account/draft verification -> idempotent Meshy start -> automatic voxel pipeline, with unpaid calls failing closed.');


### PR DESCRIPTION
Adds a server-authoritative $4.99 creation paywall before the paid Meshy property pipeline.

- Choose/prepare the photo before checkout, but do not start paid generation yet.
- Preflight the full 33-credit Meshy pipeline before opening Stripe so customers are not charged when provider capacity is unavailable.
- Stage the authorized source photo privately across Stripe Checkout and bind it to the signed-in user, draft ID, SHA-256 fingerprint, content type, and exact $4.99 amount.
- Verify the paid Stripe session server-side before the first Meshy task can start; unpaid direct generation calls fail closed with HTTP 402.
- Re-check Meshy capacity after payment before starting the provider job.
- Make Stripe-return refreshes idempotent so the same paid creation reuses its existing source 3D job instead of spending credits again.
- Delete the temporary staged photo after provider handoff or canceled checkout.
- Resume the existing automatic flow after payment: source 3D -> VoxelPop render -> final interactive 3D -> My World.
- Preserve existing image-first GLB recovery and final-3D resume behavior.
- Keep all checkout copy explicit that $4.99 pays for a digital VoxelPop creation only and creates no rights in physical real estate.
- Add regression coverage and run it in the normal property CI suite.