### PR TITLE
Fix property photo fidelity before voxel minting

### DIFF
--- a/app/property/LocalVoxelModelViewer.js
+++ b/app/property/LocalVoxelModelViewer.js
@@ -3,176 +3,113 @@
 import { useEffect, useRef, useState } from 'react';
 
 const GRID = 24;
+const MIN_SIDE = 12;
+const clamp = (value, min = 0, max = 1) => Math.max(min, Math.min(max, Number(value || 0)));
+const quantize = (value) => Math.max(0, Math.min(255, Math.round(Number(value || 0) / 12) * 12));
+const toHex = (value) => Math.round(clamp(value, 0, 255)).toString(16).padStart(2, '0');
+const rgbDistance = (a, b) => Math.hypot((a?.[0] || 0) - (b?.[0] || 0), (a?.[1] || 0) - (b?.[1] || 0), (a?.[2] || 0) - (b?.[2] || 0)) / 441.673;
+const averageRgb = (pixels) => pixels.length ? pixels.reduce((sum, p) => [sum[0] + p[0], sum[1] + p[1], sum[2] + p[2]], [0, 0, 0]).map((v) => v / pixels.length) : [128, 128, 128];
 
-function clamp(value, min = 0, max = 1) {
-  return Math.max(min, Math.min(max, Number(value || 0)));
-}
-
-function quantize(value) {
-  return Math.max(0, Math.min(255, Math.round(Number(value || 0) / 18) * 18));
-}
-
-function toHex(value) {
-  return Math.max(0, Math.min(255, Math.round(value))).toString(16).padStart(2, '0');
-}
-
-function pointerDistance(a, b) {
-  return Math.hypot(a.x - b.x, a.y - b.y);
-}
-
-function rgbDistance(a, b) {
-  const dr = Number(a?.[0] || 0) - Number(b?.[0] || 0);
-  const dg = Number(a?.[1] || 0) - Number(b?.[1] || 0);
-  const db = Number(a?.[2] || 0) - Number(b?.[2] || 0);
-  return Math.hypot(dr, dg, db) / 441.673;
-}
-
-function averageRgb(pixels) {
-  if (!pixels.length) return [128, 128, 128];
-  const total = pixels.reduce((sum, pixel) => [sum[0] + pixel[0], sum[1] + pixel[1], sum[2] + pixel[2]], [0, 0, 0]);
-  return total.map((value) => value / pixels.length);
+function gridForImage(image) {
+  const aspect = clamp((image.naturalWidth || 1) / (image.naturalHeight || 1), 0.5, 2);
+  return aspect >= 1
+    ? { width: GRID, height: Math.max(MIN_SIDE, Math.round(GRID / aspect)) }
+    : { width: Math.max(MIN_SIDE, Math.round(GRID * aspect)), height: GRID };
 }
 
 function sampleRecipe(image) {
+  const { width, height } = gridForImage(image);
   const canvas = document.createElement('canvas');
-  canvas.width = GRID;
-  canvas.height = GRID;
+  canvas.width = width;
+  canvas.height = height;
   const context = canvas.getContext('2d', { willReadFrequently: true });
   if (!context) throw new Error('Local voxel sampling is unavailable in this browser.');
-
-  const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
-  let sx = 0;
-  let sy = 0;
-  let sw = image.naturalWidth || 1;
-  let sh = image.naturalHeight || 1;
-  if (sourceRatio > 1) {
-    sw = sh;
-    sx = ((image.naturalWidth || 1) - sw) / 2;
-  } else if (sourceRatio < 1) {
-    sh = sw;
-    sy = ((image.naturalHeight || 1) - sh) / 2;
-  }
   context.filter = 'saturate(1.04) contrast(1.05)';
-  context.drawImage(image, sx, sy, sw, sh, 0, 0, GRID, GRID);
-  const data = context.getImageData(0, 0, GRID, GRID).data;
+  context.drawImage(image, 0, 0, width, height);
+  const data = context.getImageData(0, 0, width, height).data;
   const rgb = [];
   const luminance = [];
   const colors = [];
-
-  for (let index = 0; index < GRID * GRID; index += 1) {
+  for (let index = 0; index < width * height; index += 1) {
     const offset = index * 4;
-    const red = quantize(data[offset]);
-    const green = quantize(data[offset + 1]);
-    const blue = quantize(data[offset + 2]);
-    rgb.push([red, green, blue]);
-    colors.push(`${toHex(red)}${toHex(green)}${toHex(blue)}`);
-    luminance.push((red * 0.2126 + green * 0.7152 + blue * 0.0722) / 255);
+    const pixel = [quantize(data[offset]), quantize(data[offset + 1]), quantize(data[offset + 2])];
+    rgb.push(pixel);
+    colors.push(`${toHex(pixel[0])}${toHex(pixel[1])}${toHex(pixel[2])}`);
+    luminance.push((pixel[0] * 0.2126 + pixel[1] * 0.7152 + pixel[2] * 0.0722) / 255);
   }
-
   const skySamples = [];
   const groundSamples = [];
-  for (let row = 0; row < 4; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      if (column < 2 || column > GRID - 3 || row < 2) skySamples.push(rgb[row * GRID + column]);
-    }
-  }
-  for (let row = GRID - 3; row < GRID; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      if (column < 5 || column > GRID - 6 || row > GRID - 2) groundSamples.push(rgb[row * GRID + column]);
-    }
-  }
+  const topRows = Math.max(2, Math.round(height * 0.14));
+  const bottomRows = Math.max(2, Math.round(height * 0.14));
+  for (let row = 0; row < topRows; row += 1) for (let column = 0; column < width; column += 1) if (column < width * 0.28 || column > width * 0.72 || row === 0) skySamples.push(rgb[row * width + column]);
+  for (let row = height - bottomRows; row < height; row += 1) for (let column = 0; column < width; column += 1) if (column < width * 0.3 || column > width * 0.7 || row === height - 1) groundSamples.push(rgb[row * width + column]);
   const sky = averageRgb(skySamples);
   const ground = averageRgb(groundSamples);
-
-  const edgeStrength = luminance.map((value, index) => {
-    const row = Math.floor(index / GRID);
-    const column = index % GRID;
-    const left = luminance[row * GRID + Math.max(0, column - 1)] ?? value;
-    const right = luminance[row * GRID + Math.min(GRID - 1, column + 1)] ?? value;
-    const up = luminance[Math.max(0, row - 1) * GRID + column] ?? value;
-    const down = luminance[Math.min(GRID - 1, row + 1) * GRID + column] ?? value;
-    return clamp(Math.abs(left - right) * 1.8 + Math.abs(up - down) * 1.8);
+  const edges = luminance.map((value, index) => {
+    const row = Math.floor(index / width);
+    const column = index % width;
+    const left = luminance[row * width + Math.max(0, column - 1)] ?? value;
+    const right = luminance[row * width + Math.min(width - 1, column + 1)] ?? value;
+    const up = luminance[Math.max(0, row - 1) * width + column] ?? value;
+    const down = luminance[Math.min(height - 1, row + 1) * width + column] ?? value;
+    return clamp(Math.abs(left - right) * 1.65 + Math.abs(up - down) * 1.65);
   });
-
-  const rawMask = new Array(GRID * GRID).fill(false);
-  for (let row = 0; row < GRID; row += 1) {
-    for (let column = 0; column < GRID; column += 1) {
-      const index = row * GRID + column;
-      const x = column / (GRID - 1);
-      const y = row / (GRID - 1);
+  const rawMask = new Array(width * height).fill(false);
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      const index = row * width + column;
+      const x = column / Math.max(1, width - 1);
+      const y = row / Math.max(1, height - 1);
       const center = 1 - Math.min(1, Math.abs(x - 0.5) / 0.5);
       const skyDistance = rgbDistance(rgb[index], sky);
       const groundDistance = rgbDistance(rgb[index], ground);
-      const edge = edgeStrength[index];
-
-      const outsideSide = x < 0.055 || x > 0.945;
-      const obviousSky = y < 0.34 && skyDistance < (0.11 + edge * 0.15);
-      const obviousGround = y > 0.82 && groundDistance < (0.10 + edge * 0.13);
-      const buildingEvidence = skyDistance * 0.48 + edge * 0.36 + center * 0.16;
-      const centralLowerBody = y > 0.34 && y < 0.83 && center > 0.22 && skyDistance > 0.08;
-      rawMask[index] = !outsideSide && !obviousSky && !obviousGround && y > 0.07 && y < 0.94 && (buildingEvidence > 0.245 || centralLowerBody);
+      const edge = edges[index];
+      const likelySky = y < 0.46 && skyDistance < 0.115 + edge * 0.13;
+      const likelyGround = y > 0.75 && groundDistance < 0.105 + edge * 0.12;
+      const evidence = skyDistance * 0.5 + edge * 0.34 + center * 0.16;
+      rawMask[index] = x > 0.035 && x < 0.965 && y > 0.045 && y < 0.96 && !likelySky && !likelyGround && (evidence > 0.23 || (y > 0.27 && y < 0.9 && center > 0.2 && skyDistance > 0.07));
     }
   }
-
-  // Keep the central connected-looking mass and close tiny holes. This is intentionally
-  // conservative: a single photo can describe the visible facade, not unseen geometry.
-  const mask = new Array(GRID * GRID).fill(false);
-  for (let row = 0; row < GRID; row += 1) {
+  const mask = new Array(width * height).fill(false);
+  for (let row = 0; row < height; row += 1) {
     const candidates = [];
-    for (let column = 0; column < GRID; column += 1) {
-      if (rawMask[row * GRID + column]) candidates.push(column);
-    }
+    for (let column = 0; column < width; column += 1) if (rawMask[row * width + column]) candidates.push(column);
     if (!candidates.length) continue;
-    const centerColumn = (GRID - 1) / 2;
-    let nearest = candidates[0];
-    for (const candidate of candidates) {
-      if (Math.abs(candidate - centerColumn) < Math.abs(nearest - centerColumn)) nearest = candidate;
+    const centerColumn = (width - 1) / 2;
+    let anchor = candidates.reduce((best, value) => Math.abs(value - centerColumn) < Math.abs(best - centerColumn) ? value : best, candidates[0]);
+    let left = anchor;
+    let right = anchor;
+    while (left > 0 && (rawMask[row * width + left - 1] || rawMask[row * width + Math.max(0, left - 2)])) left -= 1;
+    while (right < width - 1 && (rawMask[row * width + right + 1] || rawMask[row * width + Math.min(width - 1, right + 2)])) right += 1;
+    if (right - left < Math.max(3, Math.round(width * 0.2)) && row > height * 0.32) {
+      left = Math.max(1, anchor - Math.ceil(width * 0.11));
+      right = Math.min(width - 2, anchor + Math.ceil(width * 0.11));
     }
-    let left = nearest;
-    let right = nearest;
-    while (left > 0 && (rawMask[row * GRID + (left - 1)] || rawMask[row * GRID + Math.max(0, left - 2)])) left -= 1;
-    while (right < GRID - 1 && (rawMask[row * GRID + (right + 1)] || rawMask[row * GRID + Math.min(GRID - 1, right + 2)])) right += 1;
-    if (right - left < 4 && row > Math.round(GRID * 0.35)) {
-      left = Math.max(2, nearest - 3);
-      right = Math.min(GRID - 3, nearest + 3);
-    }
-    for (let column = left; column <= right; column += 1) {
-      if (rawMask[row * GRID + column] || (column > left && column < right)) mask[row * GRID + column] = true;
-    }
+    for (let column = left; column <= right; column += 1) if (rawMask[row * width + column] || (column > left && column < right && row > height * 0.28)) mask[row * width + column] = true;
   }
-
-  let activeCount = mask.filter(Boolean).length;
-  if (activeCount < GRID * GRID * 0.18) {
-    // Fallback to a simple house-like silhouette instead of ever returning the old square slab.
+  if (mask.filter(Boolean).length < width * height * 0.16) {
     mask.fill(false);
-    for (let row = Math.round(GRID * 0.22); row < Math.round(GRID * 0.86); row += 1) {
-      const roof = row < GRID * 0.43;
-      const progress = clamp((row - GRID * 0.22) / (GRID * 0.21));
-      const halfWidth = roof ? Math.round(2 + progress * GRID * 0.30) : Math.round(GRID * 0.34);
-      const center = Math.round((GRID - 1) / 2);
-      for (let column = Math.max(1, center - halfWidth); column <= Math.min(GRID - 2, center + halfWidth); column += 1) {
-        mask[row * GRID + column] = true;
-      }
+    const center = Math.round((width - 1) / 2);
+    for (let row = Math.round(height * 0.2); row < Math.round(height * 0.88); row += 1) {
+      const roof = row < height * 0.43;
+      const progress = clamp((row - height * 0.2) / Math.max(1, height * 0.23));
+      const half = roof ? Math.round(2 + progress * width * 0.31) : Math.round(width * 0.34);
+      for (let column = Math.max(1, center - half); column <= Math.min(width - 2, center + half); column += 1) mask[row * width + column] = true;
     }
-    activeCount = mask.filter(Boolean).length;
   }
-
   const depths = luminance.map((value, index) => {
     if (!mask[index]) return 0;
-    const edge = edgeStrength[index];
-    const facadeRelief = Math.round(4 + value * 2 + edge * 2);
-    return Math.max(3, Math.min(8, facadeRelief));
+    return Math.max(3, Math.min(9, Math.round(4 + value * 1.8 + edges[index] * 2.6)));
   });
-
-  return { version: 1, width: GRID, height: GRID, colors, depths };
+  return { version: 1, width, height, colors, depths };
 }
 
 export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onReady }) {
   const mountRef = useRef(null);
   const callbackRef = useRef(onReady);
-  const reportedRef = useRef('');
   const [ready, setReady] = useState(false);
   const [error, setError] = useState('');
+  const [showSource, setShowSource] = useState(false);
   callbackRef.current = onReady;
 
   useEffect(() => {
@@ -182,240 +119,107 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
     let cleanup = () => {};
     setReady(false);
     setError('');
-    reportedRef.current = '';
-
+    setShowSource(false);
     const image = new Image();
     image.decoding = 'async';
     image.src = sampleUrl;
-
-    image.onload = () => {
+    image.onload = async () => {
       let recipe;
+      try { recipe = sampleRecipe(image); } catch (cause) { if (!dead) setError(String(cause?.message || cause)); return; }
       try {
-        recipe = sampleRecipe(image);
-      } catch (sampleError) {
-        if (!dead) setError(String(sampleError?.message || sampleError || 'Local voxel sampling failed.'));
-        return;
-      }
-
-      import('three').then((THREE) => {
+        const THREE = await import('three');
         if (dead || !mountRef.current) return;
         const mount = mountRef.current;
-        let renderer;
-        try {
-          renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-        } catch {
-          setError('Interactive 3D is unavailable here. The VoxelPop image remains visible.');
-          return;
-        }
-
+        const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
         const initialWidth = Math.max(280, mount.clientWidth || 360);
         const initialHeight = Math.max(280, mount.clientHeight || 360);
-        const compact = initialWidth < 720 || window.matchMedia?.('(pointer: coarse)')?.matches;
-        const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.12 : 1.38));
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, initialWidth < 720 ? 1.15 : 1.4));
         renderer.setSize(initialWidth, initialHeight);
         renderer.outputColorSpace = THREE.SRGBColorSpace;
         renderer.toneMapping = THREE.ACESFilmicToneMapping;
         renderer.toneMappingExposure = 1.06;
         renderer.domElement.style.touchAction = 'none';
         renderer.domElement.style.opacity = '0';
-        renderer.domElement.style.transition = 'opacity .36s ease';
+        renderer.domElement.style.transition = 'opacity .3s ease';
         mount.innerHTML = '';
         mount.appendChild(renderer.domElement);
-
         const scene = new THREE.Scene();
         scene.add(new THREE.HemisphereLight(0xfffbef, 0x21122d, 2.6));
-        const key = new THREE.DirectionalLight(0xffedd5, 4.0);
+        const key = new THREE.DirectionalLight(0xffedd5, 4);
         key.position.set(5, 8, 7);
         scene.add(key);
-        const rim = new THREE.DirectionalLight(0xc5b4ff, 2.0);
-        rim.position.set(-5, 3, -4);
-        scene.add(rim);
-
         const camera = new THREE.PerspectiveCamera(34, initialWidth / initialHeight, 0.1, 80);
-        let cameraDistance = compact ? 11.3 : 10.6;
-        camera.position.set(0, 0.15, cameraDistance);
-        camera.lookAt(0, -0.2, 0);
-
+        let cameraDistance = initialWidth < 720 ? 10.8 : 10.2;
+        camera.position.set(0, 0.12, cameraDistance);
+        camera.lookAt(0, -0.15, 0);
         const root = new THREE.Group();
-        root.rotation.x = -0.08;
-        root.rotation.y = 0.10;
+        root.rotation.set(-0.07, 0.1, 0);
         scene.add(root);
-
-        const active = recipe.depths.reduce((count, depth) => count + (depth > 0 ? 1 : 0), 0);
         const geometry = new THREE.BoxGeometry(0.255, 0.255, 1);
         const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.76, metalness: 0.015 });
+        const active = recipe.depths.filter((depth) => depth > 0).length;
         const mesh = new THREE.InstancedMesh(geometry, material, Math.max(1, active));
         const dummy = new THREE.Object3D();
         const color = new THREE.Color();
         const cell = 0.285;
         let instance = 0;
-
-        for (let row = 0; row < recipe.height; row += 1) {
-          for (let column = 0; column < recipe.width; column += 1) {
-            const index = row * recipe.width + column;
-            if (recipe.depths[index] <= 0) continue;
-            const depth = 0.58 + (recipe.depths[index] / 9) * 0.78;
-            dummy.position.set(
-              (column - (recipe.width - 1) / 2) * cell,
-              ((recipe.height - 1) / 2 - row) * cell - 0.18,
-              depth / 2 - 0.58,
-            );
-            dummy.scale.set(1, 1, depth);
-            dummy.updateMatrix();
-            mesh.setMatrixAt(instance, dummy.matrix);
-            color.set(`#${recipe.colors[index]}`);
-            mesh.setColorAt(instance, color);
-            instance += 1;
-          }
+        for (let row = 0; row < recipe.height; row += 1) for (let column = 0; column < recipe.width; column += 1) {
+          const index = row * recipe.width + column;
+          if (recipe.depths[index] <= 0) continue;
+          const depth = 0.58 + recipe.depths[index] / 9 * 0.78;
+          dummy.position.set((column - (recipe.width - 1) / 2) * cell, ((recipe.height - 1) / 2 - row) * cell - 0.15, depth / 2 - 0.58);
+          dummy.scale.set(1, 1, depth);
+          dummy.updateMatrix();
+          mesh.setMatrixAt(instance, dummy.matrix);
+          color.set(`#${recipe.colors[index]}`);
+          mesh.setColorAt(instance, color);
+          instance += 1;
         }
         mesh.instanceMatrix.needsUpdate = true;
         if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
         root.add(mesh);
-
-        const baseGeometry = new THREE.CylinderGeometry(3.2, 3.45, 0.22, 32);
-        const baseMaterial = new THREE.MeshStandardMaterial({ color: 0xefe6d8, roughness: 0.94, metalness: 0 });
+        const bodyWidth = Math.max(2.2, recipe.width * cell * 0.5);
+        const baseGeometry = new THREE.CylinderGeometry(bodyWidth, bodyWidth + 0.22, 0.2, 32);
+        const baseMaterial = new THREE.MeshStandardMaterial({ color: 0xefe6d8, roughness: 0.94 });
         const base = new THREE.Mesh(baseGeometry, baseMaterial);
-        base.position.set(0, -3.42, -0.12);
+        base.position.set(0, -recipe.height * cell * 0.54, -0.12);
         scene.add(base);
-
-        const ringGeometry = new THREE.TorusGeometry(2.65, 0.055, 10, 64);
-        const ringMaterial = new THREE.MeshBasicMaterial({ color: 0xc9ff54, transparent: true, opacity: 0.88 });
-        const ring = new THREE.Mesh(ringGeometry, ringMaterial);
-        ring.rotation.x = Math.PI / 2;
-        ring.position.set(0, -3.29, -0.08);
-        scene.add(ring);
-
         const pointers = new Map();
-        let lastX = 0;
-        let lastY = 0;
-        let pinch = 0;
-        let targetX = -0.08;
-        let targetY = 0.10;
-
-        const distance = () => {
-          const pair = [...pointers.values()].slice(0, 2);
-          return pair.length === 2 ? pointerDistance(pair[0], pair[1]) : 0;
-        };
-        const updateCamera = () => {
-          camera.position.set(0, 0.15, cameraDistance);
-          camera.lookAt(0, -0.2, 0);
-        };
-        const down = (event) => {
-          pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-          renderer.domElement.setPointerCapture?.(event.pointerId);
-          lastX = event.clientX;
-          lastY = event.clientY;
-          if (pointers.size === 2) pinch = distance();
-        };
+        let lastX = 0, lastY = 0, pinch = 0, targetX = -0.07, targetY = 0.1;
+        const distance = () => { const pair = [...pointers.values()].slice(0, 2); return pair.length === 2 ? Math.hypot(pair[0].x - pair[1].x, pair[0].y - pair[1].y) : 0; };
+        const updateCamera = () => { camera.position.set(0, 0.12, cameraDistance); camera.lookAt(0, -0.15, 0); };
+        const down = (event) => { pointers.set(event.pointerId, { x: event.clientX, y: event.clientY }); renderer.domElement.setPointerCapture?.(event.pointerId); lastX = event.clientX; lastY = event.clientY; pinch = distance(); };
         const move = (event) => {
           if (!pointers.has(event.pointerId)) return;
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
-          if (pointers.size >= 2) {
-            const next = distance();
-            if (pinch) cameraDistance = Math.max(8.1, Math.min(14.2, cameraDistance - (next - pinch) * 0.012));
-            pinch = next;
-            updateCamera();
-            return;
-          }
-          const dx = event.clientX - lastX;
-          const dy = event.clientY - lastY;
-          targetY += dx * 0.0075;
-          targetX = Math.max(-0.50, Math.min(0.34, targetX + dy * 0.004));
-          lastX = event.clientX;
-          lastY = event.clientY;
+          if (pointers.size >= 2) { const next = distance(); if (pinch > 0 && next > 0) { cameraDistance = clamp(cameraDistance - (next - pinch) * 0.012, 7, 14.5); updateCamera(); } pinch = next; return; }
+          const dx = event.clientX - lastX, dy = event.clientY - lastY; lastX = event.clientX; lastY = event.clientY; targetY += dx * 0.007; targetX = clamp(targetX + dy * 0.004, -0.42, 0.35);
         };
-        const up = (event) => {
-          pointers.delete(event.pointerId);
-          renderer.domElement.releasePointerCapture?.(event.pointerId);
-          if (pointers.size < 2) pinch = 0;
-        };
-        const wheel = (event) => {
-          event.preventDefault();
-          cameraDistance = Math.max(8.1, Math.min(14.2, cameraDistance + Math.sign(event.deltaY) * 0.42));
-          updateCamera();
-        };
+        const up = (event) => { pointers.delete(event.pointerId); pinch = distance(); renderer.domElement.releasePointerCapture?.(event.pointerId); };
         renderer.domElement.addEventListener('pointerdown', down);
         renderer.domElement.addEventListener('pointermove', move);
         renderer.domElement.addEventListener('pointerup', up);
         renderer.domElement.addEventListener('pointercancel', up);
-        renderer.domElement.addEventListener('wheel', wheel, { passive: false });
-
         let frame = 0;
-        let firstFrame = true;
-        const animate = () => {
-          frame = requestAnimationFrame(animate);
-          root.rotation.x += (targetX - root.rotation.x) * 0.08;
-          root.rotation.y += (targetY - root.rotation.y) * 0.08;
-          if (!reducedMotion) ring.rotation.z += 0.0012;
-          renderer.render(scene, camera);
-          if (firstFrame) {
-            firstFrame = false;
-            renderer.domElement.style.opacity = '1';
-            setReady(true);
-            const activeCount = recipe.depths.filter((depth) => depth > 0).length;
-            const signature = `${recipe.width}x${recipe.height}:${activeCount}:${recipe.colors.slice(0, 4).join('')}`;
-            if (reportedRef.current !== signature) {
-              reportedRef.current = signature;
-              callbackRef.current?.(recipe);
-            }
-          }
-        };
+        const animate = () => { if (dead) return; root.rotation.x += (targetX - root.rotation.x) * 0.13; root.rotation.y += (targetY - root.rotation.y) * 0.13; renderer.render(scene, camera); frame = requestAnimationFrame(animate); };
         animate();
-
-        const resize = () => {
-          if (!mountRef.current) return;
-          const width = Math.max(280, mountRef.current.clientWidth || 360);
-          const height = Math.max(280, mountRef.current.clientHeight || 360);
-          renderer.setSize(width, height);
-          camera.aspect = width / height;
-          camera.updateProjectionMatrix();
-        };
-        window.addEventListener('resize', resize);
-
-        cleanup = () => {
-          cancelAnimationFrame(frame);
-          window.removeEventListener('resize', resize);
-          renderer.domElement.removeEventListener('pointerdown', down);
-          renderer.domElement.removeEventListener('pointermove', move);
-          renderer.domElement.removeEventListener('pointerup', up);
-          renderer.domElement.removeEventListener('pointercancel', up);
-          renderer.domElement.removeEventListener('wheel', wheel);
-          geometry.dispose();
-          material.dispose();
-          baseGeometry.dispose();
-          baseMaterial.dispose();
-          ringGeometry.dispose();
-          ringMaterial.dispose();
-          renderer.dispose();
-          mount.innerHTML = '';
-        };
-      }).catch(() => {
-        if (!dead) setError('Interactive 3D could not start. The VoxelPop image remains visible.');
-      });
+        requestAnimationFrame(() => { if (dead) return; renderer.domElement.style.opacity = '1'; setReady(true); callbackRef.current?.(recipe); });
+        const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => { if (!mountRef.current) return; const w = Math.max(280, mountRef.current.clientWidth || initialWidth), h = Math.max(280, mountRef.current.clientHeight || initialHeight); renderer.setSize(w, h); camera.aspect = w / h; camera.updateProjectionMatrix(); }) : null;
+        observer?.observe(mount);
+        cleanup = () => { cancelAnimationFrame(frame); observer?.disconnect(); geometry.dispose(); material.dispose(); baseGeometry.dispose(); baseMaterial.dispose(); renderer.dispose(); };
+      } catch (cause) {
+        if (!dead) { setError(String(cause?.message || cause || 'Interactive 3D could not start.')); setReady(true); callbackRef.current?.(recipe); }
+      }
     };
-    image.onerror = () => {
-      if (!dead) setError('The property photo could not be opened for local 3D.');
-    };
-
-    return () => {
-      dead = true;
-      cleanup();
-    };
+    image.onerror = () => setError('The property photo could not be opened for voxel creation.');
+    return () => { dead = true; cleanup(); };
   }, [imageUrl, sourceImageUrl]);
 
