### PR TITLE
Keep $4.99 creation while using zero Meshy credits and the improved 3D map

### DIFF
--- a/app/api/property-generation/checkout/route.ts
+++ b/app/api/property-generation/checkout/route.ts
@@ -1,8 +1,20 @@
 import { NextResponse } from 'next/server';
+import { stripe } from '../../../../lib/stripe-server';
 import { requireVoxelVaultUser } from '../../../../lib/user-auth';
+import {
+  PROPERTY_VOXEL_GENERATION_KIND,
+  PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+  PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+  paidPropertyGenerationReceipt,
+  propertyGenerationCheckoutDraft,
+} from '../../../../lib/property-generation-payment';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+function clean(value: unknown, max = 500) {
+  return String(value || '').trim().slice(0, max);
+}
 
 function privateJson(body: unknown, init: ResponseInit = {}) {
   return NextResponse.json(body, {
@@ -15,15 +27,94 @@ export async function POST(request: Request) {
   const auth = await requireVoxelVaultUser(request);
   if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
 
-  return privateJson({
-    ok: false,
-    migrated: true,
-    error: 'VoxelPop creation no longer needs a pre-generation checkout, private photo staging, or Meshy credits. Refresh the Property maker to use the on-device VoxelPop preview and source-backed 3D map.',
-  }, { status: 409 });
+  try {
+    const body = await request.json().catch(() => ({}));
+    const draftId = propertyGenerationCheckoutDraft(body?.draftId);
+    const rightsConfirmed = body?.rightsConfirmed === true;
+    if (!rightsConfirmed) {
+      return privateJson({ ok: false, error: 'Confirm that you took this photo or have permission to use it.' }, { status: 400 });
+    }
+
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const email = typeof auth.user.email === 'string' && auth.user.email.includes('@') ? auth.user.email : undefined;
+    const checkout = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{
+        quantity: 1,
+        price_data: {
+          currency: 'usd',
+          unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+          product_data: {
+            name: 'VoxelPop Property Creation',
+            description: 'One digital VoxelPop property creation with an on-device voxel preview and source-backed interactive 3D map. No Meshy generation credits are used. No rights in physical real estate.',
+          },
+        },
+      }],
+      client_reference_id: auth.user.id,
+      ...(email ? { customer_email: email } : {}),
+      metadata: {
+        kind: PROPERTY_VOXEL_GENERATION_KIND,
+        voxelpop_user_id: auth.user.id,
+        draft_id: draftId,
+        rights_confirmed: 'true',
+        price_cents: String(PROPERTY_VOXEL_GENERATION_PRICE_CENTS),
+        creation_engine: 'on_device_voxel_plus_source_backed_3d_map',
+        source_photo_storage: 'device_only_not_uploaded_for_creation',
+        meshy_credits: '0',
+      },
+      success_url: `${origin}/property?generation_session={CHECKOUT_SESSION_ID}&draftId=${encodeURIComponent(draftId)}`,
+      cancel_url: `${origin}/property?generation_checkout=cancelled&draftId=${encodeURIComponent(draftId)}`,
+    });
+
+    if (!checkout.url) throw new Error('Stripe did not return a checkout URL.');
+    return privateJson({
+      ok: true,
+      url: checkout.url,
+      draftId,
+      priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+      priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+      meshyCredits: 0,
+      sourcePhotoUploaded: false,
+    });
+  } catch (error) {
+    return privateJson({
+      ok: false,
+      error: error instanceof Error ? error.message : 'VoxelPop checkout could not be opened.',
+    }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const url = new URL(request.url);
+    const sessionId = clean(url.searchParams.get('sessionId'), 260);
+    const expectedDraftId = clean(url.searchParams.get('draftId'), 100);
+    const receipt = await paidPropertyGenerationReceipt(auth, stripe, sessionId);
+    if (expectedDraftId && receipt.draftId !== propertyGenerationCheckoutDraft(expectedDraftId)) {
+      return privateJson({ ok: false, error: 'This payment does not match the current VoxelPop creation.' }, { status: 409 });
+    }
+    return privateJson({
+      ok: true,
+      paid: true,
+      draftId: receipt.draftId,
+      priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
+      priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
+      meshyCredits: 0,
+      creationEngine: 'on-device-voxel-plus-source-backed-3d-map',
+    });
+  } catch (error) {
+    return privateJson({
+      ok: false,
+      error: error instanceof Error ? error.message : 'VoxelPop payment could not be verified.',
+    }, { status: 400 });
+  }
 }
 
 export async function DELETE(request: Request) {
   const auth = await requireVoxelVaultUser(request);
   if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
-  return privateJson({ ok: true, deleted: false, migrated: true });
+  return privateJson({ ok: true, deleted: false, localOnly: true });
 }

--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -1,36 +1,10 @@
-import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { stripe } from '../../../lib/stripe-server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
-import { readCatalog3D, saveCatalog3D } from '../../../lib/catalog3dStore';
-import { propertyDraftItemId } from '../../../lib/property-generation-ids';
-import {
-  createPropertyGenerationRecoveryTaskId,
-  propertyGenerationCanonicalTaskId,
-} from '../../../lib/property-generation-task';
-import {
-  PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
-  PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
-  deleteStagedPropertyPhoto,
-  loadPaidPropertyGenerationPhoto,
-  paidPropertyGenerationReceipt,
-} from '../../../lib/property-generation-payment';
-import {
-  MESHY_PROPERTY_CREDITS,
-  meshyClientStatus,
-  meshyCreditError,
-  meshyCreditsSufficient,
-  meshyProviderFailure,
-  readMeshyCreditBalance,
-} from '../../../lib/meshy-credits';
+import { paidPropertyGenerationReceipt } from '../../../lib/property-generation-payment';
 
 export const runtime = 'nodejs';
-export const maxDuration = 120;
 export const dynamic = 'force-dynamic';
-
-const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
-const MAX_BYTES = 8 * 1024 * 1024;
-const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
 function clean(value: unknown, max = 260) {
   return String(value || '').trim().slice(0, max);
@@ -43,56 +17,10 @@ function privateJson(body: unknown, init: ResponseInit = {}) {
   });
 }
 
