### PR TITLE
Make property creation show 3D preview before voxel and mint

### DIFF
--- a/app/api/property-voxel-nft/confirm/route.ts
+++ b/app/api/property-voxel-nft/confirm/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
+import { verifyOwnedFinalVoxelModel } from '../../../../../lib/property-collectible-commerce';
+import { propertyVoxelMetadataUrl, propertyVoxelVoucherId, verifyPropertyVoxelMint } from '../../../../../lib/property-voxel-mint';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const LOCAL_PROVIDER = 'voxelpop-local-webgl-v1';
+
+function clean(value: unknown, max = 300) {
+  return String(value || '').trim().slice(0, max);
+}
+function privateJson(body: unknown, init: ResponseInit = {}) {
+  return NextResponse.json(body, { ...init, headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) } });
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const draftId = clean(body?.draftId, 100);
+    const taskId = clean(body?.taskId, 260);
+    const name = clean(body?.name, 72) || 'VoxelPop Property';
+    const wallet = clean(body?.wallet, 60);
+    const tokenId = clean(body?.tokenId, 100);
+    const txHash = clean(body?.txHash, 100);
+    if (!draftId || !taskId || !ADDRESS_RE.test(wallet) || !tokenId || !txHash) {
+      return privateJson({ ok: false, error: 'Mint confirmation details are incomplete.' }, { status: 400 });
+    }
+
+    const owned = await verifyOwnedFinalVoxelModel({ userId: auth.user.id, draftId, modelTaskId: taskId });
+    if (!owned.savedModel || owned.savedModel.provider !== LOCAL_PROVIDER || !taskId.startsWith('local-v1:')) {
+      return privateJson({ ok: false, error: 'This mint does not match a finished local property voxel owned by this account.' }, { status: 403 });
+    }
+
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const metadataUrl = propertyVoxelMetadataUrl(origin, owned.draftId, taskId, name);
+    const voucherId = propertyVoxelVoucherId(auth.user.id, owned.draftId, taskId);
+    const verified = await verifyPropertyVoxelMint({ tokenId, wallet, txHash, voucherId, metadataUrl });
+
+    return privateJson({
+      ok: true,
+      verified: true,
+      ...verified,
+      draftId: owned.draftId,
+      taskId,
+      digitalOnly: true,
+      physicalPropertyRights: false,
+    });
+  } catch (error) {
+    return privateJson({ ok: false, error: error instanceof Error ? error.message : 'The Base mint could not be verified.' }, { status: 409 });
+  }
+}