-  return <div className="localViewerShell">
-    {imageUrl ? <img className={`localPoster ${ready ? 'hidden' : ''}`} src={imageUrl} alt="VoxelPop rendered building preview"/> : null}
-    <div ref={mountRef} className="localCanvas" aria-label="Interactive photo-matched VoxelPop building"/>
-    {!ready && !error ? <div className="stage">MATCHING BUILDING · LOCAL 3D</div> : null}
-    {error ? <div className="softError">{error}</div> : null}
-    <div className="hint">{ready ? 'DRAG BUILDING · PINCH TO ZOOM' : 'PHOTO → BUILDING-SHAPED VOXEL'}</div>
-    <style jsx>{`
-      .localViewerShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:radial-gradient(circle at 50% 34%,#4a3561 0,#25182f 55%,#17101c 100%)}
-      .localPoster,.localCanvas{position:absolute;inset:0;width:100%;height:100%}.localPoster{z-index:1;object-fit:cover;opacity:1;transition:opacity .36s ease}.localPoster.hidden{opacity:0;pointer-events:none}.localCanvas{z-index:2}
-      .stage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.8);backdrop-filter:blur(10px);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.12em}
-      .softError{position:absolute;z-index:5;left:12px;right:12px;bottom:36px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.86);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
-      .hint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#e6deeb;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.12em;pointer-events:none;text-shadow:0 1px 6px #000}
-    `}</style>
+  return <div className="viewerShell">
+    <div ref={mountRef} className="viewerMount" aria-label="Interactive VoxelPop 3D model"/>
+    {showSource && (sourceImageUrl || imageUrl) ? <div className="sourceOverlay"><img src={sourceImageUrl || imageUrl} alt="Original property source"/></div> : null}
+    <div className="viewerTools"><button type="button" className={!showSource ? 'active' : ''} onClick={() => setShowSource(false)}>VOXEL</button><button type="button" className={showSource ? 'active' : ''} onClick={() => setShowSource(true)}>SOURCE</button></div>
+    <div className="viewerHelp"><b>{ready ? 'DRAG BUILDING · PINCH TO ZOOM' : 'BUILDING VOXEL…'}</b><span>{error || 'Compare VOXEL with SOURCE. The original house framing is preserved instead of square-cropped.'}</span></div>
+    <style jsx>{`.viewerShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:#21172c}.viewerMount{position:absolute;inset:0}.sourceOverlay{position:absolute;inset:0;z-index:2;background:#17111d}.sourceOverlay img{width:100%;height:100%;object-fit:contain;display:block}.viewerTools{position:absolute;z-index:4;top:14px;right:14px;display:flex;gap:6px;padding:5px;border-radius:999px;background:rgba(18,12,23,.72)}.viewerTools button{min-height:36px;border:0;border-radius:999px;padding:0 11px;background:transparent;color:#d8cedf;font:900 8px inherit}.viewerTools button.active{background:#c9ff54;color:#2d3b15}.viewerHelp{position:absolute;z-index:4;left:14px;right:14px;bottom:14px;padding:10px 12px;border-radius:16px;background:rgba(20,13,26,.72);color:#fff;display:grid;gap:2px;text-align:left;pointer-events:none}.viewerHelp b{font-size:9px;letter-spacing:.09em}.viewerHelp span{font-size:9px;color:#ddd2e5}`}</style>
   </div>;
 }

