### PR TITLE
Fix VoxelPop checkout storage and focus the property map

### DIFF
--- a/app/vault/earth/PlanetStreamGlobe.js
+++ b/app/vault/earth/PlanetStreamGlobe.js
@@ -82,6 +82,20 @@ function pointerDistance(a, b) {
   return Math.hypot(a.x - b.x, a.y - b.y);
 }
 
+function selectedFocusPoint(next = {}) {
+  const listing = (next.listings || []).find((item) => (
+    item?.id === next.selectedId
+    && Number.isFinite(Number(item?.latitude))
+    && Number.isFinite(Number(item?.longitude))
+  ));
+  if (listing) return listing;
+  return (next.atlasBuildings || []).find((item) => (
+    item?.atlasId === next.selectedAtlasId
+    && Number.isFinite(Number(item?.latitude))
+    && Number.isFinite(Number(item?.longitude))
+  )) || null;
+}
+
 export default function PlanetStreamGlobe({
   listings = [],
   selectedId = '',
@@ -196,11 +210,11 @@ export default function PlanetStreamGlobe({
         const normal = position.clone().normalize();
         const up = new THREE.Vector3(0, 1, 0);
         const quaternion = new THREE.Quaternion().setFromUnitVectors(up, normal);
-        const scale = selected ? 1.45 : 1;
+        const scale = selected ? 1.8 : 1;
         const bodyGeometry = new THREE.BoxGeometry(0.12 * scale, 0.15 * scale, 0.12 * scale);
         const roofGeometry = new THREE.ConeGeometry(0.105 * scale, 0.09 * scale, 4);
-        const bodyMaterial = new THREE.MeshStandardMaterial({ color: selected ? 0xffffff : 0x79efbc, emissive: selected ? 0x6e5bff : 0x164f3d, emissiveIntensity: selected ? 1.5 : 0.7, roughness: 0.38 });
-        const roofMaterial = new THREE.MeshStandardMaterial({ color: selected ? 0xd9d1ff : 0x25352f, emissive: selected ? 0x5844ce : 0x10231c, emissiveIntensity: 0.7, roughness: 0.48 });
+        const bodyMaterial = new THREE.MeshStandardMaterial({ color: selected ? 0xffffff : 0x79efbc, emissive: selected ? 0x6e5bff : 0x164f3d, emissiveIntensity: selected ? 1.75 : 0.7, roughness: 0.38 });
+        const roofMaterial = new THREE.MeshStandardMaterial({ color: selected ? 0xd9d1ff : 0x25352f, emissive: selected ? 0x5844ce : 0x10231c, emissiveIntensity: selected ? 0.9 : 0.7, roughness: 0.48 });
         markerResources.push(bodyGeometry, roofGeometry, bodyMaterial, roofMaterial);
         const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
         const roof = new THREE.Mesh(roofGeometry, roofMaterial);
@@ -283,6 +297,18 @@ export default function PlanetStreamGlobe({
       };
 
       const updateCamera = () => camera.position.set(0, 0.18, cameraDistance);
+
+      function focusSelected(next = dataRef.current) {
+        const point = selectedFocusPoint(next);
+        if (!point) return false;
+        targetX = Math.max(-1.05, Math.min(1.05, Number(point.latitude) * Math.PI / 180));
+        targetY = -Number(point.longitude) * Math.PI / 180;
+        if (simpleMode) cameraDistance = compact ? 10.9 : 10.5;
+        updateCamera();
+        scheduleViewport(520);
+        return true;
+      }
+
       const down = (event) => {
         activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
         renderer.domElement.setPointerCapture?.(event.pointerId);
@@ -369,7 +395,7 @@ export default function PlanetStreamGlobe({
         lastRender = time;
         root.rotation.x += (targetX - root.rotation.x) * 0.075;
         root.rotation.y += (targetY - root.rotation.y) * 0.075;
-        if (!reducedMotion && activePointers.size === 0 && Math.abs(targetY - root.rotation.y) < 0.002) targetY += 0.00018;
+        if (!simpleMode && !reducedMotion && activePointers.size === 0 && Math.abs(targetY - root.rotation.y) < 0.002) targetY += 0.00018;
         renderer.render(scene, camera);
       };
 
@@ -384,8 +410,12 @@ export default function PlanetStreamGlobe({
       window.addEventListener('resize', resize);
 
       const engine = {
-        updateMarkers,
+        updateMarkers(next) {
+          updateMarkers(next);
+          if (simpleMode) focusSelected(next);
+        },
         reset() {
+          if (simpleMode && focusSelected(dataRef.current)) return;
           targetX = 0.18;
           targetY = -0.42;
           cameraDistance = compact ? 13.9 : 13.1;
@@ -401,6 +431,7 @@ export default function PlanetStreamGlobe({
       };
       engineRef.current = engine;
       updateMarkers(dataRef.current);
+      if (simpleMode) focusSelected(dataRef.current);
       animate();
       scheduleViewport(900);
 
@@ -435,7 +466,7 @@ export default function PlanetStreamGlobe({
 
   return <div className="planetRoot">
     <div ref={mountRef} className="planetMount" />
-    <div className="planetStatus"><i className={streaming ? 'busy' : ''}/><span>{simpleMode ? 'PUBLIC 3D PROPERTY WORLD' : streaming ? 'STREAMING VISIBLE REGION' : 'GLOBAL ON-DEMAND ATLAS'}</span></div>
+    <div className="planetStatus"><i className={streaming ? 'busy' : ''}/><span>{simpleMode ? 'PROPERTY WORLD · FOCUSED LOCATION' : streaming ? 'STREAMING VISIBLE REGION' : 'GLOBAL ON-DEMAND ATLAS'}</span></div>
     <div className="planetControls" aria-label="Globe controls">
       <button type="button" onClick={() => engineRef.current?.zoom?.(-0.7)} aria-label="Zoom in">+</button>
       <button type="button" onClick={() => engineRef.current?.zoom?.(0.7)} aria-label="Zoom out">−</button>

--- a/lib/property-generation-payment.ts
+++ b/lib/property-generation-payment.ts
@@ -18,13 +18,31 @@ function safeSegment(value: unknown, fallback = 'item') {
   return text || fallback;
 }
 
+function bucketMissing(error: any) {
+  const status = Number(error?.statusCode ?? error?.status ?? 0);
+  const message = String(error?.message || error || '');
+  return status === 404 || /bucket.*not found|not found.*bucket|bucket.*does not exist/i.test(message);
+}
+
 async function ensureBucket(admin: any) {
-  const { data, error } = await admin.storage.listBuckets();
-  if (!error && data?.some((bucket: any) => bucket.name === BUCKET)) return;
   const created = await admin.storage.createBucket(BUCKET, { public: false, fileSizeLimit: '75MB' });
   if (created.error && !/already exists/i.test(created.error.message || '')) {
-    throw new Error('Private VoxelPop checkout storage could not be prepared.');
+    throw new Error('Private VoxelPop storage is unavailable on this deployment.');
   }
+}
+
+async function uploadStagedPhoto(admin: any, storagePath: string, bytes: Buffer, contentType: string) {
+  const options = { contentType, cacheControl: '0', upsert: true };
+  let uploaded = await admin.storage.from(BUCKET).upload(storagePath, bytes, options);
+  if (!uploaded.error) return;
+
+  if (!bucketMissing(uploaded.error)) {
+    throw new Error('Your photo could not be staged securely for checkout.');
+  }
+
+  await ensureBucket(admin);
+  uploaded = await admin.storage.from(BUCKET).upload(storagePath, bytes, options);
+  if (uploaded.error) throw new Error('Your photo could not be staged securely for checkout.');
 }
 
 export function propertyGenerationStagePath(userId: unknown, draftIdRaw: unknown) {
@@ -42,13 +60,7 @@ export async function stagePaidPropertyPhoto(auth: any, draftIdRaw: unknown, pho
   const bytes = Buffer.from(await photo.arrayBuffer());
   const digest = createHash('sha256').update(bytes).digest('hex');
   const storagePath = propertyGenerationStagePath(auth.user.id, draftId);
-  await ensureBucket(auth.admin);
-  const { error } = await auth.admin.storage.from(BUCKET).upload(storagePath, bytes, {
-    contentType,
-    cacheControl: '0',
-    upsert: true,
-  });
-  if (error) throw new Error('Your photo could not be staged securely for checkout.');
+  await uploadStagedPhoto(auth.admin, storagePath, bytes, contentType);
 
   return {
     draftId,

--- a/scripts/check-mobile-webgl.mjs
+++ b/scripts/check-mobile-webgl.mjs
@@ -31,6 +31,11 @@ assert.match(planetGlobe, /time - lastRender < 33/, 'streaming Earth globe must 
 assert.match(planetGlobe, /activePointers\.size >= 2/, 'streaming Earth globe must retain two-finger pinch zoom');
 assert.match(planetGlobe, /IntersectionObserver/, 'streaming Earth globe must pause offscreen');
 assert.match(planetGlobe, /prefers-reduced-motion/, 'streaming Earth globe must respect reduced motion');
+assert.match(planetGlobe, /function selectedFocusPoint\(next = \{\}\)/, 'property World mode must be able to resolve the selected map point without a provider call');
+assert.match(planetGlobe, /targetY = -Number\(point\.longitude\) \* Math\.PI \/ 180/, 'selected property longitude must rotate to the front of the globe');
+assert.match(planetGlobe, /simpleMode \? 10\.9 : 10\.5|compact \? 10\.9 : 10\.5/, 'selected property World mode must use a closer focused camera');
+assert.match(planetGlobe, /if \(simpleMode && focusSelected\(dataRef\.current\)\) return/, 'World reset must return to the selected property instead of an arbitrary global view');
+assert.match(planetGlobe, /PROPERTY WORLD · FOCUSED LOCATION/, 'focused property World mode must explain what the map is showing');
 assert.match(earthGlobe, /MAX_STREAMED_BUILDINGS = 420/, 'client globe cache must remain bounded');
 assert.match(earthGlobe, /MAX_VISITED_REGIONS = 96/, 'visited-region memory must remain bounded');
 assert.match(earthGlobe, /\/api\/world-atlas\/stream/, 'globe must stream visible Earth regions through the bounded API');
@@ -62,4 +67,4 @@ assert.match(realEstateCss, /mobileTabBar/, 'Real estate homepage must expose mo
 assert.match(realEstateCss, /safe-area-inset-bottom/, 'Real estate homepage must account for iPhone safe area');
 assert.match(realEstateCss, /calc\(100% - 22px\)/, 'Real estate mobile shell width must use valid CSS math');
 
-console.log('Mobile WebGL source guard passed: Voxel, GEO, streaming Globe, free open street Compare, Meshy GLB and iPhone reference-photo flows retain touch-safe mobile fallbacks, bounded caches and rendering limits.');
+console.log('Mobile WebGL source guard passed: Voxel, GEO, focused no-credit property World map, streaming Globe, free open street Compare, Meshy GLB and iPhone reference-photo flows retain touch-safe mobile fallbacks, bounded caches and rendering limits.');

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -16,6 +16,11 @@ assert.match(payment, /metadata\.voxelpop_user_id !== auth\.user\.id/, 'Stripe m
 assert.match(payment, /Number\(session\.amount_total \|\| 0\) !== PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'the server must verify the exact paid amount');
 assert.match(payment, /source_sha256/, 'the staged source must be cryptographically bound to the checkout');
 assert.match(payment, /digest !== receipt\.digest/, 'source bytes must be re-verified after returning from Stripe');
+assert.match(payment, /function bucketMissing\(error/, 'checkout staging must distinguish a genuinely missing storage bucket from unrelated storage errors');
+assert.match(payment, /let uploaded = await admin\.storage\.from\(BUCKET\)\.upload/, 'checkout staging must try the existing private bucket directly before management operations');
+assert.match(payment, /if \(!bucketMissing\(uploaded\.error\)\)/, 'bucket creation must not run for ordinary upload failures');
+assert.match(payment, /await ensureBucket\(admin\)/, 'a genuinely missing private bucket must retain a one-time recovery path');
+assert.doesNotMatch(payment, /storage\.listBuckets\(\)/, 'checkout must not fail just because runtime bucket listing is unavailable');
 
 assert.match(checkout, /requireVoxelVaultUser/, 'checkout must require a signed-in Voxel Vault account');
 assert.match(checkout, /MESHY_PROPERTY_CREDITS\.fullPipeline/, 'provider capacity must be checked before charging');
@@ -46,4 +51,4 @@ assert.match(property, /generation_checkout.*cancelled/, 'the maker must recogni
 assert.match(property, /method: 'DELETE'/, 'canceled checkout must request cleanup of the staged source photo');
 assert.match(property, /The \{CREATION_PRICE_LABEL\} charge is for one digital VoxelPop creation/, 'UI copy must explain that $4.99 buys digital generation rather than real estate');
 
-console.log('Paid VoxelPop property-generation regression passed: signed-in photo -> private staging -> Meshy capacity preflight -> server-authoritative $4.99 Stripe checkout -> paid account/draft verification -> idempotent Meshy start -> automatic voxel pipeline, with unpaid calls failing closed.');
+console.log('Paid VoxelPop property-generation regression passed: signed-in photo -> private staging with direct-upload-first bucket recovery -> Meshy capacity preflight -> server-authoritative $4.99 Stripe checkout -> paid account/draft verification -> idempotent Meshy start -> automatic voxel pipeline, with unpaid calls failing closed.');


### PR DESCRIPTION
## What this changes

- Keeps the existing VoxelPop paid-generation flow and pricing intact.
- Fixes the false `Private VoxelPop checkout storage could not be prepared` failure by trying the existing private `voxel-system` bucket directly first.
- Only attempts bucket creation when Supabase explicitly reports that the bucket is missing; runtime bucket listing is no longer required.
- Improves the existing My World property globe without calling Meshy: selected properties auto-center, use a closer camera, get a stronger marker, stop drifting away in simple property mode, and Reset returns to the selected property.
- Preserves iPhone pinch/drag, compact pixel-ratio limits, 30fps safeguards, reduced-motion handling, and the existing provider/payment safety gates.
- Adds regression guards for both the storage recovery behavior and the focused no-credit map behavior.

## Meshy credits

These map and storage changes do not start a Meshy generation task and do not spend Meshy credits. The existing paid Meshy generation path remains available separately when provider capacity exists.