### PR TITLE
Finish Voxel Vault legitimacy cleanup across remaining surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,94 @@
-# Voxel Vault — Real Property, Made Spatial
+# Voxel Vault
 
-Voxel Vault is now being developed as a real-property digital-twin and legally linked blockchain ownership platform.
+Voxel Vault is a 3D property and digital-asset app.
 
-The core model is intentionally conservative:
+The current property product lets a signed-in user:
+
+- choose a property photo they took or have permission to use;
+- pay **$4.99** for one VoxelPop digital creation;
+- keep the source photo on the device instead of uploading it for generation;
+- build the VoxelPop image and movable 3D model locally without Meshy credits;
+- map the address into source-backed 3D context;
+- place the digital property in My World;
+- optionally buy an eligible mapped **digital VoxelPop collectible** through a separate checkout;
+- organize digital assets and separately verified positions in My Vault.
+
+## Four product states
+
+| State | Meaning |
+| --- | --- |
+| **$4.99 DIGITAL** | One paid VoxelPop digital creation. No physical-property rights. |
+| **DEMO** | Sandbox only. Fake demo credit is not money and creates no property rights. |
+| **PARTNER** | A financial/investment action is live only through the required approved provider, eligibility, settlement, and verification path. |
+| **TITLE** | Real-property ownership changes only through normal closing and recorded title. |
+
+## Current VoxelPop property flow
 
 ```text
-Recorded real-property deed
-        |
-        v
-Dedicated property LLC
-        |
-        | operating/subscription agreement
-        v
-Permissioned blockchain interest token
-        |
-        +-------------------+
-        |                   |
-        v                   v
-Approved holders       Net-income distributions
+SIGN IN
+  -> AUTHORIZED PHOTO
+  -> $4.99 DIGITAL CREATION CHECKOUT
+  -> PAID SESSION VERIFIED
+  -> LOCAL VOXEL IMAGE + MOVABLE 3D
+  -> SOURCE-BACKED PROPERTY MAP
+  -> MY WORLD
+  -> OPTIONAL SEPARATE DIGITAL COLLECTIBLE CHECKOUT
+  -> VAULT
+  -> OPTIONAL SEPARATE VERIFY + MINT FLOW
 ```
 
-The blockchain does **not** replace the county deed or ordinary land-title system. The enforceable legal documents for the property entity must define what any token-linked economic or membership rights actually mean.
+The source photo remains device-local during creation. The local VoxelPop engine does not require Meshy credits. A verified paid session may resume the same creation without a second creation charge.
 
-## Current pilot
+The local visual model and mapped property record are different evidence layers. One photo is not treated as a survey, complete physical replica, title record, ownership record, or property valuation.
 
-- New real-property homepage at `/`
-- Interactive Three.js property/parcel digital twin
-- Property intake checklist at `/real-estate/onboard`
-- Fail-closed status endpoint at `/api/property-platform/status`
-- `PropertyRegistry.sol` for property/entity/title-reference hashes
-- `PropertyInterestToken.sol` for capped, allowlisted ownership-interest units
-- `PropertyDistributionVault.sol` for audited Merkle-based net-income distribution epochs
-- Base Sepolia-only pilot deployment script
-- Safety regression that prevents accidental live-investing enablement
+## What the $4.99 purchase buys
 
-The existing VoxelPop / voxel asset generator is preserved at `/studio` so it can evolve into the 3D digital-twin creation engine.
+The **$4.99 payment buys one digital VoxelPop creation** built by Voxel Vault's local generation engine.
+
+It does not buy the physical house or land, deed/title ownership, property equity, rent or occupancy rights, a fractional real-estate investment, or guaranteed appreciation/income.
+
+After the creation is mapped to an eligible source-backed building, the user may be offered a **separate optional collectible checkout**. That second purchase is also a digital asset only and does not create physical-property rights.
+
+## $1.99 Property Sandbox
+
+The `$1.99 Property Sandbox` uses free fake demo credit and proportional property math. Demo credit can be refilled for testing; it is not cash, a deposit, or a payment method.
+
+The sandbox does not transfer customer money, reserve real property, purchase a security, create equity, mint a real-estate security, or create deed, rent, or occupancy rights.
+
+A real small-dollar property investment can replace the sandbox only if an actual verified offering supports the exact amount and all required provider, eligibility, settlement, disclosure, custody, and position-verification steps are live.
+
+## Real estate and money features
+
+- **Property investments** — fail closed unless an approved provider supports the exact offering, user, eligibility, transaction, settlement, and verification path.
+- **Income** — only observed/provider-reported payments should be shown as actual income.
+- **Direct ownership** — requires ordinary diligence, closing, and recorded title.
+- **Crypto / USD rails** — require the appropriate wallet, banking/payment, exchange, custody, and compliance providers before customer money movement becomes live.
+
+Voxel Vault is **not itself a bank, broker, exchange, custodian, escrow service, or deed registry**.
+
+## Blockchain pilot
+
+The repository contains testnet-oriented smart-contract infrastructure for research and controlled pilots. That infrastructure does not make live real-estate investing available.
+
+A blockchain token does not replace a county deed or the ordinary land-title system. Any future token-linked property or security rights would come from the actual legal instrument, offering, entity records, and applicable provider/compliance structure—not from the token alone.
 
 ## Safety posture
 