--- a/app/property/PropertyJourneyExact.js
+++ b/app/property/PropertyJourneyExact.js
@@ -137,36 +137,24 @@ async function createVoxelPoster(file) {
       image.onload = resolve;
       image.onerror = () => reject(new Error('The photo could not be opened for the voxel pass.'));
     });
-    const sampleSize = 72;
+    const aspect = Math.max(0.5, Math.min(2, (image.naturalWidth || 1) / (image.naturalHeight || 1)));
+    const sampleWidth = aspect >= 1 ? 96 : Math.max(54, Math.round(96 * aspect));
+    const sampleHeight = aspect >= 1 ? Math.max(54, Math.round(96 / aspect)) : 96;
     const sample = document.createElement('canvas');
-    sample.width = sampleSize;
-    sample.height = sampleSize;
+    sample.width = sampleWidth;
+    sample.height = sampleHeight;
     const sampleContext = sample.getContext('2d');
     if (!sampleContext) throw new Error('Voxel image processing is unavailable.');
-    const sourceRatio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
-    let sx = 0;
-    let sy = 0;
-    let sw = image.naturalWidth || 1;
-    let sh = image.naturalHeight || 1;
-    if (sourceRatio > 1) { sw = sh; sx = ((image.naturalWidth || 1) - sw) / 2; }
-    else if (sourceRatio < 1) { sh = sw; sy = ((image.naturalHeight || 1) - sh) / 2; }
-    sampleContext.filter = 'saturate(1.06) contrast(1.05)';
-    sampleContext.drawImage(image, sx, sy, sw, sh, 0, 0, sampleSize, sampleSize);
+    sampleContext.filter = 'saturate(1.05) contrast(1.04)';
+    sampleContext.drawImage(image, 0, 0, sampleWidth, sampleHeight);
+    const scale = 9;
     const output = document.createElement('canvas');
