### PR TITLE
Make VoxelPop feel like upload once, then it happens

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import styles from './home.module.css';
 
-// Product truth: the consumer front door describes only what the current flow actually does.
-// Photo -> local voxel preview -> source-backed 3D map -> World -> optional digital collection/mint.
+// Product truth: upload is the single consumer starting point.
 // Nothing is uploaded, generated, or charged before sign-in.
+// After an authorized photo is chosen, the app guides the user through local VoxelPop creation,
+// interactive 3D, source-backed map placement, World, and optional digital collection.
 // Real-property investment or purchase controls only activate when a verified provider/offering and required legal path exist.
 // A 3D model, payment, map marker, Property Passport, or NFT is not a deed and does not create rent, occupancy, investment, or appreciation rights.
-// A voxel/NFT is not a deed. Estimated asset value is not settled cash. Regulated money/property rails stay separate.
 export default function Home() {
   return <main className={styles.page}>
     <div className={styles.shell}>
@@ -17,47 +17,47 @@ export default function Home() {
 
       <header className={styles.hero}>
         <div className={styles.heroCopy}>
-          <p className={styles.kicker}>✦ CREATE · MAP · COLLECT ✦</p>
-          <h1>Turn a real place<br/><em>into a VoxelPop.</em></h1>
-          <p className={styles.lead}>Choose a photo, make a voxel-style preview on your device, verify the address, then explore a source-backed interactive 3D map. Save it to your World and optionally collect or mint the digital asset.</p>
-          <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + CREATE</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
-          <p className={styles.heroFine}>No Meshy credits are required for the normal property flow. A wallet is optional. Collection and minting are separate choices.</p>
+          <p className={styles.kicker}>✦ ONE PHOTO → YOUR VOXEL WORLD ✦</p>
+          <h1>Upload a picture.<br/><em>VoxelPop does the rest.</em></h1>
+          <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so it can place the result on a source-backed property map.</p>
+          <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">＋ UPLOAD A PROPERTY PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
+          <p className={styles.heroFine}>One starting action. No Meshy credits. No wallet required to create. Collection and minting stay optional.</p>
         </div>
 
-        <div className={styles.heroVisual} aria-label="VoxelPop property flow preview">
+        <div className={styles.heroVisual} aria-label="Upload one photo and VoxelPop guides the rest">
           <div className={styles.skySparkle}>✦</div>
           <div className={styles.voxelHouse} aria-hidden="true"><div className={styles.roof}/><div className={styles.houseBody}><i/><i/><b/></div><div className={styles.lawn}/></div>
-          <div className={styles.priceBubble}><small>NORMAL CREATE</small><strong>0</strong><span>Meshy credits</span></div>
-          <div className={`${styles.assetChip} ${styles.chipUsd}`}><span>▣</span><b>PHOTO</b></div>
-          <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>◎</span><b>3D MAP</b></div>
-          <div className={`${styles.assetChip} ${styles.chipNft}`}><span>◇</span><b>VAULT</b></div>
+          <div className={styles.priceBubble}><small>START HERE</small><strong>＋</strong><span>your photo</span></div>
+          <div className={`${styles.assetChip} ${styles.chipUsd}`}><span>1</span><b>UPLOAD</b></div>
+          <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>2</span><b>VOXEL + 3D</b></div>
+          <div className={`${styles.assetChip} ${styles.chipNft}`}><span>3</span><b>MAP + WORLD</b></div>
         </div>
       </header>
 
+      <section className={styles.creationCard}>
+        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>There should be no dashboard decision before creation. Pick the picture first; the same creation screen progresses from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
+        <Link className={styles.startButton} href="/property">＋ CHOOSE MY PHOTO</Link>
+        <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>CREATING</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
+        <small>Your photo stays visible through creation. The address is requested only when the 3D is ready to be mapped. Payment, collection and minting remain explicit actions rather than hidden automatic charges.</small>
+      </section>
+
       <section className={styles.unifiedCard}>
-        <div className={styles.sectionIntro}><p>ONE SIMPLE APP</p><h2>Four places. That’s it.</h2><span>The advanced tools still exist, but the main experience stays easy to understand.</span></div>
+        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has a clear home.</h2><span>Create is the front door. World and Vault are where the finished result goes. Advanced features stay out of the way.</span></div>
         <div className={styles.assetGrid}>
-          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Make a VoxelPop</strong><span>Photo preview plus source-backed mapped 3D.</span><b>Create →</b></Link>
-          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>Explore places</strong><span>See your saved voxels in their mapped locations.</span><b>Open World →</b></Link>
-          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Your collection</strong><span>Keep saved and collected digital assets together.</span><b>Open Vault →</b></Link>
-          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox property, wallets, investments, rentals, AI and verification.</span><b>See More →</b></Link>
+          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Upload one photo</strong><span>Start the guided VoxelPop property flow.</span><b>Choose photo →</b></Link>
+          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore mapped saved VoxelPop places.</span><b>Open World →</b></Link>
+          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your collection</strong><span>Saved and collected digital assets live here.</span><b>Open Vault →</b></Link>
+          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, verified financial rails, AI and property tools.</span><b>See More →</b></Link>
         </div>
       </section>
 
-      <section className={styles.creationCard}>
-        <div className={styles.step}><span>+</span><div><p>HOW IT WORKS</p><h2>Photo → voxel → mapped 3D.</h2><span>The photo creates a stylized local preview. The interactive 3D comes from source-backed map geometry, so the app does not pretend one photo reveals unseen sides or exact dimensions.</span></div></div>
-        <Link className={styles.startButton} href="/property">START → SIGN IN + CREATE MY VOXEL</Link>
-        <div className={styles.microFlow}><b>PHOTO</b><i>→</i><b>VOXEL</b><i>→</i><b>3D</b><i>→</i><b>WORLD</b><i>→</i><b>OPTIONAL COLLECT + VAULT</b></div>
-        <small>A wallet is optional. Generation, checkout, collection, minting, trading and money movement remain explicit actions—nothing silently spends credits or moves funds.</small>
-      </section>
-
       <section className={styles.convertCard}>
-        <div className={styles.convertCopy}><p>CLEAR BOUNDARIES</p><h2>Digital asset ≠ physical property.</h2><span>Sandbox comparisons, provider-backed financial tools, legal property ownership and optional NFTs stay separate underneath one interface.</span></div>
-        <div className={styles.convertFlow} aria-label="Voxel Vault product boundaries"><FlowIcon icon="¢" label="Sandbox" note="demo"/><i>→</i><FlowIcon icon="$" label="Provider" note="when live"/><i>→</i><FlowIcon icon="⌂" label="Title" note="legal rail"/><i>→</i><FlowIcon icon="◇" label="NFT" note="digital"/></div>
-        <Link className={styles.convertAction} href="/more">OPEN OPTIONAL + ADVANCED TOOLS</Link>
+        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>The digital voxel is not the deed.</h2><span>The photo creates a stylized local VoxelPop experience; source-backed map data supplies the mapped building context. Physical-property rights remain separate and require the normal verified legal path.</span></div>
+        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="yours"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>→</i><FlowIcon icon="◇" label="Vault" note="optional"/></div>
+        <Link className={styles.convertAction} href="/property">START WITH A PHOTO</Link>
       </section>
 
-      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. Voxel Vault is not presenting an NFT as a deed, a demo balance as money, or an estimate as spendable cash.</span><Link href="/more">More tools</Link></footer>
+      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. A single photo also cannot verify unseen architecture or exact dimensions.</span><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }


### PR DESCRIPTION
## Goal
Make the consumer experience immediately read as **upload one picture, then VoxelPop guides the rest**.

## Changes
- homepage hero now starts with **Upload a picture. VoxelPop does the rest.**
- one dominant **Upload a property photo** CTA
- pipeline is shown as **Upload → Creating → 3D → Map → Ready** instead of a collection of separate products
- keeps the photo-first property maker as the destination
- makes clear that the address is requested only when the finished local 3D needs source-backed map placement
- World, Vault, and More are framed as destinations after creation, not competing starting points

## Existing behavior preserved
- explicit sign-in
- explicit photo-rights confirmation
- explicit $4.99 creation checkout
- local/no-Meshy guided 3D
- source-backed property map
- optional collection/mint
- deed/title/investment truth boundaries

This changes the presentation, not the legal/payment safety gates.