### PR TITLE
Make Voxel Vault pricing and product truth obvious

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -19,15 +19,15 @@ export default function Home() {
         <div className={styles.heroCopy}>
           <p className={styles.kicker}>✦ ONE PHOTO → YOUR VOXEL WORLD ✦</p>
           <h1>Upload a picture.<br/><em>VoxelPop does the rest.</em></h1>
-          <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so it can place the result on a source-backed property map.</p>
+          <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout ($4.99), VoxelPop keeps that photo on your device while it builds the voxel-style image and movable 3D. Add the address only when you are ready to place it on the source-backed property map.</p>
           <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
-          <p className={styles.heroFine}>One starting action. No Meshy credits. No wallet required to create. Collection and minting stay optional.</p>
+          <p className={styles.heroFine}>$4.99 creates one digital VoxelPop item. No Meshy credits. No wallet required to create. Any later collection price is shown before a separate checkout.</p>
         </div>
 
         <div className={styles.heroVisual} aria-label="Upload one photo and VoxelPop guides the rest">
           <div className={styles.skySparkle}>✦</div>
           <div className={styles.voxelHouse} aria-hidden="true"><div className={styles.roof}/><div className={styles.houseBody}><i/><i/><b/></div><div className={styles.lawn}/></div>
-          <div className={styles.priceBubble}><small>START HERE</small><strong>＋</strong><span>your photo</span></div>
+          <div className={styles.priceBubble}><small>CREATE</small><strong>$4.99</strong><span>digital item</span></div>
           <div className={`${styles.assetChip} ${styles.chipUsd}`}><span>1</span><b>UPLOAD</b></div>
           <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>2</span><b>VOXEL + 3D</b></div>
           <div className={`${styles.assetChip} ${styles.chipNft}`}><span>3</span><b>MAP + WORLD</b></div>
@@ -35,29 +35,29 @@ export default function Home() {
       </header>
 
       <section className={styles.creationCard}>
-        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>There should be no dashboard decision before creation. Pick the picture first; the same creation screen progresses from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
+        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>One photo. One guided flow.</h2><span>Choose the picture first. The same screen moves from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
         <Link className={styles.startButton} href="/property">START → SIGN IN + CHOOSE PHOTO</Link>
         <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>CREATING</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
-        <small>Your photo stays visible through creation. The address is requested only when the 3D is ready to be mapped. Payment, collection and minting remain explicit actions rather than hidden automatic charges.</small>
+        <small>Creation is $4.99. If you later collect a mapped digital voxel, its separate price is shown before checkout. Payment, collection and minting remain explicit actions—nothing is silently charged or minted.</small>
       </section>
 
       <section className={styles.unifiedCard}>
-        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has a clear home.</h2><span>Create is the front door. World and Vault are where the finished result goes. Advanced features stay out of the way.</span></div>
+        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has one clear home.</h2><span>Create is the front door. World shows mapped results. Vault keeps your digital collection. Advanced tools stay under More.</span></div>
         <div className={styles.assetGrid}>
-          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Upload one photo</strong><span>Start the guided VoxelPop property flow.</span><b>Choose photo →</b></Link>
-          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore mapped saved VoxelPop places.</span><b>Open World →</b></Link>
+          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Upload one photo</strong><span>Make one digital VoxelPop item for $4.99.</span><b>Choose photo →</b></Link>
+          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore your mapped VoxelPop places.</span><b>Open World →</b></Link>
           <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your collection</strong><span>Saved and collected digital assets live here.</span><b>Open Vault →</b></Link>
           <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, verified financial rails, AI and property tools.</span><b>See More →</b></Link>
         </div>
       </section>
 
       <section className={styles.convertCard}>
-        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>The digital voxel is not the deed.</h2><span>The photo creates a stylized local VoxelPop experience; source-backed map data supplies the mapped building context. Physical-property rights remain separate and require the normal verified legal path.</span></div>
-        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="yours"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>→</i><FlowIcon icon="◇" label="Vault" note="optional"/></div>
+        <div className={styles.convertCopy}><p>PRODUCT TRUTH</p><h2>The digital voxel is not the deed.</h2><span>Your photo creates the stylized VoxelPop item. Source-backed map data supplies location context. Neither one proves ownership of the physical property.</span></div>
+        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="authorized"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="reference"/><i>→</i><FlowIcon icon="◇" label="Vault" note="collection"/></div>
         <Link className={styles.convertAction} href="/property">START WITH A PHOTO</Link>
       </section>
 
-      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. A single photo also cannot verify unseen architecture or exact dimensions.</span><Link href="/more">More tools</Link></footer>
+      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. Live banking, crypto or real-property investing only appears through separately verified provider and legal rails.</span><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }


### PR DESCRIPTION
## What this cleans up
- keeps the new single-photo, zero-Meshy-credit creation flow intact
- makes the $4.99 creation charge visible before the user enters the maker
- explicitly separates the later optional collectible checkout from the creation charge
- condenses the home into Create → World → Vault → More
- replaces vague “legit” language with concrete product-truth language
- keeps digital voxel/map data separate from deed/title/investment rights
- states that live banking, crypto, and real-property investing only appear through separately verified provider/legal rails

## What this does not do
- no Meshy generation
- no wallet transaction
- no payment is triggered by this UI change
- no regulated financial feature is enabled
- no physical-property ownership claim is added

This branch was reset onto the latest `main` after the concurrent sandbox/entry-flow cleanup so it does not overwrite that newer work.