--- a/app/api/property-voxel-nft/confirm/route.ts
+++ b/app/api/property-voxel-nft/confirm/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
-import { verifyOwnedFinalVoxelModel } from '../../../../../lib/property-collectible-commerce';
-import { propertyVoxelMetadataUrl, propertyVoxelVoucherId, verifyPropertyVoxelMint } from '../../../../../lib/property-voxel-mint';
+import { requireVoxelVaultUser } from '../../../../lib/user-auth';
+import { verifyOwnedFinalVoxelModel } from '../../../../lib/property-collectible-commerce';
+import { propertyVoxelMetadataUrl, propertyVoxelVoucherId, verifyPropertyVoxelMint } from '../../../../lib/property-voxel-mint';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/property-voxel-nft/metadata/route.ts
+++ b/app/api/property-voxel-nft/metadata/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server';
+import { readCatalog3DByTask } from '../../../../../lib/catalog3dStore';
+import { normalizePropertyDraftId } from '../../../../../lib/property-generation-ids';
+import { verifyPropertyVoxelMetadataSignature } from '../../../../../lib/property-voxel-mint';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const PROVIDER = 'voxelpop-local-webgl-v1';
+const RECIPE_PREFIX = 'local-voxel-recipe-v1:';
+
+function clean(value: unknown, max = 300) {
+  return String(value || '').trim().slice(0, max);
+}
+function escapeXml(value: unknown) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+function decodeRecipe(value: unknown) {
+  const text = clean(value, 12000);
+  if (!text.startsWith(RECIPE_PREFIX)) throw new Error('Local voxel recipe is unavailable.');
+  const parsed = JSON.parse(Buffer.from(text.slice(RECIPE_PREFIX.length), 'base64url').toString('utf8'));
+  const width = Math.trunc(Number(parsed?.width));
+  const height = Math.trunc(Number(parsed?.height));
+  const count = width * height;
+  const colors = Array.isArray(parsed?.colors) ? parsed.colors.slice(0, count).map((item: unknown) => clean(item, 6).toLowerCase()) : [];
+  const depths = Array.isArray(parsed?.depths) ? parsed.depths.slice(0, count).map((item: unknown) => Math.max(0, Math.min(9, Math.trunc(Number(item) || 0)))) : [];
+  if (Number(parsed?.version) !== 1 || width < 8 || height < 8 || width > 24 || height > 24 || colors.length !== count || depths.length !== count) throw new Error('Local voxel recipe is invalid.');
+  if (colors.some((value: string) => !/^[a-f0-9]{6}$/.test(value))) throw new Error('Local voxel colors are invalid.');
+  return { width, height, colors, depths };
+}
+function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
+  const cell = 34;
+  const artWidth = recipe.width * cell;
+  const artHeight = recipe.height * cell;
+  const offsetX = Math.round((1200 - artWidth) / 2);
+  const offsetY = 170 + Math.round((760 - artHeight) / 2);
+  const blocks: string[] = [];
+  for (let row = 0; row < recipe.height; row += 1) {
+    for (let column = 0; column < recipe.width; column += 1) {
+      const index = row * recipe.width + column;
+      const depth = recipe.depths[index];
+      if (depth <= 0) continue;
+      const x = offsetX + column * cell;
+      const y = offsetY + row * cell;
+      const lift = Math.round(depth * 1.4);
+      blocks.push(`<rect x="${x}" y="${y - lift}" width="${cell - 2}" height="${cell - 2 + lift}" rx="3" fill="#${recipe.colors[index]}"/>`);
+    }
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200">
+    <defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#20172a"/><stop offset="1" stop-color="#473168"/></linearGradient></defs>
+    <rect width="1200" height="1200" fill="url(#bg)"/>
+    <circle cx="990" cy="190" r="140" fill="#c9ff54" opacity=".14"/>
+    <g>${blocks.join('')}</g>
+    <text x="70" y="86" fill="#c9ff54" font-family="Arial,sans-serif" font-size="25" font-weight="800" letter-spacing="6">VOXELPOP · PROPERTY VOXEL</text>
+    <text x="70" y="1060" fill="#ffffff" font-family="Arial,sans-serif" font-size="62" font-weight="800">${escapeXml(name)}</text>
+    <text x="70" y="1115" fill="#cfc4dc" font-family="Arial,sans-serif" font-size="23">PHOTO-APPROVED 3D → LOCAL VOXEL → DIGITAL NFT</text>
+    <text x="70" y="1150" fill="#9286a0" font-family="Arial,sans-serif" font-size="18">DIGITAL COLLECTIBLE ONLY · NOT A DEED OR PHYSICAL-PROPERTY RIGHT</text>
+  </svg>`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const draftId = normalizePropertyDraftId(clean(url.searchParams.get('draftId'), 100));
+    const taskId = clean(url.searchParams.get('taskId'), 260);
+    const name = clean(url.searchParams.get('name'), 72) || 'VoxelPop Property';
+    const sig = clean(url.searchParams.get('sig'), 128);
+    if (!taskId.startsWith('local-v1:') || !verifyPropertyVoxelMetadataSignature(draftId, taskId, name, sig)) {
+      return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
+    }
+    const model = await readCatalog3DByTask(taskId);
+    if (!model || model.provider !== PROVIDER || !model.source_image_url) {
+      return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
+    }
+    const recipe = decodeRecipe(model.source_image_url);
+    const svg = thumbnail(recipe, name);
+    const image = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+    const animationUrl = `${url.origin}/api/property-local-voxel?taskId=${encodeURIComponent(taskId)}`;
+    return NextResponse.json({
+      name: `${name} · VoxelPop`,
+      description: 'A photo-approved VoxelPop digital property voxel. The user saw the source-faithful 3D preview before creating this local voxel. This NFT is a digital collectible only and does not convey deed/title, occupancy, rent, investment, appraisal, or other rights in physical real estate.',
+      image,
+      animation_url: animationUrl,
+      external_url: `${url.origin}/property`,
+      attributes: [
+        { trait_type: 'Asset Type', value: 'VoxelPop Property Voxel' },
+        { trait_type: 'Creation Flow', value: 'Photo → 3D Preview → Voxel' },
+        { trait_type: '3D Engine', value: 'VoxelPop Local WebGL' },
+        { trait_type: 'Meshy Credits', value: 'Not used' },
+        { trait_type: 'Source Preview Approved', value: 'Yes' },
+        { trait_type: 'Real Property Rights', value: 'None' },
+        { trait_type: 'Deed / Title', value: 'None' },
+        { trait_type: 'Rent / Occupancy Rights', value: 'None' },
+      ],
+      properties: {
+        digital_only: true,
+        photo_source_stored_in_metadata: false,
+        source_photo_uploaded_for_generation: false,
+        real_property_rights: false,
+        deed_or_title: false,
+      },
+    }, {
+      headers: {
+        'Cache-Control': 'public, max-age=300, s-maxage=3600',
+        'X-Robots-Tag': 'noindex',
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
+  }
+}

--- a/app/api/property-voxel-nft/metadata/route.ts
+++ b/app/api/property-voxel-nft/metadata/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { readCatalog3DByTask } from '../../../../../lib/catalog3dStore';
-import { normalizePropertyDraftId } from '../../../../../lib/property-generation-ids';
-import { verifyPropertyVoxelMetadataSignature } from '../../../../../lib/property-voxel-mint';
+import { readCatalog3DByTask } from '../../../../lib/catalog3dStore';
+import { normalizePropertyDraftId } from '../../../../lib/property-generation-ids';
+import { verifyPropertyVoxelMetadataSignature } from '../../../../lib/property-voxel-mint';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/property-voxel-nft/prepare/route.ts
+++ b/app/api/property-voxel-nft/prepare/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
-import { verifyOwnedFinalVoxelModel } from '../../../../../lib/property-collectible-commerce';
-import { getVoxelFlipDeployment } from '../../../../../lib/voxelflip-deployment';
-import { buildPropertyVoxelVoucher, propertyVoxelVoucherUsed } from '../../../../../lib/property-voxel-mint';
+import { requireVoxelVaultUser } from '../../../../lib/user-auth';
+import { verifyOwnedFinalVoxelModel } from '../../../../lib/property-collectible-commerce';
+import { getVoxelFlipDeployment } from '../../../../lib/voxelflip-deployment';
+import { buildPropertyVoxelVoucher, propertyVoxelVoucherUsed } from '../../../../lib/property-voxel-mint';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/app/api/property-voxel-nft/prepare/route.ts
+++ b/app/api/property-voxel-nft/prepare/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
+import { verifyOwnedFinalVoxelModel } from '../../../../../lib/property-collectible-commerce';
+import { getVoxelFlipDeployment } from '../../../../../lib/voxelflip-deployment';
+import { buildPropertyVoxelVoucher, propertyVoxelVoucherUsed } from '../../../../../lib/property-voxel-mint';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const LOCAL_PROVIDER = 'voxelpop-local-webgl-v1';
+
+function clean(value: unknown, max = 300) {
+  return String(value || '').trim().slice(0, max);
+}
+function privateJson(body: unknown, init: ResponseInit = {}) {
+  return NextResponse.json(body, { ...init, headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) } });
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const draftId = clean(body?.draftId, 100);
+    const taskId = clean(body?.taskId, 260);
+    const wallet = clean(body?.wallet, 60);
+    const name = clean(body?.name, 72) || 'VoxelPop Property';
+    if (!draftId || !taskId || !ADDRESS_RE.test(wallet)) {
+      return privateJson({ ok: false, error: 'A finished property voxel and connected wallet are required.' }, { status: 400 });
+    }
+
+    const owned = await verifyOwnedFinalVoxelModel({ userId: auth.user.id, draftId, modelTaskId: taskId });
+    if (!owned.savedModel || owned.savedModel.provider !== LOCAL_PROVIDER || !taskId.startsWith('local-v1:')) {
+      return privateJson({ ok: false, error: 'Finish the local photo-approved voxel before minting.' }, { status: 409 });
+    }
+
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const voucher = await buildPropertyVoxelVoucher({ userId: auth.user.id, draftId: owned.draftId, taskId, wallet, name, origin });
+    const deployment = await getVoxelFlipDeployment();
+    if (voucher.signer.toLowerCase() !== deployment.mintSigner.toLowerCase()) {
+      return privateJson({ ok: false, error: 'VoxelFlip mint signer does not match the reviewed Base deployment.' }, { status: 503 });
+    }
+
+    let used = false;
+    try {
+      used = await propertyVoxelVoucherUsed(voucher.voucherId);
+    } catch {
+      return privateJson({ ok: false, error: 'Base could not be checked safely. No mint was sent. Try again before approving a wallet transaction.' }, { status: 503 });
+    }
+    if (used) {
+      return privateJson({ ok: false, alreadyMinted: true, error: 'This finished property voxel has already used its one-time VoxelFlip mint voucher. A duplicate mint is blocked.' }, { status: 409 });
+    }
+
+    return privateJson({
+      ok: true,
+      ready: true,
+      mintConfigured: true,
+      wallet,
+      draftId: owned.draftId,
+      taskId,
+      modelUrl: owned.modelUrl,
+      metadataUrl: voucher.metadataUrl,
+      voucherId: voucher.voucherId,
+      signature: voucher.signature,
+      signer: voucher.signer,
+      contractAddress: deployment.address,
+      chainId: deployment.chainId,
+      network: deployment.network,
+      digitalOnly: true,
+      noMeshy: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Property voxel mint could not be prepared.';
+    return privateJson({ ok: false, error: message }, { status: /does not belong|signed-in|valid|required/i.test(message) ? 403 : 500 });
+  }
+}

--- a/app/page.js
+++ b/app/page.js
@@ -3,93 +3,59 @@ import styles from './home.module.css';
 
 // Product truth: upload is the single consumer starting point.
 // Nothing is uploaded, generated, or charged before sign-in.
-// One $4.99 checkout unlocks one device-local VoxelPop image + interactive 3D creation.
+// One $4.99 checkout unlocks the source-faithful 3D preview and local VoxelPop voxel creation.
 // The authorized source photo stays on the user's device; normal creation does not spend Meshy credits.
+// The user sees and approves the recognizable 3D preview before the blocky voxel conversion begins.
+// Minting is an optional downstream wallet action for the finished digital voxel only.
 // Source-backed map geometry is a separate place-data layer, not a reconstruction of unseen photo details.
-// Optional Collect is a separate digital-item purchase; minting remains optional and downstream.
 // Banking, securities and physical-property rights stay on separate verified legal/provider rails.
 // A 3D model, payment, map marker, Property Passport, NFT or VoxelPop item is never a deed.
 export default function Home() {
   return <main className={styles.page}>
     <div className={styles.shell}>
       <nav className={styles.top}>
-        <Link className={styles.brand} href="/" aria-label="Voxel Vault home">
-          <span className={styles.logoMark}><i/><b>+</b></span>
-          <span>VOXEL VAULT</span>
-        </Link>
-        <div className={styles.topLinks}>
-          <Link href="/property">Create</Link>
-          <Link href="/world">World</Link>
-          <Link href="/vault">Vault</Link>
-        </div>
+        <Link className={styles.brand} href="/" aria-label="Voxel Vault home"><span className={styles.logoMark}><i/><b>+</b></span><span>VOXEL VAULT</span></Link>
+        <div className={styles.topLinks}><Link href="/property">Create</Link><Link href="/world">World</Link><Link href="/vault">Vault</Link></div>
       </nav>
 
       <section className={styles.hero}>
         <div className={styles.heroCopy}>
           <p className={styles.kicker}>VOXELPOP · PROPERTY CREATION</p>
-          <h1>Upload a picture.<br/><em>Make it 3D.</em></h1>
-          <p className={styles.lead}>After sign-in and the $4.99 creation checkout, VoxelPop turns one authorized property photo into a voxel image and a movable local 3D model. Add the address when it is ready to place it in your World.</p>
-          <div className={styles.heroActions}>
-            <Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link>
-            <Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link>
-          </div>
-          <p className={styles.heroFine}>One VoxelPop creation costs $4.99. Your source photo stays on your device and creation runs without Meshy credits. Optional Collect later is a separate digital-item purchase; no wallet is required to create.</p>
+          <h1>Upload a picture.<br/><em>See your house in 3D.</em></h1>
+          <p className={styles.lead}>After sign-in and the $4.99 creation checkout, VoxelPop shows a recognizable textured 3D preview from your authorized property photo first. You approve that preview, then VoxelPop creates the separate movable 3D voxel. Minting comes only after the voxel is ready.</p>
+          <div className={styles.heroActions}><Link className={styles.primaryAction} href="/property">START → SIGN IN + UPLOAD PHOTO</Link><Link className={styles.secondaryAction} href="/world">OPEN MY WORLD</Link></div>
+          <p className={styles.heroFine}>One VoxelPop creation costs $4.99. Your source photo stays on your device and creation runs without Meshy credits. Optional Collect later is a separate digital-item purchase; no wallet is required to create. A wallet is requested only if you choose Mint after the voxel is finished.</p>
         </div>
 
         <div className={styles.heroVisual} aria-label="VoxelPop property creation preview">
-          <div className={styles.visualBadge}>YOUR PHOTO</div>
-          <div className={styles.voxelHouse} aria-hidden="true">
-            <div className={styles.roof}/>
-            <div className={styles.houseBody}><i/><i/><b/></div>
-            <div className={styles.lawn}/>
-          </div>
-          <div className={styles.priceBubble}><small>ONE CREATION</small><strong>$4.99</strong><span>image + movable 3D</span></div>
-          <div className={styles.visualNote}>Local VoxelPop<br/><b>No Meshy credits</b></div>
+          <div className={styles.visualBadge}>YOUR PHOTO → 3D → VOXEL</div>
+          <div className={styles.voxelHouse} aria-hidden="true"><div className={styles.roof}/><div className={styles.houseBody}><i/><i/><b/></div><div className={styles.lawn}/></div>
+          <div className={styles.priceBubble}><small>ONE CREATION</small><strong>$4.99</strong><span>3D preview + voxel</span></div>
+          <div className={styles.visualNote}>See the house first<br/><b>Then build the voxel</b></div>
         </div>
       </section>
 
       <section className={styles.flowCard} aria-label="VoxelPop creation steps">
-        <div className={styles.flowIntro}>
-          <p>HOW IT WORKS</p>
-          <h2>One simple path from photo to World.</h2>
-        </div>
-        <div className={styles.microFlow}>
-          <b>UPLOAD</b><i>→</i><b>$4.99 CREATE</b><i>→</i><b>3D</b><i>→</i><b>MAP</b><i>→</i><b>READY</b>
-        </div>
+        <div className={styles.flowIntro}><p>HOW IT WORKS</p><h2>See it first. Voxelize it second. Mint last.</h2></div>
+        <div className={styles.microFlow}><b>UPLOAD</b><i>→</i><b>$4.99 CREATE</b><i>→</i><b>3D</b><i>→</i><b>VOXEL</b><i>→</i><b>MINT</b></div>
         <Link className={styles.startButton} href="/property">CREATE MY VOXELPOP →</Link>
-        <small>Collection and minting remain separate optional actions. The map adds source-backed place context; it does not turn a digital item into physical-property ownership.</small>
+        <small>Collection and minting remain separate optional actions. After the voxel is ready, <b>MAP</b> and <b>READY</b> World placement remain available as optional source-backed context. The NFT is the digital voxel, not the physical house or deed.</small>
       </section>
 
       <section className={styles.destinationSection}>
-        <div className={styles.sectionIntro}>
-          <p>AFTER CREATION</p>
-          <h2>Everything else has a clear place.</h2>
-          <span>Create is the front door. World is the map. Vault stores your digital items. Advanced tools stay under More.</span>
-        </div>
+        <div className={styles.sectionIntro}><p>AFTER CREATION</p><h2>Everything else has a clear place.</h2><span>Create is the front door. Mint is optional. World is the map. Vault stores your digital items. Advanced tools stay under More.</span></div>
         <div className={styles.assetGrid}>
-          <Link href="/world" className={`${styles.assetTile} ${styles.worldTile}`}>
-            <div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore saved creations against source-backed places.</span><b>Open World →</b>
-          </Link>
-          <Link href="/vault" className={`${styles.assetTile} ${styles.vaultTile}`}>
-            <div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your digital items</strong><span>Your saved and collected digital assets live here.</span><b>Open Vault →</b>
-          </Link>
-          <Link href="/more" className={`${styles.assetTile} ${styles.moreTile}`}>
-            <div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>The $1.99 property comparison is a sandbox; financial products remain provider-gated.</span><b>See More →</b>
-          </Link>
+          <Link href="/world" className={`${styles.assetTile} ${styles.worldTile}`}><div className={styles.tileIcon}>◎</div><small>WORLD</small><strong>See it on the map</strong><span>Explore saved creations against source-backed places.</span><b>Open World →</b></Link>
+          <Link href="/vault" className={`${styles.assetTile} ${styles.vaultTile}`}><div className={styles.tileIcon}>◇</div><small>VAULT</small><strong>Keep your digital items</strong><span>Your saved and minted digital assets live here.</span><b>Open Vault →</b></Link>
+          <Link href="/more" className={`${styles.assetTile} ${styles.moreTile}`}><div className={styles.tileIcon}>•••</div><small>MORE</small><strong>Optional tools</strong><span>The $1.99 property comparison is a sandbox; financial products remain provider-gated.</span><b>See More →</b></Link>
         </div>
       </section>
 
       <section className={styles.truthStrip}>
-        <div><small>DIGITAL</small><strong>Photo → VoxelPop → World</strong></div>
-        <span>≠</span>
-        <div><small>LEGAL</small><strong>Deed / title / regulated financial rails</strong></div>
-        <Link href="/more">See product status →</Link>
+        <div><small>DIGITAL</small><strong>Photo → 3D preview → Voxel → optional NFT</strong></div><span>≠</span><div><small>LEGAL</small><strong>Deed / title / regulated financial rails</strong></div><Link href="/more">See product status →</Link>
       </section>
 
-      <footer className={styles.footer}>
-        <span>Voxel Vault is not a bank and a VoxelPop item is not a deed. Digital creation or collectible payments do not create title, rent, occupancy, investment or appreciation rights in physical property. Banking, exchange, custody, securities and real-property transactions require their own verified providers and legal rails.</span>
-        <Link href="/more">More tools</Link>
-      </footer>
+      <footer className={styles.footer}><span>Voxel Vault is not a bank and a VoxelPop item is not a deed. Digital creation or collectible payments do not create title, rent, occupancy, investment or appreciation rights in physical property. Banking, exchange, custody, securities and real-property transactions require their own verified providers and legal rails.</span><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }

--- a/app/property/PhotoReliefModelViewer.js
+++ b/app/property/PhotoReliefModelViewer.js
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
+  const mountRef = useRef(null);
+  const callbackRef = useRef(onReady);
+  const [error, setError] = useState('');
+  callbackRef.current = onReady;
+
+  useEffect(() => {
+    if (!imageUrl || !mountRef.current) return undefined;
+    let dead = false;
+    let cleanup = () => {};
+    setError('');
+
+    const image = new Image();
+    image.decoding = 'async';
+    image.src = imageUrl;
+    image.onload = async () => {
+      try {
+        const THREE = await import('three');
+        if (dead || !mountRef.current) return;
+        const mount = mountRef.current;
+        const width = Math.max(280, mount.clientWidth || 360);
+        const height = Math.max(280, mount.clientHeight || 360);
+        const compact = width < 720 || window.matchMedia?.('(pointer: coarse)')?.matches;
+        const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.18 : 1.45));
+        renderer.setSize(width, height);
+        renderer.outputColorSpace = THREE.SRGBColorSpace;
+        renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        renderer.toneMappingExposure = 1.02;
+        renderer.domElement.style.touchAction = 'none';
+        mount.innerHTML = '';
+        mount.appendChild(renderer.domElement);
+
+        const scene = new THREE.Scene();
+        scene.background = new THREE.Color(0x21172c);
+        scene.add(new THREE.HemisphereLight(0xfffbef, 0x21122d, 2.1));
+        const key = new THREE.DirectionalLight(0xffffff, 2.7);
+        key.position.set(4, 5, 6);
+        scene.add(key);
+        const fill = new THREE.DirectionalLight(0xc7b7ff, 1.35);
+        fill.position.set(-4, 2, 3);
+        scene.add(fill);
+
+        const sourceCanvas = document.createElement('canvas');
+        const maxTexture = compact ? 1024 : 1400;
+        const scale = Math.min(1, maxTexture / Math.max(image.naturalWidth || 1, image.naturalHeight || 1));
+        sourceCanvas.width = Math.max(1, Math.round((image.naturalWidth || 1) * scale));
+        sourceCanvas.height = Math.max(1, Math.round((image.naturalHeight || 1) * scale));
+        const sourceContext = sourceCanvas.getContext('2d', { willReadFrequently: true });
+        if (!sourceContext) throw new Error('The 3D photo preview is unavailable on this device.');
+        sourceContext.drawImage(image, 0, 0, sourceCanvas.width, sourceCanvas.height);
+        const texture = new THREE.CanvasTexture(sourceCanvas);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.anisotropy = Math.min(4, renderer.capabilities.getMaxAnisotropy?.() || 1);
+
+        const sampleSize = 64;
+        const sampleCanvas = document.createElement('canvas');
+        sampleCanvas.width = sampleSize;
+        sampleCanvas.height = sampleSize;
+        const sampleContext = sampleCanvas.getContext('2d', { willReadFrequently: true });
+        if (!sampleContext) throw new Error('The 3D photo preview is unavailable on this device.');
+        sampleContext.filter = 'contrast(1.06) saturate(1.02)';
+        sampleContext.drawImage(image, 0, 0, sampleSize, sampleSize);
+        const pixels = sampleContext.getImageData(0, 0, sampleSize, sampleSize).data;
+        const luminance = (x, y) => {
+          const cx = clamp(Math.round(x), 0, sampleSize - 1);
+          const cy = clamp(Math.round(y), 0, sampleSize - 1);
+          const index = (cy * sampleSize + cx) * 4;
+          return (pixels[index] * 0.2126 + pixels[index + 1] * 0.7152 + pixels[index + 2] * 0.0722) / 255;
+        };
+
+        const ratio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
+        const planeHeight = ratio >= 1 ? 5.1 : 5.7;
+        const planeWidth = ratio >= 1 ? planeHeight * ratio : planeHeight * ratio;
+        const boundedWidth = Math.min(7.6, Math.max(3.3, planeWidth));
+        const boundedHeight = boundedWidth / ratio;
+        const geometry = new THREE.PlaneGeometry(boundedWidth, boundedHeight, 48, 48);
+        const positions = geometry.attributes.position;
+        for (let index = 0; index < positions.count; index += 1) {
+          const u = geometry.attributes.uv.getX(index);
+          const v = geometry.attributes.uv.getY(index);
+          const sx = u * (sampleSize - 1);
+          const sy = (1 - v) * (sampleSize - 1);
+          const center = luminance(sx, sy);
+          const edge = Math.abs(luminance(sx + 1, sy) - luminance(sx - 1, sy))
+            + Math.abs(luminance(sx, sy + 1) - luminance(sx, sy - 1));
+          const centerWeight = 1 - Math.min(1, Math.hypot(u - 0.5, v - 0.52) / 0.78);
+          const relief = edge * 0.48 + (center - 0.5) * 0.055 + centerWeight * 0.018;
+          positions.setZ(index, clamp(relief, -0.055, 0.34));
+        }
+        positions.needsUpdate = true;
+        geometry.computeVertexNormals();
+
+        const group = new THREE.Group();
+        scene.add(group);
+        const backing = new THREE.Mesh(
+          new THREE.BoxGeometry(boundedWidth + 0.08, boundedHeight + 0.08, 0.20),
+          new THREE.MeshStandardMaterial({ color: 0x170f20, roughness: 0.88, metalness: 0 }),
+        );
+        backing.position.z = -0.11;
+        group.add(backing);
+        const material = new THREE.MeshStandardMaterial({ map: texture, roughness: 0.78, metalness: 0.01, side: THREE.FrontSide });
+        const photoMesh = new THREE.Mesh(geometry, material);
+        photoMesh.position.z = 0.03;
+        group.add(photoMesh);
+
+        const camera = new THREE.PerspectiveCamera(32, width / height, 0.1, 60);
+        const cameraDistance = Math.max(8.4, boundedWidth * 1.45);
+        camera.position.set(0, 0, cameraDistance);
+        camera.lookAt(0, 0, 0);
+
+        let targetX = -0.035;
+        let targetY = 0.08;
+        let pointerId = null;
+        let lastX = 0;
+        let lastY = 0;
+        const down = (event) => {
+          pointerId = event.pointerId;
+          lastX = event.clientX;
+          lastY = event.clientY;
+          renderer.domElement.setPointerCapture?.(event.pointerId);
+        };
+        const move = (event) => {
+          if (pointerId !== event.pointerId) return;
+          const dx = event.clientX - lastX;
+          const dy = event.clientY - lastY;
+          lastX = event.clientX;
+          lastY = event.clientY;
+          targetY = clamp(targetY + dx * 0.006, -0.48, 0.48);
+          targetX = clamp(targetX + dy * 0.004, -0.24, 0.22);
+        };
+        const up = (event) => {
+          if (pointerId === event.pointerId) pointerId = null;
+        };
+        renderer.domElement.addEventListener('pointerdown', down);
+        renderer.domElement.addEventListener('pointermove', move);
+        renderer.domElement.addEventListener('pointerup', up);
+        renderer.domElement.addEventListener('pointercancel', up);
+
+        let frame = 0;
+        const render = () => {
+          if (dead) return;
+          group.rotation.x += (targetX - group.rotation.x) * 0.08;
+          group.rotation.y += (targetY - group.rotation.y) * 0.08;
+          renderer.render(scene, camera);
+          frame = requestAnimationFrame(render);
+        };
+        if (reducedMotion) renderer.render(scene, camera);
+        else render();
+
+        const resize = () => {
+          if (dead || !mountRef.current) return;
+          const nextWidth = Math.max(280, mountRef.current.clientWidth || width);
+          const nextHeight = Math.max(280, mountRef.current.clientHeight || height);
+          renderer.setSize(nextWidth, nextHeight);
+          camera.aspect = nextWidth / nextHeight;
+          camera.updateProjectionMatrix();
+          if (reducedMotion) renderer.render(scene, camera);
+        };
+        const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(resize) : null;
+        observer?.observe(mount);
+        callbackRef.current?.();
+
+        cleanup = () => {
+          if (frame) cancelAnimationFrame(frame);
+          observer?.disconnect();
+          renderer.domElement.removeEventListener('pointerdown', down);
+          renderer.domElement.removeEventListener('pointermove', move);
+          renderer.domElement.removeEventListener('pointerup', up);
+          renderer.domElement.removeEventListener('pointercancel', up);
+          geometry.dispose();
+          material.dispose();
+          texture.dispose();
+          backing.geometry.dispose();
+          backing.material.dispose();
+          renderer.dispose();
+          if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement);
+        };
+      } catch (previewError) {
+        if (!dead) setError(String(previewError?.message || previewError || 'The 3D photo preview could not open.'));
+      }
+    };
+    image.onerror = () => setError('The selected photo could not be opened for the 3D preview.');
+
+    return () => {
+      dead = true;
+      cleanup();
+    };
+  }, [imageUrl]);
+
+  return <div className="viewerShell" style={{ position: 'relative', width: '100%', height: '100%', minHeight: 300 }}>
+    <div ref={mountRef} style={{ position: 'absolute', inset: 0 }}/>
+    {error ? <div style={{ position: 'absolute', inset: 0, display: 'grid', placeItems: 'center', padding: 24, color: '#fff', textAlign: 'center', background: '#21172c' }}>{error}</div> : null}
+  </div>;
+}

--- a/app/property/PropertyJourneyExact.js
+++ b/app/property/PropertyJourneyExact.js
@@ -1,0 +1,654 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import LocalVoxelModelViewer from './LocalVoxelModelViewer';
+import PhotoReliefModelViewer from './PhotoReliefModelViewer';
+import PropertyWorldMap from './PropertyWorldMap';
+import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import { buildPropertyDraft, savePropertyDraft } from '../../lib/property-drafts';
+import { savePropertyDraftToAccount } from '../../lib/property-drafts-account';
+import styles from './property.module.css';
+
+const CREATION_PRICE_LABEL = '$4.99';
+const CREATION_PRICE_CENTS = 499;
+const DEVICE_DB = 'voxelpop-property-device-v1';
+const DEVICE_STORE = 'pending-photos';
+const empty3d = () => ({ status: 'NOT_STARTED', progress: 0, modelUrl: null, taskId: null });
+
+function clean(value) { return String(value || '').trim(); }
+function newDraftId() {
+  const random = globalThis.crypto?.randomUUID?.().replace(/-/g, '') || `${Date.now()}${Math.random().toString(16).slice(2)}`;
+  return `vp-${random.slice(0, 28)}`;
+}
+function isHeic(file) {
+  return /image\/(heic|heif)/i.test(String(file?.type || '')) || /\.(heic|heif)$/i.test(String(file?.name || ''));
+}
+function isSupportedPhoto(file) {
+  return ['image/jpeg', 'image/png', 'image/webp'].includes(String(file?.type || '').toLowerCase()) || isHeic(file);
+}
+function selectedOrLocation(atlas, address) {
+  const selected = atlas?.selectedBuilding || atlas?.buildings?.[0] || null;
+  if (selected) return { ...selected, mappedIdentityReady: Boolean(selected.atlasId) };
+  const latitude = Number(atlas?.latitude);
+  const longitude = Number(atlas?.longitude);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+  return {
+    atlasId: `location:${latitude.toFixed(7)},${longitude.toFixed(7)}`,
+    latitude,
+    longitude,
+    geometry: null,
+    tags: { name: address },
+    mappedIdentityReady: false,
+  };
+}
+
+function openDeviceDb() {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') return reject(new Error('Private on-device photo storage is unavailable in this browser.'));
+    const request = indexedDB.open(DEVICE_DB, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(DEVICE_STORE)) request.result.createObjectStore(DEVICE_STORE, { keyPath: 'draftId' });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('On-device photo storage could not open.'));
+  });
+}
+
+async function saveDevicePhoto(draftId, file) {
+  const db = await openDeviceDb();
+  const bytes = await file.arrayBuffer();
+  await new Promise((resolve, reject) => {
+    const request = db.transaction(DEVICE_STORE, 'readwrite').objectStore(DEVICE_STORE).put({
+      draftId,
+      bytes,
+      type: file.type || 'image/jpeg',
+      name: file.name || 'property-photo.jpg',
+      lastModified: file.lastModified || Date.now(),
+      savedAt: Date.now(),
+    });
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error || new Error('Photo could not be kept on this device for checkout.'));
+  });
+  db.close();
+}
+
+async function loadDevicePhoto(draftId) {
+  const db = await openDeviceDb();
+  const record = await new Promise((resolve, reject) => {
+    const request = db.transaction(DEVICE_STORE, 'readonly').objectStore(DEVICE_STORE).get(draftId);
+    request.onsuccess = () => resolve(request.result || null);
+    request.onerror = () => reject(request.error || new Error('Saved photo could not be reopened.'));
+  });
+  db.close();
+  if (!record?.bytes) return null;
+  return new File([record.bytes], record.name || 'property-photo.jpg', {
+    type: record.type || 'image/jpeg',
+    lastModified: record.lastModified || Date.now(),
+  });
+}
+
+async function removeDevicePhoto(draftId) {
+  if (!draftId) return;
+  try {
+    const db = await openDeviceDb();
+    await new Promise((resolve) => {
+      const request = db.transaction(DEVICE_STORE, 'readwrite').objectStore(DEVICE_STORE).delete(draftId);
+      request.onsuccess = () => resolve();
+      request.onerror = () => resolve();
+    });
+    db.close();
+  } catch {}
+}
+
+async function normalizeIphonePhoto(file) {
+  if (!isHeic(file)) return file;
+  const url = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = url;
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = () => reject(new Error('HEIC preview could not be decoded. Try a screenshot of the photo instead.'));
+    });
+    const maxEdge = 2400;
+    const scale = Math.min(1, maxEdge / Math.max(image.naturalWidth || 1, image.naturalHeight || 1));
+    const width = Math.max(1, Math.round((image.naturalWidth || 1) * scale));
+    const height = Math.max(1, Math.round((image.naturalHeight || 1) * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Photo conversion is unavailable on this device.');
+    context.drawImage(image, 0, 0, width, height);
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.93));
+    if (!blob) throw new Error('Photo conversion failed.');
+    return new File([blob], String(file.name || 'property-photo.heic').replace(/\.(heic|heif)$/i, '.jpg'), { type: 'image/jpeg', lastModified: Date.now() });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function createVoxelPoster(file) {
+  const url = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = url;
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = () => reject(new Error('The photo could not be opened for the voxel pass.'));
+    });
+    const sampleSize = 72;
+    const sample = document.createElement('canvas');
+    sample.width = sampleSize;
+    sample.height = sampleSize;
+    const sampleContext = sample.getContext('2d');
+    if (!sampleContext) throw new Error('Voxel image processing is unavailable.');
+    const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
+    let sx = 0;
+    let sy = 0;
+    let sw = image.naturalWidth || 1;
+    let sh = image.naturalHeight || 1;
+    if (sourceRatio > 1) { sw = sh; sx = ((image.naturalWidth || 1) - sw) / 2; }
+    else if (sourceRatio < 1) { sh = sw; sy = ((image.naturalHeight || 1) - sh) / 2; }
+    sampleContext.filter = 'saturate(1.06) contrast(1.05)';
+    sampleContext.drawImage(image, sx, sy, sw, sh, 0, 0, sampleSize, sampleSize);
+    const output = document.createElement('canvas');
+    output.width = 864;
+    output.height = 864;
+    const context = output.getContext('2d');
+    if (!context) throw new Error('Voxel image processing is unavailable.');
+    context.imageSmoothingEnabled = false;
+    context.fillStyle = '#ede7df';
+    context.fillRect(0, 0, output.width, output.height);
+    context.drawImage(sample, 0, 0, output.width, output.height);
+    const shade = context.createLinearGradient(0, 0, output.width, output.height);
+    shade.addColorStop(0, 'rgba(255,255,255,.08)');
+    shade.addColorStop(0.62, 'rgba(255,255,255,0)');
+    shade.addColorStop(1, 'rgba(38,18,52,.12)');
+    context.fillStyle = shade;
+    context.fillRect(0, 0, output.width, output.height);
+    return output.toDataURL('image/jpeg', 0.92);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export default function PropertyJourneyExact() {
+  const [authReady, setAuthReady] = useState(false);
+  const [session, setSession] = useState(null);
+  const [draftId, setDraftId] = useState('');
+  const [pendingPhoto, setPendingPhoto] = useState(null);
+  const [pendingPreview, setPendingPreview] = useState('');
+  const [rightsConfirmed, setRightsConfirmed] = useState(false);
+  const [paidSessionId, setPaidSessionId] = useState('');
+  const [previewReady, setPreviewReady] = useState(false);
+  const [previewApproved, setPreviewApproved] = useState(false);
+  const [voxelPoster, setVoxelPoster] = useState('');
+  const [localRecipe, setLocalRecipe] = useState(null);
+  const [final3d, setFinal3d] = useState(empty3d);
+  const [address, setAddress] = useState('');
+  const [mappedAddress, setMappedAddress] = useState('');
+  const [building, setBuilding] = useState(null);
+  const [atlasBuildings, setAtlasBuildings] = useState([]);
+  const [savedDraft, setSavedDraft] = useState(null);
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('Sign in to start.');
+  const clientRef = useRef(null);
+  const uploadInputRef = useRef(null);
+  const checkoutHandledRef = useRef('');
+  const registeringRef = useRef(false);
+
+  const localReady = final3d?.status === 'SUCCEEDED' && Boolean(final3d?.taskId && final3d?.modelUrl);
+  const mintReady = localReady && String(final3d.taskId || '').startsWith('local-v1:');
+  const stage = localReady ? 5 : previewApproved ? 4 : paidSessionId ? 3 : pendingPhoto ? 2 : 1;
+  const labels = ['PHOTO', 'PAY', '3D PREVIEW', 'VOXEL', 'MINT'];
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      if (!active) return;
+      setSession(data.session || null);
+      setAuthReady(true);
+      if (data.session?.user) {
+        setDraftId((current) => current || newDraftId());
+        setMessage('Signed in. Choose the property photo you want the 3D preview to match.');
+      }
+      const auth = client.auth.onAuthStateChange((_event, next) => {
+        if (!active) return;
+        setSession(next || null);
+        setAuthReady(true);
+        if (next?.user) {
+          setDraftId((current) => current || newDraftId());
+          setMessage('Signed in. Choose the property photo you want the 3D preview to match.');
+        } else setMessage('Sign in to start.');
+      });
+      subscription = auth.data.subscription;
+    }).catch(() => {
+      if (active) {
+        setAuthReady(true);
+        setMessage('Sign-in setup is unavailable on this deployment.');
+      }
+    });
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  function authHeaders(extra = {}) {
+    return { Authorization: `Bearer ${session?.access_token || ''}`, ...extra };
+  }
+
+  async function signIn() {
+    setBusy('signin');
+    setMessage('Opening secure sign-in…');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
+      if (error) throw error;
+    } catch (error) {
+      setMessage(String(error?.message || error || 'Could not sign in.'));
+      setBusy('');
+    }
+  }
+
+  function choosePhoto() {
+    if (!session?.access_token) return setMessage('Sign in before choosing a photo.');
+    uploadInputRef.current?.click();
+  }
+
+  async function selectPhoto(event) {
+    const selected = event.target.files?.[0];
+    event.target.value = '';
+    if (!selected) return;
+    if (!isSupportedPhoto(selected)) return setMessage('Choose a JPG, PNG, WebP, HEIC, or HEIF photo.');
+    if (selected.size > 12 * 1024 * 1024) return setMessage('Choose a photo smaller than 12 MB.');
+    setBusy('prepare');
+    setMessage(isHeic(selected) ? 'Preparing your iPhone photo…' : 'Preparing your photo…');
+    try {
+      const photo = await normalizeIphonePhoto(selected);
+      if (photo.size > 8 * 1024 * 1024) throw new Error('This photo is still too large after preparation. Try a screenshot or smaller version.');
+      setPendingPreview((current) => {
+        if (current) URL.revokeObjectURL(current);
+        return URL.createObjectURL(photo);
+      });
+      setPendingPhoto(photo);
+      setRightsConfirmed(false);
+      setPreviewReady(false);
+      setPreviewApproved(false);
+      setVoxelPoster('');
+      setLocalRecipe(null);
+      setFinal3d(empty3d());
+      setBuilding(null);
+      setAtlasBuildings([]);
+      setMappedAddress('');
+      setSavedDraft(null);
+      setMessage(paidSessionId
+        ? 'Payment is already verified. This photo will become the new 3D preview—no second charge.'
+        : `Photo ready. Confirm permission, then pay ${CREATION_PRICE_LABEL}.`);
+    } catch (error) {
+      setMessage(String(error?.message || error || 'This photo could not be prepared.'));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function verifyPaidSession(generationSessionId) {
+    const form = new FormData();
+    form.append('generationSessionId', generationSessionId);
+    const response = await fetch('/api/property-photo-upload', { method: 'POST', headers: authHeaders(), body: form });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data?.ok || data?.paid !== true || !data?.draftId) {
+      throw new Error(data?.error || 'Your paid VoxelPop creation could not be verified.');
+    }
+    return data;
+  }
+
+  useEffect(() => {
+    if (!session?.access_token || typeof window === 'undefined') return undefined;
+    const params = new URLSearchParams(window.location.search);
+    const canceled = params.get('generation_checkout') === 'cancelled';
+    const canceledDraftId = clean(params.get('draftId'));
+    if (canceled && canceledDraftId) {
+      const key = `cancel:${canceledDraftId}`;
+      if (checkoutHandledRef.current === key) return undefined;
+      checkoutHandledRef.current = key;
+      setBusy('');
+      setDraftId(canceledDraftId);
+      setMessage('Checkout canceled. Nothing was created or charged. Your photo is still on this device.');
+      window.history.replaceState({}, '', '/property');
+      return undefined;
+    }
+
+    const generationSessionId = clean(params.get('generation_session'));
+    if (!generationSessionId || checkoutHandledRef.current === generationSessionId) return undefined;
+    checkoutHandledRef.current = generationSessionId;
+    let active = true;
+    setBusy('payment-return');
+    setMessage('Payment received. Opening your private photo for the 3D preview…');
+
+    (async () => {
+      try {
+        const data = await verifyPaidSession(generationSessionId);
+        if (!active) return;
+        setPaidSessionId(generationSessionId);
+        setDraftId(data.draftId);
+        const photo = await loadDevicePhoto(data.draftId).catch(() => null);
+        if (!active) return;
+        if (!photo) {
+          setBusy('');
+          setMessage('Payment is verified. Choose the same property photo again. You will not be charged again.');
+          return;
+        }
+        setPendingPhoto(photo);
+        setPendingPreview((current) => {
+          if (current) URL.revokeObjectURL(current);
+          return URL.createObjectURL(photo);
+        });
+        setRightsConfirmed(true);
+        setPreviewReady(false);
+        setPreviewApproved(false);
+        setMessage('Payment verified. Loading the recognizable 3D photo preview first.');
+        setBusy('');
+      } catch (error) {
+        if (active) {
+          checkoutHandledRef.current = '';
+          setBusy('');
+          setMessage(String(error?.message || error || 'Your paid VoxelPop creation could not start.'));
+        }
+      }
+    })();
+
+    return () => { active = false; };
+  }, [session?.access_token]);
+
+  async function payAndCreate() {
+    if (!pendingPhoto || !session?.access_token || !draftId) return;
+    if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
+    setBusy('generation-checkout');
+    try {
+      await saveDevicePhoto(draftId, pendingPhoto);
+      if (paidSessionId) {
+        setPreviewReady(false);
+        setPreviewApproved(false);
+        setMessage('Payment already verified. Loading the 3D photo preview—no second charge.');
+        setBusy('');
+        return;
+      }
+      setMessage(`Opening secure ${CREATION_PRICE_LABEL} checkout. After payment, you will see the 3D preview before any voxel is built.`);
+      const form = new FormData();
+      form.append('draftId', draftId);
+      form.append('rightsConfirmed', 'true');
+      const response = await fetch('/api/property-generation/checkout', { method: 'POST', headers: authHeaders(), body: form });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok || !data?.url) throw new Error(data?.error || 'Secure 3D creation checkout could not open.');
+      window.location.assign(data.url);
+    } catch (error) {
+      setBusy('');
+      setMessage(String(error?.message || error || 'Secure VoxelPop creation could not start.'));
+    }
+  }
+
+  async function approvePreviewAndBuildVoxel() {
+    if (!pendingPhoto || !previewReady) return;
+    setPreviewApproved(true);
+    setBusy('voxel-image');
+    setMessage('3D preview approved. Now creating the separate VoxelPop voxel version…');
+    try {
+      const poster = await createVoxelPoster(pendingPhoto);
+      setVoxelPoster(poster);
+      setFinal3d({ status: 'IN_PROGRESS', progress: 55, modelUrl: null, taskId: null });
+      setBusy('voxel-3d');
+      setMessage('VOXEL · Building the movable block model from the same house photo.');
+    } catch (error) {
+      setPreviewApproved(false);
+      setBusy('');
+      setMessage(String(error?.message || error || 'The voxel stage could not start.'));
+    }
+  }
+
+  const registerVoxel = useCallback(async (recipe) => {
+    if (!recipe || !session?.access_token || !draftId || registeringRef.current) return;
+    registeringRef.current = true;
+    setLocalRecipe(recipe);
+    setBusy('register');
+    setFinal3d((current) => ({ ...current, status: 'IN_PROGRESS', progress: 92 }));
+    try {
+      const response = await fetch('/api/property-local-voxel', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ draftId, recipe }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok || !data?.taskId || !data?.modelUrl) throw new Error(data?.error || 'The local voxel could not be linked to your account.');
+      setFinal3d({ status: 'SUCCEEDED', progress: 100, modelUrl: data.modelUrl, taskId: data.taskId });
+      setMessage('Voxel 3D ready. You can mint this digital voxel now, or add its real address to My World.');
+    } catch (error) {
+      setFinal3d({ status: 'LOCAL_ONLY', progress: 100, modelUrl: null, taskId: null });
+      setMessage(`${String(error?.message || error || 'The voxel is visible on this device, but account registration failed.')} Retry registration before minting.`);
+    } finally {
+      registeringRef.current = false;
+      setBusy('');
+    }
+  }, [draftId, session?.access_token]);
+
+  const handleLocal3DReady = useCallback((recipe) => {
+    setLocalRecipe(recipe);
+    registerVoxel(recipe);
+  }, [registerVoxel]);
+
+  async function mapBuilding(event) {
+    event?.preventDefault?.();
+    const value = clean(address);
+    if (!value || !localReady) return;
+    setBusy('map');
+    setMessage('Matching the finished voxel to the real mapped building and nearby neighborhood…');
+    try {
+      const params = new URLSearchParams({ address: value, radius: '180' });
+      const response = await fetch(`/api/world-atlas/inspect?${params.toString()}`, { cache: 'no-store' });
+      const atlas = await response.json().catch(() => ({}));
+      if (!response.ok || !atlas?.ok) throw new Error(atlas?.error || 'That property could not be mapped.');
+      const selected = selectedOrLocation(atlas, value);
+      if (!selected) throw new Error('That address resolved without a usable map location.');
+      setBuilding(selected);
+      setAtlasBuildings(Array.isArray(atlas?.buildings) ? atlas.buildings : []);
+      setMappedAddress(value);
+      setSavedDraft(null);
+      setMessage(selected.geometry
+        ? 'Matched. The finished voxel is now paired with the source-backed building footprint.'
+        : 'Location matched. Exact source-backed footprint was unavailable, so only the verified location reference is used.');
+    } catch (error) {
+      setMessage(String(error?.message || error || 'The property map could not be built.'));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function saveToMyWorld() {
+    if (!building || !mappedAddress || !localReady) return;
+    setBusy('save');
+    setMessage('Saving this finished voxel to My World…');
+    try {
+      const base = buildPropertyDraft({ building, fallbackLabel: mappedAddress, focusAuthority: clean(building?.source?.authority) });
+      if (!base) throw new Error('This mapped property does not have enough location identity to save.');
+      const draft = {
+        ...base,
+        state: 'saved',
+        visual: { ...(base.visual || {}), modelUrl: final3d.modelUrl, modelTaskId: final3d.taskId, renderMode: 'voxelpop-local-3d' },
+        voxelpop: {
+          paidCreation: true,
+          priceCents: CREATION_PRICE_CENTS,
+          engine: 'voxelpop-local-webgl-v2',
+          sourcePhotoStoredByVoxelVault: false,
+          previewApproved: true,
+          photoMatchedFront: true,
+          mappedFootprintUsed: Boolean(building?.geometry),
+          creationDraftId: draftId,
+          modelTaskId: final3d.taskId,
+          modelUrl: final3d.modelUrl,
+        },
+        world: { ...(base.world || {}), public: false, publishedAt: null, publicLabel: 'VoxelPop Property' },
+        blockchain: { ...(base.blockchain || {}), minted: false, optionalAfterCreation: true },
+      };
+      const localSaved = savePropertyDraft(draft);
+      let synced = false;
+      try {
+        const client = clientRef.current || await getSupabaseBrowserAsync();
+        clientRef.current = client;
+        if (session?.user) {
+          await savePropertyDraftToAccount(client, session.user, localSaved);
+          synced = true;
+        }
+      } catch {}
+      setSavedDraft(localSaved);
+      setMessage(synced ? 'Saved to My World and your Vault account.' : 'Saved to My World on this device. Account sync can retry later.');
+    } catch (error) {
+      setMessage(String(error?.message || error || 'This voxel could not be saved to My World yet.'));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  function resetCreation() {
+    const oldDraft = draftId;
+    setDraftId(newDraftId());
+    setPendingPhoto(null);
+    setPendingPreview((current) => { if (current) URL.revokeObjectURL(current); return ''; });
+    setRightsConfirmed(false);
+    setPaidSessionId('');
+    setPreviewReady(false);
+    setPreviewApproved(false);
+    setVoxelPoster('');
+    setLocalRecipe(null);
+    setFinal3d(empty3d());
+    setAddress('');
+    setMappedAddress('');
+    setBuilding(null);
+    setAtlasBuildings([]);
+    setSavedDraft(null);
+    setBusy('');
+    setMessage('Choose one property photo.');
+    removeDevicePhoto(oldDraft);
+    if (typeof window !== 'undefined') window.history.replaceState({}, '', '/property');
+  }
+
+  if (!authReady) {
+    return <main className={styles.page}><section className={styles.maker}>
+      <div className={styles.brand}>VOXELPOP · PROPERTY</div>
+      <h1>Your house.<br/>Then your voxel.</h1>
+      <section className={styles.signinPanel}><div className={styles.signinMark}>V</div><p className={styles.bigPrompt}>Checking your account…</p><small>Nothing charges before sign-in.</small></section>
+    </section></main>;
+  }
+
+  if (!session?.user) {
+    return <main className={styles.page}><section className={styles.maker}>
+      <div className={styles.brand}>VOXELPOP · PROPERTY</div>
+      <h1>Your house.<br/>Then your voxel.</h1>
+      <section className={styles.signinPanel}>
+        <div className={styles.signinMark}>V</div>
+        <p className={styles.bigPrompt}>Sign in first.</p>
+        <p className={styles.signinCopy}>Your paid creation, finished voxel, optional mint, Vault, and World stay tied to one account.</p>
+        <button className={styles.primaryPurple} type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening sign-in…' : 'Continue with Google'}</button>
+        <small>No wallet is needed until you choose Mint.</small>
+      </section>
+      <p className={styles.message}>{message}</p>
+    </section></main>;
+  }
+
+  const mintHref = mintReady
+    ? `/property/mint?draftId=${encodeURIComponent(draftId)}&taskId=${encodeURIComponent(final3d.taskId)}&name=${encodeURIComponent(mappedAddress || 'VoxelPop Property')}`
+    : '#';
+
+  return <main className={styles.page}>
+    <section className={styles.maker}>
+      <div className={styles.brand}>VOXELPOP · PROPERTY</div>
+      <h1>Your house.<br/>Then your voxel.</h1>
+      <div className={styles.accountPill}><span>✓ SIGNED IN</span><b>{session.user.user_metadata?.name || session.user.user_metadata?.full_name || session.user.email || 'Google account'}</b></div>
+      <div className={styles.progress} aria-label={`Step ${stage} of 5`}>{labels.map((label, index) => <span key={label} className={index + 1 <= stage ? styles.progressOn : ''}/>)}</div>
+      <p className={styles.stageLabel}>STEP {stage} OF 5 · {labels[stage - 1]}</p>
+      <input ref={uploadInputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
+
+      {stage === 1 ? <>
+        <p className={styles.bigPrompt}>Choose a clear house photo.</p>
+        <p className={styles.flowHint}>Photo → $4.99 → recognizable 3D preview → approve → voxel 3D → optional mint.</p>
+        <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>Front or three-quarter view works best · iPhone photos supported</span></div>
+        <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>
+        <p className={styles.truth}>The first 3D preview uses your actual photo so it stays recognizable. It is a front-view visual preview, not a claim that unseen sides are reconstructed exactly.</p>
+      </> : null}
+
+      {stage === 2 ? <>
+        <p className={styles.bigPrompt}>Pay once. See the 3D first.</p>
+        <p className={styles.stepCopy}>The $4.99 creation unlocks the 3D preview and the voxel build. The voxel does not start until after you see and approve the preview.</p>
+        <div className={styles.heroCard}><img src={pendingPreview} alt="Selected property reference"/><span className={styles.badge}>YOUR ACTUAL HOUSE PHOTO · DEVICE ONLY</span></div>
+        <div className={styles.choicePanel}>
+          <label className={styles.rightsCheck}><input type="checkbox" checked={rightsConfirmed} onChange={(event) => setRightsConfirmed(event.target.checked)}/><span>I took this photo or have permission to use it.</span></label>
+          <button className={styles.primaryPurple} type="button" onClick={payAndCreate} disabled={!rightsConfirmed || busy === 'generation-checkout'}>{busy === 'generation-checkout' ? 'Opening checkout…' : `Pay ${CREATION_PRICE_LABEL} & Make 3D Preview`}</button>
+          <button className={styles.textButton} type="button" onClick={choosePhoto}>Choose another photo</button>
+        </div>
+        <p className={styles.truth}>The $4.99 payment buys the digital creation only. It does not buy the physical house, deed/title, rent, occupancy, investment rights, or guaranteed value.</p>
+      </> : null}
+
+      {stage === 3 ? <>
+        <p className={styles.bigPrompt}>This is the 3D picture first.</p>
+        <p className={styles.stepCopy}>It uses the real photo as the textured front surface, so windows, doors, siding, roofline, and visible details stay tied to what you actually uploaded. Drag gently to see the 3D relief.</p>
+        {!pendingPreview ? <section className={styles.donePanel}><b>PAYMENT VERIFIED</b><span>Choose the same photo again. You will not be charged again.</span><button className={styles.primaryPurple} type="button" onClick={choosePhoto}>Choose photo again</button></section> : <>
+          <div className={styles.heroCard}>
+            <PhotoReliefModelViewer imageUrl={pendingPreview} onReady={() => setPreviewReady(true)}/>
+            <span className={styles.badge}>3D PHOTO PREVIEW · VOXEL NOT BUILT YET</span>
+            {!previewReady ? <div className={styles.buildPulse}/> : null}
+          </div>
+          <div className={styles.choicePanel}>
+            <b>{previewReady ? 'Does this look like the house in your photo?' : 'Building the recognizable 3D preview…'}</b>
+            <button className={styles.primaryPurple} type="button" onClick={approvePreviewAndBuildVoxel} disabled={!previewReady || busy === 'voxel-image'}>{busy === 'voxel-image' ? 'Starting voxel…' : 'Looks right → Build the 3D Voxel'}</button>
+            <button className={styles.textButton} type="button" onClick={choosePhoto}>Use a different photo · no second charge</button>
+          </div>
+        </>}
+        <p className={styles.truth}>This stage intentionally shows the source-faithful front first. VoxelPop does not pretend one photo proves the exact geometry of the hidden sides or back.</p>
+      </> : null}
+
+      {stage === 4 ? <>
+        <p className={styles.bigPrompt}>Now build the 3D voxel.</p>
+        <p className={styles.stepCopy}>This is a separate conversion step. The voxel renderer samples the same approved house photo instead of inventing a random generic building.</p>
+        <div className={styles.heroCard}>
+          <LocalVoxelModelViewer imageUrl={voxelPoster || pendingPreview} sourceImageUrl={pendingPreview || voxelPoster} onReady={handleLocal3DReady}/>
+          <span className={styles.badge}>{final3d.status === 'LOCAL_ONLY' ? 'VOXEL VISIBLE · REGISTRATION NEEDS RETRY' : 'BUILDING PHOTO-MATCHED 3D VOXEL'}</span>
+          {!localReady ? <div className={styles.buildPulse}/> : null}
+        </div>
+        {final3d.status === 'LOCAL_ONLY' && localRecipe ? <button className={styles.primaryPurple} type="button" onClick={() => registerVoxel(localRecipe)} disabled={busy === 'register'}>{busy === 'register' ? 'Registering…' : 'Retry voxel registration'}</button> : <div className={styles.autoPanel}><b>3D PREVIEW APPROVED → VOXEL</b><span>The original photo stays on this device. No Meshy credits are used for this local voxel build.</span></div>}
+      </> : null}
+
+      {stage === 5 ? <>
+        <p className={styles.bigPrompt}>Voxel ready. Mint is next.</p>
+        <p className={styles.stepCopy}>You have already seen the photo-faithful 3D preview and then created the voxel version. Minting is now a separate wallet action for the finished digital voxel.</p>
+        <div className={styles.heroCard}>
+          <LocalVoxelModelViewer imageUrl={voxelPoster || pendingPreview} sourceImageUrl={pendingPreview || voxelPoster}/>
+          <span className={styles.badge}>FINAL 3D VOXEL · READY TO MINT</span>
+        </div>
+        <div className={styles.choicePanel}>
+          <a className={styles.primaryLink} href={mintHref}>Mint this digital voxel →</a>
+          <span style={{fontSize:11,color:'#7b7068',lineHeight:1.5}}>Your wallet opens only now. You approve the Base transaction yourself; Voxel Vault does not auto-sign or auto-spend.</span>
+        </div>
+
+        <form className={styles.searchForm} onSubmit={mapBuilding}>
+          <input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Optional: property address for My World" aria-label="Property address" autoComplete="street-address"/>
+          <button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Matching building…' : 'Also match this voxel to the real map'}</button>
+        </form>
+        {building ? <>
+          <div className={styles.worldCard}><PropertyWorldMap selectedBuilding={building} buildings={atlasBuildings}/><span className={styles.worldBadge}>{building?.geometry ? 'SOURCE-BACKED BUILDING FOOTPRINT' : 'VERIFIED LOCATION REFERENCE'}</span></div>
+          <section className={styles.donePanel}>
+            <b>{mappedAddress}</b>
+            <span>Map context is separate from the voxel image and from NFT ownership.</span>
+            <button className={styles.primaryTeal} type="button" onClick={saveToMyWorld} disabled={busy === 'save'}>{busy === 'save' ? 'Saving…' : savedDraft ? 'Saved to My World ✓' : 'Save to My World'}</button>
+            {savedDraft ? <a className={styles.secondaryLink} href="/world">View My World</a> : null}
+          </section>
+        </> : null}
+        <p className={styles.truth}>Minting creates a digital NFT for the finished voxel. It does not create or transfer deed/title, occupancy, rent, fractional investment, appreciation, or other rights in the physical property.</p>
+      </> : null}
+
+      {stage > 1 ? <button className={styles.change} type="button" onClick={resetCreation}>Start over with another photo</button> : null}
+      <p className={styles.message} role="status">{message}</p>
+    </section>
+  </main>;
+}

--- a/app/property/mint/page.js
+++ b/app/property/mint/page.js
@@ -1,0 +1,174 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import MeshyModelViewer from '../../vault/earth/MeshyModelViewer';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import { connectVoxelFlipWallet, mintVoxelFlip } from '../../../lib/voxelflip';
+
+function clean(value) { return String(value || '').trim(); }
+function short(value) { const text = clean(value); return text ? `${text.slice(0, 7)}…${text.slice(-5)}` : ''; }
+function errorText(error) { return String(error?.reason || error?.shortMessage || error?.message || error || 'Minting failed.'); }
+function storageKey(draftId, taskId) { return `voxelpop:property-mint:${draftId}:${taskId}`; }
+
+export default function PropertyVoxelMintPage() {
+  const [authReady, setAuthReady] = useState(false);
+  const [session, setSession] = useState(null);
+  const [params, setParams] = useState({ draftId: '', taskId: '', name: 'VoxelPop Property' });
+  const [wallet, setWallet] = useState('');
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('Opening your finished property voxel…');
+  const [minted, setMinted] = useState(null);
+  const clientRef = useRef(null);
+
+  const modelUrl = useMemo(() => params.taskId?.startsWith('local-v1:')
+    ? `/api/property-local-voxel?taskId=${encodeURIComponent(params.taskId)}`
+    : '', [params.taskId]);
+
+  useEffect(() => {
+    const query = new URLSearchParams(window.location.search);
+    const next = {
+      draftId: clean(query.get('draftId')),
+      taskId: clean(query.get('taskId')),
+      name: clean(query.get('name')) || 'VoxelPop Property',
+    };
+    setParams(next);
+    try {
+      const saved = JSON.parse(localStorage.getItem(storageKey(next.draftId, next.taskId)) || 'null');
+      if (saved?.verified && saved?.tokenId) {
+        setMinted(saved);
+        setWallet(saved.owner || '');
+        setMessage(`VoxelFlip #${saved.tokenId} is already verified for this finished voxel.`);
+      }
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      if (!active) return;
+      setSession(data.session || null);
+      setAuthReady(true);
+      const auth = client.auth.onAuthStateChange((_event, next) => {
+        if (!active) return;
+        setSession(next || null);
+        setAuthReady(true);
+      });
+      subscription = auth.data.subscription;
+    }).catch(() => {
+      if (active) {
+        setAuthReady(true);
+        setMessage('Sign-in setup is unavailable on this deployment.');
+      }
+    });
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  async function signIn() {
+    setBusy('signin');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
+      if (error) throw error;
+    } catch (error) {
+      setBusy('');
+      setMessage(errorText(error));
+    }
+  }
+
+  async function mint() {
+    if (!session?.access_token || !params.draftId || !params.taskId || !modelUrl || busy || minted) return;
+    let connected = null;
+    setBusy('wallet');
+    setMessage('Connect the wallet that should own this digital voxel. Nothing is sent yet.');
+    try {
+      connected = await connectVoxelFlipWallet();
+      setWallet(connected.address);
+      setBusy('prepare');
+      setMessage('Checking this exact finished voxel and its one-time Base mint voucher…');
+      const response = await fetch('/api/property-voxel-nft/prepare', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({ draftId: params.draftId, taskId: params.taskId, wallet: connected.address, name: params.name }),
+      });
+      const prepared = await response.json().catch(() => ({}));
+      if (!response.ok || !prepared?.ready || !prepared?.signature) {
+        throw new Error(prepared?.error || 'This finished voxel could not be prepared for minting.');
+      }
+
+      setBusy('mint');
+      setMessage('Confirm the VoxelFlip mint in your wallet. This is the only blockchain transaction in this step.');
+      const result = await mintVoxelFlip({ metadataUrl: prepared.metadataUrl, voucherId: prepared.voucherId, signature: prepared.signature });
+      if (!result?.tokenId || !result?.hash) throw new Error('The wallet transaction completed, but the token ID could not be read.');
+
+      setBusy('verify');
+      setMessage(`VoxelFlip #${result.tokenId} was submitted. Verifying ownership and metadata on Base…`);
+      const confirm = await fetch('/api/property-voxel-nft/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+        body: JSON.stringify({
+          draftId: params.draftId,
+          taskId: params.taskId,
+          name: params.name,
+          wallet: result.owner || connected.address,
+          tokenId: result.tokenId,
+          txHash: result.hash,
+        }),
+      });
+      const verified = await confirm.json().catch(() => ({}));
+      if (!confirm.ok || !verified?.verified) {
+        throw new Error(verified?.error || `VoxelFlip #${result.tokenId} was submitted, but Base verification is not complete. Do not mint it again.`);
+      }
+      const finalResult = { ...result, ...verified, verified: true };
+      setMinted(finalResult);
+      setWallet(finalResult.owner || connected.address);
+      try { localStorage.setItem(storageKey(params.draftId, params.taskId), JSON.stringify(finalResult)); } catch {}
+      setMessage(`Done. VoxelFlip #${finalResult.tokenId} is verified and owned by ${short(finalResult.owner)}.`);
+    } catch (error) {
+      if (error?.code === 'NO_WALLET_PROVIDER' && error?.deepLink) {
+        window.location.href = error.deepLink;
+        return;
+      }
+      setMessage(errorText(error));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  const invalid = !params.draftId || !params.taskId?.startsWith('local-v1:');
+  if (!authReady) return <main className="page"><section className="shell"><div className="mark">V</div><h1>Opening mint…</h1><p>{message}</p><style jsx>{styles}</style></section></main>;
+
+  return <main className="page"><section className="shell">
+    <nav><Link href="/property">← PROPERTY</Link><span>VOXELPOP · FINAL STEP</span><Link href="/vault">VAULT</Link></nav>
+    <header><small>3D PREVIEW ✓ · VOXEL ✓ · MINT</small><h1>Mint the voxel.<br/><em>Not the house.</em></h1><p>The NFT is the finished digital VoxelPop model you just created. It is not the deed, title, equity, rent rights, or ownership of the physical property.</p></header>
+
+    {invalid ? <section className="notice"><b>Open Mint from a finished property voxel.</b><Link href="/property">Create a property voxel</Link></section> : <>
+      <div className="viewer"><MeshyModelViewer modelUrl={modelUrl}/><span>FINAL LOCAL 3D VOXEL</span></div>
+      <section className="facts">
+        <div><small>MODEL</small><b>Photo-approved local voxel</b></div>
+        <div><small>NETWORK</small><b>Base</b></div>
+        <div><small>MESHY</small><b>Not used</b></div>
+        <div><small>REAL PROPERTY</small><b>No rights transferred</b></div>
+      </section>
+
+      {!session?.user ? <button className="primary" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Sign in to mint'}</button> : minted ? <section className="done">
+        <div className="doneMark">✓</div>
+        <b>VoxelFlip #{minted.tokenId}</b>
+        <span>Verified owner · {short(minted.owner)}</span>
+        <div className="links">{minted.openSeaUrl ? <a href={minted.openSeaUrl} target="_blank" rel="noreferrer">View on OpenSea ↗</a> : null}{minted.explorerUrl ? <a href={minted.explorerUrl} target="_blank" rel="noreferrer">View transaction ↗</a> : null}<Link href="/vault">Open Vault</Link></div>
+      </section> : <button className="primary" type="button" onClick={mint} disabled={Boolean(busy)}>{busy === 'wallet' ? 'Connecting wallet…' : busy === 'prepare' ? 'Checking voxel…' : busy === 'mint' ? 'Confirm in wallet…' : busy === 'verify' ? 'Verifying on Base…' : 'Connect wallet + Mint digital voxel'}</button>}
+      {wallet && !minted ? <p className="wallet">Wallet · {short(wallet)}</p> : null}
+      <p className="status" role="status">{message}</p>
+      <p className="truth">Your wallet approves the Base transaction itself; Voxel Vault does not auto-sign or auto-spend. The one-time voucher prevents a second mint of this same finished local voxel. The original property photo is not placed in NFT metadata.</p>
+    </>}
+    <style jsx>{styles}</style>
+  </section></main>;
+}
+
+const styles = `
+:global(body){margin:0;background:#fffaf0;color:#281a10;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:18px 14px calc(52px + env(safe-area-inset-bottom));background:radial-gradient(circle at 10% 8%,#fff0cc,transparent 28%),radial-gradient(circle at 90% 10%,#eee5ff,transparent 29%),radial-gradient(circle at 50% 96%,#efffc8,transparent 26%),#fffaf0}.shell{width:min(700px,100%);margin:auto;text-align:center}nav{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:8px;font-weight:950;letter-spacing:.12em;color:#8b7f76}nav a{color:#684db4;text-decoration:none}header{margin:50px auto 24px}header small{color:#7138f5;font-weight:1000;letter-spacing:.14em;font-size:9px}header h1{font-size:clamp(44px,10vw,72px);line-height:.9;letter-spacing:-.06em;margin:11px 0 16px}header h1 em{font-style:normal;color:#7138f5}header p{max-width:600px;margin:auto;color:#7f736b;font-size:13px;line-height:1.6}.viewer{position:relative;width:100%;height:470px;overflow:hidden;border-radius:38px;background:#21172c;border:1px solid #e3d9cf;box-shadow:0 24px 58px rgba(80,50,25,.18)}.viewer>div{height:100%!important;min-height:100%!important}.viewer :global(.viewerShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.viewer>span{position:absolute;z-index:7;top:17px;left:17px;padding:9px 12px;border-radius:999px;background:rgba(28,19,13,.76);color:#fff;font-size:8px;font-weight:950;letter-spacing:.1em}.facts{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin:12px 0}.facts div{padding:13px 10px;border:1px solid #e7ded3;border-radius:16px;background:#fff;text-align:left}.facts small{display:block;color:#95887d;font-size:7px;font-weight:950;letter-spacing:.08em}.facts b{display:block;margin-top:5px;font-size:9px;line-height:1.35}.primary{width:100%;min-height:66px;border:0;border-radius:23px;background:linear-gradient(180deg,#7d42ff,#6630e9);color:#fff;box-shadow:0 9px 0 #4d1bc5,0 18px 32px rgba(116,72,244,.21);font:1000 18px inherit;cursor:pointer}.primary:disabled{opacity:.58;box-shadow:none}.status{min-height:22px;margin:18px auto 0;max-width:600px;color:#6f645c;font-size:12px;font-weight:750;line-height:1.5}.wallet{font-size:9px;color:#85796f}.truth{max-width:620px;margin:13px auto;color:#9e948c;font-size:8.5px;line-height:1.6}.done{display:grid;gap:10px;padding:22px;border:1px solid #d9ecb2;border-radius:28px;background:#f7ffe8}.doneMark,.mark{width:64px;height:64px;margin:auto;border-radius:21px;background:#c9ff54;color:#456318;display:grid;place-items:center;font-size:29px;font-weight:1000;box-shadow:0 8px 0 #aada35}.done>b{font-size:22px}.done>span{font-size:11px;color:#6f7b59}.links{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:5px}.links a{min-height:48px;display:grid;place-items:center;border-radius:15px;background:#fff;border:1px solid #dfd7e4;color:#614fa2;text-decoration:none;font-size:9px;font-weight:950}.links a:last-child{grid-column:1/-1;background:#21172c;color:#fff}.notice{display:grid;gap:13px;padding:30px;border:1px dashed #d9ccff;border-radius:28px;background:#fff}.notice a{padding:14px;border-radius:14px;background:#7138f5;color:#fff;text-decoration:none;font-weight:900}@media(max-width:620px){.page{padding:12px 10px calc(40px + env(safe-area-inset-bottom))}header{margin-top:42px}.viewer{height:410px;border-radius:30px}.facts{grid-template-columns:1fr 1fr}.links{grid-template-columns:1fr}.links a:last-child{grid-column:auto}.primary{min-height:61px;border-radius:20px;font-size:17px}}`;

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -1,7 +1,7 @@
 'use client';
 
