### PR TITLE
Make Voxel Vault pricing and product status completely clear

### DIFF
--- a/app/more/page.js
+++ b/app/more/page.js
@@ -3,8 +3,8 @@ import { APP_SECTIONS } from '../../lib/product-map';
 import styles from './more.module.css';
 
 export const metadata = {
-  title: 'More',
-  description: 'The organized directory for Voxel Vault products, tools, ownership workflows and owner operations.',
+  title: 'More · Voxel Vault',
+  description: 'A clear directory for Voxel Vault live, sandbox, provider-gated and owner tools.',
 };
 
 export default function MorePage() {
@@ -12,16 +12,16 @@ export default function MorePage() {
     <div className={styles.shell}>
       <header className={styles.top}>
         <Link className={styles.brand} href="/">VOXEL VAULT</Link>
-        <span>ONE APP · CLEARLY ORGANIZED</span>
+        <span>LIVE · SANDBOX · PROVIDER-GATED</span>
       </header>
 
       <section className={styles.hero}>
-        <small>EVERYTHING, WITHOUT THE CLUTTER</small>
-        <h1>One Vault.<br/>Clear places for everything.</h1>
-        <p>Voxel Vault now separates the main jobs instead of making every screen explain the whole company. Explore real places, create 3D assets, manage your Vault, use provider-backed money tools, and keep operator controls in their own advanced area.</p>
+        <small>EVERYTHING ELSE, ORGANIZED</small>
+        <h1>Know what each feature actually is.</h1>
+        <p>The main app is Create → World → Vault. This directory keeps map tools, digital assets, sandbox experiments, regulated/provider-dependent features, and owner controls in separate groups.</p>
         <div className={styles.heroActions}>
-          <Link href="/vault/earth">EXPLORE EARTH</Link>
-          <Link href="/studio">CREATE 3D</Link>
+          <Link href="/property">CREATE PROPERTY</Link>
+          <Link href="/world">OPEN MY WORLD</Link>
           <Link href="/vault">OPEN MY VAULT</Link>
         </div>
       </section>
@@ -43,8 +43,8 @@ export default function MorePage() {
       </section>)}
 
       <div className={styles.note}>
-        <b>PRODUCT TRUTH RULE</b>
-        <span>Map data, AI models, creator assets, securities, wallet holdings, income records and real-property title are intentionally separate data layers. Organizing them into one app does not make them legally equivalent.</span>
+        <b>ONE SIMPLE RULE</b>
+        <span>A digital asset, map record, wallet balance, payment record, security, lease and property deed are different things. Voxel Vault may show them in one interface, but it never treats them as legally or financially interchangeable.</span>
       </div>
     </div>
   </main>;

--- a/app/page.js
+++ b/app/page.js
@@ -3,10 +3,12 @@ import styles from './home.module.css';
 
 // Product truth: upload is the single consumer starting point.
 // Nothing is uploaded, generated, or charged before sign-in.
-// After an authorized photo is chosen, the app guides the user through local VoxelPop creation,
-// interactive 3D, source-backed map placement, World, and optional digital collection.
-// Real-property investment or purchase controls only activate when a verified provider/offering and required legal path exist.
-// A 3D model, payment, map marker, Property Passport, or NFT is not a deed and does not create rent, occupancy, investment, or appreciation rights.
+// One $4.99 checkout unlocks one device-local VoxelPop image + interactive 3D creation.
+// The authorized source photo stays on the user's device; normal creation does not spend Meshy credits.
+// Source-backed map geometry is a separate place-data layer, not a reconstruction of unseen photo details.
+// Optional Collect is a separate digital-item purchase; minting remains optional and downstream.
+// Banking, securities and physical-property rights stay on separate verified legal/provider rails.
+// A 3D model, payment, map marker, Property Passport, NFT or VoxelPop item is never a deed.
 export default function Home() {
   return <main className={styles.page}>
     <div className={styles.shell}>
@@ -19,15 +21,15 @@ export default function Home() {
         <div className={styles.heroCopy}>
           <p className={styles.kicker}>✦ ONE PHOTO → YOUR VOXEL WORLD ✦</p>
           <h1>Upload a picture.<br/><em>VoxelPop does the rest.</em></h1>
-          <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so it can place the result on a source-backed property map.</p>
+          <p className={styles.lead}>Start with one authorized property photo. After sign-in and the $4.99 creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so the result can be placed against source-backed property-map data.</p>
           <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
-          <p className={styles.heroFine}>One starting action. No Meshy credits. No wallet required to create. Collection and minting stay optional.</p>
+          <p className={styles.heroFine}>One VoxelPop creation costs $4.99. Your source photo stays on your device and the image + interactive 3D are built locally without Meshy credits. Optional Collect later is a separate digital-item purchase; no wallet is required to create.</p>
         </div>
 
         <div className={styles.heroVisual} aria-label="Upload one photo and VoxelPop guides the rest">
           <div className={styles.skySparkle}>✦</div>
           <div className={styles.voxelHouse} aria-hidden="true"><div className={styles.roof}/><div className={styles.houseBody}><i/><i/><b/></div><div className={styles.lawn}/></div>
-          <div className={styles.priceBubble}><small>START HERE</small><strong>＋</strong><span>your photo</span></div>
+          <div className={styles.priceBubble}><small>CREATE 3D</small><strong>$4.99</strong><span>local engine</span></div>
           <div className={`${styles.assetChip} ${styles.chipUsd}`}><span>1</span><b>UPLOAD</b></div>
           <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>2</span><b>VOXEL + 3D</b></div>
           <div className={`${styles.assetChip} ${styles.chipNft}`}><span>3</span><b>MAP + WORLD</b></div>
@@ -35,29 +37,29 @@ export default function Home() {
       </header>
 
       <section className={styles.creationCard}>
-        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>There should be no dashboard decision before creation. Pick the picture first; the same creation screen progresses from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
+        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>Pick the picture first. The same creation screen progresses through the explicit $4.99 checkout, VoxelPop image, movable local 3D, address mapping and finished World preview.</span></div></div>
         <Link className={styles.startButton} href="/property">START → SIGN IN + CHOOSE PHOTO</Link>
-        <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>CREATING</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
-        <small>Your photo stays visible through creation. The address is requested only when the 3D is ready to be mapped. Payment, collection and minting remain explicit actions rather than hidden automatic charges.</small>
+        <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>$4.99 CREATE</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
+        <small>Your photo stays on this device through creation. The address is requested only when the 3D is ready to be mapped. Collection and minting remain separate optional actions rather than hidden charges.</small>
       </section>
 
       <section className={styles.unifiedCard}>
         <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has a clear home.</h2><span>Create is the front door. World and Vault are where the finished result goes. Advanced features stay out of the way.</span></div>
         <div className={styles.assetGrid}>
-          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Upload one photo</strong><span>Start the guided VoxelPop property flow.</span><b>Choose photo →</b></Link>
-          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore mapped saved VoxelPop places.</span><b>Open World →</b></Link>
-          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your collection</strong><span>Saved and collected digital assets live here.</span><b>Open Vault →</b></Link>
-          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, verified financial rails, AI and property tools.</span><b>See More →</b></Link>
+          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>$4.99 local VoxelPop</strong><span>Authorized photo → voxel image → movable 3D. No Meshy credits.</span><b>Choose photo →</b></Link>
+          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore your saved voxels against source-backed mapped locations.</span><b>Open World →</b></Link>
+          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your digital items</strong><span>Saved and collected digital assets live here.</span><b>Open Vault →</b></Link>
+          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, provider-gated financial rails, AI and property verification.</span><b>See More →</b></Link>
         </div>
       </section>
 
       <section className={styles.convertCard}>
-        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>The digital voxel is not the deed.</h2><span>The photo creates a stylized local VoxelPop experience; source-backed map data supplies the mapped building context. Physical-property rights remain separate and require the normal verified legal path.</span></div>
-        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="yours"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>→</i><FlowIcon icon="◇" label="Vault" note="optional"/></div>
-        <Link className={styles.convertAction} href="/property">START WITH A PHOTO</Link>
+        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>Digital asset ≠ physical property.</h2><span>The photo creates the digital VoxelPop; source-backed map data supplies mapped place context. The $1.99 property comparison is a sandbox, and financial products remain provider-gated. Physical-property rights require the normal verified legal path.</span></div>
+        <div className={styles.convertFlow} aria-label="VoxelPop product boundaries"><FlowIcon icon="▣" label="Photo" note="device-local"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>≠</i><FlowIcon icon="⌂" label="Deed" note="legal rail"/></div>
+        <Link className={styles.convertAction} href="/more">SEE SANDBOX + PROVIDER TOOLS</Link>
       </section>
 
-      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. A single photo also cannot verify unseen architecture or exact dimensions.</span><Link href="/more">More tools</Link></footer>
+      <footer className={styles.footer}><span>Voxel Vault is not a bank and a VoxelPop item is not a deed. Digital creation or collectible payments do not create title, rent, occupancy, investment or appreciation rights in physical property. Banking, exchange, custody, securities and real-property transactions require their own verified providers and legal rails.</span><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }

--- a/lib/product-map.js
+++ b/lib/product-map.js
@@ -16,12 +16,12 @@ export const APP_DOCK = Object.freeze([
 
 export const APP_SECTIONS = Object.freeze([
   { id: 'explore', eyebrow: 'WORLD + PLACES', title: 'Explore real places', description: 'Map and 3D evidence live here. Map geometry is never treated as legal ownership.', items: [
-    { id: 'earth', href: '/vault/earth', label: 'World Atlas', icon: '◎', description: 'Explore source-backed buildings and open street context around the world.', badge: 'MAP' },
+    { id: 'earth', href: '/vault/earth', label: 'World Atlas', icon: '◎', description: 'Explore source-backed buildings and open street context around the world.', badge: 'MAP DATA' },
     { id: 'geo', href: '/geo', label: 'Property details', icon: '⌖', description: 'Inspect one place with parcel, building and evidence context.', badge: 'EVIDENCE' },
     { id: 'discover', href: '/discover', label: 'Discover', icon: '✦', description: 'Browse public Voxel Vault experiences and digital assets.', badge: 'BROWSE' },
   ]},
   { id: 'create', eyebrow: 'CREATE + COLLECT', title: 'Digital assets', description: 'Create and organize digital assets first. Wallets and minting stay optional.', items: [
-    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Photo → local voxel preview → source-backed mapped 3D → World.', badge: 'CREATE' },
+    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Authorized photo → $4.99 local VoxelPop image + interactive 3D → source-backed map → World → optional collection.', badge: 'LIVE' },
     { id: 'studio', href: '/studio', label: 'Voxel Studio', icon: '+', description: 'Create and prepare other 3D voxel assets.', badge: 'CREATE' },
     { id: 'capture', href: '/capture', label: 'Capture', icon: '◉', description: 'Bring a real object or image into an asset workflow.', badge: 'SCAN' },
     { id: 'receipt', href: '/receipt', label: 'Receipt Scan', icon: '▣', description: 'Verify an eligible purchase before an optional collectible workflow.', badge: 'VERIFY' },
@@ -31,13 +31,13 @@ export const APP_SECTIONS = Object.freeze([
     { id: 'marketplace', href: '/marketplace', label: 'Marketplace', icon: '▦', description: 'Browse published digital assets and explicit checkout flows.', badge: 'SHOP' },
     { id: 'ai-licensing', href: '/ai-licensing', label: 'AI Licensing', icon: 'AI', description: 'Manage reviewed AI-use licensing for eligible digital assets.', badge: 'LICENSE' },
   ]},
-  { id: 'property-money', eyebrow: 'OPTIONAL PROPERTY + MONEY TOOLS', title: 'Sandbox, providers + verification', description: 'These tools stay separate because a demo, financial position, lease, deed and NFT are not the same thing.', items: [
+  { id: 'property-money', eyebrow: 'SANDBOX + VERIFIED PROVIDERS', title: 'Money + real property', description: 'These tools stay separate because a demo, financial position, lease, deed and NFT are not the same thing. Live financial or property rights require verified providers, eligibility and legal rails.', items: [
     { id: 'property-slice', href: '/geo/slice', label: '$1.99 Property Sandbox', icon: '¢', description: 'Compare tiny hypothetical property slices with demo balances only. No real funds or property rights move.', badge: 'SANDBOX' },
-    { id: 'rentals', href: '/vault/rentals', label: 'Rented', icon: '⌂', description: 'View verified lease and payment records when evidence exists.', badge: 'LEASE' },
-    { id: 'invest', href: '/real-estate/reits', label: 'Provider investments', icon: '$', description: 'Browse provider-backed real-estate securities and sandbox/live states.', badge: 'PROVIDER' },
-    { id: 'income', href: '/vault/income', label: 'Observed income', icon: '↗', description: 'See provider-observed payment history without invented yield.', badge: 'OBSERVED' },
-    { id: 'acquire', href: '/real-estate/acquire', label: 'Direct ownership path', icon: '⌂', description: 'Plan normal diligence, title and closing toward actual real-property ownership.', badge: 'DEED PATH' },
-    { id: 'verify', href: '/vault/properties/claim', label: 'Verify property', icon: '✓', description: 'Create a Property Passport downstream of evidence; it is not a deed.', badge: 'VERIFY' },
+    { id: 'rentals', href: '/vault/rentals', label: 'Lease Records', icon: '⌂', description: 'View verified lease and payment records only when supporting evidence exists.', badge: 'VERIFIED DATA' },
+    { id: 'invest', href: '/real-estate/reits', label: 'Real-Estate Investments', icon: '$', description: 'Provider-backed securities may appear only when an approved provider, offering and eligibility path are actually active.', badge: 'PROVIDER-GATED' },
+    { id: 'income', href: '/vault/income', label: 'Income Records', icon: '↗', description: 'Show provider-observed payment history without inventing yield, returns or spendable balances.', badge: 'OBSERVED' },
+    { id: 'acquire', href: '/real-estate/acquire', label: 'Direct Property Path', icon: '⌂', description: 'Plan ordinary diligence, financing, closing and title steps. A token or VoxelPop item is never the deed.', badge: 'LEGAL PATH' },
+    { id: 'verify', href: '/vault/properties/claim', label: 'Verify Property', icon: '✓', description: 'Create a Property Passport downstream of evidence; it is not a deed or investment security.', badge: 'VERIFY' },
     { id: 'twins', href: '/vault/estates/mine', label: 'Digital Twins', icon: '◇', description: 'See account-secured digital twins and optional wallet bindings.', badge: 'DIGITAL' },
   ]},
   { id: 'intelligence', eyebrow: 'OPTIONAL EXPERIENCES', title: 'AI + playful tools', description: 'Useful extras stay available without crowding the core Create → World → Vault flow.', items: [
@@ -47,8 +47,8 @@ export const APP_SECTIONS = Object.freeze([
   { id: 'advanced', eyebrow: 'OWNER + ADVANCED', title: 'Infrastructure + blockchain', description: 'Power tools stay out of the normal customer journey.', items: [
     { id: 'forge', href: '/forge/mainnet', label: 'Voxel Forge', icon: '⚒', description: 'Open the reviewed Forge workflow and explicit wallet-signing path.', badge: 'ADVANCED' },
     { id: 'integrations', href: '/admin/integrations', label: 'Integrations', icon: '≋', description: 'Owner-only provider and infrastructure readiness center.', badge: 'OWNER' },
-    { id: 'reits-admin', href: '/admin/digital-reits', label: 'Investment provider admin', icon: 'R', description: 'Owner tools for provider onboarding and controlled configuration.', badge: 'OWNER' },
-    { id: 'claims-admin', href: '/admin/property-claims', label: 'Property claims admin', icon: 'P', description: 'Review property evidence without weakening title boundaries.', badge: 'OWNER' },
+    { id: 'reits-admin', href: '/admin/digital-reits', label: 'Investment Provider Admin', icon: 'R', description: 'Owner tools for provider onboarding and fail-closed investment configuration.', badge: 'OWNER' },
+    { id: 'claims-admin', href: '/admin/property-claims', label: 'Property Claims Admin', icon: 'P', description: 'Review property evidence without weakening title boundaries.', badge: 'OWNER' },
   ]},
 ]);
 

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -28,6 +28,9 @@ for (const route of ['/property', '/vault/earth', '/geo', '/studio', '/capture',
 }
 assert.match(productMap, /\$1\.99 Property Sandbox/, 'the tiny property comparison must remain explicitly sandboxed under More');
 assert.match(productMap, /No real funds or property rights move/, 'sandbox description must preserve the no-rights boundary');
+assert.match(productMap, /\$4\.99 local VoxelPop image \+ interactive 3D/, 'property creator directory entry must disclose the local paid creation');
+assert.match(productMap, /badge: 'PROVIDER-GATED'/, 'regulated investment tools must be visibly provider-gated');
+assert.match(productMap, /A token or VoxelPop item is never the deed/, 'direct ownership path must keep title separate from the token');
 assert.match(productMap, /APP_USER_PREFIXES[\s\S]*'\/admin'/, 'owner routes should keep the global app shell');
 assert.match(productMap, /isOrganizedUserRoute/);
 assert.match(productMap, /isSimplePropertyRoute/);
@@ -61,24 +64,29 @@ assert.match(commandCenter, /!isSimplePropertyRoute\(pathname\)/, 'advanced tool
 assert.match(commandCenter, /never automatically spends money, mints an NFT, or starts a paid 3D generation/, 'tool finder must disclose its non-execution boundary');
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
-// Consumer Home describes the actual guided, local-generation property flow.
+// Consumer Home describes the actual guided, paid local-generation property flow.
 assert.match(rootHome, /START → SIGN IN \+ UPLOAD PHOTO/, 'root Home should accurately disclose sign-in before the upload picker');
 assert.match(rootHome, /href="\/property"/, 'root Home should route the primary CTA into the account-gated maker');
 assert.match(rootHome, /Upload a picture\./, 'root Home should make one photo the obvious starting point');
-assert.match(rootHome, /After sign-in and your explicit creation checkout/, 'root Home should disclose the paid creation gate without implying hidden charging');
+assert.match(rootHome, /After sign-in and the \$4\.99 creation checkout/, 'root Home should disclose the exact paid creation gate without implying hidden charging');
+assert.match(rootHome, /One VoxelPop creation costs \$4\.99/i, 'root Home must disclose the generation price');
+assert.match(rootHome, /source photo stays on your device/i, 'root Home must explain the device-local source-photo boundary');
+assert.match(rootHome, /without Meshy credits/i, 'root Home must accurately describe the local generation engine');
+assert.match(rootHome, /Optional Collect later is a separate digital-item purchase/i, 'root Home must distinguish generation from the later collectible checkout');
 assert.match(rootHome, /<b>UPLOAD<\/b>/, 'root Home should show the upload stage');
-assert.match(rootHome, /<b>CREATING<\/b>/, 'root Home should show local creation as the next stage');
+assert.match(rootHome, /<b>\$4\.99 CREATE<\/b>/, 'root Home should disclose the paid creation stage in the flow');
 assert.match(rootHome, /<b>3D<\/b>/, 'root Home should expose movable 3D');
 assert.match(rootHome, /<b>MAP<\/b>/, 'root Home should expose source-backed mapping');
 assert.match(rootHome, /<b>READY<\/b>/, 'root Home should make the guided finish state obvious');
-assert.match(rootHome, /Payment, collection and minting remain explicit actions/, 'paid and blockchain actions must never appear automatic');
-assert.match(rootHome, /No wallet required to create/i, 'wallet must remain optional for creation');
-assert.match(rootHome, /No Meshy credits/i, 'normal property creation should accurately disclose the zero-Meshy dependency');
-assert.match(rootHome, /does not buy the physical property/i, 'root Home must distinguish collecting a voxel from buying physical property');
-assert.match(rootHome, /deed\/title, rent, occupancy, or investment rights/, 'root Home must preserve digital versus legal-rights truth');
+assert.match(rootHome, /Collection and minting remain separate optional actions/, 'paid and blockchain actions must never appear automatic');
+assert.match(rootHome, /no wallet is required to create/i, 'wallet must remain optional for creation');
+assert.match(rootHome, /Voxel Vault is not a bank/i, 'root Home must not imply bank status');
+assert.match(rootHome, /VoxelPop item is not a deed/i, 'root Home must distinguish a digital item from title');
+assert.match(rootHome, /\$1\.99 property comparison is a sandbox/i, 'root Home must label the property slice as sandbox');
+assert.match(rootHome, /financial products remain provider-gated/i, 'root Home must label regulated financial tools as provider-gated');
 assert.match(rootHome, /href="\/more"/, 'optional and advanced tools must remain deliberately reachable');
 assert.doesNotMatch(rootHome, /YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT|TRY THE \$1\.99 SLICE/, 'bank-like and sandbox-heavy language must not dominate the front door');
-assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING/, 'unverified physical-property purchase execution must stay out of the consumer front door');
+assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING|guaranteed returns|guaranteed yield|risk[- ]free/i, 'unverified physical-property purchase or return claims must stay out of the consumer front door');
 assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root home must not alias an older real-estate subsystem');
 
 // The $1.99 comparison is intentionally a pure sandbox, not a faux bank/wallet surface.
@@ -99,10 +107,11 @@ assert.doesNotMatch(homeCapabilities, /process\.env|MESHY_API_KEY|BRIDGE_ACCESS_
 assert.match(capabilitiesApi, /automaticGeneration:\s*false/, 'server capability contract must keep Meshy automatic generation disabled');
 assert.match(capabilitiesApi, /Boolean\(process\.env\.MESHY_API_KEY\?\.trim\(\)\)/, 'Meshy readiness may expose only a boolean');
 
-assert.match(more, /Everything, without the clutter/i);
+assert.match(more, /Know what each feature actually is/i, 'More must explain its status-driven purpose');
 assert.match(more, /APP_SECTIONS/);
-assert.match(more, /PRODUCT TRUTH RULE/);
-assert.match(more, /Explore real places, create 3D assets, manage your Vault/i);
+assert.match(more, /ONE SIMPLE RULE/);
+assert.match(more, /Create → World → Vault/, 'More must keep the main consumer journey short');
+assert.match(more, /LIVE · SANDBOX · PROVIDER-GATED/, 'More must expose feature status at the top');
 
 assert.match(integrationsApi, /requireVoxelVaultAdmin/, 'integration status must be owner-authenticated');
 assert.match(integrationsApi, /MESHY_API_KEY/);
@@ -136,4 +145,4 @@ assert.match(home, /Fail-closed for real money/);
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault guided upload -> local creation -> 3D -> map -> ready journey + unambiguous $1.99 sandbox + separated optional property/money tools + fail-closed advanced rails coherence checks passed');
+console.log('Voxel Vault guided sign-in -> upload -> $4.99 local creation -> 3D -> map -> ready journey + unambiguous $1.99 sandbox + separated optional property/money tools + fail-closed advanced rails coherence checks passed');

--- a/scripts/test-global-rent-engine.mjs
+++ b/scripts/test-global-rent-engine.mjs
@@ -42,8 +42,6 @@ assert.ok(plan.purchases.every((asset) => asset.acquisitionCost > 0), 'only vali
 const tinyPlan = buildAcquisitionPlan({ capital: 400, reserveFloor: 0.1 });
 assert.equal(tinyPlan.purchases.length, 0, 'engine must keep cash rather than force an unaffordable purchase');
 
-// Real rental V1: payment delinquency may change workflow status, but does not itself
-// terminate the lease or remove tenant-layer permissions.
 for (const status of ['current', 'late', 'notice', 'legal-process']) {
   assert.equal(canTenantUseProperty({ status, leaseVerifiedAt: '2026-08-01T00:00:00Z' }), true, `${status} must retain tenant-layer access before lawful termination`);
 }
@@ -58,27 +56,9 @@ assert.equal(assertRentalTransition('late', 'ended', {
   terminationReferenceHash: 'b'.repeat(64),
 }), true, 'lawfully verified termination may end the digital tenant layer');
 
-assert.equal(canAttachMintedVoxel({
-  status: 'current',
-  leaseVerifiedAt: '2026-08-01T00:00:00Z',
-  tokenId: '42',
-  accountMintConfirmed: true,
-  walletOwnershipVerified: true,
-}), true, 'account-confirmed mint plus current wallet owner proof may be associated with an active rental');
-assert.equal(canAttachMintedVoxel({
-  status: 'current',
-  leaseVerifiedAt: '2026-08-01T00:00:00Z',
-  tokenId: '42',
-  accountMintConfirmed: true,
-  walletOwnershipVerified: false,
-}), false, 'a stored token ID alone is not enough to attach a voxel');
-assert.equal(canAttachMintedVoxel({
-  status: 'current',
-  leaseVerifiedAt: '2026-08-01T00:00:00Z',
-  tokenId: '',
-  accountMintConfirmed: false,
-  walletOwnershipVerified: false,
-}), false, 'unminted creation must not be permanently attached');
+assert.equal(canAttachMintedVoxel({ status: 'current', leaseVerifiedAt: '2026-08-01T00:00:00Z', tokenId: '42', accountMintConfirmed: true, walletOwnershipVerified: true }), true, 'account-confirmed mint plus current wallet owner proof may be associated with an active rental');
+assert.equal(canAttachMintedVoxel({ status: 'current', leaseVerifiedAt: '2026-08-01T00:00:00Z', tokenId: '42', accountMintConfirmed: true, walletOwnershipVerified: false }), false, 'a stored token ID alone is not enough to attach a voxel');
+assert.equal(canAttachMintedVoxel({ status: 'current', leaseVerifiedAt: '2026-08-01T00:00:00Z', tokenId: '', accountMintConfirmed: false, walletOwnershipVerified: false }), false, 'unminted creation must not be permanently attached');
 
 const ownershipMessage = tenantVoxelOwnershipMessage({ userId: 'user-1', leaseId: 'lease-1', sessionId: 'voxel-1', tokenId: '42', signedAt: '2026-08-29T00:00:00.000Z' });
 assert.match(ownershipMessage, /does not transfer the voxel, property, lease, money, or any ownership right/i, 'wallet proof must be non-transactional and narrowly scoped');
@@ -157,9 +137,10 @@ assert.match(roomDecorator, /Save layout/, 'decorator must provide an explicit t
 assert.match(roomDecorator, /DRAG TO TURN ROOM · PINCH TO ZOOM · TAP A VOXEL/, 'decorator must expose mobile 3D controls');
 assert.match(voxelAccount, /modelUrl:\s*String\(normalized\.payload\.mesh\?\.modelUrl/, 'rental room must receive ready VoxelPop GLB URLs when available');
 
-assert.match(productMap, /href: '\/vault\/rentals', label: 'Rented'/, 'Rented must be discoverable from the simple VoxelPop property dock');
-assert.match(productMap, /path === '\/vault\/rentals'/, 'Rented must stay inside the simplified property navigation mode');
+assert.match(productMap, /href: '\/vault\/rentals', label: 'Lease Records'/, 'lease records must remain discoverable under the organized More directory');
+assert.match(productMap, /badge: 'VERIFIED DATA'/, 'lease records must be labeled as verified data rather than a primary ownership action');
+assert.match(productMap, /path === '\/vault\/rentals'|path\.startsWith\('\/vault\/'\)/, 'rental routes must remain inside the organized Voxel Vault navigation shell');
 assert.match(rentalDocs, /does \*\*not\*\* yet provide:[\s\S]*production e-signature provider/i, 'docs must fail closed about legal lease execution');
 assert.match(rentalDocs, /late rent does not automatically end tenancy/i, 'docs must preserve lawful termination boundary');
 
-console.log('Global rent + room decorator safety checks passed: verified lease -> monthly status -> private room reference -> wallet-owned minted voxels -> bounded tenant layout -> lawful lease end/archive, never automatic eviction or fake floor-plan truth.');
+console.log('Global rent + room decorator safety checks passed: lease records remain discoverable under More without cluttering the five-item consumer dock; verified lease/payment safety, lawful termination, private room references and wallet-owned voxel placement remain enforced.');

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -62,9 +62,6 @@ requireMarkers(launch, 'legal launch engine', [
   'authority-evidence-not-verified',
 ]);
 
-// The owner-only securities rail and the direct-property rail are intentionally separate.
-// A simple consumer homepage is allowed, but it must fail closed and the advanced directory
-// must preserve access to provider-backed investment workflows and their legal status.
 requireMarkers(status, 'property status route', [
   'liveSecuritiesImplementationReady = DINARI_LIVE_TRADING_IMPLEMENTATION_READY === true',
   'liveSecuritiesProviderActivated = dinari.productionTradingEnabled === true',
@@ -115,16 +112,20 @@ requireMarkers(distribution, 'distribution vault', [
 ]);
 
 requireMarkers(root, 'simple root homepage', [
-  'START → SIGN IN',
-  'Nothing is uploaded, generated, or charged before sign-in.',
-  'Real-property investment or purchase controls only activate when a verified provider/offering and required legal path exist.',
-  'A 3D model, payment, map marker, Property Passport, or NFT is not a deed',
+  'START → SIGN IN + UPLOAD PHOTO',
+  'One VoxelPop creation costs $4.99.',
+  'source photo stays on your device',
+  'without Meshy credits',
+  'Optional Collect later is a separate digital-item purchase',
+  'Voxel Vault is not a bank',
+  'VoxelPop item is not a deed',
   'href="/more"',
 ]);
 requireMarkers(productMap, 'advanced product directory', [
   "href: '/real-estate/reits'",
-  'Browse provider-backed real-estate securities and sandbox/live states.',
+  'Provider-backed securities may appear only when an approved provider, offering and eligibility path are actually active.',
   "href: '/real-estate/acquire'",
+  'A token or VoxelPop item is never the deed.',
   "href: '/vault/properties/claim'",
 ]);
 
@@ -240,4 +241,4 @@ assert.equal(regulatedLaunchPacket.liveMoneyMovement, 'blocked', 'direct-propert
 assert.equal(regulatedLaunchPacket.liveOwnershipMinting, 'blocked', 'direct-property ownership minting must remain blocked');
 assert.ok(regulatedLaunchPacket.reviewDocuments.some((doc) => doc.path === 'docs/REGULATED_LAUNCH_PACKET.md'), 'launch packet doc should be listed for review');
 
-console.log('Property-platform safety checks passed: the sign-in-first simple home stays fail-closed without advertising regulated rails, advanced provider-backed investment routes remain discoverable, direct-property environment assertions cannot satisfy authority-evidence gates, legal clearance is never claimed, the Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment is Base Sepolia-only.');
+console.log('Property-platform safety checks passed: the clear $4.99 device-local non-Meshy consumer flow remains separate from regulated rails; provider-backed investment routes remain gated, legal clearance is never claimed, Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment remains Base Sepolia-only.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -32,10 +32,14 @@ const command = read('app/components/AppCommandCenter.js');
 
 assert.match(home, /ONE PHOTO → YOUR VOXEL WORLD|Upload a picture\./, 'home describes the current one-photo guided journey');
 assert.match(home, /START → SIGN IN \+ UPLOAD PHOTO/, 'home truthfully exposes the account gate before the photo picker');
-assert.match(home, /No wallet required to create/i, 'wallet must not block creation or checkout');
-assert.match(home, /does not buy the physical property/i, 'home distinguishes the voxel from physical real estate');
-assert.match(home, /No Meshy credits/i, 'home makes the no-Meshy provider dependency explicit');
-assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed/i, 'unverified property-purchase language stays out of the simple home');
+assert.match(home, /One VoxelPop creation costs \$4\.99/, 'home clearly discloses the creation price');
+assert.match(home, /source photo stays on your device/i, 'home explains the device-local source photo boundary');
+assert.match(home, /without Meshy credits/i, 'home makes the no-Meshy dependency explicit');
+assert.match(home, /Optional Collect later is a separate digital-item purchase/i, 'home distinguishes creation payment from the later collectible checkout');
+assert.match(home, /no wallet is required to create/i, 'wallet must not block core creation');
+assert.match(home, /Voxel Vault is not a bank/i, 'home must not imply bank status');
+assert.match(home, /VoxelPop item is not a deed/i, 'home must separate digital items from real-property title');
+assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed|guaranteed returns|guaranteed yield/i, 'unverified property-purchase or return language stays out of the simple home');
 
 for (const source of [homeCss, propertyCss, vault, world]) assert.match(source, /#fffaf0/i, 'simple surfaces keep the warm VoxelPop canvas');
 assert.match(propertyCss, /#7138f5/i, 'VoxelPop purple remains');
@@ -50,7 +54,7 @@ assert.match(property, /Choose one photo\./, 'first signed-in step stays photo-f
 assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC/HEIF selection remains supported');
 assert.match(property, /normalizeIphonePhoto/, 'iPhone photo preparation remains automatic');
 assert.match(property, /I took this photo or have permission to use it\./, 'source photo still requires rights confirmation');
-assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} · Use photo → start build/, 'the same paid creation CTA remains explicit');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} · Use photo → start build/, 'the paid creation CTA remains explicit');
 
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'source photo is kept privately on-device across checkout');
 assert.match(property, /createVoxelPoster/, 'VoxelPop image is built locally');
@@ -107,7 +111,7 @@ assert.match(canonicalRegistry, /PropertyAlreadyRegistered/, 'canonical registry
 assert.match(propertyPassport, /PassportAlreadyMinted/, 'Property Passport rejects a second canonical mint');
 assert.match(interestToken, /off-chain legal/, 'economic rights remain defined separately by legal agreements');
 
-assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the same condensed consumer navigation instead of a separate mini-app dock');
+assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> authorized device-local photo -> explicit paid unlock -> VoxelPop image -> local interactive 3D -> improved source-backed property map -> digital collection/Vault, without Meshy credits or checkout Storage.');
+console.log('Guided VoxelPop property checks passed: sign in -> authorized device-local photo -> clear $4.99 local creation -> VoxelPop image -> interactive 3D -> source-backed property map -> optional digital collection/Vault, without Meshy credits or checkout Storage.');


### PR DESCRIPTION
## Final clarity pass

This keeps the newest sign-in-first, upload-once VoxelPop experience and the new pure $1.99 sandbox, then fixes the remaining trust gap: users now see the real creation price and the legal/product boundaries before entering the maker.

- Keeps `START → SIGN IN + UPLOAD PHOTO`.
- Discloses **$4.99** for one device-local VoxelPop image + interactive 3D creation.
- States the source photo stays on-device and the normal flow uses **no Meshy credits**.
- Makes **Optional Collect** a separate later digital-item checkout.
- Keeps source-backed map data separate from photo-derived digital 3D.
- Keeps Home / Create / World / Vault / More as the primary navigation.
- Keeps the $1.99 property experience a pure sandbox: no wallet, crypto, NFT faux-balance, checkout, ownership, or real funds.
- Keeps Lease Records discoverable under More without forcing a sixth primary tab.
- Labels financial/investment tools as provider-gated and direct-property title as a separate legal rail.
- Explicitly states Voxel Vault is not a bank and VoxelPop/NFT is not a deed.

No Stripe execution, local Three.js engine, map renderer, wallet/mint execution, or regulated-investment activation logic is changed. Existing legal launch gates remain fail-closed.