### PR TITLE
Keep the $1.99 Property Sandbox unmistakably demo-only

### DIFF
--- a/app/geo/slice/page.js
+++ b/app/geo/slice/page.js
@@ -2,162 +2,207 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { useWalletIdentity } from '../../components/WalletIdentity';
 import styles from './page.module.css';
 
-const SLICE_KEY='voxel-vault:property-slice-sandbox';
-const PURCHASE_KEY='voxel-vault:property-slice-purchases';
-const MONEY_KEY='voxel-vault:unified-money-preview';
-const DEFAULT_DEMO_USD_CENTS=1240;
-function toCents(value){const n=Number(value||0);return Number.isFinite(n)?Math.round(n*100):0}
-function money(cents){return new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(cents||0)/100)}
-function referenceMoney(value){const n=Number(value||0);return Number.isFinite(n)?new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:0}).format(n):'$0'}
-function percent(value){const n=Number(value||0);if(!Number.isFinite(n))return'0%';return n>0&&n<0.0001?`${n.toExponential(3)}%`:`${n.toFixed(6)}%`}
-function indexLabel(value){const n=Number(value||0);return Number.isFinite(n)?`${n.toFixed(2)}×`:'—'}
+const SLICE_KEY = 'voxel-vault:property-slice-sandbox';
+const PURCHASE_KEY = 'voxel-vault:property-slice-purchases';
+const DEFAULT_DEMO_USD_CENTS = 1240;
 
-export default function PropertySlicePage(){
-  const {address,connected,connect}=useWalletIdentity();
-  const [slice,setSlice]=useState({selectedName:'Selected property',selectedPrice:'100000',benchmarkName:'My anchor property',benchmarkPrice:'100000',amount:'1.99'});
-  const [sliceResult,setSliceResult]=useState(null);
-  const [purchase,setPurchase]=useState({demoUsdCents:DEFAULT_DEMO_USD_CENTS,demoUnits:0,lastPurchase:null});
-  const [sliceBusy,setSliceBusy]=useState(false);
-  const [moneyInputs,setMoneyInputs]=useState({usd:'12.40',crypto:'0',nft:'0',property:'0'});
-  const [moneyResult,setMoneyResult]=useState(null);
-  const [moneyBusy,setMoneyBusy]=useState(false);
-  const [message,setMessage]=useState('Sandbox only · no real money or property rights move here.');
-  const shortWallet=useMemo(()=>address?`${address.slice(0,6)}…${address.slice(-4)}`:'',[address]);
-  const selected=Number(slice.selectedPrice||0);const benchmark=Number(slice.benchmarkPrice||0);const amount=Number(slice.amount||0);
-  const benchmarkWeight=sliceResult?.relativePropertyPriceIndex??(benchmark>0?selected/benchmark:0);
-  const adjustedCents=sliceResult?.adjustedTestPriceCents??(benchmark>0?Math.max(1,Math.round(toCents(slice.amount)*(selected/benchmark))):toCents(slice.amount));
-  const slicePercent=sliceResult?.hypotheticalPercent??(benchmark>0?(amount/benchmark)*100:0);
-  const demoUsdDisplay=money(purchase.demoUsdCents);
-  const unitLabel=purchase.demoUnits===1?'1 demo slice':`${purchase.demoUnits} demo slices`;
+function toCents(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? Math.round(number * 100) : 0;
+}
+function money(cents) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(cents || 0) / 100);
+}
+function referenceMoney(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(number) : '$0';
+}
+function percent(value) {
+  const number = Number(value || 0);
+  if (!Number.isFinite(number)) return '0%';
+  return number > 0 && number < 0.0001 ? `${number.toExponential(3)}%` : `${number.toFixed(6)}%`;
+}
+function indexLabel(value) {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? `${number.toFixed(2)}×` : '—';
+}
+function unitLabelFor(count) {
+  return Number(count) === 1 ? '1 demo slice' : `${Number(count) || 0} demo slices`;
+}
 