-import PropertyJourneySimple from './PropertyJourneySimple';
+import PropertyJourneyExact from './PropertyJourneyExact';
 
 export default function PropertyJourneyPage() {
-  return <PropertyJourneySimple/>;
+  return <PropertyJourneyExact/>;
 }

--- a/lib/property-voxel-mint.ts
+++ b/lib/property-voxel-mint.ts
@@ -1,0 +1,140 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { Contract, getBytes, JsonRpcProvider, keccak256, solidityPackedKeccak256, toUtf8Bytes, Wallet } from 'ethers';
+import { getVoxelFlipDeployment } from './voxelflip-deployment';
+
+const PRIVATE_KEY_RE = /^[a-fA-F0-9]{64}$/;
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const VOUCHER_ABI = [
+  'function usedVouchers(bytes32 voucherId) view returns (bool)',
+  'function ownerOf(uint256 tokenId) view returns (address)',
+  'function tokenURI(uint256 tokenId) view returns (string)',
+];
+
+function normalizePrivateKey(value: string) {
+  const trimmed = String(value || '').trim();
+  if (PRIVATE_KEY_RE.test(trimmed)) return `0x${trimmed}`;
+  if (/^0X[a-fA-F0-9]{64}$/.test(trimmed)) return `0x${trimmed.slice(2)}`;
+  return trimmed;
+}
+
+function signingSecret() {
+  const raw = process.env.VOXELFLIP_MINT_SIGNER_PRIVATE_KEY?.trim() || '';
+  return raw ? normalizePrivateKey(raw) : '';
+}
+
+function metadataSecret() {
+  return process.env.PROPERTY_VOXEL_METADATA_SECRET?.trim() || signingSecret();
+}
+
+function cleanName(value: unknown) {
+  return String(value || 'VoxelPop Property').trim().slice(0, 72).replace(/[^a-z0-9 .,_-]+/gi, '').replace(/\s+/g, ' ') || 'VoxelPop Property';
+}
+
+export function propertyVoxelVoucherId(userId: string, draftId: string, taskId: string) {
+  return `0x${createHash('sha256').update(`voxelpop-property-nft-v1:${String(userId).trim()}:${String(draftId).trim()}:${String(taskId).trim()}`).digest('hex')}`;
+}
+
+export function propertyVoxelMetadataSignature(draftId: string, taskId: string, name: string) {
+  const secret = metadataSecret();
+  if (!secret) return '';
+  return createHmac('sha256', secret)
+    .update(`property-voxel-metadata-v1:${String(draftId).trim()}:${String(taskId).trim()}:${cleanName(name)}`)
+    .digest('hex');
+}
+
+export function verifyPropertyVoxelMetadataSignature(draftId: string, taskId: string, name: string, signature: string) {
+  const expected = propertyVoxelMetadataSignature(draftId, taskId, name);
+  const actual = String(signature || '').trim().toLowerCase();
+  if (!expected || !actual || expected.length !== actual.length) return false;
+  return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(actual, 'hex'));
+}
+
+export function propertyVoxelMetadataUrl(origin: string, draftId: string, taskId: string, name: string) {
+  const safeName = cleanName(name);
+  const signature = propertyVoxelMetadataSignature(draftId, taskId, safeName);
+  if (!signature) throw new Error('Property voxel metadata signing is not configured.');
+  const url = new URL('/api/property-voxel-nft/metadata', origin);
+  url.searchParams.set('draftId', draftId);
+  url.searchParams.set('taskId', taskId);
+  url.searchParams.set('name', safeName);
+  url.searchParams.set('sig', signature);
+  return url.toString();
+}
+
+export function propertyVoxelMintConfigured() {
+  return /^0x[a-fA-F0-9]{64}$/.test(signingSecret());
+}
+
+export async function buildPropertyVoxelVoucher(input: {
+  userId: string;
+  draftId: string;
+  taskId: string;
+  wallet: string;
+  name: string;
+  origin: string;
+}) {
+  if (!ADDRESS_RE.test(input.wallet)) throw new Error('Connect a valid wallet before minting.');
+  const privateKey = signingSecret();
+  if (!/^0x[a-fA-F0-9]{64}$/.test(privateKey)) throw new Error('VoxelFlip mint signer is not configured.');
+  const signer = new Wallet(privateKey);
+  const metadataUrl = propertyVoxelMetadataUrl(input.origin, input.draftId, input.taskId, input.name);
+  const voucherId = propertyVoxelVoucherId(input.userId, input.draftId, input.taskId);
+  const uriHash = keccak256(toUtf8Bytes(metadataUrl));
+  const digest = solidityPackedKeccak256(['address', 'bytes32', 'bytes32'], [input.wallet, uriHash, voucherId]);
+  const signature = await signer.signMessage(getBytes(digest));
+  return { metadataUrl, voucherId, signature, signer: signer.address, name: cleanName(input.name) };
+}
+
+function rpcUrl() {
+  return process.env.VOXELFLIP_RPC_URL?.trim() || process.env.BASE_RPC_URL?.trim() || 'https://mainnet.base.org';
+}
+
+export async function propertyVoxelVoucherUsed(voucherId: string) {
+  const deployment = await getVoxelFlipDeployment();
+  const provider = new JsonRpcProvider(rpcUrl(), 8453, { staticNetwork: true });
+  try {
+    const contract = new Contract(deployment.address, VOUCHER_ABI, provider);
+    return Boolean(await contract.usedVouchers(voucherId));
+  } finally {
+    provider.destroy();
+  }
+}
+
+export async function verifyPropertyVoxelMint(input: {
+  tokenId: string;
+  wallet: string;
+  txHash: string;
+  voucherId: string;
+  metadataUrl: string;
+}) {
+  if (!ADDRESS_RE.test(input.wallet)) throw new Error('Mint wallet is invalid.');
+  if (!/^0x[a-fA-F0-9]{64}$/.test(String(input.txHash || ''))) throw new Error('Mint transaction hash is invalid.');
+  if (!/^\d+$/.test(String(input.tokenId || ''))) throw new Error('Mint token ID is invalid.');
+  const deployment = await getVoxelFlipDeployment();
+  const provider = new JsonRpcProvider(rpcUrl(), 8453, { staticNetwork: true });
+  try {
+    const receipt = await provider.getTransactionReceipt(input.txHash);
+    if (!receipt || Number(receipt.status) !== 1) throw new Error('The Base mint transaction is not confirmed successfully.');
+    if (String(receipt.to || '').toLowerCase() !== deployment.address.toLowerCase()) throw new Error('The transaction did not mint from the reviewed VoxelFlip contract.');
+    const contract = new Contract(deployment.address, VOUCHER_ABI, provider);
+    const [owner, tokenUri, used] = await Promise.all([
+      contract.ownerOf(input.tokenId),
+      contract.tokenURI(input.tokenId),
+      contract.usedVouchers(input.voucherId),
+    ]);
+    if (String(owner).toLowerCase() !== input.wallet.toLowerCase()) throw new Error('The connected wallet does not own this minted voxel.');
+    if (String(tokenUri) !== input.metadataUrl) throw new Error('The minted token metadata does not match this property voxel.');
+    if (!used) throw new Error('The one-time mint voucher is not marked used on Base.');
+    return {
+      tokenId: String(input.tokenId),
+      owner: String(owner),
+      txHash: input.txHash,
+      metadataUrl: String(tokenUri),
+      contractAddress: deployment.address,
+      explorerUrl: `https://basescan.org/tx/${input.txHash}`,
+      openSeaUrl: `https://opensea.io/assets/base/${deployment.address}/${String(input.tokenId)}`,
+    };
+  } finally {
+    provider.destroy();
+  }
+}

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -4,15 +4,20 @@ import fs from 'node:fs';
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
 const route = read('app/property/page.js');
