### PR TITLE
Let property checkout continue when photo cache is unavailable

### DIFF
--- a/app/property/PropertyJourneyExact.js
+++ b/app/property/PropertyJourneyExact.js
@@ -532,9 +532,13 @@ export default function PropertyJourneyExact() {
     if (!pendingPhoto || !session?.access_token || !draftId) return;
     if (!rightsConfirmed) return setMessage('Confirm that you took this photo or have permission to use it.');
     setBusy('generation-checkout');
+    let cachedOnDevice = false;
     try {
-      await saveDevicePhoto(draftId, pendingPhoto);
-      if (selectedProperty?.id) await saveDevicePhoto(propertyPhotoKey(selectedProperty.id), pendingPhoto);
+      try {
+        await saveDevicePhoto(draftId, pendingPhoto);
+        cachedOnDevice = true;
+      } catch {}
+      if (selectedProperty?.id) await saveDevicePhoto(propertyPhotoKey(selectedProperty.id), pendingPhoto).catch(() => {});
       writeGenerationContext(draftId, selectedProperty);
       if (paidSessionId) {
         setCreationUnlocked(true);
@@ -544,7 +548,9 @@ export default function PropertyJourneyExact() {
         setBusy('');
         return;
       }
-      setMessage(`Opening secure ${CREATION_PRICE_LABEL} checkout. After payment, you will see the 3D preview before any voxel is built.`);
+      setMessage(cachedOnDevice
+        ? `Opening secure ${CREATION_PRICE_LABEL} checkout. After payment, you will see the 3D preview before any voxel is built.`
+        : `Opening secure ${CREATION_PRICE_LABEL} checkout. Your browser could not keep the photo through checkout, so after payment you may need to choose the same photo once. You will not be charged again.`);
       const form = new FormData();
       form.append('draftId', draftId);
       form.append('rightsConfirmed', 'true');

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -38,7 +38,9 @@ assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|a
 
 assert.match(property, /CREATION_PRICE_LABEL = '\$4\.99'/, 'maker shows the $4.99 creation price');
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'the authorized photo persists across Stripe on the same device');
-assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'photo is retained on-device before checkout');
+assert.match(property, /await saveDevicePhoto\(draftId, pendingPhoto\)/, 'photo is retained on-device before checkout when private storage works');
+assert.match(property, /let cachedOnDevice = false/, 'private photo caching is best-effort and cannot be a checkout prerequisite');
+assert.match(property, /browser could not keep the photo through checkout/, 'checkout has an explicit recovery path when private browser storage is unavailable');
 assert.match(property, /\/api\/property-generation\/checkout/, 'photo approval opens paid generation checkout');
 assert.match(property, /Pay \$\{CREATION_PRICE_LABEL\} & Make 3D Preview/, 'paid CTA promises the preview first, not an immediate generic voxel');
 assert.match(property, /After payment, you will see the 3D preview before any voxel is built/, 'checkout handoff preserves the strict stage order');


### PR DESCRIPTION
This is the narrow follow-up to the newer property preview/voxel work already on main.

What it fixes:
- IndexedDB/private on-device photo caching is now best-effort instead of a prerequisite for the $4.99 checkout.
- If caching works, the existing seamless return-to-preview flow is unchanged.
- If caching is unavailable or fails on iPhone/private browsing, checkout still opens. After payment the user can choose the same property photo once and is explicitly told there is no second charge.
- Saving the stable copy for an already-selected property also cannot block checkout.

What it intentionally does not change:
- the current photo -> pay -> recognizable 3D preview -> approve -> photo-matched voxel -> optional mint order;
- the latest full-aspect house-shaped voxel implementation on main;
- the newer My Properties/reuse flow;
- the no-Meshy local generation path or real-property rights boundary.

Regression coverage adds explicit assertions that local photo caching is best-effort and that the recovery message exists.