-  useEffect(()=>{try{
-    const saved=JSON.parse(window.localStorage.getItem(SLICE_KEY)||'null');if(saved?.slice)setSlice(saved.slice);if(saved?.result)setSliceResult(saved.result);
-    const purchaseSaved=JSON.parse(window.localStorage.getItem(PURCHASE_KEY)||'null');
-    const persistedDemoUsdCents=purchaseSaved?.demoUsdCents>=0?Number(purchaseSaved.demoUsdCents):null;
-    if(persistedDemoUsdCents!==null)setPurchase({demoUsdCents:persistedDemoUsdCents,demoUnits:Number(purchaseSaved.demoUnits||0),lastPurchase:purchaseSaved.lastPurchase||null});
-    const moneySaved=JSON.parse(window.localStorage.getItem(MONEY_KEY)||'null');
-    if(moneySaved?.inputs)setMoneyInputs({...moneySaved.inputs,...(persistedDemoUsdCents!==null?{usd:(persistedDemoUsdCents/100).toFixed(2)}:{})});
-    else if(persistedDemoUsdCents!==null)setMoneyInputs(c=>({...c,usd:(persistedDemoUsdCents/100).toFixed(2)}));
-    if(moneySaved?.result)setMoneyResult(moneySaved.result);
-  }catch{}},[]);
+export default function PropertySlicePage() {
+  const [slice, setSlice] = useState({
+    selectedName: 'Selected property',
+    selectedPrice: '100000',
+    benchmarkName: 'Anchor property',
+    benchmarkPrice: '100000',
+    amount: '1.99',
+  });
+  const [sliceResult, setSliceResult] = useState(null);
+  const [purchase, setPurchase] = useState({ demoUsdCents: DEFAULT_DEMO_USD_CENTS, demoUnits: 0, lastPurchase: null });
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('Sandbox only · no real money moves and no property rights are created.');
 
-  function changeSlice(key,value){setSlice(c=>({...c,[key]:value}));setSliceResult(null)}
-  function changeMoney(key,value){
-    setMoneyInputs(c=>({...c,[key]:value}));
-    if(key==='usd')setPurchase(c=>({...c,demoUsdCents:Math.max(0,toCents(value))}));
+  const selected = Number(slice.selectedPrice || 0);
+  const benchmark = Number(slice.benchmarkPrice || 0);
+  const amount = Number(slice.amount || 0);
+  const relativeIndex = sliceResult?.relativePropertyPriceIndex ?? (benchmark > 0 ? selected / benchmark : 0);
+  const adjustedCents = sliceResult?.adjustedTestPriceCents ?? (benchmark > 0 ? Math.max(1, Math.round(toCents(slice.amount) * (selected / benchmark))) : toCents(slice.amount));
+  const slicePercent = sliceResult?.hypotheticalPercent ?? (benchmark > 0 ? (amount / benchmark) * 100 : 0);
+  const demoBalance = money(purchase.demoUsdCents);
+  const unitLabel = useMemo(() => unitLabelFor(purchase.demoUnits), [purchase.demoUnits]);
+
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(window.localStorage.getItem(SLICE_KEY) || 'null');
+      if (saved?.slice) setSlice(saved.slice);
+      if (saved?.result) setSliceResult(saved.result);
+      const purchaseSaved = JSON.parse(window.localStorage.getItem(PURCHASE_KEY) || 'null');
+      if (purchaseSaved?.demoUsdCents >= 0) {
+        setPurchase({
+          demoUsdCents: Number(purchaseSaved.demoUsdCents),
+          demoUnits: Number(purchaseSaved.demoUnits || 0),
+          lastPurchase: purchaseSaved.lastPurchase || null,
+        });
+      }
+    } catch {}
+  }, []);
+
+  function changeSlice(key, value) {
+    setSlice((current) => ({ ...current, [key]: value }));
+    setSliceResult(null);
   }
 