-const property = read('app/property/PropertyJourneySimple.js');
+const property = read('app/property/PropertyJourneyExact.js');
+const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const checkout = read('app/api/property-generation/checkout/route.ts');
 const paidVerify = read('app/api/property-photo-upload/route.ts');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
 const localStore = read('lib/local-voxel-store.js');
 const payment = read('lib/property-generation-payment.ts');
 const viewer = read('app/property/LocalVoxelModelViewer.js');
+const mintPrepare = read('app/api/property-voxel-nft/prepare/route.ts');
+const mintConfirm = read('app/api/property-voxel-nft/confirm/route.ts');
+const mintMetadata = read('app/api/property-voxel-nft/metadata/route.ts');
+const mintPage = read('app/property/mint/page.js');
 
-assert.match(route, /PropertyJourneySimple/, 'the /property route must use the simplified paid journey');
+assert.match(route, /PropertyJourneyExact/, 'the /property route must use the strict preview -> voxel -> mint journey');
 assert.match(payment, /PROPERTY_VOXEL_GENERATION_PRICE_CENTS = 499/, 'server-authoritative VoxelPop creation price must stay $4.99');
 assert.match(payment, /PROPERTY_VOXEL_GENERATION_KIND = 'property_voxel_generation_v1'/, 'paid creation keeps its dedicated Stripe rail');
 assert.match(payment, /PROPERTY_VOXEL_GENERATION_ENGINE = 'browser-local-v1'/, 'paid creation must identify the no-credit local engine');
