### PR TITLE
Superseded: paid property flow fidelity experiment

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,10 +1,9 @@
 import Link from 'next/link';
 import styles from './home.module.css';
 
-// Product truth: upload is the single consumer starting point.
-// Nothing is uploaded, generated, or charged before sign-in.
-// After an authorized photo is chosen, the app guides the user through local VoxelPop creation,
-// interactive 3D, source-backed map placement, World, and optional digital collection.
+// Product truth: one photo is the starting point.
+// The $4.99 creation checkout unlocks the photo-based local 3D, mapping and saved digital creation.
+// No second collection checkout is required in the normal property flow.
 // Real-property investment or purchase controls only activate when a verified provider/offering and required legal path exist.
 // A 3D model, payment, map marker, Property Passport, or NFT is not a deed and does not create rent, occupancy, investment, or appreciation rights.
 export default function Home() {
@@ -19,45 +18,45 @@ export default function Home() {
         <div className={styles.heroCopy}>
           <p className={styles.kicker}>✦ ONE PHOTO → YOUR VOXEL WORLD ✦</p>
           <h1>Upload a picture.<br/><em>VoxelPop does the rest.</em></h1>
-          <p className={styles.lead}>Start with one property photo. After sign-in and your explicit creation checkout, VoxelPop keeps that photo visible while it builds the local voxel-style image and movable 3D. Then you add the address so it can place the result on a source-backed property map.</p>
+          <p className={styles.lead}>Sign in, choose a property photo, then pay <strong>$4.99 once</strong>. VoxelPop keeps the photo on your device while it creates a recognizable photo-based 3D. Add the address to connect it to source-backed map context and save the finished digital creation.</p>
           <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
-          <p className={styles.heroFine}>One starting action. No Meshy credits. No wallet required to create. Collection and minting stay optional.</p>
+          <p className={styles.heroFine}>$4.99 includes the local 3D, map placement and saved digital creation. No Meshy credits. No second collection checkout. Wallet and minting stay optional.</p>
         </div>
 
         <div className={styles.heroVisual} aria-label="Upload one photo and VoxelPop guides the rest">
           <div className={styles.skySparkle}>✦</div>
           <div className={styles.voxelHouse} aria-hidden="true"><div className={styles.roof}/><div className={styles.houseBody}><i/><i/><b/></div><div className={styles.lawn}/></div>
-          <div className={styles.priceBubble}><small>START HERE</small><strong>＋</strong><span>your photo</span></div>
+          <div className={styles.priceBubble}><small>ONE CREATION</small><strong>$4.99</strong><span>paid once</span></div>
           <div className={`${styles.assetChip} ${styles.chipUsd}`}><span>1</span><b>UPLOAD</b></div>
-          <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>2</span><b>VOXEL + 3D</b></div>
-          <div className={`${styles.assetChip} ${styles.chipNft}`}><span>3</span><b>MAP + WORLD</b></div>
+          <div className={`${styles.assetChip} ${styles.chipCrypto}`}><span>2</span><b>PHOTO → 3D</b></div>
+          <div className={`${styles.assetChip} ${styles.chipNft}`}><span>3</span><b>MAP + SAVE</b></div>
         </div>
       </header>
 
       <section className={styles.creationCard}>
-        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>You provide the photo. We guide everything after it.</h2><span>There should be no dashboard decision before creation. Pick the picture first; the same creation screen progresses from your photo to the VoxelPop image, movable 3D, address mapping, and finished World preview.</span></div></div>
+        <div className={styles.step}><span>+</span><div><p>THE EXPERIENCE</p><h2>Pay once. Create the 3D. Save it.</h2><span>The same creation screen goes from your photo to a movable photo-based 3D, then to the property map and saved Vault item. Background account sync never blocks the paid creation.</span></div></div>
         <Link className={styles.startButton} href="/property">START → SIGN IN + CHOOSE PHOTO</Link>
-        <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>CREATING</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b></div>
-        <small>Your photo stays visible through creation. The address is requested only when the 3D is ready to be mapped. Payment, collection and minting remain explicit actions rather than hidden automatic charges.</small>
+        <div className={styles.microFlow}><b>PHOTO</b><i>→</i><b>$4.99</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>SAVED</b></div>
+        <small>The visible façade and silhouette come from your photo. One photo cannot reveal unseen sides or exact dimensions, so hidden geometry is never presented as verified fact.</small>
       </section>
 
       <section className={styles.unifiedCard}>
-        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has a clear home.</h2><span>Create is the front door. World and Vault are where the finished result goes. Advanced features stay out of the way.</span></div>
+        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything has a clear home.</h2><span>Create is the front door. World shows mapped context. Vault keeps your saved digital 3D. Advanced financial and legal tools stay separate.</span></div>
         <div className={styles.assetGrid}>
-          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Upload one photo</strong><span>Start the guided VoxelPop property flow.</span><b>Choose photo →</b></Link>
-          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore mapped saved VoxelPop places.</span><b>Open World →</b></Link>
-          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your collection</strong><span>Saved and collected digital assets live here.</span><b>Open Vault →</b></Link>
-          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, verified financial rails, AI and property tools.</span><b>See More →</b></Link>
+          <Link href="/property" className={`${styles.assetTile} ${styles.propertyTile}`}><div className={styles.tileIcon}>+</div><small>CREATE</small><strong>Photo → 3D for $4.99</strong><span>One paid creation, then map and save.</span><b>Choose photo →</b></Link>
+          <Link href="/world" className={`${styles.assetTile} ${styles.usdTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See mapped context</strong><span>Explore saved VoxelPop places on source-backed maps.</span><b>Open World →</b></Link>
+          <Link href="/vault" className={`${styles.assetTile} ${styles.cryptoTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your 3D creations</strong><span>Saved digital VoxelPop items live here.</span><b>Open Vault →</b></Link>
+          <Link href="/more" className={`${styles.assetTile} ${styles.nftTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>Sandbox, wallets, verified provider rails, AI and property tools.</span><b>See More →</b></Link>
         </div>
       </section>
 
       <section className={styles.convertCard}>
-        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>The digital voxel is not the deed.</h2><span>The photo creates a stylized local VoxelPop experience; source-backed map data supplies the mapped building context. Physical-property rights remain separate and require the normal verified legal path.</span></div>
-        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="yours"/><i>→</i><FlowIcon icon="◆" label="Voxel" note="digital"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>→</i><FlowIcon icon="◇" label="Vault" note="optional"/></div>
+        <div className={styles.convertCopy}><p>CLEAR + LEGIT</p><h2>The digital voxel is not the deed.</h2><span>The photo creates the digital VoxelPop 3D; source-backed map data supplies mapped building context. Physical-property rights remain separate and require the normal verified legal path.</span></div>
+        <div className={styles.convertFlow} aria-label="VoxelPop guided flow"><FlowIcon icon="▣" label="Photo" note="yours"/><i>→</i><FlowIcon icon="◆" label="3D" note="photo-based"/><i>→</i><FlowIcon icon="◎" label="Map" note="source-backed"/><i>→</i><FlowIcon icon="◇" label="Vault" note="saved"/></div>
         <Link className={styles.convertAction} href="/property">START WITH A PHOTO</Link>
       </section>
 
-      <footer className={styles.footer}><span>Collecting or minting a voxel does not buy the physical property or create deed/title, rent, occupancy, or investment rights. A single photo also cannot verify unseen architecture or exact dimensions.</span><Link href="/more">More tools</Link></footer>
+      <footer className={styles.footer}><span>Paying for, saving, or optionally minting a VoxelPop 3D does not buy the physical property or create deed/title, rent, occupancy, or investment rights. A single photo also cannot verify unseen architecture or exact dimensions.</span><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }

--- a/app/property/PhotoVoxelViewer.js
+++ b/app/property/PhotoVoxelViewer.js
@@ -1,0 +1,335 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const MAX_GRID = 24;
+const MIN_GRID = 12;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function quantize(value) {
+  return clamp(Math.round(Number(value || 0) / 16) * 16, 0, 255);
+}
+
+function toHex(value) {
+  return clamp(Math.round(value), 0, 255).toString(16).padStart(2, '0');
+}
+
+function pointerDistance(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function recipeDimensions(image) {
+  const width = Math.max(1, image.naturalWidth || 1);
+  const height = Math.max(1, image.naturalHeight || 1);
+  const ratio = clamp(width / height, 0.5, 2);
+  if (ratio >= 1) return { width: MAX_GRID, height: Math.max(MIN_GRID, Math.round(MAX_GRID / ratio)) };
+  return { width: Math.max(MIN_GRID, Math.round(MAX_GRID * ratio)), height: MAX_GRID };
+}
+
+function normalizeRecipe(input) {
+  const width = Math.trunc(Number(input?.width));
+  const height = Math.trunc(Number(input?.height));
+  const count = width * height;
+  if (Number(input?.version) !== 1 || width < 8 || height < 8 || width > MAX_GRID || height > MAX_GRID) return null;
+  if (!Array.isArray(input?.colors) || !Array.isArray(input?.depths) || input.colors.length !== count || input.depths.length !== count) return null;
+  const colors = input.colors.map((value) => String(value || '').toLowerCase()).slice(0, count);
+  const depths = input.depths.map((value) => clamp(Math.trunc(Number(value) || 0), 0, 9)).slice(0, count);
+  if (colors.some((value) => !/^[a-f0-9]{6}$/.test(value))) return null;
+  return { version: 1, width, height, colors, depths };
+}
+
+function sampleRecipe(image) {
+  const dimensions = recipeDimensions(image);
+  const canvas = document.createElement('canvas');
+  canvas.width = dimensions.width;
+  canvas.height = dimensions.height;
+  const context = canvas.getContext('2d', { willReadFrequently: true });
+  if (!context) throw new Error('Local voxel sampling is unavailable in this browser.');
+
+  // Preserve the full photo framing instead of square-cropping the building.
+  context.filter = 'saturate(1.06) contrast(1.05)';
+  context.drawImage(image, 0, 0, image.naturalWidth || 1, image.naturalHeight || 1, 0, 0, dimensions.width, dimensions.height);
+  const data = context.getImageData(0, 0, dimensions.width, dimensions.height).data;
+  const luminance = [];
+  const colors = [];
+
+  for (let index = 0; index < dimensions.width * dimensions.height; index += 1) {
+    const offset = index * 4;
+    const red = quantize(data[offset]);
+    const green = quantize(data[offset + 1]);
+    const blue = quantize(data[offset + 2]);
+    colors.push(`${toHex(red)}${toHex(green)}${toHex(blue)}`);
+    luminance.push((red * 0.2126 + green * 0.7152 + blue * 0.0722) / 255);
+  }
+
+  const depths = luminance.map((value, index) => {
+    const row = Math.floor(index / dimensions.width);
+    const column = index % dimensions.width;
+    const left = luminance[row * dimensions.width + Math.max(0, column - 1)] ?? value;
+    const right = luminance[row * dimensions.width + Math.min(dimensions.width - 1, column + 1)] ?? value;
+    const up = luminance[Math.max(0, row - 1) * dimensions.width + column] ?? value;
+    const down = luminance[Math.min(dimensions.height - 1, row + 1) * dimensions.width + column] ?? value;
+    // Structural contrast drives depth. Bright sky no longer becomes a giant block.
+    const edge = clamp((Math.abs(value - left) + Math.abs(value - right) + Math.abs(value - up) + Math.abs(value - down)) * 1.9, 0, 1);
+    const centerX = dimensions.width > 1 ? Math.abs((column / (dimensions.width - 1)) - 0.5) * 2 : 0;
+    const centerY = dimensions.height > 1 ? Math.abs((row / (dimensions.height - 1)) - 0.5) * 2 : 0;
+    const centerWeight = clamp(1 - Math.max(centerX, centerY), 0, 1);
+    return clamp(Math.round(1 + edge * 7 + centerWeight * 0.7), 1, 9);
+  });
+
+  return { version: 1, width: dimensions.width, height: dimensions.height, colors, depths };
+}
+
+export default function PhotoVoxelViewer({ imageUrl = '', sourceImageUrl = '', recipe = null, onReady }) {
+  const mountRef = useRef(null);
+  const callbackRef = useRef(onReady);
+  const reportedRef = useRef('');
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState('');
+  callbackRef.current = onReady;
+
+  useEffect(() => {
+    if (!mountRef.current) return undefined;
+    const supplied = normalizeRecipe(recipe);
+    const samplingUrl = sourceImageUrl || imageUrl;
+    if (!supplied && !samplingUrl) return undefined;
+
+    let dead = false;
+    let cleanup = () => {};
+    setReady(false);
+    setError('');
+    reportedRef.current = '';
+
+    const renderRecipe = (activeRecipe) => {
+      import('three').then((THREE) => {
+        if (dead || !mountRef.current) return;
+        const mount = mountRef.current;
+        let renderer;
+        try {
+          renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+        } catch {
+          setError('Interactive 3D is unavailable here. The VoxelPop image remains visible.');
+          return;
+        }
+
+        const initialWidth = Math.max(280, mount.clientWidth || 360);
+        const initialHeight = Math.max(280, mount.clientHeight || 360);
+        const compact = initialWidth < 720 || window.matchMedia?.('(pointer: coarse)')?.matches;
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.15 : 1.4));
+        renderer.setSize(initialWidth, initialHeight);
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.08;
+        renderer.domElement.style.touchAction = 'none';
+        renderer.domElement.style.opacity = '0';
+        renderer.domElement.style.transition = 'opacity .35s ease';
+        mount.innerHTML = '';
+        mount.appendChild(renderer.domElement);
+
+        const scene = new THREE.Scene();
+        scene.add(new THREE.HemisphereLight(0xfffbef, 0x191020, 2.25));
+        const key = new THREE.DirectionalLight(0xffead3, 3.8);
+        key.position.set(5, 7, 8);
+        scene.add(key);
+        const rim = new THREE.DirectionalLight(0xc6b5ff, 1.8);
+        rim.position.set(-5, 2, -3);
+        scene.add(rim);
+
+        const cell = compact ? 0.255 : 0.27;
+        const facadeWidth = activeRecipe.width * cell;
+        const facadeHeight = activeRecipe.height * cell;
+        const maxDimension = Math.max(facadeWidth, facadeHeight);
+        const camera = new THREE.PerspectiveCamera(35, initialWidth / initialHeight, 0.1, 80);
+        let cameraDistance = clamp(maxDimension * 1.55 + 1.9, 7.2, 13.8);
+        camera.position.set(0, 0.05, cameraDistance);
+        camera.lookAt(0, 0, 0.18);
+
+        const root = new THREE.Group();
+        root.rotation.x = -0.04;
+        root.rotation.y = 0.08;
+        scene.add(root);
+
+        const geometry = new THREE.BoxGeometry(cell * 0.94, cell * 0.94, 1);
+        const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.78, metalness: 0.01 });
+        const mesh = new THREE.InstancedMesh(geometry, material, activeRecipe.width * activeRecipe.height);
+        const dummy = new THREE.Object3D();
+        const color = new THREE.Color();
+
+        for (let row = 0; row < activeRecipe.height; row += 1) {
+          for (let column = 0; column < activeRecipe.width; column += 1) {
+            const index = row * activeRecipe.width + column;
+            const depth = 0.08 + (activeRecipe.depths[index] / 9) * 0.74;
+            dummy.position.set(
+              (column - (activeRecipe.width - 1) / 2) * cell,
+              ((activeRecipe.height - 1) / 2 - row) * cell,
+              depth / 2,
+            );
+            dummy.scale.set(1, 1, depth);
+            dummy.updateMatrix();
+            mesh.setMatrixAt(index, dummy.matrix);
+            color.set(`#${activeRecipe.colors[index]}`);
+            mesh.setColorAt(index, color);
+          }
+        }
+        mesh.instanceMatrix.needsUpdate = true;
+        if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+        root.add(mesh);
+
+        const backingGeometry = new THREE.BoxGeometry(facadeWidth + 0.08, facadeHeight + 0.08, 0.08);
+        const backingMaterial = new THREE.MeshStandardMaterial({ color: 0x21172c, roughness: 0.94, metalness: 0 });
+        const backing = new THREE.Mesh(backingGeometry, backingMaterial);
+        backing.position.z = -0.08;
+        root.add(backing);
+
+        const shadowGeometry = new THREE.CircleGeometry(Math.max(2.4, facadeWidth * 0.58), 48);
+        const shadowMaterial = new THREE.MeshBasicMaterial({ color: 0x130d18, transparent: true, opacity: 0.24 });
+        const shadow = new THREE.Mesh(shadowGeometry, shadowMaterial);
+        shadow.rotation.x = -Math.PI / 2;
+        shadow.position.set(0, -facadeHeight / 2 - 0.24, 0.8);
+        scene.add(shadow);
+
+        const pointers = new Map();
+        let lastX = 0;
+        let lastY = 0;
+        let pinch = 0;
+        let targetX = -0.04;
+        let targetY = 0.08;
+
+        const distance = () => {
+          const pair = [...pointers.values()].slice(0, 2);
+          return pair.length === 2 ? pointerDistance(pair[0], pair[1]) : 0;
+        };
+        const updateCamera = () => {
+          camera.position.set(0, 0.05, cameraDistance);
+          camera.lookAt(0, 0, 0.18);
+        };
+        const down = (event) => {
+          pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+          renderer.domElement.setPointerCapture?.(event.pointerId);
+          lastX = event.clientX;
+          lastY = event.clientY;
+          if (pointers.size === 2) pinch = distance();
+        };
+        const move = (event) => {
+          if (!pointers.has(event.pointerId)) return;
+          pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+          if (pointers.size >= 2) {
+            const next = distance();
+            if (pinch) cameraDistance = clamp(cameraDistance - (next - pinch) * 0.012, 5.8, 15.5);
+            pinch = next;
+            updateCamera();
+            return;
+          }
+          const dx = event.clientX - lastX;
+          const dy = event.clientY - lastY;
+          targetY += dx * 0.008;
+          targetX = clamp(targetX + dy * 0.004, -0.5, 0.34);
+          lastX = event.clientX;
+          lastY = event.clientY;
+        };
+        const up = (event) => {
+          pointers.delete(event.pointerId);
+          renderer.domElement.releasePointerCapture?.(event.pointerId);
+          if (pointers.size < 2) pinch = 0;
+        };
+        const wheel = (event) => {
+          event.preventDefault();
+          cameraDistance = clamp(cameraDistance + Math.sign(event.deltaY) * 0.45, 5.8, 15.5);
+          updateCamera();
+        };
+        renderer.domElement.addEventListener('pointerdown', down);
+        renderer.domElement.addEventListener('pointermove', move);
+        renderer.domElement.addEventListener('pointerup', up);
+        renderer.domElement.addEventListener('pointercancel', up);
+        renderer.domElement.addEventListener('wheel', wheel, { passive: false });
+
+        let frame = 0;
+        let firstFrame = true;
+        const animate = () => {
+          frame = requestAnimationFrame(animate);
+          root.rotation.x += (targetX - root.rotation.x) * 0.08;
+          root.rotation.y += (targetY - root.rotation.y) * 0.08;
+          renderer.render(scene, camera);
+          if (firstFrame) {
+            firstFrame = false;
+            renderer.domElement.style.opacity = '1';
+            setReady(true);
+            const signature = `${activeRecipe.width}x${activeRecipe.height}:${activeRecipe.colors.slice(0, 6).join('')}`;
+            if (reportedRef.current !== signature) {
+              reportedRef.current = signature;
+              callbackRef.current?.(activeRecipe);
+            }
+          }
+        };
+        animate();
+
+        const resize = () => {
+          if (!mountRef.current) return;
+          const width = Math.max(280, mountRef.current.clientWidth || 360);
+          const height = Math.max(280, mountRef.current.clientHeight || 360);
+          renderer.setSize(width, height);
+          camera.aspect = width / height;
+          camera.updateProjectionMatrix();
+        };
+        window.addEventListener('resize', resize);
+
+        cleanup = () => {
+          cancelAnimationFrame(frame);
+          window.removeEventListener('resize', resize);
+          renderer.domElement.removeEventListener('pointerdown', down);
+          renderer.domElement.removeEventListener('pointermove', move);
+          renderer.domElement.removeEventListener('pointerup', up);
+          renderer.domElement.removeEventListener('pointercancel', up);
+          renderer.domElement.removeEventListener('wheel', wheel);
+          geometry.dispose();
+          material.dispose();
+          backingGeometry.dispose();
+          backingMaterial.dispose();
+          shadowGeometry.dispose();
+          shadowMaterial.dispose();
+          renderer.dispose();
+          mount.innerHTML = '';
+        };
+      }).catch(() => {
+        if (!dead) setError('Interactive 3D could not start. The VoxelPop image remains visible.');
+      });
+    };
+
+    if (supplied) {
+      renderRecipe(supplied);
+    } else {
+      const image = new Image();
+      image.decoding = 'async';
+      image.src = samplingUrl;
+      image.onload = () => {
+        try { renderRecipe(sampleRecipe(image)); }
+        catch (sampleError) { if (!dead) setError(String(sampleError?.message || sampleError || 'Local voxel sampling failed.')); }
+      };
+      image.onerror = () => { if (!dead) setError('The property photo could not be opened for local 3D.'); };
+    }
+
+    return () => {
+      dead = true;
+      cleanup();
+    };
+  }, [imageUrl, sourceImageUrl, recipe]);
+
+  const posterUrl = imageUrl || sourceImageUrl;
+  return <div className="photoVoxelShell">
+    {posterUrl ? <img className={`photoVoxelPoster ${ready ? 'hidden' : ''}`} src={posterUrl} alt="VoxelPop property image"/> : null}
+    <div ref={mountRef} className="photoVoxelCanvas" aria-label="Interactive photo-derived VoxelPop 3D model"/>
+    {!ready && !error ? <div className="stage">PHOTO → BUILDING LOCAL 3D</div> : null}
+    {error ? <div className="softError">{error}</div> : null}
+    <div className="hint">{ready ? 'PHOTO-BASED 3D · DRAG · PINCH TO ZOOM' : 'YOUR PHOTO STAYS VISIBLE UNTIL 3D IS READY'}</div>
+    <style jsx>{`
+      .photoVoxelShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:radial-gradient(circle at 50% 32%,#3a2850,#18101f 64%)}
+      .photoVoxelPoster,.photoVoxelCanvas{position:absolute;inset:0;width:100%;height:100%}.photoVoxelPoster{z-index:1;object-fit:contain;background:#18101f;opacity:1;transition:opacity .35s ease}.photoVoxelPoster.hidden{opacity:0;pointer-events:none}.photoVoxelCanvas{z-index:2}
+      .stage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.78);backdrop-filter:blur(10px);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.12em}
+      .softError{position:absolute;z-index:5;left:12px;right:12px;bottom:36px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.84);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
+      .hint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#d8cedf;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.12em;pointer-events:none;text-shadow:0 1px 6px #000}
+    `}</style>
+  </div>;
+}

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -1,14 +1,17 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import LocalVoxelModelViewer from './LocalVoxelModelViewer';
+import PhotoVoxelViewer from './PhotoVoxelViewer';
 import PropertyWorldMap from './PropertyWorldMap';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import { savePropertyDraft } from '../../lib/property-drafts';
 import styles from './property.module.css';
 
 const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
 const empty3d = () => ({ status: 'NOT_STARTED', progress: 0, modelUrl: null, thumbnailUrl: null, taskId: null });
 const CREATION_PRICE_LABEL = '$4.99';