-  async function testBuy(event){
-    event?.preventDefault?.();setSliceBusy(true);
-    try{
-      const r=await fetch('/api/geo/property-slice',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({
-        mode:'purchase',amountCents:toCents(slice.amount),propertyReferencePriceCents:toCents(slice.selectedPrice),benchmarkReferencePriceCents:toCents(slice.benchmarkPrice),selectedName:slice.selectedName,demoUsdBalanceCents:purchase.demoUsdCents,existingDemoUnits:purchase.demoUnits,
-      })});
-      const d=await r.json().catch(()=>({}));if(!r.ok||!d?.ok)throw new Error(d?.error||'Could not complete the sandbox purchase.');
-      const result=d.result;
-      const nextUsd=(result.balances.demoUsdAfterCents/100).toFixed(2);
-      const nextPurchase={demoUsdCents:result.balances.demoUsdAfterCents,demoUnits:result.purchase.demoUnitsAfter,lastPurchase:{selectedName:result.purchase.selectedName,priceCents:result.purchase.debitDemoUsdCents,percent:result.purchase.hypotheticalPercentPerUnit,boughtAt:new Date().toISOString()}};
-      const nextMoneyInputs={...moneyInputs,usd:nextUsd};
-      setSliceResult(result.slice);setPurchase(nextPurchase);setMoneyInputs(nextMoneyInputs);setMoneyResult(null);
-      try{
-        const savedAt=new Date().toISOString();
-        window.localStorage.setItem(SLICE_KEY,JSON.stringify({slice,result:result.slice,savedAt}));
-        window.localStorage.setItem(PURCHASE_KEY,JSON.stringify(nextPurchase));
-        window.localStorage.setItem(MONEY_KEY,JSON.stringify({inputs:nextMoneyInputs,result:null,savedAt}));
-      }catch{}
-      setMessage(`${money(result.purchase.debitDemoUsdCents)} demo purchase complete · ${unitLabelFor(result.purchase.demoUnitsAfter)} in your sandbox Vault · no real funds, deed, equity, security, or NFT moved.`);
-    }catch(e){setMessage(e instanceof Error?e.message:'Could not complete the sandbox purchase.')}finally{setSliceBusy(false)}
-  }
+  async function testBuy(event) {
+    event?.preventDefault?.();
+    setBusy(true);
+    setMessage('Running the sandbox purchase…');
+    try {
+      const response = await fetch('/api/geo/property-slice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'purchase',
+          amountCents: toCents(slice.amount),
+          propertyReferencePriceCents: toCents(slice.selectedPrice),
+          benchmarkReferencePriceCents: toCents(slice.benchmarkPrice),
+          selectedName: slice.selectedName,
+          demoUsdBalanceCents: purchase.demoUsdCents,
+          existingDemoUnits: purchase.demoUnits,
+        }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok) throw new Error(data?.error || 'Could not complete the sandbox purchase.');
 
-  async function previewMoney(event){event?.preventDefault?.();setMoneyBusy(true);try{const r=await fetch('/api/geo/property-slice',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({mode:'conversion_preview',settledUsdCents:purchase.demoUsdCents,estimatedCryptoValueCents:toCents(moneyInputs.crypto),estimatedNftValueCents:toCents(moneyInputs.nft),propertyGoalCents:toCents(moneyInputs.property)})});const d=await r.json().catch(()=>({}));if(!r.ok||!d?.ok)throw new Error(d?.error||'Could not update Vault preview.');setMoneyResult(d.result);try{const savedAt=new Date().toISOString();window.localStorage.setItem(PURCHASE_KEY,JSON.stringify(purchase));window.localStorage.setItem(MONEY_KEY,JSON.stringify({inputs:{...moneyInputs,usd:(purchase.demoUsdCents/100).toFixed(2)},result:d.result,savedAt}))}catch{}setMessage('Vault preview saved · only settled/provider-confirmed USD can become spendable in a live version; crypto/NFT numbers remain estimates until a provider settles them.')}catch(e){setMessage(e instanceof Error?e.message:'Could not update Vault preview.')}finally{setMoneyBusy(false)}}
+      const result = data.result;
+      const nextPurchase = {
+        demoUsdCents: result.balances.demoUsdAfterCents,
+        demoUnits: result.purchase.demoUnitsAfter,
+        lastPurchase: {
+          selectedName: result.purchase.selectedName,
+          priceCents: result.purchase.debitDemoUsdCents,
+          percent: result.purchase.hypotheticalPercentPerUnit,
+          boughtAt: new Date().toISOString(),
+        },
+      };
+      setSliceResult(result.slice);
+      setPurchase(nextPurchase);
+      try {
+        window.localStorage.setItem(SLICE_KEY, JSON.stringify({ slice, result: result.slice, savedAt: new Date().toISOString() }));
+        window.localStorage.setItem(PURCHASE_KEY, JSON.stringify(nextPurchase));
+      } catch {}
+      setMessage(`${money(result.purchase.debitDemoUsdCents)} demo purchase complete · ${unitLabelFor(result.purchase.demoUnitsAfter)} · no real funds, deed, equity, security, rent rights, or NFT moved.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not complete the sandbox purchase.');
+    } finally {
+      setBusy(false);
+    }
+  }
 
   return <main className={styles.page}><div className={styles.phone}>
     <header className={styles.topbar}>
       <Link href="/" className={styles.brand}><VoxelLock/><strong>Voxel Vault</strong></Link>
-      <button className={styles.avatarButton} type="button" onClick={connect} aria-label={connected?`Wallet ${shortWallet}`:'Connect wallet'}><PixelAvatar/><i className={connected?styles.online:styles.offline}/></button>
+      <Link href="/more" className={styles.avatarButton} aria-label="Advanced tools"><span className={styles.pixelAvatar}><b/></span></Link>
     </header>
 
-    <section className={styles.heading}><span>PROPERTY · USD · CRYPTO · NFT</span><h1>Your $1.99 property world</h1><p>Set your anchor property to $1.99. Every other sandbox property scales by its reference value, so the comparison stays proportional.</p></section>
+    <section className={styles.heading}>
+      <span>PROPERTY SLICE · SANDBOX</span>
+      <h1>What would $1.99 represent?</h1>
+      <p>Compare a tiny test amount across property reference values. This is math and demo credits—not a real investment, property reservation, security purchase, or deed transfer.</p>
+    </section>
 
     <form onSubmit={testBuy} className={styles.sliceForm}>
       <section className={styles.heroCard}>
         <div className={styles.sceneSide}>
-          <div className={styles.demoPill}>DEMO USD · {demoUsdDisplay}</div>
+          <div className={styles.demoPill}>DEMO BALANCE · NOT MONEY · {demoBalance}</div>
           <VoxelScene/>
-          <div className={styles.sceneCaption}><b>{slice.selectedName||'Selected property'}</b><span>{referenceMoney(slice.selectedPrice)} reference value</span></div>
+          <div className={styles.sceneCaption}><b>{slice.selectedName || 'Selected property'}</b><span>{referenceMoney(slice.selectedPrice)} reference value</span></div>
         </div>
         <div className={styles.buySide}>
-          <small>SANDBOX SLICE PRICE</small>
+          <small>DEMO SLICE PRICE</small>
           <div className={styles.heroPrice}>{money(adjustedCents)}</div>
-          <button className={styles.buyButton} disabled={sliceBusy||adjustedCents>purchase.demoUsdCents}><span className={styles.bag}>✚</span>{sliceBusy?'Buying…':adjustedCents>purchase.demoUsdCents?'Demo USD too low':'Test Buy'}</button>
-          <div className={styles.sandbox}>Your anchor stays {money(toCents(slice.amount))} · demo purchase only</div>
+          <button className={styles.buyButton} disabled={busy || adjustedCents > purchase.demoUsdCents}>
+            <span className={styles.bag}>+</span>{busy ? 'Testing…' : adjustedCents > purchase.demoUsdCents ? 'Demo balance too low' : 'Test Buy'}
+          </button>
+          <div className={styles.sandbox}>Simulation only · no checkout · no wallet · no ownership</div>
         </div>
       </section>
 
       <section className={styles.compareGrid}>
-        <div><span className={styles.houseBadge}>⌂</span><small>SELECTED</small><strong>{slice.selectedName||'Selected property'}</strong><b>{referenceMoney(slice.selectedPrice)} reference</b></div>
-        <div><span className={styles.anchorBadge}>★</span><small>MY ANCHOR</small><strong>{slice.benchmarkName||'My anchor property'}</strong><b>{referenceMoney(slice.benchmarkPrice)} → {money(toCents(slice.amount))}</b></div>
+        <div><span className={styles.houseBadge}>⌂</span><small>SELECTED</small><strong>{slice.selectedName || 'Selected property'}</strong><b>{referenceMoney(slice.selectedPrice)} reference</b></div>
+        <div><span className={styles.anchorBadge}>★</span><small>ANCHOR</small><strong>{slice.benchmarkName || 'Anchor property'}</strong><b>{referenceMoney(slice.benchmarkPrice)} → {money(toCents(slice.amount))}</b></div>
       </section>
 
       <section className={styles.metrics}>
-        <div><PieIcon/><span><small>Same proportional slice</small><strong>{percent(slicePercent)}</strong></span></div>
-        <div><BarsIcon/><span><small>Selected vs. anchor</small><strong>{indexLabel(benchmarkWeight)}</strong></span></div>
+        <div><span className={styles.pie}><i/></span><span><small>Hypothetical fraction</small><strong>{percent(slicePercent)}</strong></span></div>
+        <div><span className={styles.bars}><i/><i/><i/></span><span><small>Selected vs. anchor</small><strong>{indexLabel(relativeIndex)}</strong></span></div>
       </section>
 
       <div className={styles.formula}><b>{money(toCents(slice.amount))}</b><span>×</span><b>{referenceMoney(slice.selectedPrice)}</b><span>÷</span><b>{referenceMoney(slice.benchmarkPrice)}</b><span>=</span><strong>{money(adjustedCents)}</strong></div>
 
-      <details className={styles.details}><summary>Change property comparison</summary><div className={styles.fields}>
-        <label>Selected property name<input value={slice.selectedName} onChange={e=>changeSlice('selectedName',e.target.value)}/></label>
-        <label>Selected reference value<input inputMode="decimal" value={slice.selectedPrice} onChange={e=>changeSlice('selectedPrice',e.target.value)}/></label>
-        <label>My anchor property name<input value={slice.benchmarkName} onChange={e=>changeSlice('benchmarkName',e.target.value)}/></label>
-        <label>My anchor reference value<input inputMode="decimal" value={slice.benchmarkPrice} onChange={e=>changeSlice('benchmarkPrice',e.target.value)}/></label>
-        <label className={styles.fullField}>My anchor test price<input inputMode="decimal" value={slice.amount} onChange={e=>changeSlice('amount',e.target.value)}/></label>
-      </div></details>
+      <details className={styles.details}>
+        <summary>Change the comparison</summary>
+        <div className={styles.fields}>
+          <label>Selected property<input value={slice.selectedName} onChange={(event) => changeSlice('selectedName', event.target.value)}/></label>
+          <label>Selected reference value<input inputMode="decimal" value={slice.selectedPrice} onChange={(event) => changeSlice('selectedPrice', event.target.value)}/></label>
+          <label>Anchor property<input value={slice.benchmarkName} onChange={(event) => changeSlice('benchmarkName', event.target.value)}/></label>
+          <label>Anchor reference value<input inputMode="decimal" value={slice.benchmarkPrice} onChange={(event) => changeSlice('benchmarkPrice', event.target.value)}/></label>
+          <label className={styles.fullField}>Anchor demo price<input inputMode="decimal" value={slice.amount} onChange={(event) => changeSlice('amount', event.target.value)}/></label>
+        </div>
+      </details>
     </form>
 
-    <div className={styles.sectionLabel}><span>ONE VAULT</span><b>Property + money + wallet, without mixing what each asset legally is</b></div>
-    <section className={styles.assetGrid}>
-      <AssetCard kind="property" art={<MiniHouse/>} label="Property" value={purchase.demoUnits?unitLabel:'Ready to test'}/>
-      <AssetCard kind="usd" art={<CashStack/>} label="USD" value={`Demo ${demoUsdDisplay}`}/>
-      <AssetCard kind="crypto" art={<EthMark/>} label="Crypto" value={connected?'Wallet linked':'Connect wallet'} onClick={connect}/>
-      <AssetCard kind="nft" art={<NftFrame/>} label="NFTs" value="Hold · mint · sell"/>
-    </section>
-
-    {purchase.lastPurchase?<section className={styles.activityCard}>
-      <div><span>RECENT SANDBOX ACTIVITY</span><h2>{purchase.lastPurchase.selectedName}</h2><p>{money(purchase.lastPurchase.priceCents)} demo USD → 1 property slice</p></div>
-      <div className={styles.activityValue}><small>VAULT TOTAL</small><strong>{unitLabel}</strong><span>{demoUsdDisplay} demo USD left</span></div>
-    </section>:null}
-
-    <section className={styles.convertCard}><div><span>NFT UTILITY</span><h2>Make the NFT useful</h2><p>Keep the 3D asset, optionally mint it, sell through a supported market, then route settled proceeds to crypto or USD. Estimated value is never shown as cash before settlement.</p></div><div className={styles.convertFlow}>
-      <Flow art={<NftFrame/>} label="NFT"/><span>→</span><Flow art={<MarketStall/>} label="Market"/><span>→</span><Flow art={<CashStack/>} label="USD"/><span>→</span><Flow art={<MiniHouse/>} label="Property"/>
-    </div></section>
-
-    <details className={styles.details}><summary>Try unified Vault balances</summary><form onSubmit={previewMoney} className={styles.fields}>
-      <label>USD demo balance<input value={moneyInputs.usd} onChange={e=>changeMoney('usd',e.target.value)}/></label>
-      <label>Crypto estimated value<input value={moneyInputs.crypto} onChange={e=>changeMoney('crypto',e.target.value)}/></label>
-      <label>NFT estimated value<input value={moneyInputs.nft} onChange={e=>changeMoney('nft',e.target.value)}/></label>
-      <label>Property goal<input value={moneyInputs.property} onChange={e=>changeMoney('property',e.target.value)}/></label>
-      <button className={styles.updateButton} disabled={moneyBusy}>{moneyBusy?'Updating…':'Save Vault preview'}</button>
-    </form></details>
+    {purchase.lastPurchase ? <section className={styles.activityCard}>
+      <div><span>RECENT DEMO</span><h2>{purchase.lastPurchase.selectedName}</h2><p>{money(purchase.lastPurchase.priceCents)} demo balance → 1 simulated slice</p></div>
+      <div className={styles.activityValue}><small>SANDBOX TOTAL</small><strong>{unitLabel}</strong><span>{demoBalance} demo balance left</span></div>
+    </section> : null}
 
     <div className={styles.status}>{message}</div>
-    <div className={styles.nextLinks}><Link href="/property">Create a 3D property →</Link><Link href="/vault">Open full Vault →</Link></div>
-  </div></main>
+    <div className={styles.nextLinks}>
+      <Link href="/property">Create a digital property voxel →</Link>
+      <Link href="/more">See verified/provider-gated features →</Link>
+    </div>
+  </div></main>;
 }
 
-function unitLabelFor(count){return Number(count)===1?'1 demo slice':`${Number(count)||0} demo slices`}
-function AssetCard({kind,art,label,value,onClick}){const Tag=onClick?'button':'div';return <Tag type={onClick?'button':undefined} onClick={onClick} className={`${styles.assetCard} ${styles[kind]}`}><div className={styles.assetArt}>{art}</div><b>{label}</b><small>{value}</small></Tag>}
-function Flow({art,label}){return <div className={styles.flow}><div>{art}</div><b>{label}</b></div>}
-function VoxelLock(){return <span className={styles.voxelLock}><i/><b>+</b></span>}
-function PixelAvatar(){return <span className={styles.pixelAvatar}><i/><b/></span>}
-function PieIcon(){return <span className={styles.pie}><i/></span>}
-function BarsIcon(){return <span className={styles.bars}><i/><i/><i/></span>}
-function VoxelScene(){return <svg className={styles.scene} viewBox="0 0 260 220" aria-hidden="true"><defs><filter id="sh"><feDropShadow dx="0" dy="8" stdDeviation="6" floodOpacity=".18"/></filter></defs><g filter="url(#sh)"><polygon points="30,105 145,55 232,94 116,148" fill="#85c94b"/><polygon points="30,105 116,148 116,196 30,151" fill="#8f5b32"/><polygon points="116,148 232,94 232,142 116,196" fill="#6e452b"/><rect x="58" y="78" width="14" height="55" fill="#70451f"/><rect x="44" y="52" width="42" height="42" rx="4" fill="#76b83d"/><rect x="51" y="43" width="33" height="32" rx="4" fill="#8bc64b"/><rect x="39" y="66" width="35" height="30" rx="4" fill="#68a934"/><polygon points="94,91 145,69 188,86 137,110" fill="#f58a46"/><polygon points="102,78 139,56 178,72 141,94" fill="#f27636"/><rect x="105" y="91" width="66" height="49" fill="#f6eee0"/><polygon points="171,91 188,86 188,132 171,140" fill="#e3d7c4"/><rect x="129" y="111" width="17" height="29" fill="#8a572c"/><rect x="112" y="104" width="12" height="15" fill="#6cc7e1"/><rect x="151" y="101" width="12" height="15" fill="#6cc7e1"/><rect x="166" y="54" width="11" height="25" fill="#a98b78"/><rect x="171" y="38" width="10" height="10" fill="#eee7e4"/><rect x="176" y="25" width="11" height="11" fill="#f4eeee"/><rect x="90" y="147" width="22" height="7" fill="#d7c9b3"/><rect x="78" y="155" width="19" height="7" fill="#d7c9b3"/><rect x="68" y="163" width="17" height="7" fill="#d7c9b3"/><rect x="195" y="116" width="7" height="14" fill="#fff"/><rect x="205" y="112" width="7" height="14" fill="#fff"/><rect x="196" y="112" width="16" height="5" fill="#fff"/><rect x="187" y="133" width="8" height="8" fill="#ff7b77"/><rect x="194" y="134" width="7" height="7" fill="#ffd15b"/></g></svg>}
-function MiniHouse(){return <span className={styles.miniHouse}><i/><b/></span>}
-function CashStack(){return <span className={styles.cashStack}><i/><i/><b>$</b></span>}
-function EthMark(){return <span className={styles.eth}>◆</span>}
-function NftFrame(){return <span className={styles.nftFrame}><i>●</i></span>}
-function MarketStall(){return <span className={styles.market}><i/><b/></span>}
+function VoxelLock() {
+  return <span className={styles.voxelLock}><i/><b>+</b></span>;
+}
+
+function VoxelScene() {
+  return <svg className={styles.scene} viewBox="0 0 260 220" aria-hidden="true">
+    <g>
+      <polygon points="30,105 145,55 232,94 116,148" fill="#85c94b"/>
+      <polygon points="30,105 116,148 116,196 30,151" fill="#8f5b32"/>
+      <polygon points="116,148 232,94 232,142 116,196" fill="#6e452b"/>
+      <polygon points="70,99 136,68 192,94 125,126" fill="#f2d4ae"/>
+      <polygon points="70,99 125,126 125,164 70,136" fill="#efb971"/>
+      <polygon points="125,126 192,94 192,132 125,164" fill="#d89558"/>
+      <polygon points="62,91 130,58 202,91 136,112" fill="#76503c"/>
+      <rect x="91" y="111" width="18" height="32" fill="#774a35"/>
+      <rect x="143" y="112" width="20" height="15" fill="#8ed5dc"/>
+    </g>
+  </svg>;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -20,7 +20,7 @@ export default function Home() {
           <p className={styles.kicker}>✦ ONE PHOTO → YOUR VOXEL WORLD ✦</p>
           <h1>Upload a picture.<br/><em>VoxelPop does the rest.</em></h1>
           <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so it can place the result on a source-backed property map.</p>
-          <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">＋ UPLOAD A PROPERTY PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
+          <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
           <p className={styles.heroFine}>One starting action. No Meshy credits. No wallet required to create. Collection and minting stay optional.</p>
         </div>
 
@@ -36,7 +36,7 @@ export default function Home() {
 
       <section className={styles.creationCard}>
         <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>There should be no dashboard decision before creation. Pick the picture first; the same creation screen progresses from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
-        <Link className={styles.startButton} href="/property">＋ CHOOSE MY PHOTO</Link>
+        <Link className={styles.startButton} href="/property">START → SIGN IN + CHOOSE PHOTO</Link>
         <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>CREATING</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
         <small>Your photo stays visible through creation. The address is requested only when the 3D is ready to be mapped. Payment, collection and minting remain explicit actions rather than hidden automatic charges.</small>
       </section>

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -9,6 +9,7 @@ const productMap = fs.readFileSync(new URL('../lib/product-map.js', import.meta.
 const interactions = fs.readFileSync(new URL('../app/spatial-os-interactions.css', import.meta.url), 'utf8');
 const rootHome = fs.readFileSync(new URL('../app/page.js', import.meta.url), 'utf8');
 const more = fs.readFileSync(new URL('../app/more/page.js', import.meta.url), 'utf8');
+const slice = fs.readFileSync(new URL('../app/geo/slice/page.js', import.meta.url), 'utf8');
 const integrationsPage = fs.readFileSync(new URL('../app/admin/integrations/page.js', import.meta.url), 'utf8');
 const integrationsApi = fs.readFileSync(new URL('../app/api/admin/integrations/status/route.ts', import.meta.url), 'utf8');
 const layout = fs.readFileSync(new URL('../app/layout.js', import.meta.url), 'utf8');
@@ -78,6 +79,13 @@ assert.doesNotMatch(rootHome, /YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · 
 assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING/, 'unverified physical-property purchase execution must stay out of the consumer front door');
 assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root home must not alias an older real-estate subsystem');
 
+// The $1.99 comparison is intentionally a pure sandbox, not a faux bank/wallet surface.
+assert.match(slice, /PROPERTY SLICE · SANDBOX/, 'slice page must identify itself as a sandbox before the demo interaction');
+assert.match(slice, /DEMO BALANCE · NOT MONEY/, 'demo balance must never look like settled cash');
+assert.match(slice, /Simulation only · no checkout · no wallet · no ownership/, 'slice CTA must disclose that it cannot execute a real transaction');
+assert.match(slice, /no real funds, deed, equity, security, rent rights, or NFT moved/, 'demo completion must preserve the full legal/financial boundary');
+assert.doesNotMatch(slice, /useWalletIdentity|Connect wallet|Crypto estimated value|NFT estimated value|Make the NFT useful|PROPERTY · USD · CRYPTO · NFT/, 'the property sandbox must not imitate live wallet, crypto, NFT or banking execution');
+
 // Capability status remains safe even though it is not on the consumer front door.
 assert.match(homeCapabilities, /\/api\/world-atlas\/capabilities/, 'capability strip must use the safe public readiness endpoint wherever it is surfaced');
 for (const label of ['WORLD DATA', 'OPEN STREET', 'MESHY 7', 'MARKET FEEDS']) assert.match(homeCapabilities, new RegExp(label));
@@ -126,4 +134,4 @@ assert.match(home, /Fail-closed for real money/);
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault condensed Create -> World -> Vault consumer journey + separated optional property/money tools + fail-closed advanced rails coherence checks passed');
+console.log('Voxel Vault condensed Create -> World -> Vault consumer journey + unambiguous $1.99 sandbox + separated optional property/money tools + fail-closed advanced rails coherence checks passed');

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -61,17 +61,19 @@ assert.match(commandCenter, /!isSimplePropertyRoute\(pathname\)/, 'advanced tool
 assert.match(commandCenter, /never automatically spends money, mints an NFT, or starts a paid 3D generation/, 'tool finder must disclose its non-execution boundary');
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
-// Consumer Home describes only the current zero-credit property flow.
-assert.match(rootHome, /START → SIGN IN \+ CREATE/, 'root Home should make the account-first transition explicit');
+// Consumer Home describes the actual guided, local-generation property flow.
+assert.match(rootHome, /START → SIGN IN \+ UPLOAD PHOTO/, 'root Home should accurately disclose sign-in before the upload picker');
 assert.match(rootHome, /href="\/property"/, 'root Home should route the primary CTA into the account-gated maker');
-assert.match(rootHome, /Photo → voxel → mapped 3D\./, 'root Home should describe the actual photo/local-preview/map flow');
-assert.match(rootHome, /<b>PHOTO<\/b>/, 'root Home should put the authorized photo first');
-assert.match(rootHome, /<b>VOXEL<\/b>/, 'root Home should expose the local VoxelPop stage');
-assert.match(rootHome, /<b>3D<\/b>/, 'root Home should expose mapped interactive 3D');
-assert.match(rootHome, /<b>WORLD<\/b>/, 'root Home should preview the asset in World before optional collection');
-assert.match(rootHome, /OPTIONAL COLLECT \+ VAULT/, 'root Home should make digital collection optional');
-assert.match(rootHome, /A wallet is optional/i, 'wallet must remain optional until a user chooses a downstream wallet action');
-assert.match(rootHome, /No Meshy credits are required/i, 'normal property creation should advertise its zero-Meshy dependency accurately');
+assert.match(rootHome, /Upload a picture\./, 'root Home should make one photo the obvious starting point');
+assert.match(rootHome, /After sign-in and your explicit creation checkout/, 'root Home should disclose the paid creation gate without implying hidden charging');
+assert.match(rootHome, /<b>UPLOAD<\/b>/, 'root Home should show the upload stage');
+assert.match(rootHome, /<b>CREATING<\/b>/, 'root Home should show local creation as the next stage');
+assert.match(rootHome, /<b>3D<\/b>/, 'root Home should expose movable 3D');
+assert.match(rootHome, /<b>MAP<\/b>/, 'root Home should expose source-backed mapping');
+assert.match(rootHome, /<b>READY<\/b>/, 'root Home should make the guided finish state obvious');
+assert.match(rootHome, /Payment, collection and minting remain explicit actions/, 'paid and blockchain actions must never appear automatic');
+assert.match(rootHome, /No wallet required to create/i, 'wallet must remain optional for creation');
+assert.match(rootHome, /No Meshy credits/i, 'normal property creation should accurately disclose the zero-Meshy dependency');
 assert.match(rootHome, /does not buy the physical property/i, 'root Home must distinguish collecting a voxel from buying physical property');
 assert.match(rootHome, /deed\/title, rent, occupancy, or investment rights/, 'root Home must preserve digital versus legal-rights truth');
 assert.match(rootHome, /href="\/more"/, 'optional and advanced tools must remain deliberately reachable');
@@ -134,4 +136,4 @@ assert.match(home, /Fail-closed for real money/);
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault condensed Create -> World -> Vault consumer journey + unambiguous $1.99 sandbox + separated optional property/money tools + fail-closed advanced rails coherence checks passed');
+console.log('Voxel Vault guided upload -> local creation -> 3D -> map -> ready journey + unambiguous $1.99 sandbox + separated optional property/money tools + fail-closed advanced rails coherence checks passed');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -30,11 +30,11 @@ const drafts = read('lib/property-drafts.js');
 const dock = read('app/components/FinancialOSNav.js');
 const command = read('app/components/AppCommandCenter.js');
 
-assert.match(home, /Photo → voxel → mapped 3D\./, 'home describes the actual local preview plus mapped 3D journey');
-assert.match(home, /START → SIGN IN \+ CREATE/, 'home enters the account-gated maker');
-assert.match(home, /wallet is optional|A wallet is optional/i, 'wallet must not block creation or checkout');
+assert.match(home, /ONE PHOTO → YOUR VOXEL WORLD|Upload a picture\./, 'home describes the current one-photo guided journey');
+assert.match(home, /START → SIGN IN \+ UPLOAD PHOTO/, 'home truthfully exposes the account gate before the photo picker');
+assert.match(home, /No wallet required to create/i, 'wallet must not block creation or checkout');
 assert.match(home, /does not buy the physical property/i, 'home distinguishes the voxel from physical real estate');
-assert.match(home, /No Meshy credits are required/i, 'home makes the no-Meshy provider dependency explicit');
+assert.match(home, /No Meshy credits/i, 'home makes the no-Meshy provider dependency explicit');
 assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed/i, 'unverified property-purchase language stays out of the simple home');
 
 for (const source of [homeCss, propertyCss, vault, world]) assert.match(source, /#fffaf0/i, 'simple surfaces keep the warm VoxelPop canvas');


### PR DESCRIPTION
Follow-up to #430 and #433.

The broad consumer cleanup and guided Upload → Creating → 3D → Map → Ready Property flow are already on `main`. This PR fixes the remaining page that still visually blurred sandbox property math with live-finance concepts, and makes the homepage truthfully say that sign-in happens before the photo picker.

## Change
- Keep the existing $1.99 property comparison and sandbox purchase engine.
- Remove wallet connection from the sandbox page.
- Remove crypto and NFT estimated-balance inputs.
- Remove the `PROPERTY · USD · CRYPTO · NFT` heading.
- Remove NFT-to-cash / unified Vault simulation from this screen.
- Label the balance `DEMO BALANCE · NOT MONEY`.
- Label the interaction `Simulation only · no checkout · no wallet · no ownership`.
- Explicitly state that a demo purchase moves no real funds, deed, equity, security, rent rights, or NFT.
- Route users to `/more` for separately labeled verified/provider-gated features.
- Change the upload-first homepage CTA to `START → SIGN IN + UPLOAD PHOTO`, matching the actual account gate while preserving the one-photo-first experience.

## Regression guards
- The financial/product coherence test fails if wallet, crypto, NFT, banking-style, or settlement-looking UI is reintroduced into the $1.99 sandbox.
- Homepage coherence now follows the current guided Upload → Creating → 3D → Map → Ready flow rather than the superseded presentation copy.

No real-money, investment, property-rights, wallet, or blockchain execution is enabled by this PR.