@@ -28,7 +33,6 @@ assert.match(checkout, /generation_engine: PROPERTY_VOXEL_GENERATION_ENGINE/, 'c
 assert.match(checkout, /source_storage: 'device-local'/, 'checkout records that the photo stays on device');
 assert.match(checkout, /generation_session=\{CHECKOUT_SESSION_ID\}/, 'successful payment returns through the paid resume path');
 assert.doesNotMatch(checkout, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|meshyCreditsSufficient|stagePaidPropertyPhoto|createBucket|storage\.from/i, 'checkout must not call Meshy or private photo staging');
-
 assert.match(paidVerify, /paidPropertyGenerationReceipt\(auth, stripe, generationSessionId\)/, 'Stripe receipt is verified before local creation unlocks');
 assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|api\.meshy|storage\.from|createBucket/i, 'paid verification must not start a provider job or use Storage');
 
@@ -36,31 +40,50 @@ assert.match(property, /CREATION_PRICE_LABEL = '\$4\.99'/, 'maker shows the $4.9
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'the authorized photo persists across Stripe on the same device');
 assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'photo is retained on-device before checkout');
 assert.match(property, /\/api\/property-generation\/checkout/, 'photo approval opens paid generation checkout');
-assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} & Create 3D/, 'primary CTA clearly says payment immediately creates 3D');
-assert.match(property, /The \$4\.99 purchase includes this VoxelPop 3D creation and saving it to My World/, 'one payment must include the useful creation journey');
-assert.match(property, /no second collection payment required just to continue/i, 'the guided journey must not introduce a second paywall');
-assert.match(property, /generation_session/, 'maker resumes a successful paid creation after Stripe');
-assert.match(property, /form\.append\('generationSessionId', generationSessionId\)/, 'Stripe return passes the session into the payment verifier');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} & Make 3D Preview/, 'paid CTA promises the preview first, not an immediate generic voxel');
+assert.match(property, /After payment, you will see the 3D preview before any voxel is built/, 'checkout handoff preserves the strict stage order');
 assert.match(property, /you will not be charged again/i, 'missing local photo recovery must never charge twice');