-    output.width = 864;
-    output.height = 864;
+    output.width = sampleWidth * scale;
+    output.height = sampleHeight * scale;
     const context = output.getContext('2d');
     if (!context) throw new Error('Voxel image processing is unavailable.');
     context.imageSmoothingEnabled = false;
-    context.fillStyle = '#ede7df';
-    context.fillRect(0, 0, output.width, output.height);
     context.drawImage(sample, 0, 0, output.width, output.height);
-    const shade = context.createLinearGradient(0, 0, output.width, output.height);
-    shade.addColorStop(0, 'rgba(255,255,255,.08)');
-    shade.addColorStop(0.62, 'rgba(255,255,255,0)');
-    shade.addColorStop(1, 'rgba(38,18,52,.12)');
-    context.fillStyle = shade;
-    context.fillRect(0, 0, output.width, output.height);
     return output.toDataURL('image/jpeg', 0.92);
   } finally {
     URL.revokeObjectURL(url);
@@ -275,7 +263,7 @@ export default function PropertyJourneyExact() {
         return URL.createObjectURL(photo);
       });
       setPendingPhoto(photo);
-      setRightsConfirmed(false);
+      setRightsConfirmed(Boolean(paidSessionId));
       setPreviewReady(false);
       setPreviewApproved(false);
       setVoxelPoster('');