-function generationResult(input: {
-  draftId: string;
-  digest: string;
-  taskId: string;
-  status?: string | null;
-  progress?: number | null;
-  recoveryMode?: boolean;
-  reused?: boolean;
-  paymentSessionId: string;
-}) {
-  const uploadedAt = new Date().toISOString();
-  const taskId = input.taskId;
-  return {
-    ok: true,
-    paid: true,
-    reused: input.reused === true,
-    priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
-    priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
-    paymentSessionId: input.paymentSessionId,
-    draftId: input.draftId,
-    reference: {
-      url: null,
-      draftId: input.draftId,
-      rightsBasis: 'user-owned',
-      rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital creation.',
-      label: 'Selected property photo',
-      sourcePhotoId: `upload:${input.digest.slice(0, 20)}`,
-      provider: 'user-photo-direct-generation',
-      storagePath: `meshy-source:${taskId}`,
-      uploadedAt,
-    },
-    source3d: {
-      taskId,
-      status: input.status || 'PENDING',
-      progress: Number(input.progress || 0),
-    },
-    recoveryMode: input.recoveryMode === true,
-    privacy: 'After the paid provider handoff, Voxel Vault does not store the original source photo in its Storage bucket. Checkout temporarily stages the authorized photo privately, then removes that staged source when generation starts; the account keeps the SHA-256 fingerprint and account-bound generation record rather than the original photo.',
-  };
-}
-
 export async function POST(request: Request) {
   const auth = await requireVoxelVaultUser(request);
   if (auth.ok === false) {
     return privateJson({ ok: false, error: auth.error, setupRequired: auth.setupRequired === true }, { status: auth.status });
-  }
-
-  const apiKey = process.env.MESHY_API_KEY?.trim();
-  if (!apiKey) {
-    return privateJson({ ok: false, error: 'VoxelPop 3D generation is not configured on this deployment.' }, { status: 503 });
   }
 
   try {
@@ -102,136 +30,25 @@ export async function POST(request: Request) {
       return privateJson({
         ok: false,
         paymentRequired: true,
-        priceCents: PROPERTY_VOXEL_GENERATION_PRICE_CENTS,
-        priceLabel: PROPERTY_VOXEL_GENERATION_PRICE_LABEL,
-        checkoutEndpoint: '/api/property-generation/checkout',
-        error: `Pay ${PROPERTY_VOXEL_GENERATION_PRICE_LABEL} before VoxelPop starts paid 3D generation.`,
+        migrated: true,
+        error: 'Use the Property maker to pay $4.99 before creating a VoxelPop preview.',
       }, { status: 402 });
     }
 
     const receipt = await paidPropertyGenerationReceipt(auth, stripe, generationSessionId);
-    const draftId = receipt.draftId;
-    const digest = receipt.digest;
-    const rightsConfirmed = true;
-    const itemId = propertyDraftItemId(auth.user.id, draftId, 'source');
-    const sourceFingerprint = `inline-photo:${digest}`;
-
-    // A Stripe success page can be refreshed. Reuse the exact account/draft job
-    // instead of spending Meshy credits a second time for the same paid source.
-    const existing = await readCatalog3D(itemId);
-    if (existing?.task_id && existing?.source_image_url === sourceFingerprint) {
-      await deleteStagedPropertyPhoto(auth, draftId);
-      return privateJson(generationResult({
-        draftId,
-        digest,
-        taskId: existing.task_id,
-        status: existing.status,
-        progress: existing.progress,
-        reused: true,
-        paymentSessionId: generationSessionId,
-      }));
-    }
-
-    const paidInput = await loadPaidPropertyGenerationPhoto(auth, receipt);
-    const photo = new File([paidInput.bytes], paidInput.fileName, { type: paidInput.contentType });
-
-    if (!(photo instanceof File)) {
-      return privateJson({ ok: false, error: 'Choose a property photo first.' }, { status: 400 });
-    }
-    if (!rightsConfirmed) {
-      return privateJson({ ok: false, error: 'Confirm that you took this photo or have permission to use it.' }, { status: 400 });
-    }
-    if (!ALLOWED_TYPES.has(String(photo.type || '').toLowerCase())) {
-      return privateJson({ ok: false, error: 'Use a JPG, PNG, or WebP property photo.' }, { status: 415 });
-    }
-    if (photo.size <= 0 || photo.size > MAX_BYTES) {
-      return privateJson({ ok: false, error: 'Property photos must be smaller than 8 MB after preparation.' }, { status: 413 });
-    }
-
-    // The automatic Property journey is three paid Meshy calls: 15 credits for
-    // this textured Smart Topology source 3D, 3 for nano-banana image-to-image,
-    // and 15 for the final textured Smart Topology 3D. Check again after Stripe
-    // so a paid user is never sent into a knowingly underfunded provider flow.
-    const balance = await readMeshyCreditBalance(apiKey);
-    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.fullPipeline)) {
-      return privateJson(
-        meshyCreditError('starting the complete paid property build', MESHY_PROPERTY_CREDITS.fullPipeline),
-        { status: 503 },
-      );
-    }
-
-    const bytes = Buffer.from(await photo.arrayBuffer());
-    const verifiedDigest = createHash('sha256').update(bytes).digest('hex');
-    if (verifiedDigest !== digest) throw new Error('The paid source photo fingerprint no longer matches checkout.');
-    const dataUri = `data:${photo.type};base64,${bytes.toString('base64')}`;
-
-    const response = await fetch(ENDPOINT, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        image_url: dataUri,
-        model_type: 'smart-topology',
-        ai_model: 'meshy-t2',
-        target_polycount: 15000,
-        should_texture: true,
-        enable_pbr: true,
-        texture_resolution: '2k',
-        target_formats: ['glb'],
-      }),
-      cache: 'no-store',
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      return privateJson(
-        meshyProviderFailure(
-          response.status,
-          data,
-          `3D provider returned ${response.status}.`,
-          'starting the first paid property 3D build',
-          MESHY_PROPERTY_CREDITS.source3d,
-        ),
-        { status: meshyClientStatus(response.status) },
-      );
-    }
-
-    const providerTaskId = clean(data?.result || data?.id, 240);
-    if (!providerTaskId) throw new Error('The 3D provider did not return a task ID.');
-    const canonicalTaskId = propertyGenerationCanonicalTaskId(providerTaskId);
-    const saved = await saveCatalog3D(itemId, {
-      task_id: canonicalTaskId,
-      source_image_url: sourceFingerprint,
-      source_image_urls: [sourceFingerprint],
-      provider: 'meshy-property-direct-photo-to-3d',
-      status: 'PENDING',
-      progress: 0,
-      model_url: null,
-      model_storage_path: null,
-      thumbnail_url: null,
-      exact_model_approved: false,
-      started_at: new Date().toISOString(),
-      completed_at: null,
-      error: null,
-    });
-
-    // Do not orphan a provider job just because account catalog persistence is
-    // temporarily unavailable. The signed recovery ID remains account-bound.
-    const taskId = saved?.task_id
-      || createPropertyGenerationRecoveryTaskId(apiKey, auth.user.id, providerTaskId);
-
-    await deleteStagedPropertyPhoto(auth, draftId);
-    return privateJson(generationResult({
-      draftId,
-      digest,
-      taskId,
-      status: saved?.status || 'PENDING',
-      progress: Number(saved?.progress || 0),
-      recoveryMode: !saved?.task_id,
-      paymentSessionId: generationSessionId,
-    }));
+    return privateJson({
+      ok: false,
+      paid: true,
+      migrated: true,
+      draftId: receipt.draftId,
+      meshyCredits: 0,
+      sourcePhotoUploaded: false,
+      error: 'Payment is verified. This creation now runs on-device and uses the source-backed 3D map; the legacy Meshy photo-upload handoff is disabled. Return to the Property maker to continue without spending Meshy credits.',
+    }, { status: 409 });
   } catch (error) {
     return privateJson({
       ok: false,
-      error: error instanceof Error ? error.message : 'Property photo generation handoff failed.',
+      error: error instanceof Error ? error.message : 'The legacy property generation handoff is unavailable.',
     }, { status: 400 });
   }
 }

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -4,7 +4,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import GeoReferenceModel from '../geo/GeoReferenceModel';
 import PlanetStreamGlobe from '../vault/earth/PlanetStreamGlobe';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import {
+  deletePaidPropertyPhoto,
+  loadPaidPropertyPhoto,
+  savePaidPropertyPhoto,
+} from '../../lib/property-generation-browser-store';
 import styles from './property.module.css';