-assert.match(property, /createVoxelPoster/, 'the VoxelPop image is generated locally');
-assert.match(property, /LocalVoxelModelViewer/, 'the paid flow uses the local interactive 3D viewer');
-assert.match(property, /\/api\/property-local-voxel/, 'local model recipe is account-linked after rendering');
-assert.match(property, /saveToMyWorld/, 'post-map continuation saves directly to My World');
+assert.match(property, /PhotoReliefModelViewer imageUrl=\{pendingPreview\}/, 'paid flow shows a source-faithful photo-based 3D preview');
+assert.match(property, /Looks right → Build the 3D Voxel/, 'the user explicitly approves the 3D preview before voxel conversion');
+assert.match(property, /approvePreviewAndBuildVoxel/, 'preview approval owns the voxel-build transition');
+assert.match(property, /createVoxelPoster\(pendingPhoto\)/, 'voxelization starts only after preview approval');
+assert.match(property, /LocalVoxelModelViewer/, 'the separate voxel stage uses local interactive voxel geometry');
+assert.match(property, /\/api\/property-local-voxel/, 'local voxel recipe is account-linked after rendering');
+assert.match(property, /\/property\/mint\?draftId=/, 'finished local voxel exposes the dedicated digital mint path');
+assert.match(property, /Mint this digital voxel/, 'mint CTA names the digital asset rather than the physical property');
 assert.doesNotMatch(property, /\/api\/property-collectible\/checkout|collectAndSave|Collect voxel ·/, 'guided creation must not demand a second collectible checkout');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided paid property creation must not call metered Meshy endpoints');
 assert.doesNotMatch(property, /insufficient funds|needs credits|add Meshy credits/i, 'guided UI must not expose provider-credit dead ends');
 