@@ -300,9 +288,7 @@ export default function PropertyJourneyExact() {
     form.append('generationSessionId', generationSessionId);
     const response = await fetch('/api/property-photo-upload', { method: 'POST', headers: authHeaders(), body: form });
     const data = await response.json().catch(() => ({}));
-    if (!response.ok || !data?.ok || data?.paid !== true || !data?.draftId) {
-      throw new Error(data?.error || 'Your paid VoxelPop creation could not be verified.');
-    }
+    if (!response.ok || !data?.ok || data?.paid !== true || !data?.draftId) throw new Error(data?.error || 'Your paid VoxelPop creation could not be verified.');
     return data;
   }
 
@@ -317,18 +303,16 @@ export default function PropertyJourneyExact() {
       checkoutHandledRef.current = key;
       setBusy('');
       setDraftId(canceledDraftId);
-      setMessage('Checkout canceled. Nothing was created or charged. Your photo is still on this device.');
+      setMessage('Checkout canceled. Nothing was created or charged.');
       window.history.replaceState({}, '', '/property');
       return undefined;
     }
-
     const generationSessionId = clean(params.get('generation_session'));
     if (!generationSessionId || checkoutHandledRef.current === generationSessionId) return undefined;
     checkoutHandledRef.current = generationSessionId;
     let active = true;
     setBusy('payment-return');