-Live investing is disabled in code. Environment variables alone cannot unlock it. The pilot deployment script refuses every chain except Base Sepolia (`84532`). New property registry entries are unverified and inactive by default, and interest tokens cannot move to or from wallets that are not explicitly allowlisted.
-
-This is prototype infrastructure, not a public real-estate security offering, title product, escrow service or custody service.
-
-Read [`docs/REAL_ESTATE_PILOT.md`](docs/REAL_ESTATE_PILOT.md) for the operating model and launch gates.
+- Paid VoxelPop creation is explicitly a digital-creation purchase.
+- Optional digital property collection is a separate, digital-only purchase.
+- The $1.99 sandbox remains fake demo credit only.
+- Map evidence is not converted into an ownership claim.
+- Wallet holdings, provider positions, property title, and digital collectibles remain separate records.
+- Live investing stays disabled unless the exact provider/legal gates are satisfied.
+- No private keys, investor identity documents, bank information, tenant PII, confidential deeds/leases, or private closing documents belong in the public repository or token metadata.
 
 ## Local verification
 
 ```bash
 npm install
 npm run test:property-platform
-npm run chain:compile
-npm run chain:test:property
+npm run test:simple-property-world
 npm run build
 ```
 
-## Base Sepolia deployment
-
-Set a Base Sepolia RPC plus a testnet deployer key in your private environment, then run:
-
-```bash
-npm run chain:deploy:property-pilot
-```
-
-The deploy script creates a registry, one pilot interest token and a distribution vault. It intentionally leaves the property record unverified/inactive.
-
-Never commit a private key, investor identity document, bank information, confidential deed/lease, tenant PII or private closing document to GitHub or public token metadata.
+For regulated-pilot architecture and launch gates, see `docs/REAL_ESTATE_PILOT.md`, `docs/UNIFIED_PROPERTY_MONEY_VAULT.md`, and the legal-review documentation under `docs/`.

--- a/app/layout.js
+++ b/app/layout.js
@@ -10,18 +10,18 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_AP
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
-  title: { default: 'Voxel Vault | Your 3D Asset Vault', template: '%s | Voxel Vault' },
-  description: 'Create and collect 3D voxel assets, explore real places, organize NFTs and connected financial tools, and keep ownership status clear in one spatial app.',
-  keywords: ['3D assets', 'voxel creator', 'NFT vault', 'spatial wallet', 'real estate digital twin', 'digital assets', 'Voxel Vault'],
+  title: { default: 'Voxel Vault | 3D Property + Digital Assets', template: '%s | Voxel Vault' },
+  description: 'Your 3D Asset Vault for paid digital VoxelPop creations, source-backed property maps, digital collectibles, and clearly separated sandbox, provider-backed, and title-based property workflows.',
+  keywords: ['3D property', 'voxel creator', 'digital property', 'NFT vault', 'real estate digital twin', 'digital assets', 'Voxel Vault'],
   alternates: { canonical: SITE_URL },
   robots: { index: true, follow: true },
   icons: { icon: '/voxelpop/voxelpop-logo.png', apple: '/voxelpop/voxelpop-logo.png' },
   openGraph: {
-    title: 'Voxel Vault | Your 3D Asset Vault',
-    description: 'A playful spatial home for 3D creation, NFTs, real-world exploration and connected financial tools.',
+    title: 'Voxel Vault | 3D Property + Digital Assets',
+    description: 'Create digital VoxelPop property assets, explore source-backed places in 3D, and keep digital assets, sandbox tools, provider positions, and real-property title clearly separated.',
     type: 'website', url: SITE_URL, siteName: 'Voxel Vault', images: [{ url: '/voxelpop/voxelpop-logo.png', alt: 'Voxel Vault' }],
   },
-  twitter: { card: 'summary', title: 'Voxel Vault | Your 3D Asset Vault', description: 'Create, explore, collect and organize spatial assets from one app.', images: ['/voxelpop/voxelpop-logo.png'] },
+  twitter: { card: 'summary', title: 'Voxel Vault | 3D Property + Digital Assets', description: 'Create, map, collect, and organize digital property assets with clear ownership boundaries.', images: ['/voxelpop/voxelpop-logo.png'] },
 };
 
 export const viewport = {
@@ -33,15 +33,5 @@ export const viewport = {
 };
 
 export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>
-        <WalletIdentityProvider>
-          {children}
-          <AppCommandCenter />
-          <FinancialOSNav />
-        </WalletIdentityProvider>
-      </body>
-    </html>
-  );
+  return <html lang="en"><body><WalletIdentityProvider>{children}<AppCommandCenter /><FinancialOSNav /></WalletIdentityProvider></body></html>;
 }

--- a/app/real-estate/page.js
+++ b/app/real-estate/page.js
@@ -1,220 +1,72 @@
 import PropertyTwinCanvas from './PropertyTwinCanvas';
 import styles from './real-estate.module.css';
 