-assert.match(viewer, /const GRID = 24/, 'photo-matched building uses a higher-detail local grid');
-assert.match(viewer, /if \(!mask\[index\]\) return 0/, 'background cells must become empty space');
-assert.match(viewer, /if \(recipe\.depths\[index\] <= 0\) continue/, 'interactive viewer must not instantiate background voxels');
-assert.match(viewer, /sourceImageUrl/, '3D sampling can use the original property photo instead of the stylized poster');
-assert.match(viewer, /InstancedMesh/, 'local 3D is real WebGL voxel geometry');
+assert.match(photoPreview, /CanvasTexture/, 'recognizable preview keeps the real source photo as the visible texture');
+assert.match(photoPreview, /PlaneGeometry/, 'preview is a real Three.js surface rather than a static label change');
+assert.match(photoPreview, /setZ\(/, 'preview adds bounded relief before voxelization');
+assert.match(photoPreview, /targetY = clamp/, 'preview rotation is deliberately bounded so unseen sides are not invented');
+
+assert.match(viewer, /const GRID = 24/, 'photo-matched building uses a higher-detail local voxel grid');
+assert.match(viewer, /if \(!mask\[index\]\) return 0/, 'background cells become empty space');
+assert.match(viewer, /if \(recipe\.depths\[index\] <= 0\) continue/, 'interactive voxel viewer does not instantiate background voxels');
+assert.match(viewer, /sourceImageUrl/, 'voxel sampling uses the original property photo');
+assert.match(viewer, /InstancedMesh/, 'local voxel is real WebGL geometry');
 assert.doesNotMatch(viewer, /backingGeometry/, 'the old square backing slab must stay removed');
 
-assert.match(localVoxel, /if \(recipe\.depths\[index\] <= 0\) continue/, 'saved glTF must preserve the empty background too');
+assert.match(localVoxel, /if \(recipe\.depths\[index\] <= 0\) continue/, 'saved glTF preserves the empty background');
 assert.match(localVoxel, /silhouette-aware voxel recipe/, 'saved record documents the silhouette-aware model');
 assert.match(localVoxel, /model\/gltf\+json/, 'a durable glTF can be rebuilt from the compact recipe');
 assert.match(localStore, /Deliberately table-only/, 'local record persistence deliberately avoids Storage');
 assert.doesNotMatch(localStore, /createBucket|storage\.from/, 'local record persistence must not touch a Storage bucket');
 
-console.log('Paid VoxelPop property regression passed: sign in -> photo -> one $4.99 payment -> photo-matched local 3D -> address/map -> save to My World, with no second creation paywall, Meshy credits, or checkout bucket.');
+assert.match(mintPrepare, /requireVoxelVaultUser/, 'mint preparation requires the signed-in account');
+assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint preparation verifies the exact account-owned local model');
+assert.match(mintPrepare, /LOCAL_PROVIDER = 'voxelpop-local-webgl-v1'/, 'mint accepts only the local no-Meshy property model');
+assert.match(mintPrepare, /propertyVoxelVoucherUsed/, 'mint preparation checks the one-time voucher before signing');
+assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'property voxel mint preparation must not require Meshy');
+assert.match(mintConfirm, /verifyOwnedFinalVoxelModel/, 'mint confirmation re-verifies model ownership');
+assert.match(mintConfirm, /verifyPropertyVoxelMint/, 'mint confirmation verifies Base owner, metadata, voucher, and transaction');
+assert.match(mintMetadata, /animation_url/, 'NFT metadata points to the finished local 3D model');
+assert.match(mintMetadata, /Real Property Rights.*None/s, 'NFT metadata explicitly carries no physical property rights');
+assert.match(mintPage, /connectVoxelFlipWallet/, 'wallet connection happens only on the final mint page');
+assert.match(mintPage, /mintVoxelFlip/, 'final page performs the explicit user-approved VoxelFlip mint');
+assert.match(mintPage, /Mint the voxel\.[\s\S]*Not the house\./, 'mint UI clearly distinguishes the digital voxel from real estate title');
+
+console.log('Paid VoxelPop property regression passed: sign in -> photo -> one $4.99 payment -> recognizable 3D preview -> explicit approval -> local voxel -> optional Base mint, with no Meshy credits, hidden second paywall, or physical-property claim.');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -2,43 +2,51 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
-const property = read('app/property/PropertyJourneySimple.js');
+const property = read('app/property/PropertyJourneyExact.js');
+const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const checkout = read('app/api/property-generation/checkout/route.ts');
 const paidVerify = read('app/api/property-photo-upload/route.ts');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
 const viewer = read('app/property/LocalVoxelModelViewer.js');
 const map = read('app/property/PropertyWorldMap.js');
+const mintPrepare = read('app/api/property-voxel-nft/prepare/route.ts');
 
 assert.match(property, /async function payAndCreate\(\)/, 'photo approval owns the paid creation handoff');
 assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'approved photo is retained on-device before checkout');
-assert.match(property, /await startLocalBuild\(pendingPhoto, draftId\)/, 'a verified paid session can start locally without another charge');
-assert.match(property, /createVoxelPoster\(photo\)/, 'local build creates the VoxelPop image first');
-assert.match(property, /LocalVoxelModelViewer imageUrl=\{voxelPoster \|\| pendingPreview\} sourceImageUrl=\{pendingPreview \|\| voxelPoster\}/, 'the local viewer receives the original photo reference for better building matching');
-assert.match(property, /\/api\/property-local-voxel/, 'finished local 3D is registered for continuity');
-assert.match(property, /Enter the property address to match it to the real mapped building footprint/, 'successful local 3D has an obvious next step');
-assert.match(property, /async function mapBuilding\(event\)/, 'address step maps the selected real-world building');
-assert.match(property, /async function saveToMyWorld\(\)/, 'map step has a direct save continuation');
-assert.match(property, /Save to My World/, 'the next action is visible to the user');
-assert.match(property, /View My World/, 'the completed journey has a clear destination');
+assert.match(property, /setMessage\('Payment verified\. Loading the recognizable 3D photo preview first\.'/,
+  'a verified paid session stops at the recognizable 3D preview');
+assert.match(property, /PhotoReliefModelViewer/, 'source-faithful 3D preview is a distinct stage');
+assert.match(photoPreview, /CanvasTexture/, 'the actual uploaded photo remains the visible material in the first 3D stage');
+assert.match(photoPreview, /PlaneGeometry/, 'the first stage is interactive Three.js geometry');
+assert.match(property, /Looks right → Build the 3D Voxel/, 'user approval is required before voxel generation');
+assert.match(property, /async function approvePreviewAndBuildVoxel\(\)/, 'voxel generation has an explicit post-preview gate');
+assert.match(property, /const poster = await createVoxelPoster\(pendingPhoto\)/, 'voxel image is not created until after preview approval');
+assert.match(property, /LocalVoxelModelViewer imageUrl=\{voxelPoster \|\| pendingPreview\} sourceImageUrl=\{pendingPreview \|\| voxelPoster\}/,
+  'the voxel stage uses the approved original photo for building matching');
+assert.match(property, /\/api\/property-local-voxel/, 'finished local voxel is registered for continuity and minting');
+assert.match(property, /Voxel 3D ready\. You can mint this digital voxel now/, 'successful voxel creation exposes mint as the next digital action');
+assert.match(property, /\/property\/mint\?draftId=/, 'mint route is built from the finished local task');
+assert.match(property, /async function mapBuilding\(event\)/, 'address/map remains available after voxel creation');
+assert.match(property, /async function saveToMyWorld\(\)/, 'mapped voxel can still save to My World');
+assert.match(property, /Save to My World/, 'map save action remains visible');
+assert.match(property, /View My World/, 'saved mapped voxel retains a World destination');
 
-assert.match(viewer, /sampleRecipe/, 'interactive local 3D is derived from the property photo');
-assert.match(viewer, /rgbDistance/, 'viewer estimates photo background separately from the building');
-assert.match(viewer, /rawMask/, 'viewer computes a building foreground mask');
+assert.match(viewer, /sampleRecipe/, 'interactive local voxel is derived from the property photo');
+assert.match(viewer, /rgbDistance/, 'voxel viewer estimates background separately from the building');
+assert.match(viewer, /rawMask/, 'voxel viewer computes a building foreground mask');
 assert.match(viewer, /if \(!mask\[index\]\) return 0/, 'sky and ground can become empty voxel cells');
-assert.match(viewer, /InstancedMesh/, 'interactive 3D uses actual Three.js voxel instances');
-assert.match(viewer, /renderer\.domElement\.style\.opacity = '0'/, '3D canvas begins hidden behind the image');
-assert.match(viewer, /renderer\.domElement\.style\.opacity = '1'/, '3D canvas fades in after a successful first render');
-assert.match(viewer, /callbackRef\.current\?\.\(recipe\)/, 'server registration starts only after local render');
-assert.match(viewer, /DRAG BUILDING · PINCH TO ZOOM/, 'local 3D remains interactive on iPhone');
-assert.doesNotMatch(viewer, /backingGeometry/, 'viewer must not restore the old square picture-wall backing');
+assert.match(viewer, /InstancedMesh/, 'voxel 3D uses actual Three.js voxel instances');
+assert.match(viewer, /callbackRef\.current\?\.\(recipe\)/, 'server registration starts only after a real local voxel render');
+assert.match(viewer, /DRAG BUILDING · PINCH TO ZOOM/, 'local voxel remains interactive on iPhone');
+assert.doesNotMatch(viewer, /backingGeometry/, 'voxel viewer must not restore the old square picture-wall backing');
 
 assert.match(checkout, /generation_engine: PROPERTY_VOXEL_GENERATION_ENGINE/, 'checkout explicitly selects the local generation engine');
 assert.match(checkout, /source_storage: 'device-local'/, 'checkout must not imply source upload');
-assert.doesNotMatch(checkout, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|meshyCreditsSufficient|stagePaidPropertyPhoto/i, 'paid checkout must never call Meshy capacity checks');
-assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|api\.meshy|image-to-3d|storage\.from/i, 'paid resume must never call Meshy or Supabase Storage');
-assert.match(localVoxel, /saveLocalVoxelRecord/, 'local 3D uses the table-only account record');
+assert.doesNotMatch(checkout, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|meshyCreditsSufficient|stagePaidPropertyPhoto/i, 'paid checkout never calls Meshy capacity checks');
+assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|api\.meshy|image-to-3d|storage\.from/i, 'paid resume never calls Meshy or Supabase Storage');
+assert.match(localVoxel, /saveLocalVoxelRecord/, 'local voxel uses the table-only account record');
 assert.match(localVoxel, /buildGltf\(recipe\)/, 'saved local recipes remain reconstructable as real glTF');
