### PR TITLE
Make finished VoxelPop 3D usable even when Vault save fails

### DIFF
--- a/app/api/property-local-voxel/route.ts
+++ b/app/api/property-local-voxel/route.ts
@@ -30,6 +30,7 @@ type LocalVoxelRecipe = {
   height: number;
   colors: string[];
   depths: number[];
+  mask: number[];
 };
 
 function normalizeRecipe(input: any): LocalVoxelRecipe {
@@ -41,10 +42,13 @@ function normalizeRecipe(input: any): LocalVoxelRecipe {
   const count = width * height;
   const colors = Array.isArray(input?.colors) ? input.colors.slice(0, count).map((value: unknown) => clean(value, 6).toLowerCase()) : [];
   const depths = Array.isArray(input?.depths) ? input.depths.slice(0, count).map((value: unknown) => Math.max(0, Math.min(9, Math.trunc(Number(value) || 0)))) : [];
+  const suppliedMask = Array.isArray(input?.mask) ? input.mask.slice(0, count).map((value: unknown) => Number(value) > 0 ? 1 : 0) : [];
+  const mask = suppliedMask.length === count ? suppliedMask : Array.from({ length: count }, () => 1);
   if (colors.length !== count || depths.length !== count || colors.some((value) => !/^[a-f0-9]{6}$/.test(value))) {
     throw new Error('The local VoxelPop model recipe is incomplete.');
   }
-  return { version: 1, width, height, colors, depths };
+  if (!mask.some(Boolean)) throw new Error('The local VoxelPop building silhouette is empty.');
+  return { version: 1, width, height, colors, depths, mask };
 }
 
 function encodeRecipe(recipe: LocalVoxelRecipe) {
@@ -52,7 +56,7 @@ function encodeRecipe(recipe: LocalVoxelRecipe) {
 }
 
 function decodeRecipe(value: unknown) {
-  const text = clean(value, 12000);
+  const text = clean(value, 16000);
   if (!text.startsWith(RECIPE_PREFIX)) throw new Error('This is not a local VoxelPop model.');
   const encoded = text.slice(RECIPE_PREFIX.length);
   const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
@@ -73,7 +77,7 @@ function buildGltf(recipe: LocalVoxelRecipe) {
   const indices: number[] = [];
   const width = recipe.width;
   const height = recipe.height;
-  const cell = 0.34;
+  const cell = 0.27;
   const half = cell * 0.46;
   const faceIndices = [
     0, 2, 1, 0, 3, 2,
@@ -88,17 +92,16 @@ function buildGltf(recipe: LocalVoxelRecipe) {
   for (let row = 0; row < height; row += 1) {
     for (let column = 0; column < width; column += 1) {
       const index = row * width + column;
+      if (!recipe.mask[index]) continue;
       const [red, green, blue] = hexRgb(recipe.colors[index]);
-      const brightness = (red + green + blue) / 765;
       const depthUnit = recipe.depths[index] / 9;
-      // Keep even darker pixels as shallow voxels so silhouettes remain intact.
-      const depth = 0.12 + depthUnit * 0.68 + brightness * 0.08;
+      const depth = 0.34 + depthUnit * 1.12;
       const hx = half;
       const hy = half;
       const hz = depth / 2;
       const x = (column - (width - 1) / 2) * cell;
       const y = ((height - 1) / 2 - row) * cell;
-      const z = hz - 0.34;
+      const z = hz - 0.42;
       positions.push(
         x - hx, y - hy, z - hz,
         x + hx, y - hy, z - hz,
@@ -129,11 +132,11 @@ function buildGltf(recipe: LocalVoxelRecipe) {
   const yExtent = Math.max(cell, height * cell) / 2;
   const uri = `data:application/octet-stream;base64,${binary.toString('base64')}`;
   return {
-    asset: { version: '2.0', generator: 'VoxelPop Local WebGL v1' },
+    asset: { version: '2.0', generator: 'VoxelPop Local WebGL v1 photo-matched silhouette' },
     extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
     scenes: [{ nodes: [0] }],
-    nodes: [{ mesh: 0, name: 'VoxelPop local collectible' }],
+    nodes: [{ mesh: 0, name: 'VoxelPop local property silhouette' }],
     meshes: [{ primitives: [{ attributes: { POSITION: 0, COLOR_0: 1 }, indices: 2, material: 0, mode: 4 }] }],
     materials: [{
       name: 'Voxel colors',
@@ -154,8 +157,8 @@ function buildGltf(recipe: LocalVoxelRecipe) {
         componentType: 5126,
         count: positionArray.length / 3,
         type: 'VEC3',
-        min: [-xExtent, -yExtent, -0.34],
-        max: [xExtent, yExtent, 0.54],
+        min: [-xExtent, -yExtent, -0.42],
+        max: [xExtent, yExtent, 1.04],
       },
       { bufferView: 1, byteOffset: 0, componentType: 5121, normalized: true, count: colorArray.length / 3, type: 'VEC3' },
       { bufferView: 2, byteOffset: 0, componentType: 5123, count: indexArray.length, type: 'SCALAR' },
@@ -201,7 +204,7 @@ export async function POST(request: Request) {
       persisted: Boolean(saved?.task_id),
       collectionReady: Boolean(saved?.task_id && saved?.model_url),
       note: saved?.task_id
-        ? 'The compact voxel recipe is account-bound in the catalog. The original source photo was not uploaded for generation.'
+        ? 'The compact photo-matched voxel silhouette is account-bound in the catalog. The original source photo was not uploaded for generation.'
         : 'The local 3D preview is ready on this device, but durable catalog persistence is unavailable, so collection checkout remains disabled.',
     });
   } catch (error) {

--- a/app/property/LocalVoxelModelViewer.js
+++ b/app/property/LocalVoxelModelViewer.js
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-const GRID = 18;
+const GRID = 24;
 
 function quantize(value) {
-  return Math.max(0, Math.min(255, Math.round(Number(value || 0) / 24) * 24));
+  return Math.max(0, Math.min(255, Math.round(Number(value || 0) / 20) * 20));
 }
 
 function toHex(value) {
@@ -16,6 +16,10 @@ function pointerDistance(a, b) {
   return Math.hypot(a.x - b.x, a.y - b.y);
 }
 
+function colorDistance(a, b) {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
 function sampleRecipe(image) {
   const canvas = document.createElement('canvas');
   canvas.width = GRID;
@@ -24,19 +28,21 @@ function sampleRecipe(image) {
   if (!context) throw new Error('Local voxel sampling is unavailable in this browser.');
 
   const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
+  const targetRatio = 1;
   let sx = 0;
   let sy = 0;
   let sw = image.naturalWidth || 1;
   let sh = image.naturalHeight || 1;
-  if (sourceRatio > 1) {
-    sw = sh;
+  if (sourceRatio > targetRatio) {
+    sw = sh * targetRatio;
     sx = ((image.naturalWidth || 1) - sw) / 2;
-  } else if (sourceRatio < 1) {
-    sh = sw;
-    sy = ((image.naturalHeight || 1) - sh) / 2;
+  } else if (sourceRatio < targetRatio) {
+    sh = sw / targetRatio;
+    sy = Math.max(0, ((image.naturalHeight || 1) - sh) * 0.42);
   }
   context.drawImage(image, sx, sy, sw, sh, 0, 0, GRID, GRID);
   const data = context.getImageData(0, 0, GRID, GRID).data;
+  const rgb = [];
   const luminance = [];
   const colors = [];
 
@@ -45,8 +51,55 @@ function sampleRecipe(image) {
     const red = quantize(data[offset]);
     const green = quantize(data[offset + 1]);
     const blue = quantize(data[offset + 2]);
+    rgb.push([red, green, blue]);
     colors.push(`${toHex(red)}${toHex(green)}${toHex(blue)}`);
     luminance.push((red * 0.2126 + green * 0.7152 + blue * 0.0722) / 255);
+  }
+
+  const cornerIndices = [];
+  for (let row = 0; row < 4; row += 1) {
+    for (let column = 0; column < 4; column += 1) {
+      cornerIndices.push(row * GRID + column);
+      cornerIndices.push(row * GRID + (GRID - 1 - column));
+    }
+  }
+  const background = cornerIndices.reduce((sum, index) => {
+    const value = rgb[index];
+    return [sum[0] + value[0], sum[1] + value[1], sum[2] + value[2]];
+  }, [0, 0, 0]).map((value) => value / Math.max(1, cornerIndices.length));
+  const backgroundLuma = (background[0] * 0.2126 + background[1] * 0.7152 + background[2] * 0.0722) / 255;
+
+  const rawMask = rgb.map((value, index) => {
+    const row = Math.floor(index / GRID);
+    const column = index % GRID;
+    const distance = colorDistance(value, background);
+    const lumaDelta = Math.abs(luminance[index] - backgroundLuma);
+    const inUsefulFrame = column >= 1 && column <= GRID - 2 && row >= 1 && row <= GRID - 2;
+    const centerBias = Math.abs(column - (GRID - 1) / 2) / (GRID / 2);
+    const threshold = row > GRID * 0.8 ? 74 : 48 + Math.max(0, centerBias - 0.72) * 28;
+    return inUsefulFrame && (distance > threshold || lumaDelta > 0.17) ? 1 : 0;
+  });
+
+  const mask = rawMask.map((value, index) => {
+    if (value) return 1;
+    const row = Math.floor(index / GRID);
+    const column = index % GRID;
+    if (row < 1 || row >= GRID - 1 || column < 1 || column >= GRID - 1) return 0;
+    let neighbors = 0;
+    for (let y = -1; y <= 1; y += 1) {
+      for (let x = -1; x <= 1; x += 1) {
+        if (!x && !y) continue;
+        neighbors += rawMask[(row + y) * GRID + column + x] || 0;
+      }
+    }
+    return neighbors >= 5 ? 1 : 0;
+  });
+
+  const activeCount = mask.reduce((sum, value) => sum + value, 0);
+  if (activeCount < GRID * 4) {
+    for (let row = 3; row < GRID - 3; row += 1) {
+      for (let column = 4; column < GRID - 4; column += 1) mask[row * GRID + column] = 1;
+    }
   }
 
   const depths = luminance.map((value, index) => {
@@ -54,11 +107,13 @@ function sampleRecipe(image) {
     const column = index % GRID;
     const right = luminance[row * GRID + Math.min(GRID - 1, column + 1)] ?? value;
     const down = luminance[Math.min(GRID - 1, row + 1) * GRID + column] ?? value;
-    const edge = Math.min(1, Math.abs(value - right) * 2.4 + Math.abs(value - down) * 2.4);
-    return Math.max(1, Math.min(9, Math.round(2 + value * 4 + edge * 3)));
+    const left = luminance[row * GRID + Math.max(0, column - 1)] ?? value;
+    const edge = Math.min(1, Math.abs(value - right) * 2.2 + Math.abs(value - down) * 2.2 + Math.abs(value - left) * 1.4);
+    const roofBias = row < GRID * 0.42 ? 1 : 0;
+    return Math.max(2, Math.min(9, Math.round(3 + edge * 3 + (1 - value) * 2 + roofBias)));
   });
 
-  return { version: 1, width: GRID, height: GRID, colors, depths };
+  return { version: 1, width: GRID, height: GRID, colors, depths, mask };
 }
 
 export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
@@ -117,62 +172,63 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
         mount.appendChild(renderer.domElement);
 
         const scene = new THREE.Scene();
-        scene.add(new THREE.HemisphereLight(0xfffbef, 0x180f25, 2.35));
-        const key = new THREE.DirectionalLight(0xffedd5, 4.2);
+        scene.add(new THREE.HemisphereLight(0xfffbef, 0x180f25, 2.45));
+        const key = new THREE.DirectionalLight(0xffedd5, 4.4);
         key.position.set(5, 7, 8);
         scene.add(key);
-        const rim = new THREE.DirectionalLight(0xbca8ff, 2.1);
+        const rim = new THREE.DirectionalLight(0xbca8ff, 2.15);
         rim.position.set(-5, 2, -3);
         scene.add(rim);
 
-        const camera = new THREE.PerspectiveCamera(35, initialWidth / initialHeight, 0.1, 80);
-        let cameraDistance = compact ? 10.7 : 9.8;
+        const camera = new THREE.PerspectiveCamera(34, initialWidth / initialHeight, 0.1, 80);
+        let cameraDistance = compact ? 10.1 : 9.3;
         camera.position.set(0, 0.2, cameraDistance);
         camera.lookAt(0, 0, 0);
 
         const root = new THREE.Group();
-        root.rotation.x = -0.12;
-        root.rotation.y = 0.34;
+        root.rotation.x = -0.1;
+        root.rotation.y = 0.28;
+        root.position.y = 0.2;
         scene.add(root);
 
-        const geometry = new THREE.BoxGeometry(0.31, 0.31, 1);
-        const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.74, metalness: 0.02 });
-        const mesh = new THREE.InstancedMesh(geometry, material, recipe.width * recipe.height);
+        const activeIndices = recipe.mask.map((value, index) => value ? index : -1).filter((index) => index >= 0);
+        const geometry = new THREE.BoxGeometry(0.25, 0.25, 1);
+        const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.7, metalness: 0.015 });
+        const mesh = new THREE.InstancedMesh(geometry, material, Math.max(1, activeIndices.length));
         const dummy = new THREE.Object3D();
         const color = new THREE.Color();
-        const cell = 0.34;
+        const cell = 0.27;
 
-        for (let row = 0; row < recipe.height; row += 1) {
-          for (let column = 0; column < recipe.width; column += 1) {
-            const index = row * recipe.width + column;
-            const depth = 0.12 + (recipe.depths[index] / 9) * 0.68;
-            dummy.position.set(
-              (column - (recipe.width - 1) / 2) * cell,
-              ((recipe.height - 1) / 2 - row) * cell,
-              depth / 2 - 0.34,
-            );
-            dummy.scale.set(1, 1, depth);
-            dummy.updateMatrix();
-            mesh.setMatrixAt(index, dummy.matrix);
-            color.set(`#${recipe.colors[index]}`);
-            mesh.setColorAt(index, color);
-          }
-        }
+        activeIndices.forEach((index, instanceIndex) => {
+          const row = Math.floor(index / recipe.width);
+          const column = index % recipe.width;
+          const depth = 0.34 + (recipe.depths[index] / 9) * 1.12;
+          dummy.position.set(
+            (column - (recipe.width - 1) / 2) * cell,
+            ((recipe.height - 1) / 2 - row) * cell,
+            depth / 2 - 0.42,
+          );
+          dummy.scale.set(1, 1, depth);
+          dummy.updateMatrix();
+          mesh.setMatrixAt(instanceIndex, dummy.matrix);
+          color.set(`#${recipe.colors[index]}`);
+          mesh.setColorAt(instanceIndex, color);
+        });
         mesh.instanceMatrix.needsUpdate = true;
         if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
         root.add(mesh);
 
-        const backingGeometry = new THREE.BoxGeometry(6.35, 6.35, 0.12);
-        const backingMaterial = new THREE.MeshStandardMaterial({ color: 0x1d1427, roughness: 0.9, metalness: 0.01 });
-        const backing = new THREE.Mesh(backingGeometry, backingMaterial);
-        backing.position.z = -0.48;
-        root.add(backing);
+        const floorGeometry = new THREE.BoxGeometry(6.7, 0.16, 3.5);
+        const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x7b9656, roughness: 0.96, metalness: 0 });
+        const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+        floor.position.set(0, -3.08, 0.15);
+        root.add(floor);
 
-        const shadowGeometry = new THREE.CircleGeometry(3.9, 48);
-        const shadowMaterial = new THREE.MeshBasicMaterial({ color: 0x120c18, transparent: true, opacity: 0.28 });
+        const shadowGeometry = new THREE.CircleGeometry(3.4, 48);
+        const shadowMaterial = new THREE.MeshBasicMaterial({ color: 0x120c18, transparent: true, opacity: 0.25 });
         const shadow = new THREE.Mesh(shadowGeometry, shadowMaterial);
         shadow.rotation.x = -Math.PI / 2;
-        shadow.position.set(0, -3.35, 0.6);
+        shadow.position.set(0, -3.13, 0.55);
         scene.add(shadow);
 
         const pointers = new Map();
@@ -180,8 +236,8 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
         let lastX = 0;
         let lastY = 0;
         let pinch = 0;
-        let targetX = -0.12;
-        let targetY = 0.34;
+        let targetX = -0.1;
+        let targetY = 0.28;
 
         const distance = () => {
           const pair = [...pointers.values()].slice(0, 2);
@@ -204,7 +260,7 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
           if (pointers.size >= 2) {
             const next = distance();
-            if (pinch) cameraDistance = Math.max(7.4, Math.min(13.5, cameraDistance - (next - pinch) * 0.012));
+            if (pinch) cameraDistance = Math.max(6.8, Math.min(13, cameraDistance - (next - pinch) * 0.012));
             pinch = next;
             updateCamera();
             moved = true;
@@ -214,7 +270,7 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
           const dy = event.clientY - lastY;
           if (Math.abs(dx) + Math.abs(dy) > 2) moved = true;
           targetY += dx * 0.008;
-          targetX = Math.max(-0.55, Math.min(0.38, targetX + dy * 0.004));
+          targetX = Math.max(-0.52, Math.min(0.34, targetX + dy * 0.004));
           lastX = event.clientX;
           lastY = event.clientY;
         };
@@ -225,7 +281,7 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
         };
         const wheel = (event) => {
           event.preventDefault();
-          cameraDistance = Math.max(7.4, Math.min(13.5, cameraDistance + Math.sign(event.deltaY) * 0.45));
+          cameraDistance = Math.max(6.8, Math.min(13, cameraDistance + Math.sign(event.deltaY) * 0.45));
           updateCamera();
         };
         renderer.domElement.addEventListener('pointerdown', down);
@@ -238,7 +294,7 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
         let firstFrame = true;
         const animate = () => {
           frame = requestAnimationFrame(animate);
-          if (!reducedMotion && pointers.size === 0 && !moved) targetY += 0.00045;
+          if (!reducedMotion && pointers.size === 0 && !moved) targetY += 0.00042;
           root.rotation.x += (targetX - root.rotation.x) * 0.075;
           root.rotation.y += (targetY - root.rotation.y) * 0.075;
           renderer.render(scene, camera);
@@ -246,7 +302,7 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
             firstFrame = false;
             renderer.domElement.style.opacity = '1';
             setReady(true);
-            const signature = `${recipe.width}x${recipe.height}:${recipe.colors.slice(0, 4).join('')}`;
+            const signature = `${recipe.width}x${recipe.height}:${activeIndices.length}:${recipe.colors.slice(0, 4).join('')}`;
             if (reportedRef.current !== signature) {
               reportedRef.current = signature;
               callbackRef.current?.(recipe);
@@ -275,8 +331,8 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
           renderer.domElement.removeEventListener('wheel', wheel);
           geometry.dispose();
           material.dispose();
-          backingGeometry.dispose();
-          backingMaterial.dispose();
+          floorGeometry.dispose();
+          floorMaterial.dispose();
           shadowGeometry.dispose();
           shadowMaterial.dispose();
           renderer.dispose();
@@ -299,9 +355,9 @@ export default function LocalVoxelModelViewer({ imageUrl, onReady }) {
   return <div className="localViewerShell">
     {imageUrl ? <img className={`localPoster ${ready ? 'hidden' : ''}`} src={imageUrl} alt="VoxelPop rendered 3D image"/> : null}
     <div ref={mountRef} className="localCanvas" aria-label="Interactive on-device VoxelPop 3D model"/>
-    {!ready && !error ? <div className="stage">3D IMAGE · BUILDING LOCAL 3D</div> : null}
+    {!ready && !error ? <div className="stage">3D IMAGE · BUILDING PROPERTY SHAPE</div> : null}
     {error ? <div className="softError">{error}</div> : null}
-    <div className="hint">{ready ? 'DRAG · PINCH TO ZOOM · NO MESHY CREDITS' : '3D IMAGE → INTERACTIVE 3D'}</div>
+    <div className="hint">{ready ? 'DRAG · PINCH TO ZOOM · PHOTO-MATCHED SILHOUETTE' : '3D IMAGE → INTERACTIVE 3D'}</div>
     <style jsx>{`
       .localViewerShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:radial-gradient(circle at 50% 32%,#3a2850,#18101f 64%)}
       .localPoster,.localCanvas{position:absolute;inset:0;width:100%;height:100%}.localPoster{z-index:1;object-fit:cover;opacity:1;transition:opacity .42s ease}.localPoster.hidden{opacity:0;pointer-events:none}.localCanvas{z-index:2}

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -139,7 +139,7 @@ async function createVoxelPoster(file) {
       image.onload = resolve;
       image.onerror = () => reject(new Error('The photo could not be opened for the VoxelPop image.'));
     });
-    const sampleSize = 54;
+    const sampleSize = 72;
     const sample = document.createElement('canvas');
     sample.width = sampleSize;
     sample.height = sampleSize;
@@ -151,8 +151,8 @@ async function createVoxelPoster(file) {
     let sw = image.naturalWidth || 1;
     let sh = image.naturalHeight || 1;
     if (sourceRatio > 1) { sw = sh; sx = ((image.naturalWidth || 1) - sw) / 2; }
-    else if (sourceRatio < 1) { sh = sw; sy = ((image.naturalHeight || 1) - sh) / 2; }
-    sampleContext.filter = 'saturate(1.08) contrast(1.06)';
+    else if (sourceRatio < 1) { sh = sw; sy = Math.max(0, ((image.naturalHeight || 1) - sh) * 0.42); }
+    sampleContext.filter = 'saturate(1.06) contrast(1.08)';
     sampleContext.drawImage(image, sx, sy, sw, sh, 0, 0, sampleSize, sampleSize);
 
     const output = document.createElement('canvas');
@@ -163,12 +163,12 @@ async function createVoxelPoster(file) {
     context.imageSmoothingEnabled = false;
     context.drawImage(sample, 0, 0, output.width, output.height);
     const shade = context.createLinearGradient(0, 0, output.width, output.height);
-    shade.addColorStop(0, 'rgba(255,255,255,.10)');
+    shade.addColorStop(0, 'rgba(255,255,255,.08)');
     shade.addColorStop(0.58, 'rgba(255,255,255,0)');
-    shade.addColorStop(1, 'rgba(38,18,52,.15)');
+    shade.addColorStop(1, 'rgba(38,18,52,.12)');
     context.fillStyle = shade;
     context.fillRect(0, 0, output.width, output.height);
-    return output.toDataURL('image/jpeg', 0.91);
+    return output.toDataURL('image/jpeg', 0.92);
   } finally {
     URL.revokeObjectURL(url);
   }
@@ -188,6 +188,7 @@ export default function PropertyJourneyPage() {
   const [final3d, setFinal3d] = useState(empty3d);
   const [localRecipe, setLocalRecipe] = useState(null);
   const [collectionReady, setCollectionReady] = useState(false);
+  const [vaultLinkError, setVaultLinkError] = useState('');
   const [pipelinePhase, setPipelinePhase] = useState('photo');
   const [address, setAddress] = useState('');
   const [mappedAddress, setMappedAddress] = useState('');
@@ -259,6 +260,7 @@ export default function PropertyJourneyPage() {
     setFinal3d(empty3d());
     setLocalRecipe(null);
     setCollectionReady(false);
+    setVaultLinkError('');
     setBuilding(null);
     setAtlasBuildings([]);
     setMappedAddress('');
@@ -302,19 +304,22 @@ export default function PropertyJourneyPage() {
         taskId: data.taskId,
       });
       setCollectionReady(data.collectionReady === true);
+      setVaultLinkError(data.collectionReady === true ? '' : clean(data.note));
       setPipelinePhase('world');
       setMessage(data.collectionReady
-        ? 'Your voxel is ready without Meshy credits. Add the property address to place it on My World.'
-        : 'Your local 3D is ready. Add the address now; collection checkout stays off until the account model record can be saved.');
+        ? 'Your 3D model is ready. Add the property address to place it on My World.'
+        : 'Your 3D model is ready. You can continue to the map and World now; saving to Vault can be retried separately.');
       await removeDevicePhoto(draftId);
       if (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('generation_session')) {
         window.history.replaceState({}, '', '/property');
       }
     } catch (error) {
+      const detail = String(error?.message || error || 'Vault save is unavailable.');
       setFinal3d({ status: 'SUCCEEDED', progress: 100, modelUrl: null, thumbnailUrl: voxelImage || null, taskId: `local-device:${draftId}` });
       setCollectionReady(false);
+      setVaultLinkError(detail);
       setPipelinePhase('world');
-      setMessage(`The local 3D is ready, but its Vault link needs a retry. ${String(error?.message || error || '')}`.trim());
+      setMessage('Your 3D model is ready. Continue to the map and World; only Save to Vault needs a retry.');
     } finally {
       setBusy('');
     }
@@ -459,14 +464,19 @@ export default function PropertyJourneyPage() {
   async function retryLocalPersistence() {
     if (!localRecipe) return setMessage('The local 3D recipe is not available. Rebuild the voxel first.');
     setBusy('register');
-    setMessage('Reconnecting this local voxel to your Vault record…');
+    setMessage('Saving this finished 3D model to your Vault…');
     try {
       const data = await registerLocalRecipe(localRecipe);
       setFinal3d((current) => ({ ...current, taskId: data.taskId, modelUrl: data.modelUrl || null }));
       setCollectionReady(data.collectionReady === true);
-      setMessage(data.collectionReady ? 'Vault link ready. You can collect this digital voxel now.' : data.note || 'The Vault record is still unavailable.');
+      setVaultLinkError(data.collectionReady === true ? '' : clean(data.note));
+      setMessage(data.collectionReady
+        ? 'Saved to Vault. Your 3D and map remain ready.'
+        : 'Your 3D and map are still ready. Vault saving is temporarily unavailable, so collection checkout stays off.');
     } catch (error) {
-      setMessage(String(error?.message || error || 'The Vault link is still unavailable.'));
+      const detail = String(error?.message || error || 'The Vault link is still unavailable.');
+      setVaultLinkError(detail);
+      setMessage('Your 3D and map are still ready. Vault saving can be retried later without rebuilding or paying again.');
     } finally { setBusy(''); }
   }
 
@@ -505,15 +515,15 @@ export default function PropertyJourneyPage() {
       setMessage(priced.sold
         ? 'This mapped digital voxel has already been collected.'
         : collectionReady
-          ? 'My World preview ready. If it looks right, collect the voxel and save it to your Vault.'
-          : 'My World preview ready. The local 3D works; reconnect its Vault record before collection checkout.');
+          ? 'Your 3D + World preview are ready. If it looks right, you can optionally collect the voxel.'
+          : 'Your 3D + World preview are ready. Vault saving is separate and can be retried below without blocking the result.');
     } catch (error) {
       setMessage(String(error?.message || error || 'World placement failed.'));
     } finally { setBusy(''); }
   }
 
   async function collectAndSave() {
-    if (!collectionReady) return setMessage('Reconnect the local voxel to its Vault record before opening collection checkout.');
+    if (!collectionReady) return setMessage('Your 3D and map are ready. Save the model to Vault before opening optional collection checkout.');
     if (!quote || !building?.atlasId || !final3d?.taskId || !session?.access_token) return;
     setBusy('checkout');
     setMessage('Opening secure checkout for the digital voxel…');
@@ -545,6 +555,7 @@ export default function PropertyJourneyPage() {
     setFinal3d(empty3d());
     setLocalRecipe(null);
     setCollectionReady(false);
+    setVaultLinkError('');
     setPipelinePhase('photo');
     setAddress('');
     setMappedAddress('');
@@ -606,36 +617,46 @@ export default function PropertyJourneyPage() {
 
       {step === 3 ? <>
         <p className={styles.bigPrompt}>VoxelPop image → movable 3D.</p>
-        <p className={styles.stepCopy}>Your rendered voxel image stays visible until the interactive local 3D has actually rendered.</p>
+        <p className={styles.stepCopy}>Your rendered voxel image stays visible until the interactive local 3D has actually rendered. The local viewer now follows the building silhouette from your photo instead of extruding the whole square image.</p>
         <div className={styles.heroCard}>
           <LocalVoxelModelViewer imageUrl={voxelImage || displaySource} onReady={handleLocal3DReady}/>
           <span className={styles.badge}>VOXEL IMAGE → INTERACTIVE 3D</span>
           {!finalReady ? <div className={styles.buildPulse}/> : null}
         </div>
-        <div className={styles.autoPanel}><b>AUTOMATIC · ON DEVICE</b><span>Photo → VoxelPop image → interactive 3D. No external generation credits are spent.</span></div>
+        <div className={styles.autoPanel}><b>AUTOMATIC · ON DEVICE</b><span>Photo → VoxelPop image → photo-matched silhouette 3D. No external generation credits are spent.</span></div>
       </> : null}
 
       {step === 4 ? <>
-        <p className={styles.bigPrompt}>Add the property address.</p>
-        <p className={styles.stepCopy}>Enter the address for the property shown in your photo. We use it to find source-backed building footprints and build the improved neighborhood map.</p>
-        <div className={styles.heroCard}><LocalVoxelModelViewer imageUrl={voxelImage}/><span className={styles.badge}>VOXEL READY · LOCAL 3D</span></div>
-        <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Building map…' : 'Verify address + preview'}</button></form>
+        <p className={styles.bigPrompt}>Your 3D is ready. Add the address.</p>
+        <p className={styles.stepCopy}>The finished 3D stays usable even if Vault saving is temporarily unavailable. Enter the address to build the source-backed neighborhood map.</p>
+        <div className={styles.heroCard}><LocalVoxelModelViewer imageUrl={voxelImage}/><span className={styles.badge}>3D READY · DRAG + PINCH</span></div>
+        <form className={styles.searchForm} onSubmit={placeOnWorld}><input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Property address" aria-label="Property address" autoComplete="street-address"/><button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Building map…' : 'Open property map'}</button></form>
         <small className={styles.mapNote}>The map uses source-backed building data where available. The address is not proof of ownership, title, property value, or an investment offering.</small>
       </> : null}
 
       {step === 5 ? <>
-        <p className={styles.bigPrompt}>Your World preview.</p>
-        <p className={styles.stepCopy}>The selected building is highlighted inside its nearby source-backed neighborhood, with touch rotation and zoom.</p>
+        <p className={styles.bigPrompt}>Your 3D + World are ready.</p>
+        <p className={styles.stepCopy}>View the finished movable voxel and the mapped neighborhood now. Saving to Vault is a separate account step and never blocks the finished result.</p>
         <div className={styles.worldCard}><PropertyWorldMap selectedBuilding={building} buildings={atlasBuildings}/><span className={styles.worldBadge}>MY WORLD · IMPROVED PROPERTY MAP</span></div>
         <div className={styles.miniModel}><LocalVoxelModelViewer imageUrl={voxelImage}/></div>
+        <div className={styles.resultActions}>
+          <a className={styles.primaryLink} href="/world">Open My World</a>
+          <a className={styles.secondaryLink} href="/vault/property-drafts">Open my Vault</a>
+        </div>
         <div className={styles.priceCard}>
           <div><small>DIGITAL VOXEL</small><b>{quote?.label || 'World preview'}</b><span>{mappedAddress}</span></div>
           <strong>{quote ? dollars(quote.priceCents) : '—'}</strong>
           {quote ? <p>{quote.explanation} This is the price of the generated digital voxel—not the market value of the house or land.</p> : null}
           {availability === 'SOLD' ? <div className={styles.sold}>ALREADY COLLECTED · THIS MAPPED DIGITAL VOXEL IS ONE-OF-ONE</div> : null}
-          {!quote && !building?.mappedIdentityReady ? <div className={styles.sold}>PREVIEW ONLY · A SOURCE-BACKED BUILDING ID IS NEEDED BEFORE COLLECTION</div> : null}
-          {quote && availability !== 'SOLD' && collectionReady ? <button className={styles.primaryOrange} type="button" onClick={collectAndSave} disabled={busy === 'checkout'}>{busy === 'checkout' ? 'Opening secure checkout…' : `Collect voxel · ${dollars(quote.priceCents)}`}</button> : null}
-          {quote && availability !== 'SOLD' && !collectionReady ? <div className={styles.choicePanel}><b>LOCAL 3D READY · VAULT LINK NEEDS RETRY</b><span>The model works on this device. Reconnect its compact account record before any collection payment opens.</span><button className={styles.primaryPurple} type="button" onClick={retryLocalPersistence} disabled={busy === 'register'}>{busy === 'register' ? 'Reconnecting…' : 'Reconnect Vault model'}</button></div> : null}
+          {!quote && !building?.mappedIdentityReady ? <div className={styles.sold}>PREVIEW READY · A SOURCE-BACKED BUILDING ID IS NEEDED ONLY FOR OPTIONAL COLLECTION</div> : null}
+          {quote && availability !== 'SOLD' && collectionReady ? <button className={styles.primaryOrange} type="button" onClick={collectAndSave} disabled={busy === 'checkout'}>{busy === 'checkout' ? 'Opening secure checkout…' : `Optional: collect voxel · ${dollars(quote.priceCents)}`}</button> : null}
+          {quote && availability !== 'SOLD' && !collectionReady ? <div className={styles.choicePanel}>
+            <b>YOUR 3D MODEL IS READY</b>
+            <span>The movable 3D and property map work now. Saving to Vault failed or is temporarily unavailable, but that does not invalidate the model and does not require another $4.99 payment.</span>
+            <button className={styles.primaryPurple} type="button" onClick={retryLocalPersistence} disabled={busy === 'register'}>{busy === 'register' ? 'Saving to Vault…' : 'Retry Save to Vault'}</button>
+            <a className={styles.textLink} href="/world">Continue to My World instead</a>
+            {vaultLinkError ? <small className={styles.vaultNote}>Vault save detail: {vaultLinkError}</small> : null}
+          </div> : null}
           <button className={styles.textButton} type="button" onClick={() => { setBuilding(null); setAtlasBuildings([]); setMappedAddress(''); setQuote(null); setAvailability(''); setMessage('Enter the correct property address.'); }}>Change address</button>
         </div>
         <p className={styles.truth}>This flow creates and may sell the generated digital VoxelPop item only. The photo, local 3D, address, map, payment, or optional later mint does not create deed/title, rent, occupancy, fractional investment, appreciation, or other rights in the physical property. Real-property investing can only appear through a separately verified offering.</p>

--- a/app/property/property.module.css
+++ b/app/property/property.module.css
@@ -53,12 +53,14 @@
 .worldCard>div{height:100%!important}
 .miniModel{position:relative;width:116px;height:116px;margin:-72px 20px 0 auto;z-index:7;overflow:hidden;border:5px solid #fffaf0;border-radius:30px;background:#21172c;box-shadow:0 12px 30px rgba(36,20,49,.24)}
 .voxelMini>img{width:100%;height:100%;display:block;object-fit:cover;image-rendering:pixelated}
+.resultActions{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin:18px 0 8px}
 .priceCard{margin-top:17px;padding:20px;border-radius:30px;background:#fff;border:1px solid #e8dfd2;box-shadow:0 20px 46px rgba(86,51,21,.1);text-align:left}
 .priceCard>div:first-child{display:grid;gap:4px;padding-right:110px}
 .priceCard small{color:#7138f5;font-size:8px;font-weight:1000;letter-spacing:.12em}
 .priceCard b{font-size:22px;letter-spacing:-.035em}.priceCard span{color:#847970;font-size:11px;line-height:1.4}
 .priceCard strong{display:block;margin:-49px 0 27px auto;width:max-content;color:#2b1809;font-size:28px;letter-spacing:-.04em}
 .priceCard p{margin:0 0 15px;color:#857a71;font-size:10px;line-height:1.55}
+.vaultNote{display:block;padding:11px 12px;border-radius:14px;background:#fff7e8;color:#8a6f46;font-size:9px!important;line-height:1.45;text-align:left;overflow-wrap:anywhere}
 .sold{margin:12px 0;padding:13px;border-radius:16px;background:#fff2e8;color:#8a4e23;font-size:9px;font-weight:950;line-height:1.45;letter-spacing:.04em;text-align:center}
 .signinPanel{display:grid;gap:14px;margin-top:28px;padding:30px 24px;border-radius:32px;background:rgba(255,255,255,.86);border:1px solid #e4d9ef;box-shadow:0 24px 64px rgba(82,49,113,.12)}
 .signinMark{width:66px;height:66px;margin:0 auto;border-radius:22px;display:grid;place-items:center;background:#7138f5;color:#fff;font-size:30px;font-weight:1000;box-shadow:0 8px 0 #4d1bc5}
@@ -71,4 +73,5 @@
 .truth{max-width:550px;margin:13px auto 0;color:#a0968d;font-size:9px;line-height:1.55}
 @keyframes move{0%{background-position:0 0}100%{background-position:240% 0}}
 @media(max-width:640px){.page{padding:9px 11px calc(34px + env(safe-area-inset-bottom))}.maker h1{margin-top:24px;font-size:55px}.stageLabel{margin-bottom:22px}.heroCard,.worldCard,.mapStage{border-radius:31px}.worldCard{height:390px}.mapStage{height:440px}.choicePanel,.donePanel,.priceCard{border-radius:25px;padding:16px}.searchForm{padding:14px;border-radius:26px}.searchForm input{font-size:16px;padding:17px}.primaryPurple,.primaryOrange,.primaryTeal,.primaryLink,.secondaryLink,.searchForm button{min-height:61px;border-radius:20px;font-size:18px}.bigPrompt{font-size:30px}.photoDrop{min-height:285px;border-radius:31px}.truth{font-size:8.5px}.signinPanel{margin-top:20px;padding:24px 18px;border-radius:28px}.accountPill b{max-width:210px}.miniModel{width:104px;height:104px;margin-top:-63px}.priceCard>div:first-child{padding-right:90px}.priceCard strong{font-size:25px}.mapFacts{grid-template-columns:1fr 1fr}.mapFacts div:first-child{grid-column:1/-1}.mapControls{gap:6px}.mapControls button{min-height:42px;font-size:8px}}
+@media(max-width:520px){.resultActions{grid-template-columns:1fr;gap:11px}}
 @media(max-width:390px){.maker h1{font-size:51px}.heroCard,.worldCard,.mapStage{border-radius:27px}.worldCard{height:350px}.mapStage{height:400px}.primaryPurple,.primaryOrange,.primaryLink,.secondaryLink,.searchForm button{min-height:58px;font-size:17px}.progress{width:82%}.accountPill b{max-width:165px}.priceCard>div:first-child{padding-right:0}.priceCard strong{margin:12px 0 18px;width:auto}.mapControls{grid-template-columns:1fr 1fr}.mapFacts{grid-template-columns:1fr}.mapFacts div:first-child{grid-column:auto}}

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -46,6 +46,7 @@ assert.match(propertyCss, /#7138f5/i, 'VoxelPop purple remains');
 assert.match(propertyCss, /#c9ff54/i, 'VoxelPop lime remains');
 assert.match(propertyCss, /#f7ae2d|#ee950f/i, 'collect action keeps warm orange');
 assert.match(propertyCss, /grid-template-columns:repeat\(5,1fr\)/, 'maker keeps five guided steps');
+assert.match(propertyCss, /resultActions/, 'finished result exposes direct World and Vault actions');
 
 assert.match(property, /Sign in first\./, 'maker exposes the account gate');
 assert.match(property, /Continue with Google/, 'account gate has one clear sign-in action');
@@ -60,6 +61,8 @@ assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'source photo is kept priva
 assert.match(property, /createVoxelPoster/, 'VoxelPop image is built locally');
 assert.match(property, /LocalVoxelModelViewer/, 'local interactive 3D replaces provider generation in the guided maker');
 assert.match(localViewer, /InstancedMesh/, 'local viewer builds real Three.js voxel geometry');
+assert.match(localViewer, /mask/, 'local viewer separates a photo-matched building silhouette from the background instead of extruding the whole square');
+assert.match(localViewer, /PHOTO-MATCHED SILHOUETTE/, 'viewer tells the user the local shape follows the photo silhouette');
 assert.match(localViewer, /3D IMAGE → INTERACTIVE 3D/, 'image must remain visible before interactive 3D');
 assert.match(localVoxel, /propertyDraftItemId\(auth\.user\.id, draftId, 'voxel'\)/, 'finished local voxel remains account/draft bound');
 assert.match(localVoxel, /model\/gltf\+json/, 'compact local recipe can reopen as glTF');
@@ -67,8 +70,8 @@ assert.doesNotMatch(generationCheckout, /MESHY_PROPERTY_CREDITS|readMeshyCreditB
 assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|api\.meshy|image-to-3d|storage\.from/i, 'paid resume cannot call Meshy or private Storage');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided maker must not call metered Meshy routes');
 
-assert.match(property, /Add the property address\./, 'address step follows local voxel creation');
-assert.match(property, /Verify address \+ preview/, 'address action says verification and preview');
+assert.match(property, /Your 3D is ready\. Add the address\./, 'address step begins only after the finished 3D is usable');
+assert.match(property, /Open property map/, 'address action has one clear continuation into the map');
 assert.match(property, /setAtlasBuildings/, 'address lookup retains nearby source-backed buildings');
 assert.match(property, /PropertyWorldMap/, 'private collection preview uses the improved focused map');
 assert.match(propertyMap, /ExtrudeGeometry/, 'focused map extrudes source-backed footprints');
@@ -78,9 +81,17 @@ assert.match(propertyMap, /Zoom property map in/, 'focused map exposes mobile zo
 assert.match(property, /MY WORLD · IMPROVED PROPERTY MAP/, 'map improvement is visible in the guided flow');
 assert.match(property, /\/api\/property-collectible\/quote/, 'server quote still follows World placement');
 assert.match(property, /async function collectAndSave\(\)/, 'digital collection action remains');
-assert.match(property, /Collect voxel ·/, 'final paid action identifies the digital voxel');
+assert.match(property, /Optional: collect voxel ·/, 'final paid action is explicitly optional and identifies the digital voxel');
 assert.match(property, /not the market value of the house or land/, 'price copy never looks like a real-property valuation');
 assert.match(property, /Real-property investing can only appear through a separately verified offering/, 'real investment remains on a separate verified rail');
+
+assert.match(property, /Your 3D \+ World are ready\./, 'successful creation has a positive finished-result state');
+assert.match(property, /Saving to Vault is a separate account step and never blocks the finished result/, 'Vault persistence is not allowed to redefine creation success');
+assert.match(property, /YOUR 3D MODEL IS READY/, 'Vault persistence failure keeps the finished 3D as the primary state');
+assert.match(property, /Retry Save to Vault/, 'Vault persistence remains retryable');
+assert.match(property, /Continue to My World instead/, 'a failed Vault save cannot trap the user');
+assert.match(property, /does not require another \$4\.99 payment/, 'Vault retry cannot imply another creation charge');
+assert.doesNotMatch(property, /LOCAL 3D READY · VAULT LINK NEEDS RETRY|Reconnect Vault model/, 'old dead-end Vault-first result language must not return');
 
 for (const cents of ['199', '299', '399']) assert.match(collectibleCommerce, new RegExp(`priceCents: ${cents}`), 'three low-cost digital collection tiers remain');
 for (const tier of ['classic', 'detailed', 'landmark']) assert.match(collectibleCommerce, new RegExp(`tier: '${tier}'`), `pricing keeps ${tier}`);
@@ -114,4 +125,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> authorized device-local photo -> clear $4.99 local creation -> VoxelPop image -> interactive 3D -> source-backed property map -> optional digital collection/Vault, without Meshy credits or checkout Storage.');
+console.log('Guided VoxelPop property checks passed: $4.99 -> photo-matched local 3D -> source-backed map -> World, with Vault persistence downgraded to a retryable secondary save and no Meshy credits or checkout Storage.');


### PR DESCRIPTION
Superseded by the newer Property refactor already merged into `main` at `d55b56ad8813f32e9526a0ebef9e9c67d2e84f8d`. The live flow now already does the important things this PR targeted: $4.99 paid creation, photo-matched local movable 3D, address/map continuation even when account sync is unavailable, My World save included without a second creation charge, and retryable later account/Vault sync. Closing this older conflicting branch rather than overwriting the newer implementation.