+const CREATION_PRICE_CENTS = 499;
 const DEVICE_DB = 'voxelpop-property-device-v1';
 const DEVICE_STORE = 'pending-photos';
 
@@ -23,9 +26,6 @@ function isHeic(file) {
 function isSupportedPhoto(file) {
   return ['image/jpeg', 'image/png', 'image/webp'].includes(String(file?.type || '').toLowerCase()) || isHeic(file);
 }
-function dollars(cents) {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(cents || 0) / 100);
-}
 function selectedOrLocation(atlas, address) {
   const selected = atlas?.selectedBuilding || atlas?.buildings?.[0] || null;
   if (selected) return { ...selected, mappedIdentityReady: Boolean(selected.atlasId) };
@@ -38,6 +38,7 @@ function selectedOrLocation(atlas, address) {
     longitude,
     geometry: null,
     tags: { name: address },
+    source: atlas?.sourceStatus || null,
     mappedIdentityReady: false,
   };
 }
@@ -58,8 +59,7 @@ async function saveDevicePhoto(draftId, file) {
   const db = await openDeviceDb();
   const bytes = await file.arrayBuffer();
   await new Promise((resolve, reject) => {
-    const transaction = db.transaction(DEVICE_STORE, 'readwrite');
-    const request = transaction.objectStore(DEVICE_STORE).put({
+    const request = db.transaction(DEVICE_STORE, 'readwrite').objectStore(DEVICE_STORE).put({
       draftId,
       bytes,
       type: file.type || 'image/jpeg',
@@ -139,39 +139,110 @@ async function createVoxelPoster(file) {
       image.onload = resolve;
       image.onerror = () => reject(new Error('The photo could not be opened for the VoxelPop image.'));
     });
-    const sampleSize = 54;
+
+    const sourceWidth = Math.max(1, image.naturalWidth || 1);
+    const sourceHeight = Math.max(1, image.naturalHeight || 1);
+    const ratio = Math.max(0.45, Math.min(2.2, sourceWidth / sourceHeight));
+    const sampleMax = 72;
+    const sampleWidth = ratio >= 1 ? sampleMax : Math.max(32, Math.round(sampleMax * ratio));
+    const sampleHeight = ratio >= 1 ? Math.max(32, Math.round(sampleMax / ratio)) : sampleMax;
     const sample = document.createElement('canvas');
-    sample.width = sampleSize;
-    sample.height = sampleSize;
+    sample.width = sampleWidth;
+    sample.height = sampleHeight;
     const sampleContext = sample.getContext('2d');
     if (!sampleContext) throw new Error('VoxelPop image processing is unavailable.');
-    const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
-    let sx = 0;
-    let sy = 0;
-    let sw = image.naturalWidth || 1;
-    let sh = image.naturalHeight || 1;
-    if (sourceRatio > 1) { sw = sh; sx = ((image.naturalWidth || 1) - sw) / 2; }
-    else if (sourceRatio < 1) { sh = sw; sy = ((image.naturalHeight || 1) - sh) / 2; }
     sampleContext.filter = 'saturate(1.08) contrast(1.06)';
-    sampleContext.drawImage(image, sx, sy, sw, sh, 0, 0, sampleSize, sampleSize);
+    sampleContext.drawImage(image, 0, 0, sourceWidth, sourceHeight, 0, 0, sampleWidth, sampleHeight);
 
     const output = document.createElement('canvas');
-    output.width = 864;
-    output.height = 864;
+    if (ratio >= 1) {
+      output.width = 864;
+      output.height = Math.max(432, Math.round(864 / ratio));
+    } else {
+      output.height = 864;
+      output.width = Math.max(432, Math.round(864 * ratio));
+    }
     const context = output.getContext('2d');
     if (!context) throw new Error('VoxelPop image processing is unavailable.');
     context.imageSmoothingEnabled = false;
     context.drawImage(sample, 0, 0, output.width, output.height);
     const shade = context.createLinearGradient(0, 0, output.width, output.height);
-    shade.addColorStop(0, 'rgba(255,255,255,.10)');
-    shade.addColorStop(0.58, 'rgba(255,255,255,0)');
-    shade.addColorStop(1, 'rgba(38,18,52,.15)');
+    shade.addColorStop(0, 'rgba(255,255,255,.08)');
+    shade.addColorStop(0.62, 'rgba(255,255,255,0)');
+    shade.addColorStop(1, 'rgba(38,18,52,.13)');
     context.fillStyle = shade;
     context.fillRect(0, 0, output.width, output.height);
-    return output.toDataURL('image/jpeg', 0.91);
+    return output.toDataURL('image/jpeg', 0.92);
   } finally {
     URL.revokeObjectURL(url);
   }
+}
+
+function paidDraftRecord({ draftId, address, building, recipe, modelUrl, taskId, generationSessionId }) {
+  const latitude = Number(building?.latitude);
+  const longitude = Number(building?.longitude);
+  const hasCoordinates = Number.isFinite(latitude) && Number.isFinite(longitude);
+  const source = building?.source || {};
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: 2,
+    type: 'voxel-vault-property-3d-draft',
+    id: `voxelpop:${draftId}`,
+    label: address || building?.tags?.name || 'VoxelPop property',
+    createdAt: now,
+    updatedAt: now,
+    state: 'ready',
+    fidelity: 'purchased-photo-guided-voxel-3d',
+    geometryKind: building?.geometry ? 'source-backed-building' : 'location-reference',
+    coordinates: {
+      latitude: hasCoordinates ? Number(latitude.toFixed(7)) : null,
+      longitude: hasCoordinates ? Number(longitude.toFixed(7)) : null,
+    },
+    geometry: building?.geometry || null,
+    propertyIdentity: {
+      atlasId: clean(building?.atlasId) || null,
+      parcelId: null,
+      pin: null,
+      sbl: null,
+    },
+    evidence: {
+      exactParcelLinkedBuilding: false,
+      sourceBackedBuilding: Boolean(building?.geometry),
+      authoritativeParcelBoundary: false,
+      calibratedStories: null,
+      calibratedVisualHeightMeters: Number(building?.heightMeters) || null,
+      openStreetPhotoCount: 0,
+      reconstructionReferenceCount: 1,
+      mapAuthority: clean(source?.authority) || 'World Atlas',
+      mapLicense: clean(source?.license) || null,
+      mapSourceUrl: clean(source?.sourceUrl) || null,
+      listingProvider: null,
+    },
+    visual: {
+      kind: 'photo-derived-local-voxel',
+      engine: 'browser-local-v2',
+      recipe,
+      modelUrl: modelUrl || null,
+      taskId: taskId || `local-device:${draftId}`,
+      sourcePhotoStored: false,
+      photoDerived: true,
+    },
+    commerce: {
+      kind: 'property_voxel_creation',
+      status: 'paid',
+      creationPriceCents: CREATION_PRICE_CENTS,
+      generationSessionId: generationSessionId || null,
+      additionalCollectionPaymentRequired: false,
+    },
+    blockchain: { minted: false, optional: true, tokenId: null, network: null },
+    world: { public: false, publishedAt: null, publicLabel: '3D Property' },
+    legal: {
+      titleVerified: false,
+      ownershipRightsCreatedByDraft: false,
+      ownershipRightsCreatedByMint: false,
+      note: 'This paid VoxelPop creation is a digital representation only. The $4.99 creation payment, saving it, mapping it, or later minting it does not transfer deed/title, investment rights, rent rights, occupancy rights, or guarantee value.',
+    },
+  };
 }
 
 export default function PropertyJourneyPage() {
@@ -187,14 +258,11 @@ export default function PropertyJourneyPage() {
   const [voxelImage, setVoxelImage] = useState('');
   const [final3d, setFinal3d] = useState(empty3d);
   const [localRecipe, setLocalRecipe] = useState(null);
-  const [collectionReady, setCollectionReady] = useState(false);
-  const [pipelinePhase, setPipelinePhase] = useState('photo');
   const [address, setAddress] = useState('');
   const [mappedAddress, setMappedAddress] = useState('');
   const [building, setBuilding] = useState(null);
   const [atlasBuildings, setAtlasBuildings] = useState([]);
-  const [quote, setQuote] = useState(null);
-  const [availability, setAvailability] = useState('');
+  const [savedDraft, setSavedDraft] = useState(null);
   const [busy, setBusy] = useState('');
   const [message, setMessage] = useState('Sign in to start.');
   const clientRef = useRef(null);
@@ -203,11 +271,11 @@ export default function PropertyJourneyPage() {
 
   const finalReady = final3d?.status === 'SUCCEEDED';
   const sourceReady = source3d?.status === 'SUCCEEDED';
-  const mapped = Boolean(building && mappedAddress);
+  const mapped = Boolean(building && mappedAddress && savedDraft);
   const step = !sourceReference ? 1 : !sourceReady ? 2 : !finalReady ? 3 : !mapped ? 4 : 5;
-  const labels = ['PHOTO', 'BUILD', 'VOXEL', 'WORLD', 'COLLECT'];
+  const labels = ['PHOTO', 'CREATE', '3D', 'MAP', 'READY'];
   const displaySource = pendingPreview || '';
-  const pipelineRunning = ['pipeline', 'local-3d', 'register', 'payment-return'].includes(busy);
+  const pipelineRunning = ['pipeline', 'local-3d', 'payment-return'].includes(busy);
 
   useEffect(() => {
     let active = true;
@@ -248,32 +316,23 @@ export default function PropertyJourneyPage() {
 
   async function startLocalBuild(photo, activeDraftId) {
     setBusy('pipeline');
-    setSourceReference({
-      draftId: activeDraftId,
-      rightsBasis: 'user-owned',
-      provider: 'voxelpop-local-webgl-v1',
-      storagePath: null,
-    });
-    setSource3d({ status: 'IN_PROGRESS', progress: 22, modelUrl: null, thumbnailUrl: null, taskId: `local-source:${activeDraftId}` });
+    setSourceReference({ draftId: activeDraftId, rightsBasis: 'user-owned', provider: 'voxelpop-local-webgl-v2', storagePath: null });
+    setSource3d({ status: 'IN_PROGRESS', progress: 24, modelUrl: null, thumbnailUrl: null, taskId: `local-source:${activeDraftId}` });
     setVoxelImage('');
     setFinal3d(empty3d());
     setLocalRecipe(null);
-    setCollectionReady(false);
     setBuilding(null);
     setAtlasBuildings([]);
     setMappedAddress('');
-    setQuote(null);
-    setAvailability('');
-    setPipelinePhase('source3d');
-    setMessage('Building the VoxelPop 3D image on this device…');
-    await wait(220);
+    setSavedDraft(null);
+    setMessage('Building your VoxelPop image from the photo on this device…');
+    await wait(180);
     const poster = await createVoxelPoster(photo);
     setSource3d({ status: 'SUCCEEDED', progress: 100, modelUrl: null, thumbnailUrl: poster, taskId: `local-source:${activeDraftId}` });
     setVoxelImage(poster);
-    setFinal3d({ status: 'IN_PROGRESS', progress: 72, modelUrl: null, thumbnailUrl: poster, taskId: null });
-    setPipelinePhase('voxel-3d');
+    setFinal3d({ status: 'IN_PROGRESS', progress: 76, modelUrl: null, thumbnailUrl: poster, taskId: null });
     setBusy('local-3d');
-    setMessage('3D image ready. Turning it into a movable VoxelPop model locally…');
+    setMessage('Image ready. Building the movable photo-based 3D now…');
   }
 
   async function registerLocalRecipe(recipe) {
@@ -283,40 +342,27 @@ export default function PropertyJourneyPage() {
       body: JSON.stringify({ draftId, recipe }),
     });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok || !data?.ok) throw new Error(data?.error || 'The local model could not be linked to your account.');
+    if (!response.ok || !data?.ok) throw new Error(data?.error || 'Background Vault sync is unavailable.');
     return data;
   }
 
-  const handleLocal3DReady = useCallback(async (recipe) => {
-    if (!recipe || !session?.access_token || !draftId) return;
+  const handleLocal3DReady = useCallback((recipe) => {
+    if (!recipe || !draftId) return;
+    const deviceTaskId = `local-device:${draftId}`;
     setLocalRecipe(recipe);
-    setBusy('register');
-    setFinal3d((current) => ({ ...current, status: 'IN_PROGRESS', progress: 92 }));
-    try {
-      const data = await registerLocalRecipe(recipe);
-      setFinal3d({
-        status: 'SUCCEEDED',
-        progress: 100,
-        modelUrl: data.modelUrl || null,
-        thumbnailUrl: voxelImage || null,
-        taskId: data.taskId,
-      });
-      setCollectionReady(data.collectionReady === true);
-      setPipelinePhase('world');
-      setMessage(data.collectionReady
-        ? 'Your voxel is ready without Meshy credits. Add the property address to place it on My World.'
-        : 'Your local 3D is ready. Add the address now; collection checkout stays off until the account model record can be saved.');
-      await removeDevicePhoto(draftId);
-      if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('generation_session')) {
-        window.history.replaceState({}, '', '/property');
-      }
-    } catch (error) {
-      setFinal3d({ status: 'SUCCEEDED', progress: 100, modelUrl: null, thumbnailUrl: voxelImage || null, taskId: `local-device:${draftId}` });
-      setCollectionReady(false);
-      setPipelinePhase('world');
-      setMessage(`The local 3D is ready, but its Vault link needs a retry. ${String(error?.message || error || '')}`.trim());
-    } finally {
-      setBusy('');
+    setFinal3d({ status: 'SUCCEEDED', progress: 100, modelUrl: null, thumbnailUrl: voxelImage || null, taskId: deviceTaskId });
+    setBusy('');
+    setMessage('Your $4.99 3D creation is ready. Add the property address to place it on the map and save it.');
+
+    // Account/catalog persistence is best-effort. It must never block a paid creation.
+    if (session?.access_token) {
+      registerLocalRecipe(recipe).then((data) => {
+        setFinal3d((current) => ({
+          ...current,
+          modelUrl: data?.modelUrl || current.modelUrl || null,
+          taskId: data?.taskId || current.taskId || deviceTaskId,
+        }));
+      }).catch(() => {});
     }
   }, [draftId, session?.access_token, voxelImage]);
 
@@ -330,7 +376,7 @@ export default function PropertyJourneyPage() {
       if (checkoutHandledRef.current === key) return undefined;
       checkoutHandledRef.current = key;
       setBusy('');
-      setMessage('Checkout canceled. No generation started; your photo is still kept privately on this device so you can retry.');
+      setMessage('Checkout canceled. Nothing was charged; your photo is still on this device so you can retry.');
       window.history.replaceState({}, '', '/property');
       return undefined;
     }
@@ -340,7 +386,7 @@ export default function PropertyJourneyPage() {
     checkoutHandledRef.current = generationSessionId;
     let active = true;
     setBusy('payment-return');
-    setMessage('Payment received. Reopening your private on-device photo…');
+    setMessage('Payment received. Reopening your photo and starting the 3D creation…');
 
     (async () => {
       try {
@@ -357,7 +403,7 @@ export default function PropertyJourneyPage() {
         if (!photo) {
           setBusy('');
           setRightsConfirmed(false);
-          setMessage('Payment is verified. Choose the property photo again on this device; you will not be charged again.');
+          setMessage('Payment is verified. Choose the same property photo again on this device; you will not be charged again.');
           return;
         }
         setPendingPhoto(photo);
@@ -415,8 +461,8 @@ export default function PropertyJourneyPage() {
       setPendingPhoto(photo);
       setRightsConfirmed(false);
       setMessage(paidSessionId
-        ? 'Payment verified. Confirm you can use this photo, then start the local VoxelPop build—no second charge.'
-        : `Photo ready. Confirm you can use it, then pay ${CREATION_PRICE_LABEL} to create the complete voxel.`);
+        ? 'Payment verified. Confirm you can use this photo, then continue—there is no second charge.'
+        : `Photo ready. Confirm you can use it, then pay ${CREATION_PRICE_LABEL} once for the complete 3D creation.`);
     } catch (error) {
       setMessage(String(error?.message || error || 'This photo could not be prepared.'));
     } finally { setBusy(''); }
@@ -427,7 +473,7 @@ export default function PropertyJourneyPage() {
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
     setBusy('generation-checkout');
     try {
-      setMessage(paidSessionId ? 'Starting your paid VoxelPop build locally…' : `Keeping your photo on this device and opening ${CREATION_PRICE_LABEL} checkout…`);
+      setMessage(paidSessionId ? 'Starting your already-paid VoxelPop 3D…' : `Keeping the photo on this device and opening the ${CREATION_PRICE_LABEL} creation checkout…`);
       await saveDevicePhoto(draftId, pendingPhoto);
       if (paidSessionId) {
         await startLocalBuild(pendingPhoto, draftId);
@@ -450,32 +496,18 @@ export default function PropertyJourneyPage() {
   async function retryBuild() {
     const photo = pendingPhoto || await loadDevicePhoto(draftId).catch(() => null);
     if (!photo) {
-      setMessage('Choose the property photo again. A retry will not create another charge for a verified payment.');
+      setMessage('Choose the property photo again. A verified $4.99 payment will not be charged again.');
       return;
     }
     await startLocalBuild(photo, draftId);
   }
 
-  async function retryLocalPersistence() {
-    if (!localRecipe) return setMessage('The local 3D recipe is not available. Rebuild the voxel first.');
-    setBusy('register');
-    setMessage('Reconnecting this local voxel to your Vault record…');
-    try {
-      const data = await registerLocalRecipe(localRecipe);
-      setFinal3d((current) => ({ ...current, taskId: data.taskId, modelUrl: data.modelUrl || null }));
-      setCollectionReady(data.collectionReady === true);
-      setMessage(data.collectionReady ? 'Vault link ready. You can collect this digital voxel now.' : data.note || 'The Vault record is still unavailable.');
-    } catch (error) {
-      setMessage(String(error?.message || error || 'The Vault link is still unavailable.'));
-    } finally { setBusy(''); }
-  }
-
   async function placeOnWorld(event) {
     event?.preventDefault?.();
     const value = clean(address);
-    if (!value || !finalReady) return;
+    if (!value || !finalReady || !localRecipe) return;
     setBusy('map');
-    setMessage('Checking the address and building the local property map…');
+    setMessage('Finding the address and building the source-backed property map…');
     try {
       const params = new URLSearchParams({ address: value, radius: '180' });
       const response = await fetch(`/api/world-atlas/inspect?${params.toString()}`, { cache: 'no-store' });
@@ -483,53 +515,26 @@ export default function PropertyJourneyPage() {
       if (!response.ok || !atlas?.ok) throw new Error(atlas?.error || 'That property could not be mapped.');
       const selected = selectedOrLocation(atlas, value);
       if (!selected) throw new Error('That address resolved without a usable World location.');
+      const draft = paidDraftRecord({
+        draftId,
+        address: value,
+        building: selected,
+        recipe: localRecipe,
+        modelUrl: final3d?.modelUrl || null,
+        taskId: final3d?.taskId || null,
+        generationSessionId: paidSessionId,
+      });
+      const saved = savePropertyDraft(draft);
       setBuilding(selected);
       setAtlasBuildings(Array.isArray(atlas?.buildings) ? atlas.buildings : []);
       setMappedAddress(value);
-      setQuote(null);
-      setAvailability('');
-
-      if (!selected.mappedIdentityReady || String(selected.atlasId || '').startsWith('location:')) {
-        setMessage('Map preview ready. We found the location, but not a source-backed building identity, so collection stays unavailable.');
-        return;
-      }
-      const quoteResponse = await fetch('/api/property-collectible/quote', {
-        method: 'POST',
-        headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ address: value, atlasId: selected.atlasId }),
-      });
-      const priced = await quoteResponse.json().catch(() => ({}));
-      if (!quoteResponse.ok || !priced?.ok) throw new Error(priced?.error || 'The voxel collection price could not be verified.');
-      setQuote(priced.quote);
-      setAvailability(priced.availability || 'AVAILABLE');
-      setMessage(priced.sold
-        ? 'This mapped digital voxel has already been collected.'
-        : collectionReady
-          ? 'My World preview ready. If it looks right, collect the voxel and save it to your Vault.'
-          : 'My World preview ready. The local 3D works; reconnect its Vault record before collection checkout.');
+      setSavedDraft(saved);
+      await removeDevicePhoto(draftId);
+      if (typeof window !== 'undefined') window.history.replaceState({}, '', '/property');
+      setMessage('Done. Your $4.99 VoxelPop 3D is mapped and saved. There is no second collection payment required.');
     } catch (error) {
       setMessage(String(error?.message || error || 'World placement failed.'));
     } finally { setBusy(''); }
-  }
-
-  async function collectAndSave() {
-    if (!collectionReady) return setMessage('Reconnect the local voxel to its Vault record before opening collection checkout.');
-    if (!quote || !building?.atlasId || !final3d?.taskId || !session?.access_token) return;
-    setBusy('checkout');
-    setMessage('Opening secure checkout for the digital voxel…');
-    try {
-      const response = await fetch('/api/property-collectible/checkout', {
-        method: 'POST',
-        headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ address: mappedAddress, atlasId: building.atlasId, draftId, modelTaskId: final3d.taskId }),
-      });
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.ok || !data?.url) throw new Error(data?.error || 'Checkout could not open.');
-      window.location.assign(data.url);
-    } catch (error) {
-      setMessage(String(error?.message || error || 'Checkout could not open.'));
-      setBusy('');
-    }
   }
 
   function resetCreation() {
@@ -544,14 +549,11 @@ export default function PropertyJourneyPage() {
     setVoxelImage('');
     setFinal3d(empty3d());
     setLocalRecipe(null);
-    setCollectionReady(false);
-    setPipelinePhase('photo');
     setAddress('');
     setMappedAddress('');
     setBuilding(null);
     setAtlasBuildings([]);
-    setQuote(null);
-    setAvailability('');
+    setSavedDraft(null);
     setBusy('');
     setMessage('Choose one photo to begin.');
     removeDevicePhoto(oldDraft);
@@ -570,7 +572,7 @@ export default function PropertyJourneyPage() {
         <p className={styles.bigPrompt}>Sign in first.</p>
         <p className={styles.signinCopy}>One account keeps your creations, Vault, My World items, and optional mint connected.</p>
         <button className={styles.primaryPurple} type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening sign-in…' : 'Continue with Google'}</button>
-        <small>A wallet is optional until you choose the separate Verify &amp; Mint step later.</small>
+        <small>A wallet is optional. Minting is a later choice and is not required to create or save your 3D.</small>
       </section>
       <p className={styles.message}>{message}</p>
     </section></main>;
@@ -586,59 +588,58 @@ export default function PropertyJourneyPage() {
 
       {step === 1 ? <>
         <p className={styles.bigPrompt}>{pendingPhoto ? 'Use this photo?' : 'Choose one photo.'}</p>
-        <p className={styles.flowHint}>Photo → 3D image → interactive voxel → address → improved property map → collect to Vault.</p>
+        <p className={styles.flowHint}>Photo → pay $4.99 once → photo-based 3D → map → saved. No second purchase.</p>
         <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
         {displaySource ? <div className={styles.heroCard}><img src={displaySource} alt="Selected property reference"/><span className={styles.badge}>YOUR PHOTO · DEVICE ONLY</span></div> : <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>iPhone photos supported</span></div>}
         {pendingPhoto ? <div className={styles.choicePanel}>
           <label className={styles.rightsCheck}><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
-          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'generation-checkout'}>{busy === 'generation-checkout' ? 'Preparing…' : paidSessionId ? 'Use photo → start build' : `Pay ${CREATION_PRICE_LABEL} · Use photo → start build`}</button>
+          <button className={styles.primaryPurple} type="button" onClick={usePhotoAndBuild} disabled={!rightsConfirmed || busy === 'generation-checkout'}>{busy === 'generation-checkout' ? 'Preparing…' : paidSessionId ? 'Use photo → create 3D' : `Pay ${CREATION_PRICE_LABEL} · Create 3D`}</button>
           <button className={styles.textButton} type="button" onClick={choosePhoto}>Choose another</button>
         </div> : <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>}
-        <p className={styles.truth}>The {CREATION_PRICE_LABEL} charge is for one digital VoxelPop creation. The source photo stays on this device through checkout and local generation; VoxelPop does not require Meshy credits or private checkout photo storage. One photo cannot verify unseen sides, exact dimensions, title, ownership, or property value.</p>
+        <p className={styles.truth}>The {CREATION_PRICE_LABEL} charge is for one complete digital VoxelPop creation. It includes the local 3D, map placement and saving the digital creation. The photo stays on this device; no Meshy credits are used. One photo cannot verify unseen sides, exact dimensions, title, ownership, or property value.</p>
       </> : null}
 
       {step === 2 ? <>
-        <p className={styles.bigPrompt}>Building the 3D image.</p>
-        <p className={styles.stepCopy}>VoxelPop is turning your authorized photo into the block-style image locally on your device. No Meshy generation is called.</p>
-        <div className={styles.heroCard}>{displaySource ? <img src={displaySource} alt="Source being turned into a VoxelPop image"/> : null}<span className={styles.badge}>LOCAL BUILD · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
-        <div className={styles.autoPanel}><b>NO MESHY CREDITS</b><span>The image stays visible first. Then the movable 3D loads on top only after WebGL is ready.</span></div>
+        <p className={styles.bigPrompt}>Creating your voxel image.</p>
+        <p className={styles.stepCopy}>VoxelPop keeps the original framing and turns the authorized photo into a block-style image locally. No external 3D-generation credits are used.</p>
+        <div className={styles.heroCard}>{displaySource ? <img src={displaySource} alt="Source being turned into a VoxelPop image"/> : null}<span className={styles.badge}>LOCAL CREATE · {Math.round(Number(source3d?.progress || 0))}%</span><div className={styles.buildPulse}/></div>
+        <div className={styles.autoPanel}><b>PAID CREATION IN PROGRESS</b><span>Your $4.99 payment is already verified. This step does not charge again.</span></div>
       </> : null}
 
       {step === 3 ? <>
-        <p className={styles.bigPrompt}>VoxelPop image → movable 3D.</p>
-        <p className={styles.stepCopy}>Your rendered voxel image stays visible until the interactive local 3D has actually rendered.</p>
+        <p className={styles.bigPrompt}>Your photo → movable 3D.</p>
+        <p className={styles.stepCopy}>The 3D now samples the full source photo instead of a square crop, so the visible façade and silhouette stay recognizable. Depth is stylized because one photo cannot reveal hidden sides.</p>
         <div className={styles.heroCard}>
-          <LocalVoxelModelViewer imageUrl={voxelImage || displaySource} onReady={handleLocal3DReady}/>
-          <span className={styles.badge}>VOXEL IMAGE → INTERACTIVE 3D</span>
+          <PhotoVoxelViewer imageUrl={voxelImage || displaySource} sourceImageUrl={displaySource} onReady={handleLocal3DReady}/>
+          <span className={styles.badge}>PHOTO-BASED INTERACTIVE 3D</span>
           {!finalReady ? <div className={styles.buildPulse}/> : null}
         </div>
-        <div className={styles.autoPanel}><b>AUTOMATIC · ON DEVICE</b><span>Photo → VoxelPop image → interactive 3D. No external generation credits are spent.</span></div>
+        <div className={styles.autoPanel}><b>INCLUDED IN YOUR $4.99</b><span>When the 3D renders, you automatically continue to the property map. Background Vault sync cannot stop you.</span></div>
       </> : null}
 
       {step === 4 ? <>
-        <p className={styles.bigPrompt}>Add the property address.</p>
-        <p className={styles.stepCopy}>Enter the address for the property shown in your photo. We use it to find source-backed building footprints and build the improved neighborhood map.</p>
-        <div className={styles.heroCard}><LocalVoxelModelViewer imageUrl={voxelImage}/><span className={styles.badge}>VOXEL READY · LOCAL 3D</span></div>
-        <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Building map…' : 'Verify address + preview'}</button></form>
-        <small className={styles.mapNote}>The map uses source-backed building data where available. The address is not proof of ownership, title, property value, or an investment offering.</small>
+        <p className={styles.bigPrompt}>Now add the address.</p>
+        <p className={styles.stepCopy}>This connects your photo-based 3D to source-backed map context. Enter the address shown in the photo, then save it.</p>
+        <div className={styles.heroCard}><PhotoVoxelViewer imageUrl={voxelImage} sourceImageUrl={displaySource} recipe={localRecipe}/><span className={styles.badge}>3D READY · $4.99 PAID</span></div>
+        <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Mapping + saving…' : 'Map + save to Vault'}</button></form>
+        <small className={styles.mapNote}>The map uses source-backed building data where available. Saving a digital voxel does not prove ownership or change legal title.</small>
       </> : null}
 
       {step === 5 ? <>
-        <p className={styles.bigPrompt}>Your World preview.</p>
-        <p className={styles.stepCopy}>The selected building is highlighted inside its nearby source-backed neighborhood, with touch rotation and zoom.</p>
-        <div className={styles.worldCard}><PropertyWorldMap selectedBuilding={building} buildings={atlasBuildings}/><span className={styles.worldBadge}>MY WORLD · IMPROVED PROPERTY MAP</span></div>
-        <div className={styles.miniModel}><LocalVoxelModelViewer imageUrl={voxelImage}/></div>
-        <div className={styles.priceCard}>
-          <div><small>DIGITAL VOXEL</small><b>{quote?.label || 'World preview'}</b><span>{mappedAddress}</span></div>
-          <strong>{quote ? dollars(quote.priceCents) : '—'}</strong>
-          {quote ? <p>{quote.explanation} This is the price of the generated digital voxel—not the market value of the house or land.</p> : null}
-          {availability === 'SOLD' ? <div className={styles.sold}>ALREADY COLLECTED · THIS MAPPED DIGITAL VOXEL IS ONE-OF-ONE</div> : null}
-          {!quote && !building?.mappedIdentityReady ? <div className={styles.sold}>PREVIEW ONLY · A SOURCE-BACKED BUILDING ID IS NEEDED BEFORE COLLECTION</div> : null}
-          {quote && availability !== 'SOLD' && collectionReady ? <button className={styles.primaryOrange} type="button" onClick={collectAndSave} disabled={busy === 'checkout'}>{busy === 'checkout' ? 'Opening secure checkout…' : `Collect voxel · ${dollars(quote.priceCents)}`}</button> : null}
-          {quote && availability !== 'SOLD' && !collectionReady ? <div className={styles.choicePanel}><b>LOCAL 3D READY · VAULT LINK NEEDS RETRY</b><span>The model works on this device. Reconnect its compact account record before any collection payment opens.</span><button className={styles.primaryPurple} type="button" onClick={retryLocalPersistence} disabled={busy === 'register'}>{busy === 'register' ? 'Reconnecting…' : 'Reconnect Vault model'}</button></div> : null}
-          <button className={styles.textButton} type="button" onClick={() => { setBuilding(null); setAtlasBuildings([]); setMappedAddress(''); setQuote(null); setAvailability(''); setMessage('Enter the correct property address.'); }}>Change address</button>
+        <p className={styles.bigPrompt}>Done. It is yours in Voxel Vault.</p>
+        <p className={styles.stepCopy}>Your paid photo-based 3D is saved, and the mapped building context is shown separately so the app does not invent legal or physical facts.</p>
+        <div className={styles.worldCard}><PropertyWorldMap selectedBuilding={building} buildings={atlasBuildings}/><span className={styles.worldBadge}>MY WORLD · SOURCE-BACKED MAP</span></div>
+        <div className={styles.miniModel}><PhotoVoxelViewer recipe={localRecipe}/></div>
+        <div className={styles.donePanel}>
+          <div className={styles.doneMark}>✓</div>
+          <b>CREATED + SAVED · {CREATION_PRICE_LABEL} PAID ONCE</b>
+          <span className={styles.signinCopy}>{mappedAddress}</span>
+          <Link className={styles.primaryLink} href={`/vault/property-drafts/${encodeURIComponent(savedDraft?.id || '')}`}>Open saved 3D</Link>
+          <Link className={styles.secondaryLink} href="/world">Open My World</Link>
+          <Link className={styles.textLink} href="/vault/properties/claim">Verify / mint later · optional</Link>
+          <small>No $1.99 collection checkout is required after the $4.99 creation payment.</small>
         </div>
-        <p className={styles.truth}>This flow creates and may sell the generated digital VoxelPop item only. The photo, local 3D, address, map, payment, or optional later mint does not create deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property. Real-property investing can only appear through a separately verified offering.</p>
+        <p className={styles.truth}>The VoxelPop 3D is a photo-derived digital representation, not a guaranteed exact replica or deed. The source-backed map describes mapped building context separately. Payment, saving, mapping, or optional minting does not create deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property.</p>
       </> : null}
 
       {step > 1 && !pipelineRunning ? <button className={styles.change} type="button" onClick={resetCreation}>Start over with another photo</button> : null}

--- a/app/vault/property-drafts/[draftId]/page.js
+++ b/app/vault/property-drafts/[draftId]/page.js
@@ -4,13 +4,15 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import GeoReferenceModel from '../../../geo/GeoReferenceModel';
+import PhotoVoxelViewer from '../../../property/PhotoVoxelViewer';
 import MeshyModelViewer from '../../earth/MeshyModelViewer';
 import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
 import { mergePropertyDraftRecords, readPropertyDraft, replaceLocalPropertyDrafts } from '../../../../lib/property-drafts';
 import { loadAccountPropertyDrafts } from '../../../../lib/property-drafts-account';
 
 function fidelityLabel(value) {
-  if (value === 'photo-to-3d-to-voxel-collectible' || value === 'purchased-photo-guided-voxel-3d') return 'COLLECTED · VOXELPOP 3D';
+  if (value === 'purchased-photo-guided-voxel-3d') return 'PAID · PHOTO-BASED VOXELPOP 3D';
+  if (value === 'photo-to-3d-to-voxel-collectible') return 'LEGACY COLLECTED · VOXELPOP 3D';
   if (value === 'parcel-linked-ready-for-high-fidelity') return 'PARCEL-LINKED · HIGH-FIDELITY READY';
   if (value === 'source-backed-ready-for-high-fidelity') return 'SOURCE-BACKED · HIGH-FIDELITY READY';
   if (value === 'parcel-linked-3d-draft') return 'PARCEL-LINKED 3D DRAFT';
@@ -63,14 +65,17 @@ export default function SavedPropertyDraft3DPage() {
   const params = useParams();
   const draftId = String(params?.draftId || '');
   const [draft, setDraft] = useState(null);
-  const [status, setStatus] = useState('Opening your saved 3D property snapshot…');
+  const [status, setStatus] = useState('Opening your saved 3D property…');
   const [liveStatus, setLiveStatus] = useState('');
   const [session, setSession] = useState(null);
   const [busy, setBusy] = useState(false);
   const reference = useMemo(() => savedReference(draft), [draft]);
   const authoritativeTwin = useMemo(() => savedAuthoritativeTwin(draft), [draft]);
   const generatedModelUrl = draft?.visual?.modelUrl || null;
-  const collected = draft?.commerce?.kind === 'property_voxel_collectible' && draft?.commerce?.status === 'paid';
+  const localRecipe = draft?.visual?.recipe || null;
+  const paidCreation = draft?.commerce?.kind === 'property_voxel_creation' && draft?.commerce?.status === 'paid';
+  const legacyCollected = draft?.commerce?.kind === 'property_voxel_collectible' && draft?.commerce?.status === 'paid';
+  const hasSaved3d = Boolean(localRecipe || generatedModelUrl);
 
   useEffect(() => {
     let active = true;
@@ -81,11 +86,15 @@ export default function SavedPropertyDraft3DPage() {
       const local = readPropertyDraft(draftId);
       if (local) {
         setDraft(local);
-        setStatus(local?.visual?.modelUrl ? 'Loaded the exact saved VoxelPop model from your Vault.' : 'Loaded the exact geometry snapshot saved in your Vault.');
+        setStatus(local?.visual?.recipe
+          ? 'Loaded the saved photo-based VoxelPop 3D directly from your Vault.'
+          : local?.visual?.modelUrl
+            ? 'Loaded the saved VoxelPop model from your Vault.'
+            : 'Loaded the saved source-backed property snapshot from your Vault.');
         return;
       }
       if (!nextSession?.user) {
-        setStatus('This draft is not stored on this device. Sign in to restore synced property drafts.');
+        setStatus('This creation is not stored on this device. Sign in to restore synced property drafts.');
         return;
       }
       try {
@@ -95,9 +104,15 @@ export default function SavedPropertyDraft3DPage() {
         const restored = merged.find((item) => item.id === draftId) || null;
         if (!active) return;
         setDraft(restored);
-        setStatus(restored ? (restored?.visual?.modelUrl ? 'Restored this saved VoxelPop model from your account.' : 'Restored this exact saved 3D property snapshot from your account.') : 'This draft was not found in your synced account library.');
+        setStatus(restored
+          ? restored?.visual?.recipe
+            ? 'Restored the saved photo-based VoxelPop 3D from your account.'
+            : restored?.visual?.modelUrl
+              ? 'Restored the saved VoxelPop model from your account.'
+              : 'Restored the saved source-backed property snapshot from your account.'
+          : 'This creation was not found in your synced account library.');
       } catch (error) {
-        if (active) setStatus(String(error?.message || error || 'Could not restore this draft.'));
+        if (active) setStatus(String(error?.message || error || 'Could not restore this creation.'));
       }
     }
     getSupabaseBrowserAsync().then(async (client) => {
@@ -109,7 +124,7 @@ export default function SavedPropertyDraft3DPage() {
       const local = readPropertyDraft(draftId);
       if (active) {
         setDraft(local);
-        setStatus(local ? 'Loaded the exact saved 3D property snapshot on this device.' : 'This draft is not stored on this device.');
+        setStatus(local ? 'Loaded the saved 3D property on this device.' : 'This creation is not stored on this device.');
       }
     });
     return () => { active = false; subscription?.unsubscribe?.(); };
@@ -132,7 +147,7 @@ export default function SavedPropertyDraft3DPage() {
     const lat = Number(draft?.coordinates?.latitude);
     const lng = Number(draft?.coordinates?.longitude);
     if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
-      setLiveStatus('This saved draft does not contain usable coordinates for a live map refresh.');
+      setLiveStatus('This saved creation does not contain usable coordinates for a live map refresh.');
       return;
     }
     setBusy(true);
@@ -144,33 +159,33 @@ export default function SavedPropertyDraft3DPage() {
       if (!response.ok || !data?.ok) throw new Error(data?.error || 'Current map evidence could not be loaded.');
       const source = data?.sourceStatus?.fallbackUsed ? 'OpenStreetMap fallback' : 'Overture';
       setLiveStatus(data.buildingCount
-        ? `Current ${source} evidence returns ${data.buildingCount} nearby source-backed building${data.buildingCount === 1 ? '' : 's'}. Your saved model and snapshot were not changed.`
-        : `The current ${source} lookup resolved the location but returned no building footprint. Your saved model and snapshot remain unchanged.`);
+        ? `Current ${source} evidence returns ${data.buildingCount} nearby source-backed building${data.buildingCount === 1 ? '' : 's'}. Your saved VoxelPop 3D was not changed.`
+        : `The current ${source} lookup resolved the location but returned no building footprint. Your saved VoxelPop 3D remains unchanged.`);
     } catch (error) {
-      setLiveStatus(`${String(error?.message || error)} Your saved model and snapshot remain unchanged.`);
+      setLiveStatus(`${String(error?.message || error)} Your saved VoxelPop 3D remains unchanged.`);
     } finally { setBusy(false); }
   }
 
   if (!draft) return <main className="page"><header><Link href="/vault/property-drafts">← VAULT</Link><span>VOXEL VAULT · SAVED 3D</span></header><section className="missing"><b>{status}</b>{!session ? <button onClick={signIn} disabled={busy}>{busy ? 'CONNECTING…' : 'CONTINUE WITH GOOGLE'}</button> : null}<Link href="/property">CREATE ANOTHER</Link></section><style jsx>{styles}</style></main>;
 
   return <main className="page">
-    <header><Link href="/vault/property-drafts">← MY VAULT</Link><span>{collected ? 'OWNED DIGITAL VOXEL' : 'EXACT SAVED 3D SNAPSHOT'}</span><Link href="/vault/properties/claim">{collected ? 'MINT · OPTIONAL ↗' : 'VERIFY ↗'}</Link></header>
-    <section className="hero"><small>{fidelityLabel(draft.fidelity)}</small><h1>{draft.label || 'Saved property draft'}</h1><p>{status} The generated collectible and source-backed map evidence stay separate; checking current map data never silently changes the saved voxel.</p></section>
-    <section className="viewer">{generatedModelUrl ? <MeshyModelViewer modelUrl={generatedModelUrl}/> : <GeoReferenceModel reference={reference} authoritativeTwin={authoritativeTwin} viewMode="orbit" resetKey={0}/>}</section>
+    <header><Link href="/vault/property-drafts">← MY VAULT</Link><span>{paidCreation ? '$4.99 PAID CREATION' : legacyCollected ? 'LEGACY COLLECTED VOXEL' : 'SAVED 3D'}</span><Link href="/vault/properties/claim">MINT · OPTIONAL ↗</Link></header>
+    <section className="hero"><small>{fidelityLabel(draft.fidelity)}</small><h1>{draft.label || 'Saved property'}</h1><p>{status} The photo-based 3D and source-backed map evidence stay separate; checking current map data never silently changes the saved voxel.</p></section>
+    <section className="viewer">{localRecipe ? <PhotoVoxelViewer recipe={localRecipe}/> : generatedModelUrl ? <MeshyModelViewer modelUrl={generatedModelUrl}/> : <GeoReferenceModel reference={reference} authoritativeTwin={authoritativeTwin} viewMode="orbit" resetKey={0}/>}</section>
     <section className="panel">
-      <div><small>ITEM</small><b>{collected ? 'COLLECTED DIGITAL VOXEL' : 'SAVED 3D DRAFT'}</b></div>
-      <div><small>MAP EVIDENCE</small><b>{draft.geometryKind === 'parcel-boundary' ? 'PARCEL · NO BUILDING INVENTED' : draft?.evidence?.exactParcelLinkedBuilding ? 'PARCEL-LINKED BUILDING' : draft?.evidence?.sourceBackedBuilding ? 'SOURCE-BACKED BUILDING' : 'REFERENCE'}</b></div>
+      <div><small>ITEM</small><b>{paidCreation ? 'PAID VOXELPOP 3D' : legacyCollected ? 'COLLECTED DIGITAL VOXEL' : hasSaved3d ? 'SAVED 3D' : 'MAP SNAPSHOT'}</b></div>
+      <div><small>MAP EVIDENCE</small><b>{draft.geometryKind === 'parcel-boundary' ? 'PARCEL · NO BUILDING INVENTED' : draft?.evidence?.exactParcelLinkedBuilding ? 'PARCEL-LINKED BUILDING' : draft?.evidence?.sourceBackedBuilding ? 'SOURCE-BACKED BUILDING' : 'LOCATION REFERENCE'}</b></div>
       <div><small>MINT</small><b>{draft?.blockchain?.minted ? 'MINTED' : 'OPTIONAL'}</b></div>
       <div><small>REAL TITLE</small><b>{draft?.legal?.titleVerified ? 'VERIFIED' : 'SEPARATE'}</b></div>
     </section>
-    <div className="actions"><Link className="primary" href="/property">+ CREATE ANOTHER</Link><Link href="/world">VIEW MY WORLD</Link><Link href="/vault/properties/claim">{collected ? 'MINT TO WALLET · OPTIONAL' : 'VERIFY PROPERTY RIGHTS'}</Link></div>
+    <div className="actions"><Link className="primary" href="/property">+ CREATE ANOTHER</Link><Link href="/world">VIEW MY WORLD</Link><Link href="/vault/properties/claim">VERIFY / MINT · OPTIONAL</Link></div>
     <button className="evidence" onClick={refreshLiveEvidence} disabled={busy}>{busy ? 'CHECKING CURRENT EVIDENCE…' : 'CHECK CURRENT MAP EVIDENCE'}</button>
     {liveStatus ? <div className="live" role="status">{liveStatus}</div> : null}
-    <p className="truth">The VoxelPop model is a saved digital collectible/representation, not a deed or guaranteed perfect replica. A single source photo cannot verify unseen sides, roof details or exact dimensions. Parcel-only evidence stays parcel-only; no vacant land is turned into a fake building. Payment or optional minting does not create deed/title, rent, occupancy, fractional investment or appreciation rights.</p>
+    <p className="truth">The VoxelPop model is a saved digital representation, not a deed or guaranteed perfect replica. A single source photo can preserve the visible façade and silhouette, but cannot verify unseen sides, roof details or exact dimensions. Map evidence is separate. The $4.99 payment, saving, mapping, or optional minting does not create deed/title, rent, occupancy, fractional investment or appreciation rights.</p>
     <style jsx>{styles}</style>
   </main>;
 }
 
 const styles = `
-:global(body){margin:0;background:#fffaf0;color:#24170e;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,4vw,58px) calc(70px + env(safe-area-inset-bottom));background:radial-gradient(circle at 10% 10%,#fff0cc,transparent 26%),radial-gradient(circle at 90% 8%,#eee5ff,transparent 28%),radial-gradient(circle at 50% 95%,#efffc8,transparent 25%),#fffaf0}header{max-width:1050px;margin:auto;display:flex;justify-content:space-between;gap:12px;align-items:center;font-size:8px;font-weight:950;letter-spacing:.12em;color:#80736d}header a{color:#6749bd;text-decoration:none}.hero{max-width:1050px;margin:50px auto 20px;text-align:center}.hero small{font-size:8px;letter-spacing:.15em;color:#7138f5;font-weight:950}.hero h1{font-size:clamp(38px,7vw,70px);line-height:.94;letter-spacing:-.055em;margin:9px 0 13px}.hero p{max-width:760px;margin:auto;color:#83766e;font-size:10px;line-height:1.65}.viewer{position:relative;max-width:1050px;height:min(64vh,650px);min-height:390px;margin:0 auto;border:1px solid #493b55;border-radius:30px;overflow:hidden;background:#21162c;box-shadow:0 24px 58px rgba(80,50,25,.15)}.viewer :global(.viewerShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.panel{max-width:1050px;margin:12px auto;display:grid;grid-template-columns:repeat(4,1fr);gap:7px}.panel div{padding:12px;border:1px solid #e7ded3;border-radius:14px;background:#ffffffd9}.panel small{display:block;color:#92857c;font-size:6px;font-weight:950;letter-spacing:.1em}.panel b{display:block;margin-top:5px;font-size:9px}.actions{max-width:1050px;margin:10px auto;display:grid;grid-template-columns:1.15fr .85fr 1fr;gap:8px}.actions a,.evidence{display:grid;place-items:center;min-height:50px;border:1px solid #e0d6e7;border-radius:15px;text-decoration:none;color:#65586c;background:#fff;font:inherit;font-size:8px;font-weight:950;letter-spacing:.06em}.actions .primary{background:#7138f5;color:#fff;border-color:#7138f5;box-shadow:0 6px 0 #4d1bc5}.actions a:nth-child(2){background:#c9ff54;color:#2c4306;border-color:#c9ff54;box-shadow:0 6px 0 #aee43c}.actions a:last-child{background:#20172a;color:#fff;border-color:#20172a}.evidence{max-width:1050px;width:100%;margin:10px auto;cursor:pointer}.live{max-width:1050px;margin:10px auto;padding:11px 12px;border:1px solid #d9ecbd;border-radius:12px;background:#f4ffe4;color:#66774f;font-size:8px;line-height:1.55}.truth{max-width:1050px;margin:12px auto;color:#9c928b;font-size:8px;line-height:1.6}.missing{max-width:720px;margin:110px auto;padding:28px;border:1px dashed #d9ccff;border-radius:20px;display:grid;gap:12px}.missing b{font-size:13px}.missing button,.missing a{border:0;border-radius:11px;padding:12px;background:#7138f5;color:#fff;text-align:center;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.08em}@media(max-width:620px){.page{padding:15px 11px calc(74px + env(safe-area-inset-bottom))}.hero{margin-top:42px}.viewer{height:55vh;min-height:360px;border-radius:26px}.panel{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr}}
+:global(body){margin:0;background:#fffaf0;color:#24170e;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px clamp(14px,4vw,58px) calc(70px + env(safe-area-inset-bottom));background:radial-gradient(circle at 10% 10%,#fff0cc,transparent 26%),radial-gradient(circle at 90% 8%,#eee5ff,transparent 28%),radial-gradient(circle at 50% 95%,#efffc8,transparent 25%),#fffaf0}header{max-width:1050px;margin:auto;display:flex;justify-content:space-between;gap:12px;align-items:center;font-size:8px;font-weight:950;letter-spacing:.12em;color:#80736d}header a{color:#6749bd;text-decoration:none}.hero{max-width:1050px;margin:50px auto 20px;text-align:center}.hero small{font-size:8px;letter-spacing:.15em;color:#7138f5;font-weight:950}.hero h1{font-size:clamp(38px,7vw,70px);line-height:.94;letter-spacing:-.055em;margin:9px 0 13px}.hero p{max-width:760px;margin:auto;color:#83766e;font-size:10px;line-height:1.65}.viewer{position:relative;max-width:1050px;height:min(64vh,650px);min-height:390px;margin:0 auto;border:1px solid #493b55;border-radius:30px;overflow:hidden;background:#21162c;box-shadow:0 24px 58px rgba(80,50,25,.15)}.viewer :global(.viewerShell),.viewer :global(.photoVoxelShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.panel{max-width:1050px;margin:12px auto;display:grid;grid-template-columns:repeat(4,1fr);gap:7px}.panel div{padding:12px;border:1px solid #e7ded3;border-radius:14px;background:#ffffffd9}.panel small{display:block;color:#92857c;font-size:6px;font-weight:950;letter-spacing:.1em}.panel b{display:block;margin-top:5px;font-size:9px}.actions{max-width:1050px;margin:10px auto;display:grid;grid-template-columns:1.15fr .85fr 1fr;gap:8px}.actions a,.evidence{display:grid;place-items:center;min-height:50px;border:1px solid #e0d6e7;border-radius:15px;text-decoration:none;color:#65586c;background:#fff;font:inherit;font-size:8px;font-weight:950;letter-spacing:.06em}.actions .primary{background:#7138f5;color:#fff;border-color:#7138f5;box-shadow:0 6px 0 #4d1bc5}.actions a:nth-child(2){background:#c9ff54;color:#2c4306;border-color:#c9ff54;box-shadow:0 6px 0 #aee43c}.actions a:last-child{background:#20172a;color:#fff;border-color:#20172a}.evidence{max-width:1050px;width:100%;margin:10px auto;cursor:pointer}.live{max-width:1050px;margin:10px auto;padding:11px 12px;border:1px solid #d9ecbd;border-radius:12px;background:#f4ffe4;color:#66774f;font-size:8px;line-height:1.55}.truth{max-width:1050px;margin:12px auto;color:#9c928b;font-size:8px;line-height:1.6}.missing{max-width:720px;margin:110px auto;padding:28px;border:1px dashed #d9ccff;border-radius:20px;display:grid;gap:12px}.missing b{font-size:13px}.missing button,.missing a{border:0;border-radius:11px;padding:12px;background:#7138f5;color:#fff;text-align:center;text-decoration:none;font-size:8px;font-weight:950;letter-spacing:.08em}@media(max-width:620px){.page{padding:15px 11px calc(74px + env(safe-area-inset-bottom))}.hero{margin-top:42px}.viewer{height:55vh;min-height:360px;border-radius:26px}.panel{grid-template-columns:1fr 1fr}.actions{grid-template-columns:1fr}}
 `;

--- a/lib/product-map.js
+++ b/lib/product-map.js
@@ -20,8 +20,8 @@ export const APP_SECTIONS = Object.freeze([
     { id: 'geo', href: '/geo', label: 'Property details', icon: '⌖', description: 'Inspect one place with parcel, building and evidence context.', badge: 'EVIDENCE' },
     { id: 'discover', href: '/discover', label: 'Discover', icon: '✦', description: 'Browse public Voxel Vault experiences and digital assets.', badge: 'BROWSE' },
   ]},
-  { id: 'create', eyebrow: 'CREATE + COLLECT', title: 'Digital assets', description: 'Create and organize digital assets first. Wallets and minting stay optional.', items: [
-    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Authorized photo → $4.99 local VoxelPop image + interactive 3D → source-backed map → World → optional collection.', badge: 'LIVE' },
+  { id: 'create', eyebrow: 'CREATE + SAVE', title: 'Digital assets', description: 'Create and organize digital assets first. Wallets and minting stay optional.', items: [
+    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Authorized photo → $4.99 photo-based interactive 3D → source-backed map → saved to Vault. No second collection checkout.', badge: 'LIVE' },
     { id: 'studio', href: '/studio', label: 'Voxel Studio', icon: '+', description: 'Create and prepare other 3D voxel assets.', badge: 'CREATE' },
     { id: 'capture', href: '/capture', label: 'Capture', icon: '◉', description: 'Bring a real object or image into an asset workflow.', badge: 'SCAN' },
     { id: 'receipt', href: '/receipt', label: 'Receipt Scan', icon: '▣', description: 'Verify an eligible purchase before an optional collectible workflow.', badge: 'VERIFY' },


### PR DESCRIPTION
Superseded by the newer `main` implementation from #440 plus the follow-up clarity cleanup. Current main already implements the intended customer journey: one $4.99 creation payment, building-shaped local/no-Meshy 3D, source-backed map matching, direct My World/Vault save, and no blocking second collection checkout. This experimental branch is intentionally not merged so it cannot overwrite that newer condensed flow.