-    setMessage('Payment received. Opening your private photo for the 3D preview…');
-
+    setMessage('Payment received. Opening your 3D preview…');
     (async () => {
       try {
         const data = await verifyPaidSession(generationSessionId);
@@ -339,7 +323,8 @@ export default function PropertyJourneyExact() {
         if (!active) return;
         if (!photo) {
           setBusy('');
-          setMessage('Payment is verified. Choose the same property photo again. You will not be charged again.');
+          setMessage('Payment is verified. Choose the same property photo again to open the 3D preview. You will not be charged again.');
+          window.history.replaceState({}, '', '/property');
           return;
         }
         setPendingPhoto(photo);
@@ -352,6 +337,7 @@ export default function PropertyJourneyExact() {
         setPreviewApproved(false);
         setMessage('Payment verified. Loading the recognizable 3D photo preview first.');
         setBusy('');
+        window.history.replaceState({}, '', '/property');
       } catch (error) {
         if (active) {
           checkoutHandledRef.current = '';
@@ -360,7 +346,6 @@ export default function PropertyJourneyExact() {
         }
       }
     })();
-
     return () => { active = false; };
   }, [session?.access_token]);
 
@@ -368,8 +353,14 @@ export default function PropertyJourneyExact() {
     if (!pendingPhoto || !session?.access_token || !draftId) return;
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
     setBusy('generation-checkout');
+    let cachedOnDevice = false;
     try {
-      await saveDevicePhoto(draftId, pendingPhoto);
+      try {
+        await saveDevicePhoto(draftId, pendingPhoto);
+        cachedOnDevice = true;
+      } catch {
+        cachedOnDevice = false;
+      }
       if (paidSessionId) {
         setPreviewReady(false);
         setPreviewApproved(false);
@@ -377,7 +368,9 @@ export default function PropertyJourneyExact() {
         setBusy('');
         return;
       }
-      setMessage(`Opening secure ${CREATION_PRICE_LABEL} checkout. After payment, you will see the 3D preview before any voxel is built.`);
+      setMessage(cachedOnDevice
+        ? `Opening secure ${CREATION_PRICE_LABEL} checkout. After payment, you will see the 3D preview before any voxel is built.`
+        : `Opening secure ${CREATION_PRICE_LABEL} checkout. Your browser could not keep the photo through checkout, so after payment you may need to choose the same photo once. You will not be charged again.`);
       const form = new FormData();
       form.append('draftId', draftId);
       form.append('rightsConfirmed', 'true');
@@ -401,7 +394,7 @@ export default function PropertyJourneyExact() {
       setVoxelPoster(poster);
       setFinal3d({ status: 'IN_PROGRESS', progress: 55, modelUrl: null, taskId: null });
       setBusy('voxel-3d');
-      setMessage('VOXEL · Building the movable block model from the same house photo.');
+      setMessage('VOXEL · Building the movable block model from the same house photo without square-cropping it.');
     } catch (error) {
       setPreviewApproved(false);
       setBusy('');
@@ -424,7 +417,7 @@ export default function PropertyJourneyExact() {
       const data = await response.json().catch(() => ({}));
       if (!response.ok || !data?.ok || !data?.taskId || !data?.modelUrl) throw new Error(data?.error || 'The local voxel could not be linked to your account.');
       setFinal3d({ status: 'SUCCEEDED', progress: 100, modelUrl: data.modelUrl, taskId: data.taskId });
-      setMessage('Voxel 3D ready. You can mint this digital voxel now, or add its real address to My World.');
+      setMessage('Voxel 3D ready. Compare VOXEL with SOURCE, then mint the finished digital voxel when you are happy with it.');
     } catch (error) {
       setFinal3d({ status: 'LOCAL_ONLY', progress: 100, modelUrl: null, taskId: null });
       setMessage(`${String(error?.message || error || 'The voxel is visible on this device, but account registration failed.')} Retry registration before minting.`);
@@ -573,7 +566,7 @@ export default function PropertyJourneyExact() {
       {stage === 1 ? <>
         <p className={styles.bigPrompt}>Choose a clear house photo.</p>
         <p className={styles.flowHint}>Photo → $4.99 → recognizable 3D preview → approve → voxel 3D → optional mint.</p>
-        <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0}><div>+</div><b>Choose a property photo</b><span>Front or three-quarter view works best · iPhone photos supported</span></div>
+        <div className={styles.photoDrop} onClick={choosePhoto} role="button" tabIndex={0} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') choosePhoto(); }}><div>+</div><b>Choose a property photo</b><span>Front or three-quarter view works best · iPhone photos supported</span></div>
         <button className={styles.primaryPurple} type="button" onClick={choosePhoto} disabled={busy === 'prepare'}>{busy === 'prepare' ? 'Preparing photo…' : 'Choose photo'}</button>
         <p className={styles.truth}>The first 3D preview uses your actual photo so it stays recognizable. It is a front-view visual preview, not a claim that unseen sides are reconstructed exactly.</p>
       </> : null}
@@ -592,7 +585,7 @@ export default function PropertyJourneyExact() {
 
       {stage === 3 ? <>
         <p className={styles.bigPrompt}>This is the 3D picture first.</p>
-        <p className={styles.stepCopy}>It uses the real photo as the textured front surface, so windows, doors, siding, roofline, and visible details stay tied to what you actually uploaded. Drag gently to see the 3D relief.</p>
+        <p className={styles.stepCopy}>It uses the real photo as the textured front surface, so windows, doors, siding, roofline, and visible details stay tied to what you uploaded. Drag gently to see the 3D relief.</p>
         {!pendingPreview ? <section className={styles.donePanel}><b>PAYMENT VERIFIED</b><span>Choose the same photo again. You will not be charged again.</span><button className={styles.primaryPurple} type="button" onClick={choosePhoto}>Choose photo again</button></section> : <>
           <div className={styles.heroCard}>
             <PhotoReliefModelViewer imageUrl={pendingPreview} onReady={() => setPreviewReady(true)}/>
@@ -610,7 +603,7 @@ export default function PropertyJourneyExact() {
 
       {stage === 4 ? <>
         <p className={styles.bigPrompt}>Now build the 3D voxel.</p>
-        <p className={styles.stepCopy}>This is a separate conversion step. The voxel renderer samples the same approved house photo instead of inventing a random generic building.</p>
+        <p className={styles.stepCopy}>This is a separate conversion step. The voxel uses the same approved photo at its original framing, and you can switch between VOXEL and SOURCE to check the match.</p>
         <div className={styles.heroCard}>
           <LocalVoxelModelViewer imageUrl={voxelPoster || pendingPreview} sourceImageUrl={pendingPreview || voxelPoster} onReady={handleLocal3DReady}/>
           <span className={styles.badge}>{final3d.status === 'LOCAL_ONLY' ? 'VOXEL VISIBLE · REGISTRATION NEEDS RETRY' : 'BUILDING PHOTO-MATCHED 3D VOXEL'}</span>
@@ -621,7 +614,7 @@ export default function PropertyJourneyExact() {
 
       {stage === 5 ? <>
         <p className={styles.bigPrompt}>Voxel ready. Mint is next.</p>
-        <p className={styles.stepCopy}>You have already seen the photo-faithful 3D preview and then created the voxel version. Minting is now a separate wallet action for the finished digital voxel.</p>
+        <p className={styles.stepCopy}>You saw the source-faithful 3D preview first, approved it, and then created the separate voxel. Compare VOXEL / SOURCE one last time before minting.</p>
         <div className={styles.heroCard}>
           <LocalVoxelModelViewer imageUrl={voxelPoster || pendingPreview} sourceImageUrl={pendingPreview || voxelPoster}/>
           <span className={styles.badge}>FINAL 3D VOXEL · READY TO MINT</span>
@@ -630,7 +623,6 @@ export default function PropertyJourneyExact() {
           <a className={styles.primaryLink} href={mintHref}>Mint this digital voxel →</a>
           <span style={{fontSize:11,color:'#7b7068',lineHeight:1.5}}>Your wallet opens only now. You approve the Base transaction yourself; Voxel Vault does not auto-sign or auto-spend.</span>
         </div>
-
         <form className={styles.searchForm} onSubmit={mapBuilding}>
           <input value={address} onChange={(event) => setAddress(event.target.value)} placeholder="Optional: property address for My World" aria-label="Property address" autoComplete="street-address"/>
           <button disabled={busy === 'map' || !clean(address)}>{busy === 'map' ? 'Matching building…' : 'Also match this voxel to the real map'}</button>

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -12,19 +12,22 @@ const map = read('app/property/PropertyWorldMap.js');
 const mintPrepare = read('app/api/property-voxel-nft/prepare/route.ts');
 
 assert.match(property, /async function payAndCreate\(\)/, 'photo approval owns the paid creation handoff');
-assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'approved photo is retained on-device before checkout');
+assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'approved photo is retained on-device before checkout when browser storage works');
+assert.match(property, /let cachedOnDevice = false/, 'private browser photo caching is best-effort instead of a checkout blocker');
+assert.match(property, /browser could not keep the photo through checkout/i, 'checkout explains the no-cache recovery path without charging twice');
 assert.match(property, /setMessage\('Payment verified\. Loading the recognizable 3D photo preview first\.'/,
-  'a verified paid session stops at the recognizable 3D preview');
+  'a verified paid session stops at the recognizable 3D photo preview');
 assert.match(property, /PhotoReliefModelViewer/, 'source-faithful 3D preview is a distinct stage');
 assert.match(photoPreview, /CanvasTexture/, 'the actual uploaded photo remains the visible material in the first 3D stage');
 assert.match(photoPreview, /PlaneGeometry/, 'the first stage is interactive Three.js geometry');
 assert.match(property, /Looks right → Build the 3D Voxel/, 'user approval is required before voxel generation');
 assert.match(property, /async function approvePreviewAndBuildVoxel\(\)/, 'voxel generation has an explicit post-preview gate');
 assert.match(property, /const poster = await createVoxelPoster\(pendingPhoto\)/, 'voxel image is not created until after preview approval');
+assert.match(property, /const sampleWidth = aspect >= 1/, 'voxel poster preserves the source photo aspect instead of square-cropping a house');
 assert.match(property, /LocalVoxelModelViewer imageUrl=\{voxelPoster \|\| pendingPreview\} sourceImageUrl=\{pendingPreview \|\| voxelPoster\}/,
   'the voxel stage uses the approved original photo for building matching');
 assert.match(property, /\/api\/property-local-voxel/, 'finished local voxel is registered for continuity and minting');
-assert.match(property, /Voxel 3D ready\. You can mint this digital voxel now/, 'successful voxel creation exposes mint as the next digital action');
+assert.match(property, /Compare VOXEL with SOURCE/, 'successful voxel creation asks for a final direct visual comparison');
 assert.match(property, /\/property\/mint\?draftId=/, 'mint route is built from the finished local task');
 assert.match(property, /async function mapBuilding\(event\)/, 'address/map remains available after voxel creation');
 assert.match(property, /async function saveToMyWorld\(\)/, 'mapped voxel can still save to My World');
@@ -32,12 +35,15 @@ assert.match(property, /Save to My World/, 'map save action remains visible');
 assert.match(property, /View My World/, 'saved mapped voxel retains a World destination');
 
 assert.match(viewer, /sampleRecipe/, 'interactive local voxel is derived from the property photo');
+assert.match(viewer, /gridForImage/, 'voxel recipe follows the original wide or tall property framing');
 assert.match(viewer, /rgbDistance/, 'voxel viewer estimates background separately from the building');
 assert.match(viewer, /rawMask/, 'voxel viewer computes a building foreground mask');
 assert.match(viewer, /if \(!mask\[index\]\) return 0/, 'sky and ground can become empty voxel cells');
 assert.match(viewer, /InstancedMesh/, 'voxel 3D uses actual Three.js voxel instances');
 assert.match(viewer, /callbackRef\.current\?\.\(recipe\)/, 'server registration starts only after a real local voxel render');
 assert.match(viewer, /DRAG BUILDING · PINCH TO ZOOM/, 'local voxel remains interactive on iPhone');
+assert.match(viewer, />SOURCE<\//, 'final voxel has an original-source comparison control');
+assert.match(viewer, /object-fit:contain/, 'source comparison preserves the complete property photo framing');
 assert.doesNotMatch(viewer, /backingGeometry/, 'voxel viewer must not restore the old square picture-wall backing');
 
 assert.match(checkout, /generation_engine: PROPERTY_VOXEL_GENERATION_ENGINE/, 'checkout explicitly selects the local generation engine');
@@ -60,4 +66,4 @@ assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint 
 assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal paid creation flow does not lead into another paid collectible funnel');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided property flow does not call metered provider generation routes');
 
-console.log('Property journey regression passed: authorized photo -> one paid unlock -> source-faithful 3D preview -> user approval -> local 3D voxel -> optional Base mint, with map/World still available and no Meshy credits or second paywall.');
+console.log('Property journey regression passed: authorized photo -> one paid unlock -> source-faithful 3D preview -> user approval -> aspect-preserved local 3D voxel -> source comparison -> optional Base mint, with map/World still available and no Meshy credits or second paywall.');


### PR DESCRIPTION
Closed because main advanced with PR #452 while this branch was being prepared. #452 already preserves the uploaded house aspect ratio and removes the generic-house fallback. I am replacing this conflict-heavy branch with a fresh minimal patch for the remaining checkout-cache blocker only, so the newer property/reuse work on main is not overwritten.