### PR TITLE
Keep property voxel shaped by the uploaded house

### DIFF
--- a/app/property/LocalVoxelModelViewer.js
+++ b/app/property/LocalVoxelModelViewer.js
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 const GRID = 24;
+const MIN_GRID = 12;
 
 function clamp(value, min = 0, max = 1) {
   return Math.max(min, Math.min(max, Number(value || 0)));
@@ -33,33 +34,56 @@ function averageRgb(pixels) {
   return total.map((value) => value / pixels.length);
 }
 
+function recipeDimensions(image) {
+  const width = Math.max(1, image.naturalWidth || 1);
+  const height = Math.max(1, image.naturalHeight || 1);
+  const ratio = clamp(width / height, 0.5, 2);
+  if (ratio >= 1) return { width: GRID, height: Math.max(MIN_GRID, Math.round(GRID / ratio)) };
+  return { width: Math.max(MIN_GRID, Math.round(GRID * ratio)), height: GRID };
+}
+
+function centeredMass(rawMask, width, height) {
+  const mask = new Array(width * height).fill(false);
+  const centerColumn = (width - 1) / 2;
+  for (let row = 0; row < height; row += 1) {
+    const candidates = [];
+    for (let column = 0; column < width; column += 1) {
+      if (rawMask[row * width + column]) candidates.push(column);
+    }
+    if (!candidates.length) continue;
+    let nearest = candidates[0];
+    for (const candidate of candidates) {
+      if (Math.abs(candidate - centerColumn) < Math.abs(nearest - centerColumn)) nearest = candidate;
+    }
+    let left = nearest;
+    let right = nearest;
+    while (left > 0 && (rawMask[row * width + (left - 1)] || rawMask[row * width + Math.max(0, left - 2)])) left -= 1;
+    while (right < width - 1 && (rawMask[row * width + (right + 1)] || rawMask[row * width + Math.min(width - 1, right + 2)])) right += 1;
+    for (let column = left; column <= right; column += 1) {
+      if (rawMask[row * width + column] || (column > left && column < right)) mask[row * width + column] = true;
+    }
+  }
+  return mask;
+}
+
 function sampleRecipe(image) {
+  const { width, height } = recipeDimensions(image);
   const canvas = document.createElement('canvas');
-  canvas.width = GRID;
-  canvas.height = GRID;
+  canvas.width = width;
+  canvas.height = height;
   const context = canvas.getContext('2d', { willReadFrequently: true });
   if (!context) throw new Error('Local voxel sampling is unavailable in this browser.');
 
-  const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
-  let sx = 0;
-  let sy = 0;
-  let sw = image.naturalWidth || 1;
-  let sh = image.naturalHeight || 1;
-  if (sourceRatio > 1) {
-    sw = sh;
-    sx = ((image.naturalWidth || 1) - sw) / 2;
-  } else if (sourceRatio < 1) {
-    sh = sw;
-    sy = ((image.naturalHeight || 1) - sh) / 2;
-  }
+  // Preserve the entire uploaded photo instead of center-cropping it into a square.
+  // That keeps the visible roofline, facade width and house proportions tied to the source.
   context.filter = 'saturate(1.04) contrast(1.05)';
-  context.drawImage(image, sx, sy, sw, sh, 0, 0, GRID, GRID);
-  const data = context.getImageData(0, 0, GRID, GRID).data;
+  context.drawImage(image, 0, 0, image.naturalWidth || 1, image.naturalHeight || 1, 0, 0, width, height);
+  const data = context.getImageData(0, 0, width, height).data;
   const rgb = [];
   const luminance = [];
   const colors = [];
 
-  for (let index = 0; index < GRID * GRID; index += 1) {
+  for (let index = 0; index < width * height; index += 1) {
     const offset = index * 4;
     const red = quantize(data[offset]);
     const green = quantize(data[offset + 1]);
@@ -71,100 +95,88 @@ function sampleRecipe(image) {
 
   const skySamples = [];
   const groundSamples = [];
-  for (let row = 0; row < 4; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      if (column < 2 || column > GRID - 3 || row < 2) skySamples.push(rgb[row * GRID + column]);
+  const topRows = Math.max(2, Math.round(height * 0.16));
+  const bottomRows = Math.max(2, Math.round(height * 0.14));
+  for (let row = 0; row < topRows; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      if (row < 2 || column < 2 || column > width - 3) skySamples.push(rgb[row * width + column]);
     }
   }
-  for (let row = GRID - 3; row < GRID; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      if (column < 5 || column > GRID - 6 || row > GRID - 2) groundSamples.push(rgb[row * GRID + column]);
+  for (let row = height - bottomRows; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      if (row > height - 3 || column < 3 || column > width - 4) groundSamples.push(rgb[row * width + column]);
     }
   }
   const sky = averageRgb(skySamples);
   const ground = averageRgb(groundSamples);
 
   const edgeStrength = luminance.map((value, index) => {
-    const row = Math.floor(index / GRID);
-    const column = index % GRID;
-    const left = luminance[row * GRID + Math.max(0, column - 1)] ?? value;
-    const right = luminance[row * GRID + Math.min(GRID - 1, column + 1)] ?? value;
-    const up = luminance[Math.max(0, row - 1) * GRID + column] ?? value;
-    const down = luminance[Math.min(GRID - 1, row + 1) * GRID + column] ?? value;
-    return clamp(Math.abs(left - right) * 1.8 + Math.abs(up - down) * 1.8);
+    const row = Math.floor(index / width);
+    const column = index % width;
+    const left = luminance[row * width + Math.max(0, column - 1)] ?? value;
+    const right = luminance[row * width + Math.min(width - 1, column + 1)] ?? value;
+    const up = luminance[Math.max(0, row - 1) * width + column] ?? value;
+    const down = luminance[Math.min(height - 1, row + 1) * width + column] ?? value;
+    return clamp(Math.abs(left - right) * 1.7 + Math.abs(up - down) * 1.7);
   });
 
-  const rawMask = new Array(GRID * GRID).fill(false);
-  for (let row = 0; row < GRID; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      const index = row * GRID + column;
-      const x = column / (GRID - 1);
-      const y = row / (GRID - 1);
+  const rawMask = new Array(width * height).fill(false);
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      const index = row * width + column;
+      const x = width > 1 ? column / (width - 1) : 0.5;
+      const y = height > 1 ? row / (height - 1) : 0.5;
       const center = 1 - Math.min(1, Math.abs(x - 0.5) / 0.5);
       const skyDistance = rgbDistance(rgb[index], sky);
       const groundDistance = rgbDistance(rgb[index], ground);
       const edge = edgeStrength[index];
-
-      const outsideSide = x < 0.055 || x > 0.945;
-      const obviousSky = y < 0.34 && skyDistance < (0.11 + edge * 0.15);
-      const obviousGround = y > 0.82 && groundDistance < (0.10 + edge * 0.13);
-      const buildingEvidence = skyDistance * 0.48 + edge * 0.36 + center * 0.16;
-      const centralLowerBody = y > 0.34 && y < 0.83 && center > 0.22 && skyDistance > 0.08;
-      rawMask[index] = !outsideSide && !obviousSky && !obviousGround && y > 0.07 && y < 0.94 && (buildingEvidence > 0.245 || centralLowerBody);
+      const outsideSide = x < 0.035 || x > 0.965;
+      const obviousSky = y < 0.42 && skyDistance < (0.105 + edge * 0.10);
+      const obviousGround = y > 0.79 && groundDistance < (0.095 + edge * 0.11);
+      const structuralEvidence = skyDistance * 0.44 + groundDistance * 0.12 + edge * 0.34 + center * 0.10;
+      const centralFacade = y > 0.22 && y < 0.88 && center > 0.18 && skyDistance > 0.07;
+      rawMask[index] = !outsideSide && !obviousSky && !obviousGround && y > 0.045 && y < 0.965 && (structuralEvidence > 0.225 || centralFacade);
     }
   }
 
-  // Keep the central connected-looking mass and close tiny holes. This is intentionally
-  // conservative: a single photo can describe the visible facade, not unseen geometry.
-  const mask = new Array(GRID * GRID).fill(false);
-  for (let row = 0; row < GRID; row += 1) {
-    const candidates = [];
-    for (let column = 0; column < GRID; column += 1) {
-      if (rawMask[row * GRID + column]) candidates.push(column);
-    }
-    if (!candidates.length) continue;
-    const centerColumn = (GRID - 1) / 2;
-    let nearest = candidates[0];
-    for (const candidate of candidates) {
-      if (Math.abs(candidate - centerColumn) < Math.abs(nearest - centerColumn)) nearest = candidate;
-    }
-    let left = nearest;
-    let right = nearest;
-    while (left > 0 && (rawMask[row * GRID + (left - 1)] || rawMask[row * GRID + Math.max(0, left - 2)])) left -= 1;
-    while (right < GRID - 1 && (rawMask[row * GRID + (right + 1)] || rawMask[row * GRID + Math.min(GRID - 1, right + 2)])) right += 1;
-    if (right - left < 4 && row > Math.round(GRID * 0.35)) {
-      left = Math.max(2, nearest - 3);
-      right = Math.min(GRID - 3, nearest + 3);
-    }
-    for (let column = left; column <= right; column += 1) {
-      if (rawMask[row * GRID + column] || (column > left && column < right)) mask[row * GRID + column] = true;
-    }
-  }
-
+  let mask = centeredMass(rawMask, width, height);
   let activeCount = mask.filter(Boolean).length;
-  if (activeCount < GRID * GRID * 0.18) {
-    // Fallback to a simple house-like silhouette instead of ever returning the old square slab.
-    mask.fill(false);
-    for (let row = Math.round(GRID * 0.22); row < Math.round(GRID * 0.86); row += 1) {
-      const roof = row < GRID * 0.43;
-      const progress = clamp((row - GRID * 0.22) / (GRID * 0.21));
-      const halfWidth = roof ? Math.round(2 + progress * GRID * 0.30) : Math.round(GRID * 0.34);
-      const center = Math.round((GRID - 1) / 2);
-      for (let column = Math.max(1, center - halfWidth); column <= Math.min(GRID - 2, center + halfWidth); column += 1) {
-        mask[row * GRID + column] = true;
+
+  // Difficult lighting can make a real facade resemble the sampled sky. Relax only
+  // toward evidence that is still present in the user's actual photo. Never substitute
+  // a generic roof/body silhouette that was not present in the source image.
+  if (activeCount < width * height * 0.12) {
+    const relaxed = new Array(width * height).fill(false);
+    for (let row = 0; row < height; row += 1) {
+      for (let column = 0; column < width; column += 1) {
+        const index = row * width + column;
+        const x = width > 1 ? column / (width - 1) : 0.5;
+        const y = height > 1 ? row / (height - 1) : 0.5;
+        const center = 1 - Math.min(1, Math.abs(x - 0.5) / 0.5);
+        const skyDistance = rgbDistance(rgb[index], sky);
+        const groundDistance = rgbDistance(rgb[index], ground);
+        const edge = edgeStrength[index];
+        relaxed[index] = x > 0.045 && x < 0.955 && y > 0.075 && y < 0.94 && center > 0.08 && (
+          skyDistance > 0.075 || groundDistance > 0.09 || edge > 0.09
+        );
       }
     }
+    mask = centeredMass(relaxed, width, height);
     activeCount = mask.filter(Boolean).length;
+  }
+
+  if (activeCount < Math.max(12, Math.round(width * height * 0.06))) {
+    throw new Error('VoxelPop could not isolate enough of the uploaded building to make a trustworthy voxel. Try a clearer front or three-quarter photo.');
   }
 
   const depths = luminance.map((value, index) => {
     if (!mask[index]) return 0;
     const edge = edgeStrength[index];
-    const facadeRelief = Math.round(4 + value * 2 + edge * 2);
-    return Math.max(3, Math.min(8, facadeRelief));
+    const facadeRelief = Math.round(3 + value * 2.1 + edge * 3.4);
+    return Math.max(2, Math.min(9, facadeRelief));
   });
 
-  return { version: 1, width: GRID, height: GRID, colors, depths };
+  return { version: 1, width, height, colors, depths };
 }
 
 export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onReady }) {
@@ -204,7 +216,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         try {
           renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
         } catch {
-          setError('Interactive 3D is unavailable here. The VoxelPop image remains visible.');
+          setError('Interactive 3D is unavailable here. Your approved house photo remains visible.');
           return;
         }
 
@@ -219,7 +231,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         renderer.toneMappingExposure = 1.06;
         renderer.domElement.style.touchAction = 'none';
         renderer.domElement.style.opacity = '0';
-        renderer.domElement.style.transition = 'opacity .36s ease';
+        renderer.domElement.style.transition = 'opacity .34s ease';
         mount.innerHTML = '';
         mount.appendChild(renderer.domElement);
 
@@ -232,34 +244,37 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         rim.position.set(-5, 3, -4);
         scene.add(rim);
 
+        const cell = compact ? 0.275 : 0.292;
+        const facadeWidth = recipe.width * cell;
+        const facadeHeight = recipe.height * cell;
+        const maxDimension = Math.max(facadeWidth, facadeHeight);
         const camera = new THREE.PerspectiveCamera(34, initialWidth / initialHeight, 0.1, 80);
-        let cameraDistance = compact ? 11.3 : 10.6;
-        camera.position.set(0, 0.15, cameraDistance);
-        camera.lookAt(0, -0.2, 0);
+        let cameraDistance = clamp(maxDimension * 1.55 + 1.7, 7.4, 13.6);
+        camera.position.set(0, 0.1, cameraDistance);
+        camera.lookAt(0, -0.1, 0);
 
         const root = new THREE.Group();
-        root.rotation.x = -0.08;
+        root.rotation.x = -0.075;
         root.rotation.y = 0.10;
         scene.add(root);
 
         const active = recipe.depths.reduce((count, depth) => count + (depth > 0 ? 1 : 0), 0);
-        const geometry = new THREE.BoxGeometry(0.255, 0.255, 1);
+        const geometry = new THREE.BoxGeometry(cell * 0.90, cell * 0.90, 1);
         const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.76, metalness: 0.015 });
         const mesh = new THREE.InstancedMesh(geometry, material, Math.max(1, active));
         const dummy = new THREE.Object3D();
         const color = new THREE.Color();
-        const cell = 0.285;
         let instance = 0;
 
         for (let row = 0; row < recipe.height; row += 1) {
           for (let column = 0; column < recipe.width; column += 1) {
             const index = row * recipe.width + column;
             if (recipe.depths[index] <= 0) continue;
-            const depth = 0.58 + (recipe.depths[index] / 9) * 0.78;
+            const depth = 0.44 + (recipe.depths[index] / 9) * 0.92;
             dummy.position.set(
               (column - (recipe.width - 1) / 2) * cell,
-              ((recipe.height - 1) / 2 - row) * cell - 0.18,
-              depth / 2 - 0.58,
+              ((recipe.height - 1) / 2 - row) * cell,
+              depth / 2 - 0.46,
             );
             dummy.scale.set(1, 1, depth);
             dummy.updateMatrix();
@@ -273,24 +288,25 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
         root.add(mesh);
 
-        const baseGeometry = new THREE.CylinderGeometry(3.2, 3.45, 0.22, 32);
+        const baseRadius = Math.max(2.2, facadeWidth * 0.52);
+        const baseGeometry = new THREE.CylinderGeometry(baseRadius, baseRadius + 0.24, 0.20, 32);
         const baseMaterial = new THREE.MeshStandardMaterial({ color: 0xefe6d8, roughness: 0.94, metalness: 0 });
         const base = new THREE.Mesh(baseGeometry, baseMaterial);
-        base.position.set(0, -3.42, -0.12);
+        base.position.set(0, -facadeHeight / 2 - 0.30, -0.12);
         scene.add(base);
 
-        const ringGeometry = new THREE.TorusGeometry(2.65, 0.055, 10, 64);
+        const ringGeometry = new THREE.TorusGeometry(baseRadius * 0.82, 0.05, 10, 64);
         const ringMaterial = new THREE.MeshBasicMaterial({ color: 0xc9ff54, transparent: true, opacity: 0.88 });
         const ring = new THREE.Mesh(ringGeometry, ringMaterial);
         ring.rotation.x = Math.PI / 2;
-        ring.position.set(0, -3.29, -0.08);
+        ring.position.set(0, -facadeHeight / 2 - 0.18, -0.08);
         scene.add(ring);
 
         const pointers = new Map();
         let lastX = 0;
         let lastY = 0;
         let pinch = 0;
-        let targetX = -0.08;
+        let targetX = -0.075;
         let targetY = 0.10;
 
         const distance = () => {
@@ -298,8 +314,8 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
           return pair.length === 2 ? pointerDistance(pair[0], pair[1]) : 0;
         };
         const updateCamera = () => {
-          camera.position.set(0, 0.15, cameraDistance);
-          camera.lookAt(0, -0.2, 0);
+          camera.position.set(0, 0.1, cameraDistance);
+          camera.lookAt(0, -0.1, 0);
         };
         const down = (event) => {
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
@@ -313,15 +329,15 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
           if (pointers.size >= 2) {
             const next = distance();
-            if (pinch) cameraDistance = Math.max(8.1, Math.min(14.2, cameraDistance - (next - pinch) * 0.012));
+            if (pinch) cameraDistance = clamp(cameraDistance - (next - pinch) * 0.012, 5.8, 15.5);
             pinch = next;
             updateCamera();
             return;
           }
           const dx = event.clientX - lastX;
           const dy = event.clientY - lastY;
-          targetY += dx * 0.0075;
-          targetX = Math.max(-0.50, Math.min(0.34, targetX + dy * 0.004));
+          targetY += dx * 0.008;
+          targetX = clamp(targetX + dy * 0.004, -0.50, 0.34);
           lastX = event.clientX;
           lastY = event.clientY;
         };
@@ -332,7 +348,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         };
         const wheel = (event) => {
           event.preventDefault();
-          cameraDistance = Math.max(8.1, Math.min(14.2, cameraDistance + Math.sign(event.deltaY) * 0.42));
+          cameraDistance = clamp(cameraDistance + Math.sign(event.deltaY) * 0.45, 5.8, 15.5);
           updateCamera();
         };
         renderer.domElement.addEventListener('pointerdown', down);
@@ -345,16 +361,19 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         let firstFrame = true;
         const animate = () => {
           frame = requestAnimationFrame(animate);
-          root.rotation.x += (targetX - root.rotation.x) * 0.08;
-          root.rotation.y += (targetY - root.rotation.y) * 0.08;
-          if (!reducedMotion) ring.rotation.z += 0.0012;
+          if (!reducedMotion) {
+            root.rotation.x += (targetX - root.rotation.x) * 0.08;
+            root.rotation.y += (targetY - root.rotation.y) * 0.08;
+          } else {
+            root.rotation.x = targetX;
+            root.rotation.y = targetY;
+          }
           renderer.render(scene, camera);
           if (firstFrame) {
             firstFrame = false;
             renderer.domElement.style.opacity = '1';
             setReady(true);
-            const activeCount = recipe.depths.filter((depth) => depth > 0).length;
-            const signature = `${recipe.width}x${recipe.height}:${activeCount}:${recipe.colors.slice(0, 4).join('')}`;
+            const signature = `${recipe.width}x${recipe.height}:${recipe.colors.slice(0, 6).join('')}`;
             if (reportedRef.current !== signature) {
               reportedRef.current = signature;
               callbackRef.current?.(recipe);
@@ -391,11 +410,11 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
           mount.innerHTML = '';
         };
       }).catch(() => {
-        if (!dead) setError('Interactive 3D could not start. The VoxelPop image remains visible.');
+        if (!dead) setError('Interactive voxel 3D could not start. Your approved house photo remains visible.');
       });
     };
     image.onerror = () => {
-      if (!dead) setError('The property photo could not be opened for local 3D.');
+      if (!dead) setError('The approved property photo could not be opened for voxel conversion.');
     };
 
     return () => {
@@ -404,18 +423,19 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
     };
   }, [imageUrl, sourceImageUrl]);
 
-  return <div className="localViewerShell">
-    {imageUrl ? <img className={`localPoster ${ready ? 'hidden' : ''}`} src={imageUrl} alt="VoxelPop rendered building preview"/> : null}
-    <div ref={mountRef} className="localCanvas" aria-label="Interactive photo-matched VoxelPop building"/>
-    {!ready && !error ? <div className="stage">MATCHING BUILDING · LOCAL 3D</div> : null}
-    {error ? <div className="softError">{error}</div> : null}
-    <div className="hint">{ready ? 'DRAG BUILDING · PINCH TO ZOOM' : 'PHOTO → BUILDING-SHAPED VOXEL'}</div>
+  const posterUrl = sourceImageUrl || imageUrl;
+  return <div className="viewerShell">
+    {posterUrl ? <img className={`viewerPoster ${ready ? 'hidden' : ''}`} src={posterUrl} alt="Approved property photo"/> : null}
+    <div ref={mountRef} className="viewerCanvas" aria-label="Interactive property voxel model"/>
+    {!ready && !error ? <div className="viewerStage">APPROVED HOUSE → BUILDING VOXELS</div> : null}
+    {error ? <div className="viewerError">{error}</div> : null}
+    <div className="viewerHint">{ready ? '3D VOXEL · DRAG BUILDING · PINCH TO ZOOM' : 'THE APPROVED HOUSE PHOTO STAYS VISIBLE WHILE VOXELS BUILD'}</div>
     <style jsx>{`
-      .localViewerShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:radial-gradient(circle at 50% 34%,#4a3561 0,#25182f 55%,#17101c 100%)}
-      .localPoster,.localCanvas{position:absolute;inset:0;width:100%;height:100%}.localPoster{z-index:1;object-fit:cover;opacity:1;transition:opacity .36s ease}.localPoster.hidden{opacity:0;pointer-events:none}.localCanvas{z-index:2}
-      .stage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.8);backdrop-filter:blur(10px);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.12em}
-      .softError{position:absolute;z-index:5;left:12px;right:12px;bottom:36px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.86);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
-      .hint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#e6deeb;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.12em;pointer-events:none;text-shadow:0 1px 6px #000}
+      .viewerShell{position:relative;width:100%;height:100%;min-height:280px;overflow:hidden;background:radial-gradient(circle at 50% 30%,#3c2a52,#18101f 66%)}
+      .viewerCanvas,.viewerPoster{position:absolute;inset:0;width:100%;height:100%}.viewerCanvas{z-index:2}.viewerPoster{z-index:1;object-fit:contain;background:#18101f;transition:opacity .34s ease}.viewerPoster.hidden{opacity:0;pointer-events:none}
+      .viewerStage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.80);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.11em;backdrop-filter:blur(10px)}
+      .viewerError{position:absolute;z-index:5;left:12px;right:12px;bottom:38px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.86);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
+      .viewerHint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#ded5e5;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.11em;pointer-events:none;text-shadow:0 1px 6px #000}
     `}</style>
   </div>;
 }


### PR DESCRIPTION
Focused fidelity follow-up on the new strict Photo -> 3D Preview -> Voxel -> Mint flow.

This changes only the local voxel renderer:
- preserves the full uploaded photo aspect ratio instead of square center-cropping it
- samples the approved original house photo used by PropertyJourneyExact
- removes the fabricated generic house/roof fallback
- uses a second, relaxed actual-photo evidence pass for difficult lighting
- fails clearly if there is not enough building evidence rather than silently inventing a different house
- sizes the voxel model/camera/base to the photo-derived proportions
- keeps the approved source photo visible while WebGL is building
- keeps iPhone drag/pinch interaction

No payment, mint, map, provider, or legal-rights logic is changed.