### PR TITLE
Increase real-house fidelity without inventing geometry

### DIFF
--- a/app/api/property-local-voxel/route.ts
+++ b/app/api/property-local-voxel/route.ts
@@ -10,7 +10,7 @@ export const dynamic = 'force-dynamic';
 
 const PROVIDER = 'voxelpop-local-webgl-v1';
 const RECIPE_PREFIX = 'local-voxel-recipe-v1:';
-const MAX_SIDE = 24;
+const MAX_SIDE = 32;
 const MIN_SIDE = 8;
 
 function clean(value: unknown, max = 500) {
@@ -53,7 +53,7 @@ function encodeRecipe(recipe: LocalVoxelRecipe) {
 }
 
 function decodeRecipe(value: unknown) {
-  const text = clean(value, 12000);
+  const text = clean(value, 40000);
   if (!text.startsWith(RECIPE_PREFIX)) throw new Error('This is not a local VoxelPop model.');
   const encoded = text.slice(RECIPE_PREFIX.length);
   const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
@@ -74,8 +74,8 @@ function buildGltf(recipe: LocalVoxelRecipe) {
   const indices: number[] = [];
   const width = recipe.width;
   const height = recipe.height;
-  const cell = 0.285;
-  const half = cell * 0.45;
+  const cell = 7.0 / Math.max(width, height);
+  const half = cell * 0.455;
   const faceIndices = [
     0, 2, 1, 0, 3, 2,
     4, 5, 6, 4, 6, 7,
@@ -92,13 +92,13 @@ function buildGltf(recipe: LocalVoxelRecipe) {
       if (recipe.depths[index] <= 0) continue;
       const [red, green, blue] = hexRgb(recipe.colors[index]);
       const depthUnit = recipe.depths[index] / 9;
-      const depth = 0.58 + depthUnit * 0.78;
+      const depth = 0.48 + depthUnit * 0.76;
       const hx = half;
       const hy = half;
       const hz = depth / 2;
       const x = (column - (width - 1) / 2) * cell;
-      const y = ((height - 1) / 2 - row) * cell - 0.18;
-      const z = hz - 0.58;
+      const y = ((height - 1) / 2 - row) * cell - 0.12;
+      const z = hz - 0.52;
       positions.push(
         x - hx, y - hy, z - hz,
         x + hx, y - hy, z - hz,
@@ -141,12 +141,12 @@ function buildGltf(recipe: LocalVoxelRecipe) {
   const maxRow = Math.max(...activeRows);
   const xMin = (minColumn - (width - 1) / 2) * cell - half;
   const xMax = (maxColumn - (width - 1) / 2) * cell + half;
-  const yMax = ((height - 1) / 2 - minRow) * cell - 0.18 + half;
-  const yMin = ((height - 1) / 2 - maxRow) * cell - 0.18 - half;
+  const yMax = ((height - 1) / 2 - minRow) * cell - 0.12 + half;
+  const yMin = ((height - 1) / 2 - maxRow) * cell - 0.12 - half;
   const uri = `data:application/octet-stream;base64,${binary.toString('base64')}`;
 
   return {
-    asset: { version: '2.0', generator: 'VoxelPop Local WebGL silhouette v1' },
+    asset: { version: '2.0', generator: 'VoxelPop Local WebGL proportion-preserving silhouette v2' },
     extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
     scenes: [{ nodes: [0] }],
@@ -171,8 +171,8 @@ function buildGltf(recipe: LocalVoxelRecipe) {
         componentType: 5126,
         count: positionArray.length / 3,
         type: 'VEC3',
-        min: [xMin, yMin, -0.58],
-        max: [xMax, yMax, 0.78],
+        min: [xMin, yMin, -0.52],
+        max: [xMax, yMax, 0.72],
       },
       { bufferView: 1, byteOffset: 0, componentType: 5121, normalized: true, count: colorArray.length / 3, type: 'VEC3' },
       { bufferView: 2, byteOffset: 0, componentType: 5123, count: indexArray.length, type: 'SCALAR' },
@@ -190,7 +190,7 @@ export async function POST(request: Request) {
     const recipe = normalizeRecipe(body?.recipe);
     const encodedRecipe = encodeRecipe(recipe);
     const digest = createHash('sha256')
-      .update(`voxelpop-local-v1:${auth.user.id}:${draftId}:${encodedRecipe}`)
+      .update(`voxelpop-local-v2:${auth.user.id}:${draftId}:${encodedRecipe}`)
       .digest('hex');
     const taskId = `local-v1:${digest.slice(0, 48)}`;
     const itemId = propertyDraftItemId(auth.user.id, draftId, 'voxel');
@@ -218,8 +218,8 @@ export async function POST(request: Request) {
       persisted: Boolean(saved?.task_id),
       collectionReady: Boolean(saved?.task_id && saved?.model_url),
       note: saved?.task_id
-        ? 'The compact silhouette-aware voxel recipe is account-bound in the catalog. The original source photo was not uploaded for generation.'
-        : 'The local 3D preview is ready on this device, but durable catalog persistence is unavailable. The user can still continue to map and save locally.',
+        ? 'The proportion-preserving silhouette-aware voxel recipe is account-bound in the catalog. The original source photo was not uploaded for generation.'
+        : 'The local voxel is visible on this device, but durable catalog persistence is unavailable. Retry registration before minting.',
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'Local VoxelPop model could not be registered.' }, { status: 400 });

--- a/app/api/property-voxel-nft/metadata/route.ts
+++ b/app/api/property-voxel-nft/metadata/route.ts
@@ -8,6 +8,7 @@ export const dynamic = 'force-dynamic';
 
 const PROVIDER = 'voxelpop-local-webgl-v1';
 const RECIPE_PREFIX = 'local-voxel-recipe-v1:';
+const MAX_SIDE = 32;
 
 function clean(value: unknown, max = 300) {
   return String(value || '').trim().slice(0, max);
@@ -21,7 +22,7 @@ function escapeXml(value: unknown) {
     .replaceAll("'", '&apos;');
 }
 function decodeRecipe(value: unknown) {
-  const text = clean(value, 12000);
+  const text = clean(value, 40000);
   if (!text.startsWith(RECIPE_PREFIX)) throw new Error('Local voxel recipe is unavailable.');
   const parsed = JSON.parse(Buffer.from(text.slice(RECIPE_PREFIX.length), 'base64url').toString('utf8'));
   const width = Math.trunc(Number(parsed?.width));
@@ -29,16 +30,20 @@ function decodeRecipe(value: unknown) {
   const count = width * height;
   const colors = Array.isArray(parsed?.colors) ? parsed.colors.slice(0, count).map((item: unknown) => clean(item, 6).toLowerCase()) : [];
   const depths = Array.isArray(parsed?.depths) ? parsed.depths.slice(0, count).map((item: unknown) => Math.max(0, Math.min(9, Math.trunc(Number(item) || 0)))) : [];
-  if (Number(parsed?.version) !== 1 || width < 8 || height < 8 || width > 24 || height > 24 || colors.length !== count || depths.length !== count) throw new Error('Local voxel recipe is invalid.');
+  if (Number(parsed?.version) !== 1 || width < 8 || height < 8 || width > MAX_SIDE || height > MAX_SIDE || colors.length !== count || depths.length !== count) throw new Error('Local voxel recipe is invalid.');
   if (colors.some((value: string) => !/^[a-f0-9]{6}$/.test(value))) throw new Error('Local voxel colors are invalid.');
   return { width, height, colors, depths };
 }
 function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
-  const cell = 34;
+  // Fit both wide and tall property voxels into the NFT card without forcing
+  // them back into a square model or overlapping the labels.
+  const maxArtWidth = 1040;
+  const maxArtHeight = 760;
+  const cell = Math.max(12, Math.floor(Math.min(maxArtWidth / recipe.width, maxArtHeight / recipe.height)));
   const artWidth = recipe.width * cell;
   const artHeight = recipe.height * cell;
   const offsetX = Math.round((1200 - artWidth) / 2);
-  const offsetY = 170 + Math.round((760 - artHeight) / 2);
+  const offsetY = 150 + Math.round((800 - artHeight) / 2);
   const blocks: string[] = [];
   for (let row = 0; row < recipe.height; row += 1) {
     for (let column = 0; column < recipe.width; column += 1) {
@@ -47,8 +52,8 @@ function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
       if (depth <= 0) continue;
       const x = offsetX + column * cell;
       const y = offsetY + row * cell;
-      const lift = Math.round(depth * 1.4);
-      blocks.push(`<rect x="${x}" y="${y - lift}" width="${cell - 2}" height="${cell - 2 + lift}" rx="3" fill="#${recipe.colors[index]}"/>`);
+      const lift = Math.max(1, Math.round(depth * Math.max(0.7, cell / 24)));
+      blocks.push(`<rect x="${x}" y="${y - lift}" width="${Math.max(2, cell - 2)}" height="${Math.max(2, cell - 2 + lift)}" rx="${Math.max(1, Math.round(cell * 0.09))}" fill="#${recipe.colors[index]}"/>`);
     }
   }
   return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200">
@@ -58,7 +63,7 @@ function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
     <g>${blocks.join('')}</g>
     <text x="70" y="86" fill="#c9ff54" font-family="Arial,sans-serif" font-size="25" font-weight="800" letter-spacing="6">VOXELPOP · PROPERTY VOXEL</text>
     <text x="70" y="1060" fill="#ffffff" font-family="Arial,sans-serif" font-size="62" font-weight="800">${escapeXml(name)}</text>
-    <text x="70" y="1115" fill="#cfc4dc" font-family="Arial,sans-serif" font-size="23">PHOTO-APPROVED 3D → LOCAL VOXEL → DIGITAL NFT</text>
+    <text x="70" y="1115" fill="#cfc4dc" font-family="Arial,sans-serif" font-size="23">PHOTO-APPROVED 3D → PROPORTION-PRESERVING VOXEL → DIGITAL NFT</text>
     <text x="70" y="1150" fill="#9286a0" font-family="Arial,sans-serif" font-size="18">DIGITAL COLLECTIBLE ONLY · NOT A DEED OR PHYSICAL-PROPERTY RIGHT</text>
   </svg>`;
 }
@@ -83,7 +88,7 @@ export async function GET(request: Request) {
     const animationUrl = `${url.origin}/api/property-local-voxel?taskId=${encodeURIComponent(taskId)}`;
     return NextResponse.json({
       name: `${name} · VoxelPop`,
-      description: 'A photo-approved VoxelPop digital property voxel. The user saw the source-faithful 3D preview before creating this local voxel. This NFT is a digital collectible only and does not convey deed/title, occupancy, rent, investment, appraisal, or other rights in physical real estate.',
+      description: 'A photo-approved VoxelPop digital property voxel. The user saw the source-faithful 3D preview before creating this proportion-preserving local voxel. This NFT is a digital collectible only and does not convey deed/title, occupancy, rent, investment, appraisal, or other rights in physical real estate.',
       image,
       animation_url: animationUrl,
       external_url: `${url.origin}/property`,
@@ -91,6 +96,7 @@ export async function GET(request: Request) {
         { trait_type: 'Asset Type', value: 'VoxelPop Property Voxel' },
         { trait_type: 'Creation Flow', value: 'Photo → 3D Preview → Voxel' },
         { trait_type: '3D Engine', value: 'VoxelPop Local WebGL' },
+        { trait_type: 'House Proportions', value: 'Source aspect preserved' },
         { trait_type: 'Meshy Credits', value: 'Not used' },
         { trait_type: 'Source Preview Approved', value: 'Yes' },
         { trait_type: 'Real Property Rights', value: 'None' },
@@ -101,6 +107,7 @@ export async function GET(request: Request) {
         digital_only: true,
         photo_source_stored_in_metadata: false,
         source_photo_uploaded_for_generation: false,
+        source_aspect_preserved: true,
         real_property_rights: false,
         deed_or_title: false,
       },

--- a/app/property/LocalVoxelModelViewer.js
+++ b/app/property/LocalVoxelModelViewer.js
@@ -2,7 +2,10 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+// Keep the prior 24-cell baseline visible for regression context, but use a
+// 32-cell long side for the current proportion-preserving renderer.
 const GRID = 24;
+const MAX_GRID = GRID + 8;
 const MIN_GRID = 12;
 
 function clamp(value, min = 0, max = 1) {
@@ -10,7 +13,7 @@ function clamp(value, min = 0, max = 1) {
 }
 
 function quantize(value) {
-  return Math.max(0, Math.min(255, Math.round(Number(value || 0) / 18) * 18));
+  return Math.max(0, Math.min(255, Math.round(Number(value || 0) / 16) * 16));
 }
 
 function toHex(value) {
@@ -35,11 +38,11 @@ function averageRgb(pixels) {
 }
 
 function recipeDimensions(image) {
-  const width = Math.max(1, image.naturalWidth || 1);
-  const height = Math.max(1, image.naturalHeight || 1);
-  const ratio = clamp(width / height, 0.5, 2);
-  if (ratio >= 1) return { width: GRID, height: Math.max(MIN_GRID, Math.round(GRID / ratio)) };
-  return { width: Math.max(MIN_GRID, Math.round(GRID * ratio)), height: GRID };
+  const sourceWidth = Math.max(1, image.naturalWidth || 1);
+  const sourceHeight = Math.max(1, image.naturalHeight || 1);
+  const ratio = clamp(sourceWidth / sourceHeight, MIN_GRID / MAX_GRID, MAX_GRID / MIN_GRID);
+  if (ratio >= 1) return { width: MAX_GRID, height: Math.max(MIN_GRID, Math.round(MAX_GRID / ratio)) };
+  return { width: Math.max(MIN_GRID, Math.round(MAX_GRID * ratio)), height: MAX_GRID };
 }
 
 function centeredMass(rawMask, width, height) {
@@ -74,8 +77,8 @@ function sampleRecipe(image) {
   const context = canvas.getContext('2d', { willReadFrequently: true });
   if (!context) throw new Error('Local voxel sampling is unavailable in this browser.');
 
-  // Preserve the entire uploaded photo instead of center-cropping it into a square.
-  // That keeps the visible roofline, facade width and house proportions tied to the source.
+  // Preserve the complete uploaded frame. Wide houses stay wide; portrait photos
+  // stay portrait. The renderer never center-crops the building into a square.
   context.filter = 'saturate(1.04) contrast(1.05)';
   context.drawImage(image, 0, 0, image.naturalWidth || 1, image.naturalHeight || 1, 0, 0, width, height);
   const data = context.getImageData(0, 0, width, height).data;
@@ -97,14 +100,15 @@ function sampleRecipe(image) {
   const groundSamples = [];
   const topRows = Math.max(2, Math.round(height * 0.16));
   const bottomRows = Math.max(2, Math.round(height * 0.14));
+  const edgeColumns = Math.max(2, Math.round(width * 0.07));
   for (let row = 0; row < topRows; row += 1) {
     for (let column = 0; column < width; column += 1) {
-      if (row < 2 || column < 2 || column > width - 3) skySamples.push(rgb[row * width + column]);
+      if (row < 2 || column < edgeColumns || column >= width - edgeColumns) skySamples.push(rgb[row * width + column]);
     }
   }
   for (let row = height - bottomRows; row < height; row += 1) {
     for (let column = 0; column < width; column += 1) {
-      if (row > height - 3 || column < 3 || column > width - 4) groundSamples.push(rgb[row * width + column]);
+      if (row > height - 3 || column < edgeColumns + 1 || column >= width - edgeColumns - 1) groundSamples.push(rgb[row * width + column]);
     }
   }
   const sky = averageRgb(skySamples);
@@ -117,7 +121,7 @@ function sampleRecipe(image) {
     const right = luminance[row * width + Math.min(width - 1, column + 1)] ?? value;
     const up = luminance[Math.max(0, row - 1) * width + column] ?? value;
     const down = luminance[Math.min(height - 1, row + 1) * width + column] ?? value;
-    return clamp(Math.abs(left - right) * 1.7 + Math.abs(up - down) * 1.7);
+    return clamp(Math.abs(left - right) * 1.72 + Math.abs(up - down) * 1.72);
   });
 
   const rawMask = new Array(width * height).fill(false);
@@ -130,21 +134,21 @@ function sampleRecipe(image) {
       const skyDistance = rgbDistance(rgb[index], sky);
       const groundDistance = rgbDistance(rgb[index], ground);
       const edge = edgeStrength[index];
-      const outsideSide = x < 0.035 || x > 0.965;
-      const obviousSky = y < 0.42 && skyDistance < (0.105 + edge * 0.10);
-      const obviousGround = y > 0.79 && groundDistance < (0.095 + edge * 0.11);
-      const structuralEvidence = skyDistance * 0.44 + groundDistance * 0.12 + edge * 0.34 + center * 0.10;
-      const centralFacade = y > 0.22 && y < 0.88 && center > 0.18 && skyDistance > 0.07;
-      rawMask[index] = !outsideSide && !obviousSky && !obviousGround && y > 0.045 && y < 0.965 && (structuralEvidence > 0.225 || centralFacade);
+      const outsideSide = x < 0.03 || x > 0.97;
+      const obviousSky = y < 0.42 && skyDistance < (0.102 + edge * 0.10);
+      const obviousGround = y > 0.80 && groundDistance < (0.092 + edge * 0.11);
+      const structuralEvidence = skyDistance * 0.44 + groundDistance * 0.12 + edge * 0.35 + center * 0.09;
+      const centralFacade = y > 0.21 && y < 0.89 && center > 0.15 && skyDistance > 0.065;
+      rawMask[index] = !outsideSide && !obviousSky && !obviousGround && y > 0.04 && y < 0.97 && (structuralEvidence > 0.218 || centralFacade);
     }
   }
 
   let mask = centeredMass(rawMask, width, height);
   let activeCount = mask.filter(Boolean).length;
 
-  // Difficult lighting can make a real facade resemble the sampled sky. Relax only
-  // toward evidence that is still present in the user's actual photo. Never substitute
-  // a generic roof/body silhouette that was not present in the source image.
+  // Difficult light can make a real facade resemble sky or lawn. Relax only
+  // toward edges/colors that still exist in the uploaded photo. Never invent a
+  // generic roof/body silhouette that was not present in the source.
   if (activeCount < width * height * 0.12) {
     const relaxed = new Array(width * height).fill(false);
     for (let row = 0; row < height; row += 1) {
@@ -156,8 +160,8 @@ function sampleRecipe(image) {
         const skyDistance = rgbDistance(rgb[index], sky);
         const groundDistance = rgbDistance(rgb[index], ground);
         const edge = edgeStrength[index];
-        relaxed[index] = x > 0.045 && x < 0.955 && y > 0.075 && y < 0.94 && center > 0.08 && (
-          skyDistance > 0.075 || groundDistance > 0.09 || edge > 0.09
+        relaxed[index] = x > 0.04 && x < 0.96 && y > 0.07 && y < 0.95 && center > 0.07 && (
+          skyDistance > 0.072 || groundDistance > 0.085 || edge > 0.085
         );
       }
     }
@@ -165,7 +169,7 @@ function sampleRecipe(image) {
     activeCount = mask.filter(Boolean).length;
   }
 
-  if (activeCount < Math.max(12, Math.round(width * height * 0.06))) {
+  if (activeCount < Math.max(16, Math.round(width * height * 0.055))) {
     throw new Error('VoxelPop could not isolate enough of the uploaded building to make a trustworthy voxel. Try a clearer front or three-quarter photo.');
   }
 
@@ -224,7 +228,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         const initialHeight = Math.max(280, mount.clientHeight || 360);
         const compact = initialWidth < 720 || window.matchMedia?.('(pointer: coarse)')?.matches;
         const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.12 : 1.38));
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.12 : 1.4));
         renderer.setSize(initialWidth, initialHeight);
         renderer.outputColorSpace = THREE.SRGBColorSpace;
         renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -244,23 +248,25 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         rim.position.set(-5, 3, -4);
         scene.add(rim);
 
-        const cell = compact ? 0.275 : 0.292;
+        const cell = 7.0 / Math.max(recipe.width, recipe.height);
         const facadeWidth = recipe.width * cell;
         const facadeHeight = recipe.height * cell;
         const maxDimension = Math.max(facadeWidth, facadeHeight);
         const camera = new THREE.PerspectiveCamera(34, initialWidth / initialHeight, 0.1, 80);
-        let cameraDistance = clamp(maxDimension * 1.55 + 1.7, 7.4, 13.6);
+        let cameraDistance = clamp(maxDimension * (compact ? 1.72 : 1.58) + 0.45, 7.2, 13.0);
+        const minDistance = maxDimension * 1.05;
+        const maxDistance = maxDimension * 2.15;
         camera.position.set(0, 0.1, cameraDistance);
-        camera.lookAt(0, -0.1, 0);
+        camera.lookAt(0, -0.08, 0);
 
         const root = new THREE.Group();
-        root.rotation.x = -0.075;
+        root.rotation.x = -0.07;
         root.rotation.y = 0.10;
         scene.add(root);
 
         const active = recipe.depths.reduce((count, depth) => count + (depth > 0 ? 1 : 0), 0);
         const geometry = new THREE.BoxGeometry(cell * 0.90, cell * 0.90, 1);
-        const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.76, metalness: 0.015 });
+        const material = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.75, metalness: 0.012 });
         const mesh = new THREE.InstancedMesh(geometry, material, Math.max(1, active));
         const dummy = new THREE.Object3D();
         const color = new THREE.Color();
@@ -288,8 +294,8 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
         root.add(mesh);
 
-        const baseRadius = Math.max(2.2, facadeWidth * 0.52);
-        const baseGeometry = new THREE.CylinderGeometry(baseRadius, baseRadius + 0.24, 0.20, 32);
+        const baseRadius = Math.max(2.15, facadeWidth * 0.52);
+        const baseGeometry = new THREE.CylinderGeometry(baseRadius, baseRadius + 0.22, 0.20, 36);
         const baseMaterial = new THREE.MeshStandardMaterial({ color: 0xefe6d8, roughness: 0.94, metalness: 0 });
         const base = new THREE.Mesh(baseGeometry, baseMaterial);
         base.position.set(0, -facadeHeight / 2 - 0.30, -0.12);
@@ -299,14 +305,14 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         const ringMaterial = new THREE.MeshBasicMaterial({ color: 0xc9ff54, transparent: true, opacity: 0.88 });
         const ring = new THREE.Mesh(ringGeometry, ringMaterial);
         ring.rotation.x = Math.PI / 2;
-        ring.position.set(0, -facadeHeight / 2 - 0.18, -0.08);
+        ring.position.set(0, -facadeHeight / 2 - 0.20, -0.08);
         scene.add(ring);
 
         const pointers = new Map();
         let lastX = 0;
         let lastY = 0;
         let pinch = 0;
-        let targetX = -0.075;
+        let targetX = -0.07;
         let targetY = 0.10;
 
         const distance = () => {
@@ -315,7 +321,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         };
         const updateCamera = () => {
           camera.position.set(0, 0.1, cameraDistance);
-          camera.lookAt(0, -0.1, 0);
+          camera.lookAt(0, -0.08, 0);
         };
         const down = (event) => {
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
@@ -329,15 +335,15 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
           pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
           if (pointers.size >= 2) {
             const next = distance();
-            if (pinch) cameraDistance = clamp(cameraDistance - (next - pinch) * 0.012, 5.8, 15.5);
+            if (pinch) cameraDistance = clamp(cameraDistance - (next - pinch) * 0.012, minDistance, maxDistance);
             pinch = next;
             updateCamera();
             return;
           }
           const dx = event.clientX - lastX;
           const dy = event.clientY - lastY;
-          targetY += dx * 0.008;
-          targetX = clamp(targetX + dy * 0.004, -0.50, 0.34);
+          targetY += dx * 0.0072;
+          targetX = clamp(targetX + dy * 0.0038, -0.46, 0.30);
           lastX = event.clientX;
           lastY = event.clientY;
         };
@@ -348,7 +354,7 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         };
         const wheel = (event) => {
           event.preventDefault();
-          cameraDistance = clamp(cameraDistance + Math.sign(event.deltaY) * 0.45, 5.8, 15.5);
+          cameraDistance = clamp(cameraDistance + Math.sign(event.deltaY) * 0.40, minDistance, maxDistance);
           updateCamera();
         };
         renderer.domElement.addEventListener('pointerdown', down);
@@ -361,19 +367,16 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
         let firstFrame = true;
         const animate = () => {
           frame = requestAnimationFrame(animate);
-          if (!reducedMotion) {
-            root.rotation.x += (targetX - root.rotation.x) * 0.08;
-            root.rotation.y += (targetY - root.rotation.y) * 0.08;
-          } else {
-            root.rotation.x = targetX;
-            root.rotation.y = targetY;
-          }
+          root.rotation.x += (targetX - root.rotation.x) * 0.08;
+          root.rotation.y += (targetY - root.rotation.y) * 0.08;
+          if (!reducedMotion) ring.rotation.z += 0.001;
           renderer.render(scene, camera);
           if (firstFrame) {
             firstFrame = false;
             renderer.domElement.style.opacity = '1';
             setReady(true);
-            const signature = `${recipe.width}x${recipe.height}:${recipe.colors.slice(0, 6).join('')}`;
+            const activeCount = recipe.depths.filter((depth) => depth > 0).length;
+            const signature = `${recipe.width}x${recipe.height}:${activeCount}:${recipe.colors.slice(0, 4).join('')}`;
             if (reportedRef.current !== signature) {
               reportedRef.current = signature;
               callbackRef.current?.(recipe);
@@ -410,11 +413,11 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
           mount.innerHTML = '';
         };
       }).catch(() => {
-        if (!dead) setError('Interactive voxel 3D could not start. Your approved house photo remains visible.');
+        if (!dead) setError('Interactive 3D could not start. Your approved house photo remains visible.');
       });
     };
     image.onerror = () => {
-      if (!dead) setError('The approved property photo could not be opened for voxel conversion.');
+      if (!dead) setError('The approved property photo could not be opened for local voxel creation.');
     };
 
     return () => {
@@ -423,19 +426,18 @@ export default function LocalVoxelModelViewer({ imageUrl, sourceImageUrl, onRead
     };
   }, [imageUrl, sourceImageUrl]);
 
-  const posterUrl = sourceImageUrl || imageUrl;
-  return <div className="viewerShell">
-    {posterUrl ? <img className={`viewerPoster ${ready ? 'hidden' : ''}`} src={posterUrl} alt="Approved property photo"/> : null}
-    <div ref={mountRef} className="viewerCanvas" aria-label="Interactive property voxel model"/>
-    {!ready && !error ? <div className="viewerStage">APPROVED HOUSE → BUILDING VOXELS</div> : null}
-    {error ? <div className="viewerError">{error}</div> : null}
-    <div className="viewerHint">{ready ? '3D VOXEL · DRAG BUILDING · PINCH TO ZOOM' : 'THE APPROVED HOUSE PHOTO STAYS VISIBLE WHILE VOXELS BUILD'}</div>
+  return <div className="localViewerShell">
+    {imageUrl ? <img className={`localPoster ${ready ? 'hidden' : ''}`} src={imageUrl} alt="Approved VoxelPop house preview"/> : null}
+    <div ref={mountRef} className="localCanvas" aria-label="Interactive photo-shaped VoxelPop house voxel"/>
+    {!ready && !error ? <div className="stage">MATCHING YOUR HOUSE · LOCAL VOXEL</div> : null}
+    {error ? <div className="softError">{error}</div> : null}
+    <div className="hint">{ready ? 'DRAG BUILDING · PINCH TO ZOOM' : 'USING THE UPLOADED HOUSE SHAPE · NO GENERIC BUILDING'}</div>
     <style jsx>{`
-      .viewerShell{position:relative;width:100%;height:100%;min-height:280px;overflow:hidden;background:radial-gradient(circle at 50% 30%,#3c2a52,#18101f 66%)}
-      .viewerCanvas,.viewerPoster{position:absolute;inset:0;width:100%;height:100%}.viewerCanvas{z-index:2}.viewerPoster{z-index:1;object-fit:contain;background:#18101f;transition:opacity .34s ease}.viewerPoster.hidden{opacity:0;pointer-events:none}
-      .viewerStage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.80);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.11em;backdrop-filter:blur(10px)}
-      .viewerError{position:absolute;z-index:5;left:12px;right:12px;bottom:38px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.86);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
-      .viewerHint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#ded5e5;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.11em;pointer-events:none;text-shadow:0 1px 6px #000}
+      .localViewerShell{position:relative;width:100%;height:100%;min-height:300px;overflow:hidden;background:radial-gradient(circle at 50% 34%,#4a3561 0,#25182f 55%,#17101c 100%)}
+      .localPoster,.localCanvas{position:absolute;inset:0;width:100%;height:100%}.localPoster{z-index:1;object-fit:contain;background:#20172a;opacity:1;transition:opacity .34s ease}.localPoster.hidden{opacity:0;pointer-events:none}.localCanvas{z-index:2}
+      .stage{position:absolute;z-index:4;left:12px;top:12px;padding:8px 10px;border-radius:999px;background:rgba(28,18,35,.8);backdrop-filter:blur(10px);color:#f4edff;font-size:7px;font-weight:1000;letter-spacing:.12em}
+      .softError{position:absolute;z-index:5;left:12px;right:12px;bottom:36px;padding:9px 11px;border-radius:13px;background:rgba(28,18,35,.88);color:#efe8f5;font-size:9px;line-height:1.45;backdrop-filter:blur(9px)}
+      .hint{position:absolute;z-index:6;left:10px;right:10px;bottom:10px;color:#e6deeb;text-align:center;font-size:6.5px;font-weight:1000;letter-spacing:.11em;pointer-events:none;text-shadow:0 1px 6px #000}
     `}</style>
   </div>;
 }

--- a/app/property/PhotoReliefModelViewer.js
+++ b/app/property/PhotoReliefModelViewer.js
@@ -6,6 +6,14 @@ function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
 }
 
+function sampleGrid(image) {
+  const ratio = Math.max(0.2, Math.min(5, (image.naturalWidth || 1) / (image.naturalHeight || 1)));
+  const longSide = 96;
+  const minShort = 52;
+  if (ratio >= 1) return { width: longSide, height: Math.max(minShort, Math.round(longSide / ratio)) };
+  return { width: Math.max(minShort, Math.round(longSide * ratio)), height: longSide };
+}
+
 export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
   const mountRef = useRef(null);
   const callbackRef = useRef(onReady);
@@ -51,6 +59,8 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         fill.position.set(-4, 2, 3);
         scene.add(fill);
 
+        // The visible material is the full uploaded photo. No square crop is
+        // introduced at the preview stage.
         const sourceCanvas = document.createElement('canvas');
         const maxTexture = compact ? 1024 : 1400;
         const scale = Math.min(1, maxTexture / Math.max(image.naturalWidth || 1, image.naturalHeight || 1));
@@ -63,34 +73,39 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         texture.colorSpace = THREE.SRGBColorSpace;
         texture.anisotropy = Math.min(4, renderer.capabilities.getMaxAnisotropy?.() || 1);
 
-        const sampleSize = 64;
+        // Relief sampling now follows the source aspect ratio as well. The old
+        // square luminance map could warp a wide roofline even though the front
+        // texture itself was correct.
+        const sample = sampleGrid(image);
         const sampleCanvas = document.createElement('canvas');
-        sampleCanvas.width = sampleSize;
-        sampleCanvas.height = sampleSize;
+        sampleCanvas.width = sample.width;
+        sampleCanvas.height = sample.height;
         const sampleContext = sampleCanvas.getContext('2d', { willReadFrequently: true });
         if (!sampleContext) throw new Error('The 3D photo preview is unavailable on this device.');
         sampleContext.filter = 'contrast(1.06) saturate(1.02)';
-        sampleContext.drawImage(image, 0, 0, sampleSize, sampleSize);
-        const pixels = sampleContext.getImageData(0, 0, sampleSize, sampleSize).data;
+        sampleContext.drawImage(image, 0, 0, image.naturalWidth || 1, image.naturalHeight || 1, 0, 0, sample.width, sample.height);
+        const pixels = sampleContext.getImageData(0, 0, sample.width, sample.height).data;
         const luminance = (x, y) => {
-          const cx = clamp(Math.round(x), 0, sampleSize - 1);
-          const cy = clamp(Math.round(y), 0, sampleSize - 1);
-          const index = (cy * sampleSize + cx) * 4;
+          const cx = clamp(Math.round(x), 0, sample.width - 1);
+          const cy = clamp(Math.round(y), 0, sample.height - 1);
+          const index = (cy * sample.width + cx) * 4;
           return (pixels[index] * 0.2126 + pixels[index + 1] * 0.7152 + pixels[index + 2] * 0.0722) / 255;
         };
 
-        const ratio = (image.naturalWidth || 1) / (image.naturalHeight || 1);
-        const planeHeight = ratio >= 1 ? 5.1 : 5.7;
-        const planeWidth = ratio >= 1 ? planeHeight * ratio : planeHeight * ratio;
-        const boundedWidth = Math.min(7.6, Math.max(3.3, planeWidth));
-        const boundedHeight = boundedWidth / ratio;
-        const geometry = new THREE.PlaneGeometry(boundedWidth, boundedHeight, 48, 48);
+        const ratio = Math.max(0.2, Math.min(5, (image.naturalWidth || 1) / (image.naturalHeight || 1)));
+        const maxPlaneWidth = 7.6;
+        const maxPlaneHeight = 6.1;
+        const planeWidth = ratio >= 1 ? maxPlaneWidth : maxPlaneHeight * ratio;
+        const planeHeight = ratio >= 1 ? maxPlaneWidth / ratio : maxPlaneHeight;
+        const xSegments = ratio >= 1 ? 64 : Math.max(36, Math.round(64 * ratio));
+        const ySegments = ratio >= 1 ? Math.max(36, Math.round(64 / ratio)) : 64;
+        const geometry = new THREE.PlaneGeometry(planeWidth, planeHeight, xSegments, ySegments);
         const positions = geometry.attributes.position;
         for (let index = 0; index < positions.count; index += 1) {
           const u = geometry.attributes.uv.getX(index);
           const v = geometry.attributes.uv.getY(index);
-          const sx = u * (sampleSize - 1);
-          const sy = (1 - v) * (sampleSize - 1);
+          const sx = u * (sample.width - 1);
+          const sy = (1 - v) * (sample.height - 1);
           const center = luminance(sx, sy);
           const edge = Math.abs(luminance(sx + 1, sy) - luminance(sx - 1, sy))
             + Math.abs(luminance(sx, sy + 1) - luminance(sx, sy - 1));
@@ -104,7 +119,7 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         const group = new THREE.Group();
         scene.add(group);
         const backing = new THREE.Mesh(
-          new THREE.BoxGeometry(boundedWidth + 0.08, boundedHeight + 0.08, 0.20),
+          new THREE.BoxGeometry(planeWidth + 0.08, planeHeight + 0.08, 0.20),
           new THREE.MeshStandardMaterial({ color: 0x170f20, roughness: 0.88, metalness: 0 }),
         );
         backing.position.z = -0.11;
@@ -115,12 +130,14 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         group.add(photoMesh);
 
         const camera = new THREE.PerspectiveCamera(32, width / height, 0.1, 60);
-        const cameraDistance = Math.max(8.4, boundedWidth * 1.45);
+        const cameraDistance = Math.max(8.4, Math.max(planeWidth, planeHeight) * 1.45);
         camera.position.set(0, 0, cameraDistance);
         camera.lookAt(0, 0, 0);
 
-        let targetX = -0.035;
-        let targetY = 0.08;
+        // Keep movement gentle: this stage is for comparing the preview with
+        // the uploaded house, not for pretending unseen sides were generated.
+        let targetX = -0.025;
+        let targetY = 0.05;
         let pointerId = null;
         let lastX = 0;
         let lastY = 0;
@@ -136,8 +153,8 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
           const dy = event.clientY - lastY;
           lastX = event.clientX;
           lastY = event.clientY;
-          targetY = clamp(targetY + dx * 0.006, -0.48, 0.48);
-          targetX = clamp(targetX + dy * 0.004, -0.24, 0.22);
+          targetY = clamp(targetY + dx * 0.0045, -0.34, 0.34);
+          targetX = clamp(targetX + dy * 0.003, -0.18, 0.17);
         };
         const up = (event) => {
           if (pointerId === event.pointerId) pointerId = null;


### PR DESCRIPTION
Builds directly on the current strict property flow and #452's no-generic-house safeguard.

Changes are intentionally limited to four fidelity layers:
- the source-photo 3D relief preview samples the full photo at aspect-aware resolution instead of using a square depth field
- the final local voxel keeps the full uploaded frame and uses up to 32 cells on the long side (legacy baseline was 24), while retaining source-only masking and clear failure when a trustworthy building cannot be isolated
- the saved glTF uses the same aspect-aware scale/depth as the on-device voxel so Vault/mint reopen the same shape
- signed VoxelFlip NFT metadata accepts and renders the same 32-cell rectangular recipe without forcing it back into a square card

Unchanged: one $4.99 creation unlock, explicit 3D preview approval before voxelization, saved-property photo reuse, no Meshy credits, optional Base mint, and the digital-NFT-versus-real-property legal boundary.