-const journey = [
-  {
-    number: '01',
-    title: 'Explore',
-    copy: 'Search a real address and inspect source-backed geography, mapped buildings, parcel evidence and nearby context in 3D.',
-    href: '/geo',
-    action: 'Open GEO',
-  },
-  {
-    number: '02',
-    title: 'Invest',
-    copy: 'Browse provider-confirmed tokenized real-estate securities. Sandbox and live execution stay separated and provider-gated.',
-    href: '/real-estate/reits',
-    action: 'Open investments',
-  },
-  {
-    number: '03',
-    title: 'Vault',
-    copy: 'Keep creator assets, wallet-verified collectibles and user-bound financial positions in one spatial home without mixing their legal meaning.',
-    href: '/vault',
-    action: 'Open my Vault',
-  },
-  {
-    number: '04',
-    title: 'Income',
-    copy: 'See provider-reported dividend payment history as observed income. No invented yield, rent, FX conversion or projections.',
-    href: '/vault/income',
-    action: 'Open Income',
-  },
-  {
-    number: '05',
-    title: 'Own',
-    copy: 'Plan the longer path toward a directly owned property through diligence, entity setup, normal closing and a recorded deed.',
-    href: '/real-estate/acquire',
-    action: 'Plan direct ownership',
-  },
+// Existing verified property-detail routes remain under /real-estate/property/[propertyId].
+const paths = [
+  { number: '01', status: 'LIVE DIGITAL', title: 'Explore a real place', copy: 'Search an address and inspect source-backed map, building, parcel, and nearby 3D context.', href: '/geo', action: 'Open property map' },
+  { number: '02', status: 'DEMO', title: 'Try $1.99 property math', copy: 'Use fake demo balances to compare tiny hypothetical slices. No real funds, security purchase, or property rights move.', href: '/geo/slice', action: 'Try the sandbox' },
+  { number: '03', status: 'PARTNER REQUIRED', title: 'Property investments', copy: 'Real-estate securities only become live through an approved provider, eligible offering, user checks, settlement, and position verification.', href: '/real-estate/reits', action: 'View investment status' },
+  { number: '04', status: 'TITLE REQUIRED', title: 'Own real property', copy: 'Direct ownership follows diligence, closing, and recorded title. A token, NFT, model, or map marker is not the deed.', href: '/real-estate/acquire', action: 'See ownership path' },
 ];
 
 const truthLayers = [
-  ['Place truth', 'Source-backed map, building and parcel evidence. GEO never turns map geometry into a deed claim.'],
-  ['Asset truth', 'Provider-confirmed securities stay distinct from NFTs, creator assets and direct real property.'],
-  ['Ownership truth', 'Wallet checks, account bindings and recorded title are used only for the ownership facts they can actually prove.'],
-  ['Income truth', 'Observed provider payments are shown as reported. Modeled rent and simulations remain clearly labeled models.'],
+  ['Place', 'Map, building, and parcel evidence can describe a location. They do not prove ownership.'],
+  ['Digital asset', 'A VoxelPop creation or collectible can be bought as a digital asset. It does not include physical-property rights.'],
+  ['Investment', 'A provider-confirmed security is shown only as the provider can substantiate it. Estimated values are not cash.'],
+  ['Real ownership', 'Recorded title and the normal legal closing process control ownership of the physical property.'],
 ];
 
 export default function RealEstatePlatformPage() {
-  return (
-    <main className={styles.page} style={{paddingBottom:'94px'}}>
-      <div className={styles.shell}>
-        <nav className={styles.nav}>
-          <a className={styles.brand} href="/">
-            <span className={styles.brandMark}>V</span>
-            Voxel Vault
-          </a>
-          <div className={styles.navActions}>
-            <span className={styles.statusPill}><span className={styles.statusDot} />FINANCIAL OS · PILOT</span>
-            <a className={styles.ghostPill} href="/geo">Explore GEO</a>
-            <a className={styles.ghostPill} href="/vault">My Vault</a>
-            <a className={styles.ghostPill} href="/studio">Create 3D</a>
-          </div>
-        </nav>
+  return <main className={styles.page} style={{paddingBottom:'94px'}}><div className={styles.shell}>
+    <nav className={styles.nav}>
+      <a className={styles.brand} href="/"><span className={styles.brandMark}>V</span>Voxel Vault</a>
+      <div className={styles.navActions}><span className={styles.statusPill}><span className={styles.statusDot}/>REAL ESTATE · CLEAR STATUS</span><a className={styles.ghostPill} href="/geo">Property Map</a><a className={styles.ghostPill} href="/vault">My Vault</a></div>
+    </nav>
 
-        <section className={styles.hero}>
-          <div className={styles.heroIntro}>
-            <p className={styles.eyebrow}>Explore → invest → verify → observe → own</p>
-            <h1>Your money,<br /><em>made spatial.</em></h1>
-            <p className={styles.lead}>
-              Voxel Vault is one spatial financial home for real-estate discovery, provider-backed investment assets, verified holdings, observed income and the longer path toward direct property ownership.
-            </p>
-            <div className={styles.actions}>
-              <a className={styles.primaryButton} href="/geo">Explore a real place</a>
-              <a className={styles.secondaryButton} href="/real-estate/reits">Browse investments</a>
-              <a className={styles.secondaryButton} href="/vault">Open my Vault</a>
-            </div>
-            <div className={styles.heroNote}>
-              <span>Live investing is locked unless the approved provider path says otherwise.</span>
-              <span>Demo data only where marked.</span>
-              <span>Source-backed geography.</span>
-              <span>Observed income only.</span>
-              <span>Direct property closes through normal title systems.</span>
-            </div>
-          </div>
-
-          <div className={styles.heroVisual}>
-            <PropertyTwinCanvas className={styles.twinCanvas} />
-            <div className={styles.visualTop}>
-              <span className={styles.darkPill}>SPATIAL FINANCIAL HOME</span>
-              <span className={styles.demoPill}>TRUTH-FIRST</span>
-            </div>
-            <div className={styles.visualBottom}>
-              <div className={styles.propertyCaption}>
-                <small>One coherent system</small>
-                <strong>Place → asset → ownership → income</strong>
-              </div>
-              <span className={styles.dragHint}>3D is the interface<br />evidence is the authority</span>
-            </div>
-          </div>
-        </section>
-
-        <section className={styles.metricGrid} aria-label="Financial operating principles">
-          <div className={styles.metricCard}>
-            <div className={styles.metricLabel}>Explore</div>
-            <div className={styles.metricValue}>Real places</div>
-            <div className={styles.metricSub}>Source-backed map and parcel context</div>
-          </div>
-          <div className={styles.metricCard}>
-            <div className={styles.metricLabel}>Invest</div>
-            <div className={styles.metricValue}>Provider-gated</div>
-            <div className={styles.metricSub}>No invented listings or fake execution</div>
-          </div>
-          <div className={styles.metricCard}>
-            <div className={styles.metricLabel}>Income</div>
-            <div className={styles.metricValue}>Observed</div>
-            <div className={styles.metricSub}>Reported payments stay separate from projections</div>
-          </div>
-          <div className={styles.metricCard}>
-            <div className={styles.metricLabel}>Direct ownership</div>
-            <div className={styles.metricValue}>Title-first</div>
-            <div className={styles.metricSub}>Normal diligence, closing and deed recording</div>
-          </div>
-        </section>
-
-        <section className={`${styles.section} ${styles.sectionDark}`}>
-          <div className={styles.sectionHeader}>
-            <div>
-              <p className={styles.eyebrow}>The Voxel Vault journey</p>
-              <h2>Five rooms. One financial story.</h2>
-            </div>
-            <p>Every major screen now has one job. The app can grow without making a user learn a different product every time they tap a tab.</p>
-          </div>
-
-          <div className={styles.propertyGrid}>
-            {journey.map((step) => (
-              <a href={step.href} key={step.title} className={styles.propertyLink}>
-                <article className={styles.propertyCard}>
-                  <div className={styles.propertyBody}>
-                    <span className={styles.propertyTag}>{step.number} · FINANCIAL OS</span>
-                    <h3>{step.title}</h3>
-                    <p>{step.copy}</p>
-                    <div className={styles.propertyOpen}>{step.action.toUpperCase()} →</div>
-                  </div>
-                </article>
-              </a>
-            ))}
-          </div>
-        </section>
-
-        <section className={styles.section}>
-          <div className={styles.sectionHeader}>
-            <div>
-              <p className={styles.eyebrow}>Trust architecture</p>
-              <h2>Every number should know where it came from.</h2>
-            </div>
-            <p>Voxel Vault should feel simple on the surface and strict underneath. A beautiful 3D view never upgrades weak evidence into a stronger legal or financial claim.</p>
-          </div>
-          <div className={styles.stackGrid}>
-            {truthLayers.map(([title, copy], index) => (
-              <article className={styles.stackCard} key={title}>
-                <span className={styles.stackNumber}>{index + 1}</span>
-                <h3>{title}</h3>
-                <p>{copy}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className={styles.section}>
-          <div className={styles.sectionHeader}>
-            <div>
-              <p className={styles.eyebrow}>Capital path</p>
-              <h2>Start with access. Build toward ownership.</h2>
-            </div>
-            <p>Tokenized real-estate securities can provide regulated market exposure when the connected provider permits it. That is deliberately separate from buying a particular house or holding its deed.</p>
-          </div>
-          <div className={styles.stackGrid}>
-            {[
-              ['Provider-backed exposure', 'Browse eligible real-estate securities through the connected provider layer. Provider rules control eligibility and execution.'],
-              ['Verified portfolio', 'Bring supported holdings into My Vault only when the relevant wallet, account or provider can substantiate them.'],
-              ['Observed income', 'Track actual provider payment records without calling dividends rent or manufacturing future yield.'],
-              ['Direct-property plan', 'Research candidates, complete diligence and eventually close through the normal legal title system before creating a verified property passport.'],
-            ].map(([title, copy], index) => (
-              <article className={styles.stackCard} key={title}>
-                <span className={styles.stackNumber}>{index + 1}</span>
-                {index < 3 ? <span className={styles.stackArrow}>→</span> : null}
-                <h3>{title}</h3>
-                <p>{copy}</p>
-              </article>
-            ))}
-          </div>
-          <div className={styles.actions} style={{marginTop:24}}>
-            <a className={styles.primaryButton} href="/real-estate/reits">Open provider-backed investments</a>
-            <a className={styles.secondaryButton} href="/real-estate/acquire">Open direct-property planner</a>
-            <a className={styles.secondaryButton} href="/real-estate/launch">Review launch gates</a>
-          </div>
-        </section>
-
-        <section className={styles.section}>
-          <div className={styles.gateCard}>
-            <p className={styles.eyebrow}>Product boundary</p>
-            <h3>Simple for the user. Fail-closed for real money.</h3>
-            <p>Public exploration can be broad. Personal holdings require identity or wallet evidence. Securities execution stays inside the approved provider path. Direct-property ownership requires real diligence, legal closing and recorded title. Voxel Vault can organize those layers without pretending to replace them.</p>
-            <div className={styles.actions}>
-              <a className={styles.primaryButton} href="/vault">Go to My Vault</a>
-              <a className={styles.secondaryButton} href="/vault/income">See observed income</a>
-              <a className={styles.secondaryButton} href="/real-estate/property/0001">Open clearly labeled demo property vault</a>
-            </div>
-          </div>
-        </section>
-
-        <footer className={styles.footer}>
-          <div><strong>Voxel Vault Financial OS</strong><br />Spatial discovery, provider-backed assets, verified holdings, observed income and direct-property planning.</div>
-          <div>Pilot software · not an investment recommendation · asset availability and execution depend on connected providers and applicable eligibility rules.</div>
-        </footer>
+    <section className={styles.hero}>
+      <div className={styles.heroIntro}>
+        <p className={styles.eyebrow}>Explore · sandbox · invest through providers · own through title</p>
+        <h1>Real estate,<br/><em>without pretending.</em></h1>
+        <p className={styles.lead}>Explore real places in 3D, test a $1.99 sandbox, view provider-backed investment paths, and plan direct ownership through the normal legal title system.</p>
+        <div className={styles.actions}><a className={styles.primaryButton} href="/geo">Explore a place</a><a className={styles.secondaryButton} href="/geo/slice">Try $1.99 sandbox</a><a className={styles.secondaryButton} href="/vault">Open my Vault</a></div>
+        <div className={styles.heroNote}>
+          <span>LIVE DIGITAL · 3D places + digital assets</span>
+          <span>DEMO · Demo data only · no real purchase</span>
+          <span>PARTNER REQUIRED · Live investing is locked until provider requirements are satisfied</span>
+          <span>TITLE REQUIRED · real property ownership</span>
+        </div>
       </div>
-    </main>
-  );
+      <div className={styles.heroVisual}>
+        <PropertyTwinCanvas className={styles.twinCanvas}/>
+        <div className={styles.visualTop}><span className={styles.darkPill}>3D PROPERTY INTERFACE</span><span className={styles.demoPill}>TRUTH-FIRST</span></div>
+        <div className={styles.visualBottom}><div className={styles.propertyCaption}><small>One place can have different records</small><strong>Map ≠ collectible ≠ investment ≠ deed</strong></div><span className={styles.dragHint}>3D helps you understand it<br/>evidence decides what is true</span></div>
+      </div>
+    </section>
+
+    <section className={styles.metricGrid} aria-label="Real-estate product status">
+      <div className={styles.metricCard}><div className={styles.metricLabel}>Explore</div><div className={styles.metricValue}>Live digital</div><div className={styles.metricSub}>Source-backed property and map context</div></div>
+      <div className={styles.metricCard}><div className={styles.metricLabel}>$1.99</div><div className={styles.metricValue}>Sandbox</div><div className={styles.metricSub}>No real money or ownership</div></div>
+      <div className={styles.metricCard}><div className={styles.metricLabel}>Invest</div><div className={styles.metricValue}>Partner required</div><div className={styles.metricSub}>Provider controls availability and eligibility</div></div>
+      <div className={styles.metricCard}><div className={styles.metricLabel}>Own</div><div className={styles.metricValue}>Title required</div><div className={styles.metricSub}>Normal closing and recorded deed/title</div></div>
+    </section>
+
+    <section className={`${styles.section} ${styles.sectionDark}`}>
+      <div className={styles.sectionHeader}><div><p className={styles.eyebrow}>Choose the right path</p><h2>Four paths. Four meanings.</h2></div><p>Voxel Vault can place these experiences in one app without pretending one automatically becomes another.</p></div>
+      <div className={styles.propertyGrid}>{paths.map(step=><a href={step.href} key={step.title} className={styles.propertyLink}><article className={styles.propertyCard}><div className={styles.propertyBody}><span className={styles.propertyTag}>{step.number} · {step.status}</span><h3>{step.title}</h3><p>{step.copy}</p><div className={styles.propertyOpen}>{step.action.toUpperCase()} →</div></div></article></a>)}</div>
+    </section>
+
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}><div><p className={styles.eyebrow}>What each record proves</p><h2>Keep the evidence attached to the claim.</h2></div><p>A polished 3D view can make the product easier to understand, but it never upgrades weak evidence into ownership or investment authority.</p></div>
+      <div className={styles.stackGrid}>{truthLayers.map(([title,copy],index)=><article className={styles.stackCard} key={title}><span className={styles.stackNumber}>{index+1}</span><h3>{title}</h3><p>{copy}</p></article>)}</div>
+    </section>
+
+    <section className={styles.section}><div className={styles.gateCard}>
+      <p className={styles.eyebrow}>Legitimacy boundary</p>
+      <h3>Live where Voxel Vault is ready. Locked where a regulated or legal rail is still missing.</h3>
+      <p>Voxel Vault is not itself a bank, broker, exchange, custodian, escrow service, or deed registry. Customer money movement, crypto exchange/custody, real-estate securities execution, and real-property ownership only become live through the exact approved provider or legal process required for that action.</p>
+      <div className={styles.actions}><a className={styles.primaryButton} href="/property">Create a digital property voxel</a><a className={styles.secondaryButton} href="/real-estate/reits">Check investment status</a><a className={styles.secondaryButton} href="/real-estate/acquire">See direct ownership path</a></div>
+    </div></section>
+
+    <footer className={styles.footer}><div><strong>Voxel Vault Real Estate</strong><br/>3D place data, digital property assets, sandbox tools, provider-backed investments, and title-based ownership paths.</div><div>Digital product software · not an investment recommendation · no claim of bank, broker, exchange, custody, escrow, or deed-registry status.</div></footer>
+  </div></main>;
 }

--- a/app/vault/layout.js
+++ b/app/vault/layout.js
@@ -2,7 +2,7 @@ import PropertyDraftSyncBridge from './PropertyDraftSyncBridge';
 
 export const metadata = {
   title: 'My Vault | Voxel Vault',
-  description: 'Verified creator assets, wallet collectibles, user-bound provider positions and observed income inside the Voxel Vault financial OS.',
+  description: 'Organize digital creations, wallet-verified collectibles, and separately verified provider positions without mixing their legal meaning.',
 };
 
 export default function VaultLayout({ children }) {

--- a/docs/UNIFIED_PROPERTY_MONEY_VAULT.md
+++ b/docs/UNIFIED_PROPERTY_MONEY_VAULT.md
@@ -1,132 +1,97 @@
-# Unified Property + Money Vault
+# Voxel Vault Product Truth + Money Boundaries
 
 Reviewed: August 29, 2026
 
-## Product idea
+## One simple rule
 
-Voxel Vault can present one spatial account where a user sees:
+Voxel Vault may show property, digital assets, wallets, and provider-backed positions in one interface, but different legal records must never be presented as if they are equivalent.
 
-1. a source-backed 3D property twin;
-2. any separately verified legal/economic property position;
-3. optional NFTs / digital collectibles;
-4. a user-controlled crypto wallet connection;
-5. settled USD from an approved banking/payment provider;
-6. conversion and reinvestment actions that hand off to the provider legally responsible for the transaction.
+Use four public states:
 
-The product should feel unified while the legal records and custody rails remain distinct.
+- **$4.99 DIGITAL** — one paid VoxelPop digital creation; no real-property rights.
+- **DEMO** — sandbox only; fake demo credit is not money and creates no property rights.
+- **PARTNER** — live financial/investment execution only through the required approved provider, eligibility checks, settlement, and verification.
+- **TITLE** — real-property ownership changes only through normal closing and recorded title.
 
-## $1.99 Property Slice sandbox
-
-`/geo/slice` uses a default test amount of **$1.99**.
-
-The sandbox compares that amount to a selected property's reference price and to a benchmark property price. It can show:
-
-- the mathematical percentage represented by $1.99 relative to the selected reference price;
-- selected-property price divided by benchmark-property price;
-- the benchmark-dollar amount that represents the same mathematical fraction.
-
-The sandbox **does not** transfer funds, reserve property, create deed ownership, create an LLC interest, purchase a security, mint a real-estate security, or create rent rights.
-
-A live small-dollar property purchase may replace the sandbox only when the exact offering legitimately supports the amount and all provider, investor-eligibility, settlement, custody and independent ownership-verification gates are satisfied.
-
-## Unified asset conversion model
-
-The first product model distinguishes four values:
-
-- **Settled USD** — the only amount counted as immediately spendable by the preview.
-- **Estimated crypto value** — informational until an approved exchange/off-ramp trade settles.
-- **Estimated NFT value** — informational until a real marketplace buyer executes a sale and proceeds settle.
-- **Property goal / verified position** — a savings/goal balance or a separately verified property/security position; the UI must state which one it is.
-
-Supported product journeys can eventually include:
+## Current VoxelPop property product
 
 ```text
-NFT -> marketplace sale -> crypto or USD proceeds -> settlement -> Vault balance
-crypto -> approved exchange/off-ramp -> settled USD -> Vault balance
-settled USD -> verified property offering -> provider-confirmed position -> 3D property Vault
-verified property distributions -> settled proceeds -> USD/crypto -> optional user-authorized reinvestment
+sign in
+  -> authorized photo
+  -> $4.99 digital creation checkout
+  -> paid session verification
+  -> device-local source photo
+  -> local VoxelPop image + movable 3D model
+  -> source-backed address / 3D map context
+  -> My World
+  -> optional separate digital collectible checkout
+  -> Vault
+  -> optional separate Verify + Mint path
 ```
 
-No estimated NFT or crypto value should be silently counted as available cash.
+The **$4.99 payment is for one digital VoxelPop creation**. The local generation engine does not require Meshy credits, and the source photo stays device-local for creation.
 
-## Live-provider boundaries
+A verified paid session may resume the same creation without a second creation charge. The optional mapped digital-collectible purchase is a separate transaction.
+
+The source photo, locally generated 3D model, and mapped property record are intentionally different evidence layers. One image cannot verify unseen sides, survey-grade dimensions, complete roof/facade geometry, title, ownership, or property value.
+
+Neither the $4.99 creation nor the optional digital collectible creates deed/title ownership, equity, rent rights, occupancy rights, a real-estate security, or guaranteed appreciation.
+
+## $1.99 Property Sandbox
+
+`/geo/slice` is a pure sandbox using a default **$1.99** anchor amount and free fake demo credit. Demo credit can be refilled for testing; it is not cash, a bank balance, a deposit, or a payment method.
+
+The sandbox does not transfer customer funds, reserve property, create deed ownership, create an LLC interest, purchase a security, mint a real-estate security, or create rent/occupancy rights.
+
+A real small-dollar property investment may replace the sandbox only when an exact verified offering legitimately supports the amount and all required investor-eligibility, settlement, custody, disclosure, and position-verification gates are satisfied.
+
+## Money and conversion rules
+
+Keep these values distinct:
+
+- **Settled USD** — cash only after the responsible provider reports settlement.
+- **Estimated crypto value** — informational until an approved exchange/off-ramp settles a trade.
+- **Estimated NFT value** — informational until a real marketplace sale settles.
+- **Verified property/security position** — only after the responsible provider and reconciliation layer substantiate it.
+- **Demo credit** — never presented as customer cash, a deposit, or ownership.
+
+No estimate or demo balance becomes spendable money merely because it appears in the same app.
+
+## Regulated-role boundaries
 
 ### USD
-
-Voxel Vault should not present itself as an FDIC-insured bank unless it actually becomes an insured depository institution. A practical fintech path is a disclosed partner-bank/payment-provider integration in which the UI names the actual institution/provider and accurately states whether and how any deposit-insurance eligibility applies.
+Voxel Vault should not present itself as an FDIC-insured bank unless that exact status becomes true. Customer USD should use an appropriately disclosed banking/payment provider, with accurate deposit-insurance language for the actual structure.
 
 Official reference: https://www.fdic.gov/resources/consumers/consumer-news/2023-07.html
 
 ### Crypto
-
-Prefer a user-controlled wallet for the initial live product. Custody, exchange, transmission, and customer crypto-to-fiat conversion can trigger licensing and compliance obligations, especially for New York users.
+Prefer user-controlled wallets unless an appropriately authorized custody/exchange/transmission provider is integrated. New York virtual-currency activity can require NYDFS licensing depending on the exact activity.
 
 Official reference: https://www.dfs.ny.gov/virtual_currency_businesses
 
 ### Tokenized property / securities
-
-Tokenization does not change the legal character of an underlying security. If a token represents a property-company share, REIT interest, note, or other security, the securities-law treatment follows the actual instrument and transaction structure.
+Tokenization does not erase securities-law treatment. If a token represents a property-company share, REIT interest, note, or other security, the legal treatment follows the actual instrument and transaction.
 
 Official references:
-
 - https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826-statement-tokenized-securities
 - https://www.sec.gov/resources-small-businesses/capital-raising-building-blocks/transactions-involving-crypto-assets
 - https://www.sec.gov/rules-regulations/2026/03/s7-2026-09
+- https://www.sec.gov/rules-regulations/2026/08/s7-2026-27
 
-The SEC also proposed Regulation Crypto Assets on August 18, 2026. It is a proposal, not a blanket authorization to launch tokenized real-estate securities without the applicable offering, broker, exchange, custody, transfer, and investor-protection analysis.
+The August 18, 2026 Regulation Crypto Assets item is a proposal, not blanket authorization for a tokenized real-estate product.
 
-Official reference: https://www.sec.gov/rules-regulations/2026/08/s7-2026-27
+## Public language
 
-## Product-language rule
+Preferred: `VoxelPop digital creation`, `digital property voxel`, `digital collectible`, `source-backed 3D map`, `$1.99 Property Sandbox`, `provider-backed investment`, `verified position`, and `recorded title`.
 
-Use user-facing language such as:
-
-- `Vault`
-- `USD balance`
-- `Crypto wallet`
-- `NFT collection`
-- `Property Slice (sandbox)`
-- `Verified property position`
-
-Do not call Voxel Vault itself a `bank`, `FDIC-insured`, `broker`, `exchange`, `custodian`, or `deed registry` unless that exact legal status later becomes true.
-
-## Target architecture
-
-```text
-                         VOXEL VAULT UI
-                              |
-        -------------------------------------------------
-        |                    |             |            |
-     3D GEO              PROPERTY         NFT        MONEY VIEW
-        |                 RIGHTS           |            |
- authoritative        provider/legal    wallet /      balances
- spatial data          entity records   collection      |
-        |                    |             |      -----------------
-        |                    |             |      |               |
-        |                    |             |     USD            CRYPTO
-        |                    |             |      |               |
-        |                    |             | partner bank/   user wallet or
-        |                    |             | payment rail    licensed provider
-        -------------------------------------------------
-                              |
-                       unified audit/ledger
-```
-
-The unified ledger may link all of these objects, but it must not overwrite the source of legal truth for any object.
+Do not imply Voxel Vault itself is a bank, FDIC-insured institution, broker, securities exchange, crypto exchange, custodian, escrow service, or deed registry.
 
 ## Production gates
 
-Keep live money movement disabled until the exact action has a verified implementation and provider/legal owner:
+Keep a real-money or regulated action disabled until the exact action has a verified owner and implementation, including as applicable: authentication/KYC, banking/payment provider, accurate disclosures, compliant crypto rails, approved NFT marketplace/off-ramp, verified offering, investor eligibility, legal property/entity mapping, independent position reconciliation, explicit user authorization, ledger/audit controls, fraud/transaction limits, and an emergency disable control.
 
-- customer authentication and KYC where required;
-- bank/payment-provider agreement for USD funds;
-- accurate deposit-insurance disclosures;
-- compliant crypto custody/exchange/transmission path;
-- approved marketplace/off-ramp for NFT conversion;
-- verified property offering and investor eligibility;
-- legal-property/entity mapping;
-- independent position reconciliation;
-- explicit user authorization for every trade/purchase or separately scoped auto-reinvestment authority;
-- ledger reconciliation, audit logging, limits, fraud controls and a kill switch.
+## Final rule
 
-The goal is one simple product experience backed by multiple truthful rails, not one database field pretending that every asset is the same thing.
+**3D is the interface. Evidence is the authority.**
+
+A photo, model, map marker, payment, NFT, wallet connection, Property Passport, or blockchain record never gains stronger legal meaning just because it is displayed beside another asset in Voxel Vault.

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -129,19 +129,19 @@ assert.match(integrationsPage, /getSupabaseBrowserAsync/);
 assert.match(integrationsPage, /\/api\/admin\/integrations\/status/);
 assert.match(integrationsPage, /SIGN IN WITH GOOGLE/);
 
-// Detailed real-estate remains an advanced, fail-closed subsystem.
-assert.match(home, /Explore → invest → verify → observe → own/);
-assert.match(home, /Your money,/);
-assert.match(home, /provider-backed investment assets/i);
-assert.match(home, /observed income/i);
+// Detailed real-estate stays advanced, status-driven, and fail-closed without finance-dashboard theater.
+assert.match(home, /Explore · sandbox · invest through providers · own through title/);
+assert.match(home, /Real estate,[\s\S]*without pretending\./);
+assert.match(home, /Try \$1\.99 property math/);
+assert.match(home, /LIVE DIGITAL/);
+assert.match(home, /DEMO/);
+assert.match(home, /PARTNER REQUIRED/);
+assert.match(home, /TITLE REQUIRED/);
+assert.match(home, /Map ≠ collectible ≠ investment ≠ deed/);
+assert.match(home, /Live investing is locked until provider requirements are satisfied/);
+assert.match(home, /Demo data only · no real purchase/);
 assert.match(home, /recorded title/i);
-assert.match(home, /Provider-gated/i);
-assert.match(home, /Live investing is locked/);
-assert.match(home, /Demo data only/);
-assert.match(home, /Direct property closes through normal title systems/);
-assert.match(home, /Every number should know where it came from/);
-assert.match(home, /Start with access\. Build toward ownership\./);
-assert.match(home, /Fail-closed for real money/);
+assert.match(home, /Voxel Vault is not itself a bank, broker, exchange, custodian, escrow service, or deed registry/);
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 


### PR DESCRIPTION
## Why this PR exists

Recent main-branch work already fixed the important live product surfaces: the sign-in-first upload journey now exposes the **$4.99 VoxelPop creation price**, the local no-Meshy engine, the separate optional Collect step, the condensed **Home · Create · World · Vault · More** shell, and the pure refillable `$1.99` sandbox.

This PR deliberately does **not** redo those features. It finishes the remaining stale surfaces so the whole repository tells the same story.

## What changes

Only five files:

1. **Public metadata** — describes Voxel Vault as 3D property + digital assets, not a Financial/Spatial OS.
2. **Real Estate landing page** — four clear paths:
   - LIVE DIGITAL — explore source-backed places
   - DEMO — $1.99 sandbox, no real purchase
   - PARTNER REQUIRED — provider-backed investments
   - TITLE REQUIRED — actual real-property ownership
3. **Vault metadata** — digital creations/collectibles + separately verified provider positions; no financial-institution-like positioning.
4. **README** — documents the real $4.99 paid-local VoxelPop flow, pure demo credit, provider gating, and title boundary.
5. **Product truth / money boundary doc** — keeps settled cash, estimated crypto/NFT values, demo credit, provider positions, and recorded title legally distinct.

## Legitimacy rules made explicit

- `$4.99` buys one digital VoxelPop creation.
- The source photo stays device-local; the normal creation engine does not use Meshy credits.
- The optional mapped collectible checkout is a separate digital purchase.
- `$1.99` is a refillable sandbox using fake demo credit, not money.
- Provider-backed real-estate securities remain provider/eligibility/settlement/verification gated.
- Physical real-property ownership requires ordinary diligence, closing, and recorded title.
- Map ≠ collectible ≠ investment ≠ deed.
- Voxel Vault does not claim to be a bank, broker, exchange, custodian, escrow service, or deed registry.

## What this PR does not change

It does not alter the paid creation engine, Stripe verification, local 3D persistence, sandbox refill logic, digital collectible checkout, property-provider execution gates, Base Sepolia safety controls, or legal evidence gates.