+
+const CREATION_PRICE_LABEL = '$4.99';
 
 function clean(value) { return String(value || '').trim(); }
 function newDraftId() {
@@ -130,6 +137,7 @@ export default function PropertyJourneyPage() {
   const [pendingPhoto, setPendingPhoto] = useState(null);
   const [pendingPreview, setPendingPreview] = useState('');
   const [rightsConfirmed, setRightsConfirmed] = useState(false);
+  const [paidCreation, setPaidCreation] = useState(null);
   const [sourceReference, setSourceReference] = useState(null);
   const [voxelImage, setVoxelImage] = useState('');
   const [atlas, setAtlas] = useState(null);
@@ -145,6 +153,7 @@ export default function PropertyJourneyPage() {
   const [message, setMessage] = useState('Sign in to start.');
   const clientRef = useRef(null);
   const uploadInputRef = useRef(null);
+  const checkoutHandledRef = useRef('');
 
   const step = !sourceReference ? 1 : !voxelImage ? 2 : !mappedAddress ? 3 : !worldConfirmed ? 4 : 5;
   const labels = ['PHOTO', 'BUILD', 'VOXEL', 'WORLD', 'COLLECT'];
@@ -208,11 +217,60 @@ export default function PropertyJourneyPage() {
   }, []);
 
   useEffect(() => {
-    if (!session?.access_token || typeof window === 'undefined') return;
+    if (!session?.access_token || typeof window === 'undefined') return undefined;
     const params = new URLSearchParams(window.location.search);
-    if (!params.has('generation_session') && !params.has('generation_checkout')) return;
-    window.history.replaceState({}, '', '/property');
-    setMessage('VoxelPop creation now runs without a pre-generation checkout or Meshy credits. Choose a photo to use the new on-device preview and source-backed 3D map.');
+    const canceled = params.get('generation_checkout') === 'cancelled';
+    const returnDraftId = clean(params.get('draftId'));
+
+    if (canceled && returnDraftId) {
+      const key = `cancel:${returnDraftId}`;
+      if (checkoutHandledRef.current === key) return undefined;
+      checkoutHandledRef.current = key;
+      deletePaidPropertyPhoto(returnDraftId).catch(() => {});
+      setBusy('');
+      setMessage('Checkout canceled. No VoxelPop creation was charged or created.');
+      window.history.replaceState({}, '', '/property');
+      return undefined;
+    }
+
+    const generationSessionId = clean(params.get('generation_session'));
+    if (!generationSessionId || !returnDraftId || checkoutHandledRef.current === generationSessionId) return undefined;
+    checkoutHandledRef.current = generationSessionId;
+    let active = true;
+    setBusy('payment-return');
+    setMessage('Payment received. Verifying $4.99 and creating your VoxelPop preview on this device…');
+
+    (async () => {
+      try {
+        const verifyParams = new URLSearchParams({ sessionId: generationSessionId, draftId: returnDraftId });
+        const response = await fetch(`/api/property-generation/checkout?${verifyParams.toString()}`, {
+          cache: 'no-store',
+          headers: authHeaders(),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || !data?.ok || !data?.paid) throw new Error(data?.error || 'Your VoxelPop payment could not be verified.');
+        if (!active) return;
+
+        setDraftId(data.draftId);
+        setPaidCreation({ sessionId: generationSessionId, draftId: data.draftId, verified: true });
+        const photo = await loadPaidPropertyPhoto(data.draftId);
+        if (!photo) {
+          setBusy('');
+          setMessage('Payment verified. This device no longer has the selected photo—choose it again to finish this paid creation. You will not be charged again.');
+          window.history.replaceState({}, '', '/property');
+          return;
+        }
+        await finishPaidLocalBuild(photo, data.draftId, generationSessionId);
+        if (active) window.history.replaceState({}, '', '/property');
+      } catch (error) {
+        if (active) {
+          setBusy('');
+          setMessage(String(error?.message || error || 'Your paid VoxelPop creation could not resume.'));
+        }
+      }
+    })();
+
+    return () => { active = false; };
   }, [session?.access_token]);
 
   function authHeaders(extra = {}) {
@@ -251,32 +309,63 @@ export default function PropertyJourneyPage() {
       if (photo.size > 8 * 1024 * 1024) throw new Error('This photo is still too large after preparation. Try a screenshot or smaller version.');
       setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return URL.createObjectURL(photo); });
       setPendingPhoto(photo);
-      setRightsConfirmed(false);
-      setMessage('Photo ready. Confirm you can use it, then VoxelPop makes the preview on this device—no Meshy credits or generation checkout.');
+      setRightsConfirmed(Boolean(paidCreation?.verified && paidCreation?.draftId === draftId));
+      setMessage(paidCreation?.verified && paidCreation?.draftId === draftId
+        ? 'Payment already verified. Use this photo to finish your paid creation—no second charge.'
+        : `Photo ready. Confirm you can use it, then pay ${CREATION_PRICE_LABEL} to create the VoxelPop preview and 3D map.`);
     } catch (error) {
       setMessage(String(error?.message || error || 'This photo could not be prepared.'));
+    } finally { setBusy(''); }
+  }
+
+  async function finishPaidLocalBuild(photo, paidDraftId, paymentSessionId) {
+    setBusy('local-build');
+    setDraftId(paidDraftId);
+    setSourceReference({ draftId: paidDraftId, local: true, paid: true, paymentSessionId });
+    setMessage('Payment verified. Building the VoxelPop preview on your device…');
+    try {
+      await new Promise((resolve) => window.setTimeout(resolve, 240));
+      const preview = await makeLocalVoxelPreview(photo);
+      setVoxelImage(preview);
+      try { window.localStorage.setItem(previewStorageKey(paidDraftId), preview); } catch {}
+      await deletePaidPropertyPhoto(paidDraftId).catch(() => {});
+      setPendingPhoto(null);
+      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+      setRightsConfirmed(false);
+      setPaidCreation({ sessionId: paymentSessionId, draftId: paidDraftId, verified: true });
+      setMessage('VoxelPop preview ready. Add the property address to build its source-backed interactive 3D map—still zero Meshy credits.');
+    } catch (error) {
+      setSourceReference(null);
+      setMessage(String(error?.message || error || 'The paid on-device VoxelPop preview could not be created.'));
     } finally { setBusy(''); }
   }
 
   async function usePhotoAndBuild() {
     if (!pendingPhoto || !session?.access_token || !draftId) return;
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
-    setBusy('local-build');
-    setSourceReference({ draftId, local: true });
-    setMessage('Building the VoxelPop preview on your iPhone…');
+
+    if (paidCreation?.verified && paidCreation?.draftId === draftId) {
+      await finishPaidLocalBuild(pendingPhoto, draftId, paidCreation.sessionId);
+      return;
+    }
+
+    setBusy('creation-checkout');
+    setMessage(`Keeping your photo on this device and opening secure ${CREATION_PRICE_LABEL} checkout…`);
     try {
-      await new Promise((resolve) => window.setTimeout(resolve, 240));
-      const preview = await makeLocalVoxelPreview(pendingPhoto);
-      setVoxelImage(preview);
-      try { window.localStorage.setItem(previewStorageKey(draftId), preview); } catch {}
-      setPendingPhoto(null);
-      setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
-      setRightsConfirmed(false);
-      setMessage('VoxelPop preview ready. Add the property address to build its source-backed interactive 3D map.');
+      await savePaidPropertyPhoto(draftId, pendingPhoto);
+      const response = await fetch('/api/property-generation/checkout', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ draftId, rightsConfirmed: true }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok || !data?.url) throw new Error(data?.error || 'VoxelPop checkout could not open.');
+      window.location.assign(data.url);
     } catch (error) {
-      setSourceReference(null);
-      setMessage(String(error?.message || error || 'The local VoxelPop preview could not be created.'));
-    } finally { setBusy(''); }
+      await deletePaidPropertyPhoto(draftId).catch(() => {});
+      setBusy('');
+      setMessage(String(error?.message || error || 'VoxelPop checkout could not open.'));
+    }
   }
 
   async function placeOnWorld(event) {
@@ -356,10 +445,12 @@ export default function PropertyJourneyPage() {
 
   function resetCreation() {
     const previousDraftId = draftId;
+    deletePaidPropertyPhoto(previousDraftId).catch(() => {});
     setDraftId(newDraftId());
     setPendingPhoto(null);
     setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
     setRightsConfirmed(false);
+    setPaidCreation(null);
     setSourceReference(null);
     setVoxelImage('');
     setAtlas(null);
@@ -397,7 +488,7 @@ export default function PropertyJourneyPage() {
 
   const displaySource = pendingPreview || '';
   const sourceAuthority = clean(building?.source?.authority || atlas?.reference?.source?.authority) || 'Open map data';
-  const pipelineRunning = busy === 'local-build' || busy === 'map';
+  const pipelineRunning = ['local-build', 'payment-return', 'creation-checkout', 'map'].includes(busy);
 
   return <main className={styles.page}>
     <section className={styles.maker}>
@@ -409,23 +500,23 @@ export default function PropertyJourneyPage() {
 
       {step === 1 ? <>
         <p className={styles.bigPrompt}>{pendingPhoto ? 'Ready to voxel it?' : 'Choose one photo.'}</p>
-        <p className={styles.flowHint}>Photo → VoxelPop preview → source-backed 3D map → My World → optional collection.</p>
+        <p className={styles.flowHint}>Photo → $4.99 create → VoxelPop preview → source-backed 3D map → My World → optional collection.</p>
         <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
         {displaySource ? <div className={styles.heroCard}><img src={displaySource} alt="Selected property reference"/><span className={styles.badge}>YOUR PHOTO</span></div> : <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>iPhone photos supported</span></div>}
         {pendingPhoto ? <div className={styles.choicePanel}>
           <label className={styles.rightsCheck}><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
-          <span>Preview is made on this device · no Meshy credits · no generation checkout.</span>
-          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'local-build'}>{busy === 'local-build' ? 'Building preview…' : 'Use photo → make VoxelPop preview'}</button>
+          <span>One creation · {CREATION_PRICE_LABEL} · photo stays on this device · 0 Meshy credits.</span>
+          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'creation-checkout' || busy === 'local-build'}>{busy === 'creation-checkout' ? 'Opening secure checkout…' : busy === 'local-build' ? 'Building preview…' : paidCreation?.verified && paidCreation?.draftId === draftId ? 'Create VoxelPop · paid' : `Pay ${CREATION_PRICE_LABEL} → create VoxelPop`}</button>
           <button className={styles.textButton} type="button" onClick={choosePhoto}>Choose another</button>
         </div> : <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>}
-        <p className={styles.truth}>Your source photo stays on this device for this preview and is not staged in Voxel Vault checkout storage. The VoxelPop image is a stylized visual preview; one photo cannot verify unseen sides, exact dimensions, roof details, title, ownership, or property value.</p>
+        <p className={styles.truth}>Your source photo stays on this device and is never staged in Voxel Vault checkout storage. The {CREATION_PRICE_LABEL} charge buys this digital VoxelPop creation; it does not buy the physical property or create ownership, title, rent, or investment rights.</p>
       </> : null}
 
       {step === 2 ? <>
         <p className={styles.bigPrompt}>Building your VoxelPop preview.</p>
-        <p className={styles.stepCopy}>This lightweight pass runs in your browser, so it does not spend Meshy credits or wait for a paid 3D provider.</p>
-        <div className={styles.heroCard}>{displaySource ? <img src={displaySource} alt="Photo being transformed into a VoxelPop preview"/> : null}<span className={styles.badge}>ON-DEVICE BUILD</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>NO PROVIDER CREDITS</b><span>Your interactive 3D comes next from source-backed map geometry.</span></div>
+        <p className={styles.stepCopy}>Your {CREATION_PRICE_LABEL} payment is verified. This lightweight pass runs in your browser, so it spends zero Meshy credits and does not upload the source photo for generation.</p>
+        <div className={styles.heroCard}>{displaySource ? <img src={displaySource} alt="Photo being transformed into a VoxelPop preview"/> : null}<span className={styles.badge}>PAID · ON-DEVICE BUILD</span><div className={styles.buildPulse}/></div>
+        <div className={styles.autoPanel}><b>0 MESHY CREDITS</b><span>Your interactive 3D comes next from source-backed map geometry.</span></div>
       </> : null}
 
       {step === 3 ? <>
@@ -472,7 +563,7 @@ export default function PropertyJourneyPage() {
           <button className={styles.textButton} type="button" onClick={() => { setWorldConfirmed(false); setMessage('Back in the interactive 3D map.'); }}>Back to 3D map</button>
           <button className={styles.textButton} type="button" onClick={() => { setMappedAddress(''); setAtlas(null); setBuilding(null); setQuote(null); setAvailability(''); setWorldConfirmed(false); setMessage('Enter the correct property address.'); }}>Change address</button>
         </div>
-        <p className={styles.truth}>Creation itself does not require Meshy credits or a pre-generation payment. If you choose Collect, that separate checkout purchases the digital VoxelPop collectible only. The photo, map, payment, World marker, or optional later mint does not create deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property.</p>
+        <p className={styles.truth}>The {CREATION_PRICE_LABEL} creation payment covers the on-device VoxelPop creation and source-backed 3D map; it uses zero Meshy credits. If you choose Collect, that separate checkout purchases the digital collectible only. Neither payment, the photo, map, World marker, nor optional later mint creates deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property.</p>
       </> : null}
 
       {step > 1 && !pipelineRunning ? <button className={styles.change} type="button" onClick={resetCreation}>Start over with another photo</button> : null}

--- a/lib/property-generation-browser-store.js
+++ b/lib/property-generation-browser-store.js
@@ -1,0 +1,91 @@
+const DB_NAME = 'voxelpop-paid-creation-v1';
+const DB_VERSION = 1;
+const STORE_NAME = 'source-photos';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function clean(value, max = 180) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !window.indexedDB) {
+      reject(new Error('This browser cannot safely keep your photo on-device through checkout. Use normal Safari or Chrome browsing.'));
+      return;
+    }
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) db.createObjectStore(STORE_NAME, { keyPath: 'draftId' });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('On-device VoxelPop checkout storage could not open.'));
+  });
+}
+
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error || new Error('On-device VoxelPop checkout storage failed.'));
+    transaction.onabort = () => reject(transaction.error || new Error('On-device VoxelPop checkout storage was interrupted.'));
+  });
+}
+
+export async function savePaidPropertyPhoto(draftIdRaw, file) {
+  const draftId = clean(draftIdRaw, 100);
+  if (!draftId || !(file instanceof Blob)) throw new Error('Choose a property photo first.');
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put({
+      draftId,
+      blob: file,
+      name: clean(file.name || 'property-photo', 120) || 'property-photo',
+      type: clean(file.type, 80),
+      lastModified: Number(file.lastModified || Date.now()),
+      savedAt: Date.now(),
+    });
+    await transactionDone(tx);
+  } finally {
+    db.close();
+  }
+}
+
+export async function loadPaidPropertyPhoto(draftIdRaw) {
+  const draftId = clean(draftIdRaw, 100);
+  if (!draftId) return null;
+  const db = await openDb();
+  try {
+    const record = await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const request = tx.objectStore(STORE_NAME).get(draftId);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => reject(request.error || new Error('Your on-device VoxelPop photo could not be restored.'));
+    });
+    if (!record?.blob) return null;
+    if (Date.now() - Number(record.savedAt || 0) > MAX_AGE_MS) {
+      await deletePaidPropertyPhoto(draftId).catch(() => {});
+      return null;
+    }
+    return new File([record.blob], record.name || 'property-photo', {
+      type: record.type || record.blob.type || 'image/jpeg',
+      lastModified: Number(record.lastModified || Date.now()),
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function deletePaidPropertyPhoto(draftIdRaw) {
+  const draftId = clean(draftIdRaw, 100);
+  if (!draftId || typeof window === 'undefined' || !window.indexedDB) return false;
+  const db = await openDb();
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(draftId);
+    await transactionDone(tx);
+    return true;
+  } finally {
+    db.close();
+  }
+}

--- a/lib/property-generation-payment.ts
+++ b/lib/property-generation-payment.ts
@@ -1,83 +1,15 @@
-import { createHash } from 'node:crypto';
 import { normalizePropertyDraftId } from './property-generation-ids';
 
 export const PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499;
 export const PROPERTY_VOXEL_GENERATION_PRICE_LABEL = '$4.99';
 export const PROPERTY_VOXEL_GENERATION_KIND = 'property_voxel_generation_v1';
 
-const BUCKET = 'voxel-system';
-const MAX_BYTES = 8 * 1024 * 1024;
-const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
-
 function clean(value: unknown, max = 500) {
   return String(value || '').trim().slice(0, max);
 }
 
-function safeSegment(value: unknown, fallback = 'item') {
-  const text = clean(value, 180).replace(/[^a-zA-Z0-9_.:-]+/g, '-').replace(/^-+|-+$/g, '');
-  return text || fallback;
-}
-
-function bucketMissing(error: any) {
-  const status = Number(error?.statusCode ?? error?.status ?? 0);
-  const message = String(error?.message || error || '');
-  return status === 404 || /bucket.*not found|not found.*bucket|bucket.*does not exist/i.test(message);
-}
-
-async function ensureBucket(admin: any) {
-  const created = await admin.storage.createBucket(BUCKET, { public: false, fileSizeLimit: '75MB' });
-  if (created.error && !/already exists/i.test(created.error.message || '')) {
-    throw new Error('Private VoxelPop storage is unavailable on this deployment.');
-  }
-}
-
-async function uploadStagedPhoto(admin: any, storagePath: string, bytes: Buffer, contentType: string) {
-  const options = { contentType, cacheControl: '0', upsert: true };
-  let uploaded = await admin.storage.from(BUCKET).upload(storagePath, bytes, options);
-  if (!uploaded.error) return;
-
-  if (!bucketMissing(uploaded.error)) {
-    throw new Error('Your photo could not be staged securely for checkout.');
-  }
-
-  await ensureBucket(admin);
-  uploaded = await admin.storage.from(BUCKET).upload(storagePath, bytes, options);
-  if (uploaded.error) throw new Error('Your photo could not be staged securely for checkout.');
-}
-
-export function propertyGenerationStagePath(userId: unknown, draftIdRaw: unknown) {
-  const draftId = normalizePropertyDraftId(clean(draftIdRaw, 100));
-  return `property-paid-inputs/${safeSegment(userId, 'user')}/${safeSegment(draftId, 'draft')}/source`;
-}
-
-export async function stagePaidPropertyPhoto(auth: any, draftIdRaw: unknown, photo: File) {
-  const draftId = normalizePropertyDraftId(clean(draftIdRaw, 100));
-  if (!(photo instanceof File)) throw new Error('Choose a property photo first.');
-  const contentType = String(photo.type || '').toLowerCase();
-  if (!ALLOWED_TYPES.has(contentType)) throw new Error('Use a JPG, PNG, or WebP property photo.');
-  if (photo.size <= 0 || photo.size > MAX_BYTES) throw new Error('Property photos must be smaller than 8 MB after preparation.');
-
-  const bytes = Buffer.from(await photo.arrayBuffer());
-  const digest = createHash('sha256').update(bytes).digest('hex');
-  const storagePath = propertyGenerationStagePath(auth.user.id, draftId);
-  await uploadStagedPhoto(auth.admin, storagePath, bytes, contentType);
-
-  return {
-    draftId,
-    storagePath,
-    digest,
-    contentType,
-    fileName: clean(photo.name || 'property-photo', 120) || 'property-photo',
-    sizeBytes: bytes.length,
-  };
-}
-
-export async function deleteStagedPropertyPhoto(auth: any, draftIdRaw: unknown) {
-  const storagePath = propertyGenerationStagePath(auth.user.id, draftIdRaw);
-  try {
-    await auth.admin.storage.from(BUCKET).remove([storagePath]);
-  } catch {}
-  return storagePath;
+export function propertyGenerationCheckoutDraft(draftIdRaw: unknown) {
+  return normalizePropertyDraftId(clean(draftIdRaw, 100));
 }
 
 export async function paidPropertyGenerationReceipt(auth: any, stripe: any, sessionIdRaw: unknown) {
@@ -85,9 +17,9 @@ export async function paidPropertyGenerationReceipt(auth: any, stripe: any, sess
   if (!sessionId) throw new Error('The VoxelPop payment session is missing.');
   const session = await stripe.checkout.sessions.retrieve(sessionId);
   const metadata = session?.metadata || {};
-  const draftId = normalizePropertyDraftId(clean(metadata.draft_id, 100));
+  const draftId = propertyGenerationCheckoutDraft(metadata.draft_id);
 
-  if (metadata.kind !== PROPERTY_VOXEL_GENERATION_KIND) throw new Error('This payment is not for a VoxelPop 3D creation.');
+  if (metadata.kind !== PROPERTY_VOXEL_GENERATION_KIND) throw new Error('This payment is not for a VoxelPop creation.');
   if (session.payment_status !== 'paid') throw new Error('Payment has not completed yet.');
   if (session.client_reference_id !== auth.user.id || metadata.voxelpop_user_id !== auth.user.id) {
     throw new Error('This VoxelPop purchase belongs to a different account.');
@@ -99,36 +31,5 @@ export async function paidPropertyGenerationReceipt(auth: any, stripe: any, sess
     throw new Error('The VoxelPop creation authorization is incomplete.');
   }
 
-  const expectedPath = propertyGenerationStagePath(auth.user.id, draftId);
-  const storagePath = clean(metadata.source_storage_path, 900);
-  if (storagePath !== expectedPath) throw new Error('The paid source photo does not match this creation.');
-
-  const digest = clean(metadata.source_sha256, 80);
-  const contentType = clean(metadata.source_content_type, 80).toLowerCase();
-  if (!/^[a-f0-9]{64}$/i.test(digest)) throw new Error('The paid source photo fingerprint is invalid.');
-  if (!ALLOWED_TYPES.has(contentType)) throw new Error('The paid source photo format is unsupported.');
-
-  return {
-    session,
-    draftId,
-    storagePath,
-    digest,
-    contentType,
-    fileName: clean(metadata.source_name, 120) || 'property-photo',
-  };
-}
-
-export async function loadPaidPropertyGenerationPhoto(auth: any, receipt: any) {
-  const { data, error } = await auth.admin.storage.from(BUCKET).download(receipt.storagePath);
-  if (error || !data) throw new Error('The paid source photo is no longer available.');
-  const bytes = Buffer.from(await data.arrayBuffer());
-  if (!bytes.length || bytes.length > MAX_BYTES) throw new Error('The paid source photo is invalid.');
-  const digest = createHash('sha256').update(bytes).digest('hex');
-  if (digest !== receipt.digest) throw new Error('The paid source photo changed after checkout started.');
-  return { ...receipt, bytes };
-}
-
-export async function paidPropertyGenerationInput(auth: any, stripe: any, sessionIdRaw: unknown) {
-  const receipt = await paidPropertyGenerationReceipt(auth, stripe, sessionIdRaw);
-  return loadPaidPropertyGenerationPhoto(auth, receipt);
+  return { session, draftId };
 }

--- a/scripts/test-meshy-polycount-limit.mjs
+++ b/scripts/test-meshy-polycount-limit.mjs
@@ -6,17 +6,23 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), '
 const directPhotoRoute = read('app/api/property-photo-upload/route.ts');
 const property3dRoute = read('app/api/property-voxel-3d/route.ts');
 
-for (const [name, source] of [
-  ['direct photo -> 3D', directPhotoRoute],
-  ['voxel image -> final 3D', property3dRoute],
-]) {
-  assert.match(source, /ai_model:\s*'meshy-t2'/, `${name} must keep the intended Meshy model explicit`);
-  const polycounts = [...source.matchAll(/target_polycount:\s*(\d+)/g)].map((match) => Number(match[1]));
-  assert.ok(polycounts.length > 0, `${name} must declare a target polycount`);
-  for (const value of polycounts) {
-    assert.ok(value >= 100 && value <= 15000, `${name} target_polycount ${value} must stay within the meshy-t2 100..15000 range`);
-  }
-  assert.ok(polycounts.includes(15000), `${name} should use the supported meshy-t2 maximum of 15000`);
-}
+// Normal Property creation no longer hands the photo to Meshy at all. Keep this
+// regression explicit so a future compatibility edit cannot silently make the
+// $4.99 creation path spend provider credits again.
+assert.match(directPhotoRoute, /paidPropertyGenerationReceipt/, 'retired photo handoff may only verify an already-paid creation');
+assert.match(directPhotoRoute, /migrated: true/, 'retired photo handoff must direct clients to the zero-credit maker');
+assert.match(directPhotoRoute, /meshyCredits: 0/, 'retired photo handoff must explicitly report zero Meshy credits');
+assert.doesNotMatch(directPhotoRoute, /api\.meshy\.ai|MESHY_API_KEY|ai_model|target_polycount|image-to-3d|readMeshyCreditBalance/, 'normal paid property photo handoff must never call or configure Meshy');
 
-console.log('Meshy property polycount checks passed: source and final 3D requests stay within the meshy-t2 100..15000 range.');
+// A legacy/manual 3D route still exists elsewhere in the app. If that route is
+// deliberately used by another surface, keep its provider request bounded to
+// Meshy's supported meshy-t2 polycount range. The Property maker does not call it.
+assert.match(property3dRoute, /ai_model:\s*'meshy-t2'/, 'legacy/manual property 3D route must keep the intended Meshy model explicit');
+const polycounts = [...property3dRoute.matchAll(/target_polycount:\s*(\d+)/g)].map((match) => Number(match[1]));
+assert.ok(polycounts.length > 0, 'legacy/manual property 3D route must declare a target polycount');
+for (const value of polycounts) {
+  assert.ok(value >= 100 && value <= 15000, `legacy/manual property 3D target_polycount ${value} must stay within the meshy-t2 100..15000 range`);
+}
+assert.ok(polycounts.includes(15000), 'legacy/manual property 3D route should keep the supported meshy-t2 maximum of 15000');
+
+console.log('Property 3D regression passed: the normal $4.99 Property maker spends zero Meshy credits and its retired photo handoff cannot invoke Meshy; any separate legacy/manual Meshy 3D route remains bounded to meshy-t2 100..15000.');

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -3,31 +3,49 @@ import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const property = read('app/property/page.js');
-const legacyCheckout = read('app/api/property-generation/checkout/route.ts');
+const generationCheckout = read('app/api/property-generation/checkout/route.ts');
+const payment = read('lib/property-generation-payment.ts');
+const browserStore = read('lib/property-generation-browser-store.js');
 const collectibleCheckout = read('app/api/property-collectible/checkout/route.ts');
 const collectibleCommerce = read('lib/property-collectible-commerce.ts');
 
-assert.doesNotMatch(property, /CREATION_PRICE_LABEL|Pay \$4\.99|Opening \$4\.99 checkout/, 'normal property creation must not carry the old $4.99 generation paywall');
-assert.doesNotMatch(property, /\/api\/property-generation\/checkout/, 'photo approval must not invoke pre-generation checkout');
-assert.match(property, /Preview is made on this device · no Meshy credits · no generation checkout\./, 'maker must plainly describe the free local creation step');
-assert.match(property, /Creation itself does not require Meshy credits or a pre-generation payment\./, 'collection screen must keep generation and optional purchase separate');
+assert.match(property, /CREATION_PRICE_LABEL = '\$4\.99'/, 'normal property creation must keep the $4.99 create price');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} → create VoxelPop/, 'maker must disclose payment before creation');
+assert.match(property, /\/api\/property-generation\/checkout/, 'photo approval must invoke the creation checkout');
+assert.match(property, /savePaidPropertyPhoto/, 'photo must stay on-device while the user is at Stripe');
+assert.match(property, /loadPaidPropertyPhoto/, 'paid return must restore the on-device photo');
+assert.match(property, /zero Meshy credits|0 Meshy credits/i, 'creation must remain zero-credit despite the payment gate');
+assert.doesNotMatch(property, /fetch\('\/api\/property-photo-upload'/, 'creation payment must not lead to Meshy source upload');
+assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-3d'|fetch\('\/api\/property-voxel-image'/, 'paid creation must not call paid Meshy generation routes');
 
-assert.match(legacyCheckout, /requireVoxelVaultUser/, 'legacy endpoint remains account gated while stale clients phase out');
-assert.match(legacyCheckout, /migrated: true/, 'legacy endpoint must explicitly signal the retired flow');
-assert.match(legacyCheckout, /Refresh the Property maker/, 'stale clients should get a useful recovery action');
-assert.doesNotMatch(legacyCheckout, /stagePaidPropertyPhoto/, 'legacy endpoint must never stage a private photo');
-assert.doesNotMatch(legacyCheckout, /storage\.|createBucket|voxel-system/, 'legacy endpoint must not touch private checkout storage');
-assert.doesNotMatch(legacyCheckout, /readMeshyCreditBalance|MESHY_PROPERTY_CREDITS|MESHY_API_KEY/, 'legacy endpoint must not depend on Meshy capacity');
-assert.doesNotMatch(legacyCheckout, /stripe\.checkout\.sessions\.create/, 'legacy endpoint must not charge for generation');
-assert.doesNotMatch(legacyCheckout, /Private VoxelPop checkout storage could not be prepared/, 'the exact private-storage failure must be unreachable from the retired checkout');
+assert.match(payment, /PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499/, 'server-authoritative VoxelPop creation price must be $4.99');
+assert.match(payment, /PROPERTY_VOXEL_GENERATION_KIND = 'property_voxel_generation_v1'/, 'creation checkout must retain the existing product rail');
+assert.match(payment, /session\.payment_status !== 'paid'/, 'creation unlock must require a paid Stripe session');
+assert.match(payment, /session\.client_reference_id !== auth\.user\.id/, 'paid creation must remain bound to the signed-in buyer');
+assert.match(payment, /metadata\.voxelpop_user_id !== auth\.user\.id/, 'Stripe metadata must independently bind payment to the account');
+assert.match(payment, /Number\(session\.amount_total \|\| 0\) !== PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'server must verify the exact paid amount');
+assert.doesNotMatch(payment, /storage\.|createBucket|voxel-system|stagePaidPropertyPhoto|loadPaidPropertyGenerationPhoto|MESHY/i, 'payment helper must never depend on private source storage or Meshy');
 
-assert.match(collectibleCheckout, /stripe\.checkout\.sessions\.create/, 'optional final Collect remains a real server-created Stripe checkout');
+assert.match(generationCheckout, /requireVoxelVaultUser/, 'checkout must require a signed-in account');
+assert.match(generationCheckout, /stripe\.checkout\.sessions\.create/, 'creation gate must use server-created Stripe Checkout');
+assert.match(generationCheckout, /unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'client cannot choose the generation price');
+assert.match(generationCheckout, /creation_engine: 'on_device_voxel_plus_source_backed_3d_map'/, 'Stripe must record the truthful zero-credit creation engine');
+assert.match(generationCheckout, /source_photo_storage: 'device_only_not_uploaded_for_creation'/, 'Stripe must record that the source photo stays on-device');
+assert.match(generationCheckout, /meshy_credits: '0'/, 'Stripe metadata must explicitly record zero Meshy credits');
+assert.match(generationCheckout, /paidPropertyGenerationReceipt/, 'success return must re-verify Stripe server-side');
+assert.doesNotMatch(generationCheckout, /readMeshyCreditBalance|MESHY_PROPERTY_CREDITS|MESHY_API_KEY|storage\.|createBucket|voxel-system|stagePaidPropertyPhoto/, 'creation checkout must not touch Meshy or private source storage');
+assert.doesNotMatch(generationCheckout, /Private VoxelPop checkout storage could not be prepared/, 'the old checkout-storage failure must be unreachable');
+
+assert.match(browserStore, /indexedDB/, 'source photo must remain on the customer device through Stripe');
+assert.match(browserStore, /MAX_AGE_MS = 24 \* 60 \* 60 \* 1000/, 'temporary on-device checkout photo must expire');
+
+assert.match(collectibleCheckout, /stripe\.checkout\.sessions\.create/, 'optional final Collect remains a separate real server-created Stripe checkout');
 assert.match(collectibleCheckout, /unit_amount: quote\.priceCents/, 'optional collectible price remains server-authoritative');
-assert.match(collectibleCheckout, /source-backed mapped 3D geometry/, 'Stripe must accurately describe a map-backed digital collectible');
+assert.match(collectibleCheckout, /source-backed mapped 3D geometry/, 'collectible Stripe copy must accurately describe the map-backed asset');
 assert.match(collectibleCheckout, /rights: 'digital_only_no_real_property_rights'/, 'collection payment must preserve the digital-only rights boundary');
 assert.match(collectibleCheckout, /minting: 'optional_after_purchase_and_property_verification'/, 'minting stays optional and downstream of verification');
 
 for (const cents of ['199', '299', '399']) assert.match(collectibleCommerce, new RegExp(`priceCents: ${cents}`), 'optional collectible pricing should remain in the $1.99-$3.99 sandbox range');
 assert.match(collectibleCommerce, /mapBacked: true/, 'optional checkout may securely collect the map-backed asset without a GLB');
 
-console.log('VoxelPop generation-paywall retirement regression passed: creation uses no Meshy credits or private checkout staging, while optional end-of-flow digital collection remains server-authoritative and legally separate from real property.');
+console.log('Paid zero-credit creation regression passed: $4.99 is required for the on-device VoxelPop + source-backed 3D map creation, the source photo never enters checkout storage, Meshy usage stays at zero, and optional later digital collection remains legally separate from real property.');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -6,23 +6,44 @@ const property = read('app/property/page.js');
 const css = read('app/property/property.module.css');
 const geo = read('app/geo/GeoReferenceModel.js');
 const worldAtlas = read('lib/world-atlas.js');
-const legacyCheckout = read('app/api/property-generation/checkout/route.ts');
+const generationCheckout = read('app/api/property-generation/checkout/route.ts');
+const payment = read('lib/property-generation-payment.ts');
+const browserStore = read('lib/property-generation-browser-store.js');
 const collectible = read('lib/property-collectible-commerce.ts');
 const complete = read('app/api/property-collectible/complete/route.ts');
 
-assert.match(property, /async function makeLocalVoxelPreview\(file\)/, 'photo approval must have an on-device VoxelPop renderer');
-assert.match(property, /imageSmoothingEnabled = false/, 'local preview must keep crisp pixel/voxel edges');
-assert.match(property, /toDataURL\('image\/jpeg', 0\.8\)/, 'local preview should be bounded and reusable across checkout return');
-assert.match(property, /window\.localStorage\.setItem\(previewStorageKey\(draftId\), preview\)/, 'small completed preview should stay available locally across optional collection checkout');
+assert.match(property, /async function makeLocalVoxelPreview\(file\)/, 'paid creation must still use the zero-credit on-device VoxelPop renderer');
+assert.match(property, /imageSmoothingEnabled = false/, 'local preview must keep crisp pixel\/voxel edges');
+assert.match(property, /toDataURL\('image\/jpeg', 0\.8\)/, 'local preview should remain bounded and reusable');
+assert.match(property, /window\.localStorage\.setItem\(previewStorageKey\(paidDraftId\), preview\)/, 'completed paid preview should stay available locally across optional collection checkout');
 assert.match(property, /I took this photo or have permission to use it\./, 'photo use must still require rights confirmation');
-assert.match(property, /no Meshy credits · no generation checkout/i, 'the maker must clearly explain the zero-credit creation path');
-assert.doesNotMatch(property, /fetch\('\/api\/property-generation\/checkout'/, 'the maker must not open the retired pre-generation checkout');
-assert.doesNotMatch(property, /fetch\('\/api\/property-photo-upload'/, 'the normal property maker must not upload the source photo to start generation');
-assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-3d'/, 'the normal property maker must not spend Meshy 3D credits');
-assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-image'/, 'the normal property maker must not spend Meshy image credits');
-assert.doesNotMatch(property, /MeshyModelViewer/, 'the normal maker should use map geometry instead of a provider GLB viewer');
+assert.match(property, /const CREATION_PRICE_LABEL = '\$4\.99'/, 'maker must expose the $4.99 creation price');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} → create VoxelPop/, 'primary creation action must require payment');
+assert.match(property, /savePaidPropertyPhoto\(draftId, pendingPhoto\)/, 'source photo must be retained only on-device through Stripe');
+assert.match(property, /\/api\/property-generation\/checkout/, 'maker must use the server-authoritative creation checkout');
+assert.match(property, /loadPaidPropertyPhoto\(data\.draftId\)/, 'paid return must restore the device-local source');
+assert.match(property, /0 Meshy credits|zero Meshy credits/i, 'maker must clearly explain the zero-credit creation path');
+assert.doesNotMatch(property, /fetch\('\/api\/property-photo-upload'/, 'normal paid creation must not upload the source photo for provider generation');
+assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-3d'/, 'normal creation must not spend Meshy 3D credits');
+assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-image'/, 'normal creation must not spend Meshy image credits');
+assert.doesNotMatch(property, /MeshyModelViewer/, 'normal maker should use map geometry instead of a provider GLB viewer');
 
-assert.match(property, /GeoReferenceModel/, 'the maker must use the source-backed interactive 3D renderer');
+assert.match(payment, /PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499/, 'server-authoritative creation price must be exactly $4.99');
+assert.match(payment, /session\.payment_status !== 'paid'/, 'paid return must verify Stripe payment status');
+assert.match(payment, /session\.client_reference_id !== auth\.user\.id/, 'creation payment must stay account-bound');
+assert.doesNotMatch(payment, /storage\.|createBucket|voxel-system|MESHY/i, 'payment verification must not depend on checkout storage or Meshy');
+
+assert.match(browserStore, /indexedDB/, 'source photo must survive Stripe redirect in browser-only storage');
+assert.match(browserStore, /MAX_AGE_MS = 24 \* 60 \* 60 \* 1000/, 'temporary on-device checkout source must expire');
+
+assert.match(generationCheckout, /stripe\.checkout\.sessions\.create/, 'creation gate must use real server-created Stripe Checkout');
+assert.match(generationCheckout, /unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'client cannot choose the $4.99 price');
+assert.match(generationCheckout, /meshy_credits: '0'/, 'Stripe metadata must record the zero-Meshy creation engine');
+assert.match(generationCheckout, /source_photo_storage: 'device_only_not_uploaded_for_creation'/, 'Stripe metadata must record device-only photo handling');
+assert.match(generationCheckout, /paidPropertyGenerationReceipt/, 'return endpoint must re-verify the paid session');
+assert.doesNotMatch(generationCheckout, /readMeshyCreditBalance|MESHY_PROPERTY_CREDITS|MESHY_API_KEY|storage\.|createBucket|stagePaidPropertyPhoto/, 'creation checkout must not touch Meshy or private source storage');
+
+assert.match(property, /GeoReferenceModel/, 'maker must use the source-backed interactive 3D renderer');
 assert.match(property, /\/api\/world-atlas\/inspect/, 'address verification must build from the World Atlas');
 assert.match(property, /viewMode=\{mapView\}/, '3D map must support switchable camera views');
 assert.match(property, /\['orbit', 'street', 'top'\]/, '3D map must expose orbit, street, and top modes');
@@ -34,15 +55,11 @@ assert.match(css, /\.mapControls\{/, 'property UI needs touch-friendly map camer
 assert.match(css, /\.mapFacts\{/, 'map source and selected-building context must be visible');
 
 assert.match(geo, /addVoxelShell/, 'source-backed building footprints must render as lightweight voxel geometry');
-assert.match(geo, /addPublicRealmContext/, '3D map should include source-backed street/path context when available');
-assert.match(geo, /touchAction = 'none'/, '3D map must retain iPhone drag/pinch interaction');
+assert.match(geo, /addPublicRealmContext/, '3D map should include source-backed street\/path context when available');
+assert.match(geo, /touchAction = 'none'/, '3D map must retain iPhone drag\/pinch interaction');
 assert.match(worldAtlas, /fetchOvertureBuildingNeighborhood/, 'World Atlas must use Overture building data first');
 assert.match(worldAtlas, /fetchGlobalNeighborhoodReference/, 'World Atlas must retain OpenStreetMap fallback coverage');
 assert.match(worldAtlas, /No replacement building was invented/, 'map failures must never invent a replacement building');
-
-assert.match(legacyCheckout, /migrated: true/, 'old pre-generation clients must be directed to the zero-credit flow');
-assert.match(legacyCheckout, /no longer needs a pre-generation checkout, private photo staging, or Meshy credits/, 'legacy checkout response must explain the migration');
-assert.doesNotMatch(legacyCheckout, /stagePaidPropertyPhoto|readMeshyCreditBalance|stripe\.checkout|MESHY_API_KEY/, 'retired generation checkout must not touch Storage, Stripe, or Meshy');
 
 assert.match(collectible, /const mapBackedTaskId = `map-voxel:\$\{draftId\}`/, 'collectible verification must recognize the exact map-backed draft identifier');
 assert.match(collectible, /mapBacked: true/, 'map-backed collectible verification must be explicit');
@@ -50,4 +67,4 @@ assert.match(collectible, /atlasId\.startsWith\('location:'\)/, 'map-backed coll
 assert.match(complete, /source-backed-map-geometry/, 'paid map-backed collectibles must be delivered without pretending a GLB exists');
 assert.match(complete, /no Meshy generation credit or private GLB storage is required/, 'delivery disclosure must describe the zero-credit asset truthfully');
 
-console.log('Zero-credit VoxelPop property regression passed: authorized photo -> on-device voxel preview -> source-backed Overture/OSM 3D neighborhood -> private My World preview -> optional collection, with no Meshy or pre-generation Storage dependency.');
+console.log('Paid zero-credit VoxelPop property regression passed: authorized device-local photo -> server-authoritative $4.99 Stripe payment -> on-device voxel preview -> source-backed Overture\/OSM 3D neighborhood -> private My World preview -> optional collection, with zero Meshy credits and no pre-generation source upload.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -9,7 +9,9 @@ const property = read('app/property/page.js');
 const propertyCss = read('app/property/property.module.css');
 const geo = read('app/geo/GeoReferenceModel.js');
 const worldAtlas = read('lib/world-atlas.js');
-const legacyGenerationCheckout = read('app/api/property-generation/checkout/route.ts');
+const generationCheckout = read('app/api/property-generation/checkout/route.ts');
+const generationPayment = read('lib/property-generation-payment.ts');
+const browserStore = read('lib/property-generation-browser-store.js');
 const collectibleCommerce = read('lib/property-collectible-commerce.ts');
 const quoteRoute = read('app/api/property-collectible/quote/route.ts');
 const checkoutRoute = read('app/api/property-collectible/checkout/route.ts');
@@ -46,21 +48,32 @@ assert.match(property, /Sign in first\./, 'signed-out maker must expose the acco
 assert.match(property, /Continue with Google/, 'account gate has one clear sign-in action');
 assert.match(property, /const labels = \['PHOTO', 'BUILD', 'VOXEL', 'WORLD', 'COLLECT'\]/, 'guided labels stay familiar');
 assert.match(property, /Choose one photo\./, 'first signed-in step must be photo');
-assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC/HEIF selection remains supported');
+assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC\/HEIF selection remains supported');
 assert.match(property, /normalizeIphonePhoto/, 'iPhone HEIC preparation remains automatic');
 assert.match(property, /I took this photo or have permission to use it\./, 'source photo must require rights confirmation');
-assert.match(property, /Use photo → make VoxelPop preview/, 'one photo approval must start the lightweight VoxelPop journey');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} → create VoxelPop/, 'photo approval must clearly require the $4.99 creation payment');
 
-// Creation is local and zero-credit; stale paid-generation clients fail safely.
-assert.match(property, /makeLocalVoxelPreview/, 'normal creation needs an on-device VoxelPop preview');
+// Creation is paid but local and zero-credit; no source-photo checkout bucket or Meshy is allowed.
+assert.match(property, /const CREATION_PRICE_LABEL = '\$4\.99'/, 'maker keeps the $4.99 creation price');
+assert.match(property, /makeLocalVoxelPreview/, 'paid creation uses an on-device VoxelPop preview');
 assert.match(property, /imageSmoothingEnabled = false/, 'preview must retain crisp pixel edges');
-assert.match(property, /no Meshy credits · no generation checkout/i, 'zero-credit behavior must be visible');
-assert.doesNotMatch(property, /fetch\('\/api\/property-generation\/checkout'/, 'normal creation must not open the retired generation checkout');
-assert.doesNotMatch(property, /fetch\('\/api\/property-photo-upload'/, 'source photo must not be staged server-side for normal creation');
+assert.match(property, /savePaidPropertyPhoto\(draftId, pendingPhoto\)/, 'photo must be kept on-device through checkout');
+assert.match(property, /fetch\('\/api\/property-generation\/checkout'/, 'normal creation must open the server-authoritative $4.99 checkout');
+assert.match(property, /loadPaidPropertyPhoto\(data\.draftId\)/, 'paid return must restore the local source photo');
+assert.match(property, /zero Meshy credits|0 Meshy credits/i, 'zero-credit behavior must remain visible after payment');
+assert.doesNotMatch(property, /fetch\('\/api\/property-photo-upload'/, 'normal creation must not stage or upload the source photo for generation');
 assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-3d'/, 'normal creation must not call paid provider 3D generation');
 assert.doesNotMatch(property, /fetch\('\/api\/property-voxel-image'/, 'normal creation must not call paid provider image generation');
-assert.match(legacyGenerationCheckout, /migrated: true/, 'stale clients must get a migration response');
-assert.doesNotMatch(legacyGenerationCheckout, /stagePaidPropertyPhoto|readMeshyCreditBalance|stripe\.checkout/, 'retired generation endpoint must not stage photos, check credits, or charge');
+assert.match(generationPayment, /PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499/, 'server must own the exact $4.99 price');
+assert.match(generationPayment, /session\.payment_status !== 'paid'/, 'paid creation must re-verify Stripe status');
+assert.doesNotMatch(generationPayment, /storage\.|createBucket|voxel-system|MESHY/i, 'creation payment helper cannot depend on source storage or Meshy');
+assert.match(browserStore, /indexedDB/, 'source photo must survive Stripe locally on the device');
+assert.match(generationCheckout, /stripe\.checkout\.sessions\.create/, 'creation checkout must be a real Stripe payment');
+assert.match(generationCheckout, /unit_amount: PROPERTY_VOXEL_GENERATION_PRICE_CENTS/, 'creation price cannot be chosen by the client');
+assert.match(generationCheckout, /meshy_credits: '0'/, 'checkout metadata must truthfully record zero Meshy credits');
+assert.match(generationCheckout, /source_photo_storage: 'device_only_not_uploaded_for_creation'/, 'checkout must truthfully record device-only source handling');
+assert.doesNotMatch(generationCheckout, /stagePaidPropertyPhoto|readMeshyCreditBalance|MESHY_PROPERTY_CREDITS|MESHY_API_KEY|storage\.|createBucket|voxel-system/, 'creation checkout must not stage photos, inspect Meshy, or spend provider credits');
+assert.doesNotMatch(generationCheckout, /Private VoxelPop checkout storage could not be prepared/, 'the old private checkout-storage failure must be unreachable');
 
 // Address opens the improved source-backed 3D map.
 assert.match(property, /Build 3D map \+ verify address/, 'address action must explicitly build the 3D map');
@@ -96,7 +109,7 @@ assert.match(quoteRoute, /digital build complexity, not the market value of the 
 // Map-backed assets can be collected without weakening identity/payment controls.
 assert.match(collectibleCommerce, /propertyCollectibleIdentity/, 'collection uniqueness must use server-derived World identity');
 assert.match(collectibleCommerce, /atlasId\.startsWith\('location:'\)/, 'fallback coordinates cannot become once-only property identity');
-assert.match(collectibleCommerce, /state === 'paid' \|\| state === 'minted'/, 'paid/minted reservations remain permanently locked');
+assert.match(collectibleCommerce, /state === 'paid' \|\| state === 'minted'/, 'paid\/minted reservations remain permanently locked');
 assert.match(collectibleCommerce, /const mapBackedTaskId = `map-voxel:\$\{draftId\}`/, 'map-backed item must be exactly tied to the draft');
 assert.match(collectibleCommerce, /mapBacked: true/, 'map-backed collectible path must be explicit');
 assert.match(collectibleCommerce, /propertyDraftItemId\(input\.userId, draftId, 'voxel'\)/, 'legacy generated GLBs must retain account-scoped ownership verification');
@@ -113,7 +126,7 @@ assert.match(webhook, /secureStripePropertyCollectiblePurchase/, 'signed Stripe 
 // Completion saves map geometry or legacy GLB without requiring new private model storage.
 assert.match(completeRoute, /secureStripePropertyCollectiblePurchase/, 'success path re-verifies Stripe payment and buyer');
 assert.match(completeRoute, /atlasId: purchase\.atlasId/, 'success re-binds verification to mapped identity');
-assert.match(completeRoute, /source-backed-map-geometry/, 'map-backed delivery must identify its storage/render basis');
+assert.match(completeRoute, /source-backed-map-geometry/, 'map-backed delivery must identify its storage\/render basis');
 assert.match(completeRoute, /modelUrl: durableModelUrl/, 'legacy purchased GLBs keep their durable model URL path');
 assert.match(success, /GeoReferenceModel/, 'success screen can render a map-backed collectible');
 assert.match(success, /data\.model\.mapBacked === true/, 'Vault save must distinguish map-backed and generated assets');
@@ -123,7 +136,7 @@ assert.match(success, /Create Another/, 'success loop offers another creation');
 assert.match(success, /View My World/, 'success loop offers My World');
 assert.match(success, /Verify &amp; Mint · optional/, 'mint remains optional after collection');
 
-// Vault/World privacy and canonical property minting remain unchanged.
+// Vault\/World privacy and canonical property minting remain unchanged.
 assert.match(vault, /Your collection\./, 'Vault remains the inventory hub');
 assert.match(vault, /Create Another/, 'Vault has a repeat loop');
 assert.match(vault, /View My World/, 'Vault links to My World');
@@ -145,4 +158,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /if \(pathname === '\/property'\) return null;/, 'fixed app dock stays out of guided maker');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> authorized on-device voxel preview -> source-backed Overture/OSM 3D neighborhood -> private My World preview -> optional server-priced digital collection -> Vault -> optional verified mint, with no Meshy or pre-generation Storage dependency.');
+console.log('Guided VoxelPop property checks passed: sign in -> authorized device-local photo -> server-authoritative $4.99 creation payment -> zero-credit on-device voxel preview -> source-backed Overture\/OSM 3D neighborhood -> private My World preview -> optional server-priced digital collection -> Vault -> optional verified mint, with no Meshy or source-photo checkout Storage dependency.');


### PR DESCRIPTION
Superseded by merged PR #425. #425 already implements the requested end state on current main more completely: it preserves the paid $4.99 Property journey, moves guided creation to a device-local image-first Three.js voxel engine with no metered Meshy generation, removes checkout source-photo Storage staging, and upgrades the source-backed focused property map. #425 passed the web build, full quality gate, Mobile WebGL Guard, and both contract suites, and current main is deployed successfully. Do not merge #426 over it.