-assert.match(localVoxel, /if \(recipe\.depths\[index\] <= 0\) continue/, 'reopened glTF also omits background cells');
+assert.match(localVoxel, /if \(recipe\.depths\[index\] <= 0\) continue/, 'reopened glTF omits background cells');
 
 assert.match(property, /setAtlasBuildings\(Array\.isArray\(atlas\?\.buildings\) \? atlas\.buildings : \[\]\)/, 'address resolution retains nearby source-backed buildings');
 assert.match(property, /PropertyWorldMap selectedBuilding=\{building\} buildings=\{atlasBuildings\}/, 'My World preview uses the focused property map');
@@ -47,7 +55,9 @@ assert.match(map, /touchAction = 'none'/, 'property map supports direct touch in
 assert.match(map, /Zoom property map in/, 'property map exposes explicit mobile zoom controls');
 assert.match(map, /selected \? 0x7138f5/, 'selected building is visually distinct');
 
-assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal paid creation flow must not lead into another paid collectible funnel');
-assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided property flow must not call metered provider generation routes');
+assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint checks the exact account-owned finished voxel');
+assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint must not sneak Meshy back into the property journey');
+assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal paid creation flow does not lead into another paid collectible funnel');
+assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided property flow does not call metered provider generation routes');
 
-console.log('Property journey regression passed: authorized photo -> one paid unlock -> recognizable local building 3D -> source-backed address/map -> save/view My World, with no Meshy credits or second paywall.');
+console.log('Property journey regression passed: authorized photo -> one paid unlock -> source-faithful 3D preview -> user approval -> local 3D voxel -> optional Base mint, with map/World still available and no Meshy credits or second paywall.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -6,13 +6,18 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), '
 const home = read('app/page.js');
 const homeCss = read('app/home.module.css');
 const propertyRoute = read('app/property/page.js');
-const property = read('app/property/PropertyJourneySimple.js');
+const property = read('app/property/PropertyJourneyExact.js');
 const propertyCss = read('app/property/property.module.css');
+const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const localViewer = read('app/property/LocalVoxelModelViewer.js');
 const propertyMap = read('app/property/PropertyWorldMap.js');
 const paidVerify = read('app/api/property-photo-upload/route.ts');
 const generationCheckout = read('app/api/property-generation/checkout/route.ts');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
+const mintPrepare = read('app/api/property-voxel-nft/prepare/route.ts');
+const mintConfirm = read('app/api/property-voxel-nft/confirm/route.ts');
+const mintMetadata = read('app/api/property-voxel-nft/metadata/route.ts');
+const mintPage = read('app/property/mint/page.js');
 const collectibleCommerce = read('lib/property-collectible-commerce.ts');
 const quoteRoute = read('app/api/property-collectible/quote/route.ts');
 const checkoutRoute = read('app/api/property-collectible/checkout/route.ts');
@@ -31,12 +36,13 @@ const drafts = read('lib/property-drafts.js');
 const dock = read('app/components/FinancialOSNav.js');
 const command = read('app/components/AppCommandCenter.js');
 
-assert.match(propertyRoute, /PropertyJourneySimple/, '/property must use the condensed journey');
-assert.match(home, /ONE PHOTO → YOUR VOXEL WORLD|Upload a picture\./, 'home describes the current one-photo guided journey');
+assert.match(propertyRoute, /PropertyJourneyExact/, '/property must use the strict preview -> voxel -> mint journey');
+assert.match(home, /Upload a picture\./, 'home describes the photo-first journey');
 assert.match(home, /START → SIGN IN \+ UPLOAD PHOTO/, 'home truthfully exposes the account gate before the photo picker');
 assert.match(home, /One VoxelPop creation costs \$4\.99/, 'home clearly discloses the creation price');
 assert.match(home, /source photo stays on your device/i, 'home explains the device-local source photo boundary');
 assert.match(home, /without Meshy credits/i, 'home makes the no-Meshy dependency explicit');
+assert.match(home, /3D preview[\s\S]*voxel[\s\S]*Mint/i, 'home states the required preview -> voxel -> mint order');
 assert.match(home, /Optional Collect later is a separate digital-item purchase/i, 'home may describe the separate optional collectible product');
 assert.match(home, /no wallet is required to create/i, 'wallet must not block core creation');
 assert.match(home, /Voxel Vault is not a bank/i, 'home must not imply bank status');
@@ -51,20 +57,25 @@ assert.match(propertyCss, /grid-template-columns:repeat\(5,1fr\)/, 'maker keeps 
 
 assert.match(property, /Sign in first\./, 'maker exposes the account gate');
 assert.match(property, /Continue with Google/, 'account gate has one clear sign-in action');
-assert.match(property, /const labels = \['PHOTO', 'PAY', '3D', 'MAP', 'MY WORLD'\]/, 'labels explain the actual creation journey');
-assert.match(property, /Choose the building photo\./, 'first signed-in step is photo-first');
+assert.match(property, /const labels = \['PHOTO', 'PAY', '3D PREVIEW', 'VOXEL', 'MINT'\]/, 'labels enforce the requested creation order');
+assert.match(property, /Choose a clear house photo\./, 'first signed-in step is photo-first');
 assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC/HEIF selection remains supported');
 assert.match(property, /normalizeIphonePhoto/, 'iPhone photo preparation remains automatic');
 assert.match(property, /I took this photo or have permission to use it\./, 'source photo requires rights confirmation');
-assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} & Create 3D/, 'the paid CTA says what happens next');
-assert.match(property, /The \$4\.99 purchase includes this VoxelPop 3D creation and saving it to My World/, 'the creation purchase includes the useful creation journey');
-assert.match(property, /There is no second collection payment required just to continue/, 'a second payment cannot block the normal creation journey');
+assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} & Make 3D Preview/, 'paid CTA explicitly creates the preview first');
+assert.match(property, /The \$4\.99 creation unlocks the 3D preview and the voxel build/, 'one payment includes both visual creation stages');
+assert.match(property, /The voxel does not start until after you see and approve the preview/, 'voxel creation is gated behind preview approval');
 
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'source photo is kept privately on-device across checkout');
-assert.match(property, /createVoxelPoster/, 'VoxelPop image is built locally');
-assert.match(property, /LocalVoxelModelViewer/, 'local interactive 3D replaces provider generation');
-assert.match(localViewer, /const GRID = 24/, 'building 3D uses the higher-detail local grid');
-assert.match(localViewer, /rawMask/, 'building/background separation is part of the local viewer');
+assert.match(property, /PhotoReliefModelViewer/, 'recognizable 3D photo preview is a first-class stage');
+assert.match(photoPreview, /CanvasTexture/, 'first 3D preview uses the actual uploaded photo texture');
+assert.match(photoPreview, /PlaneGeometry/, 'first preview uses actual Three.js geometry');
+assert.match(photoPreview, /setZ\(/, 'first preview applies bounded relief to the photo surface');
+assert.match(property, /Looks right → Build the 3D Voxel/, 'user explicitly approves the preview before voxelization');
+assert.match(property, /createVoxelPoster/, 'VoxelPop voxel image is built only after preview approval');
+assert.match(property, /LocalVoxelModelViewer/, 'local interactive voxel is a separate later stage');
+assert.match(localViewer, /const GRID = 24/, 'building voxel uses the higher-detail local grid');
+assert.match(localViewer, /rawMask/, 'building/background separation is part of the local voxel viewer');
 assert.match(localViewer, /if \(!mask\[index\]\) return 0/, 'background becomes empty space');
 assert.match(localViewer, /InstancedMesh/, 'local viewer builds real Three.js voxel geometry');
 assert.doesNotMatch(localViewer, /backingGeometry/, 'the old picture-wall slab is gone');
@@ -75,8 +86,20 @@ assert.doesNotMatch(generationCheckout, /MESHY_PROPERTY_CREDITS|readMeshyCreditB
 assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|api\.meshy|image-to-3d|storage\.from/i, 'paid resume cannot call Meshy or private Storage');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided maker must not call metered Meshy routes');
 
-assert.match(property, /Enter the property address to match it to the real mapped building footprint/, 'address follows successful local 3D');
-assert.match(property, /Match 3D to this building/, 'address action is understandable');
+assert.match(property, /Voxel 3D ready\. You can mint this digital voxel now/, 'mint becomes available only after the local voxel is registered');
+assert.match(property, /Mint this digital voxel/, 'mint CTA explicitly names the digital voxel');
+assert.match(property, /\/property\/mint\?draftId=/, 'finished voxel points to its dedicated mint route');
+assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint preparation verifies ownership of the finished local voxel');
+assert.match(mintPrepare, /propertyVoxelVoucherUsed/, 'mint preparation prevents duplicate one-time voucher use');
+assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'property mint does not require Meshy');
+assert.match(mintConfirm, /verifyPropertyVoxelMint/, 'mint confirmation verifies the Base result');
+assert.match(mintMetadata, /animation_url/, 'NFT metadata exposes the finished local 3D model');
+assert.match(mintMetadata, /digital collectible only/i, 'NFT metadata states its digital-only legal meaning');
+assert.match(mintPage, /connectVoxelFlipWallet/, 'wallet is connected only in the final mint step');
+assert.match(mintPage, /mintVoxelFlip/, 'final step uses the reviewed VoxelFlip contract flow');
+assert.match(mintPage, /Mint the voxel\.[\s\S]*Not the house\./, 'mint page cannot imply physical-property ownership');
+
+assert.match(property, /Also match this voxel to the real map/, 'address/map remains available after voxel creation');
 assert.match(property, /setAtlasBuildings/, 'address lookup retains nearby source-backed buildings');
 assert.match(property, /PropertyWorldMap/, 'guided map uses the focused property map');
 assert.match(propertyMap, /ExtrudeGeometry/, 'focused map extrudes source-backed footprints');
@@ -84,8 +107,7 @@ assert.match(propertyMap, /PROPERTY MAP ·/, 'focused map identifies itself');
 assert.match(propertyMap, /pointerdown/, 'focused map supports touch drag interaction');
 assert.match(propertyMap, /Zoom property map in/, 'focused map exposes mobile zoom controls');
 assert.match(property, /Save to My World/, 'map has an obvious continuation action');
-assert.match(property, /View My World/, 'completed creation has an obvious destination');
-assert.match(property, /Open My Vault/, 'completed creation can open the saved Vault item');
+assert.match(property, /View My World/, 'mapped creation has an obvious destination');
 assert.match(property, /savePropertyDraft\(draft\)/, 'creation saves directly to the existing property draft library');
 assert.match(property, /savePropertyDraftToAccount/, 'creation attempts account sync without blocking local success');
 assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|Collect voxel ·|collectAndSave/, 'normal creation no longer enters the separate collectible checkout');
@@ -112,7 +134,7 @@ assert.match(worldApi, /toFixed\(3\)/, 'public coordinates remain privacy-rounde
 assert.match(drafts, /world:\s*\{\s*public:\s*false/, 'new saved drafts remain private by default');
 
 assert.match(propertyClaimRules, /Address text is intentionally excluded/, 'canonical identity never uses display address text');
-assert.match(propertyClaimsApi, /oneCanonicalTwinPerParcel:\s*true/, 'canonical claim API preserves one mint per verified parcel');
+assert.match(propertyClaimsApi, /oneCanonicalTwinPerParcel:\s*true/, 'canonical claim API preserves one canonical property identity per verified parcel');
 assert.match(canonicalRegistry, /PropertyAlreadyRegistered/, 'canonical registry rejects duplicate identity registration');
 assert.match(propertyPassport, /PassportAlreadyMinted/, 'Property Passport rejects a second canonical mint');
 assert.match(interestToken, /off-chain legal/, 'economic rights remain defined separately by legal agreements');
@@ -120,4 +142,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> recognizable local 3D -> source-backed map -> save/view My World, while the separate optional collectible product remains distinct and non-blocking.');
+console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> recognizable 3D preview -> explicit approval -> local voxel -> optional Base mint, while map/World and separate regulated/property-rights rails remain distinct.');


### PR DESCRIPTION
## User problem
The property result could look unlike the uploaded house because the current flow jumped directly into a pixelated/local voxel model and called that the 3D result.

## New strict flow
**PHOTO → PAY → 3D PREVIEW → VOXEL → MINT**

1. User signs in and chooses an authorized house photo.
2. One **$4.99** checkout unlocks the creation.
3. VoxelPop shows a recognizable Three.js **3D photo-relief preview** using the actual device-local photo as its texture.
4. The user must explicitly approve that preview with **Looks right → Build the 3D Voxel**.
5. Only then does the existing local 24×24 silhouette-aware voxel renderer build the movable voxel.
6. After the local voxel is account-bound and registered, **Mint this digital voxel** becomes available.
7. The optional address/map/My World path remains available after the voxel is ready.

## No-Meshy property mint
Adds a dedicated property VoxelFlip mint path for the completed `local-v1:` model. It:
- re-verifies the exact signed-in account/draft/model binding;
- accepts only `voxelpop-local-webgl-v1` models;
- uses the reviewed VoxelFlip Base contract and existing user-approved wallet transaction;
- checks the one-time voucher before signing so duplicates fail closed;
- verifies transaction receipt, contract, owner, tokenURI and used voucher after mint;
- creates signed public NFT metadata from the compact voxel recipe without publishing the original property photo;
- does **not** require or call Meshy.

## Property / legal boundary
The NFT is the finished digital voxel, not the physical property. The UI and metadata explicitly state that minting does not create deed/title, equity, occupancy, rent, investment, appraisal, or appreciation rights.

## Regression protection
Updates the property tests so the source-faithful 3D preview must exist and must be approved before voxelization, and the property mint rail must remain local/no-Meshy and account-bound.