### PR TITLE
Finish VoxelPop front-door SEO and trust navigation

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -19,7 +19,7 @@ export default function AboutPage() {
       <p>The core creation flow is designed to process the source property image in the browser. That keeps the original photo out of public NFT metadata and reduces the need to maintain a central property-photo archive just to generate the local 3D experience.</p>
       <h2>Project status</h2>
       <p>Voxel Vault is an actively developed software project. The repository also contains research, testnet, provider-gated, and experimental systems that are intentionally kept outside the main consumer flow unless their real dependencies and legal requirements are satisfied.</p>
-      <h2>Contact and feedback</h2>
+      <h2 id="contact">Contact and feedback</h2>
       <p>For product bugs, feedback, or public technical questions, use the GitHub repository issue tracker. Do not post passwords, private keys, seed phrases, card information, identity documents, private deeds or leases, tenant information, or other sensitive personal data in a public issue.</p>
       <div className={styles.links}><a href="https://github.com/hartensteindominic/Voxel-Vault/issues" target="_blank" rel="noreferrer">Open GitHub issues ↗</a><Link href="/demo">See public demo</Link><Link href="/privacy">Privacy</Link><Link href="/terms">Terms</Link></div>
     </section>

--- a/app/demo/page.js
+++ b/app/demo/page.js
@@ -61,7 +61,7 @@ export default function DemoPage() {
         <span>You can inspect the product interaction before creating an account. It does not claim that one photo can reconstruct unseen walls, exact dimensions, roof geometry, title, or any physical-property right.</span>
       </section>
 
-      <footer className={styles.footer}><Link href="/privacy">Privacy</Link><Link href="/terms">Terms</Link><Link href="/about">About + contact</Link><Link href="/more">More tools</Link></footer>
+      <footer className={styles.footer}><Link href="/privacy">Privacy</Link><Link href="/terms">Terms</Link><Link href="/about">About</Link><Link href="/about#contact">Contact</Link><Link href="/more">More tools</Link></footer>
     </div>
   </main>;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -55,7 +55,7 @@ export default function Home() {
         <div><small>DIGITAL</small><strong>Photo → 3D preview → voxel → optional NFT</strong></div><span>≠</span><div><small>PHYSICAL PROPERTY</small><strong>Deed / title / rent / regulated investment rights</strong></div><Link href="/terms">Read terms →</Link>
       </section>
 
-      <footer className={styles.footer}><span>Voxel Vault is a digital creation product. Voxel Vault is not a bank, broker, exchange, custodian, escrow service, or deed registry, and a VoxelPop item is not a deed. The $1.99 property comparison is a sandbox; financial products remain provider-gated.</span><span><Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link> · <Link href="/about">About + contact</Link> · <Link href="/more">More</Link></span></footer>
+      <footer className={styles.footer}><span>Voxel Vault is a digital creation product. Voxel Vault is not a bank, broker, exchange, custodian, escrow service, or deed registry, and a VoxelPop item is not a deed. The $1.99 property comparison is a sandbox; financial products remain provider-gated.</span><span><Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link> · <Link href="/about">About</Link> · <Link href="/about#contact">Contact</Link> · <Link href="/more">More</Link></span></footer>
     </div>
   </main>;
 }

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -3,7 +3,11 @@ export default function sitemap() {
   const now = new Date();
   const routes = [
     { path: '/', changeFrequency: 'daily', priority: 1 },
-    { path: '/studio', changeFrequency: 'daily', priority: 0.9 },
+    { path: '/demo', changeFrequency: 'weekly', priority: 0.95 },
+    { path: '/property', changeFrequency: 'weekly', priority: 0.9 },
+    { path: '/world', changeFrequency: 'weekly', priority: 0.65 },
+    { path: '/vault', changeFrequency: 'weekly', priority: 0.6 },
+    { path: '/about', changeFrequency: 'monthly', priority: 0.5 },
     { path: '/privacy', changeFrequency: 'monthly', priority: 0.3 },
     { path: '/terms', changeFrequency: 'monthly', priority: 0.3 },
   ];

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -6,6 +6,7 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), '
 const home = read('app/page.js');
 const demo = read('app/demo/page.js');
 const layout = read('app/layout.js');
+const sitemap = read('app/sitemap.js');
 const privacy = read('app/privacy/page.js');
 const terms = read('app/terms/page.js');
 const about = read('app/about/page.js');
@@ -20,19 +21,28 @@ assert.match(home, /\$4\.99/, 'the focused paid-creation price must remain publi
 assert.match(home, /3D preview[\s\S]*voxel/i, 'home must preserve preview-before-voxel positioning');
 assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');
-assert.match(home, /About \+ contact/, 'home footer must expose About/contact');
+assert.match(home, /href="\/about">About<\/Link>/, 'home footer must expose a distinct About link');
+assert.match(home, /href="\/about#contact">Contact<\/Link>/, 'home footer must expose a distinct Contact link');
 
 assert.match(demo, /PhotoReliefModelViewer/, 'public demo must use the production photo-relief viewer');
 assert.match(demo, /LocalVoxelModelViewer/, 'public demo must use the production local voxel viewer');
 assert.match(demo, /NO LOGIN · NO PAYMENT · PUBLIC SAMPLE/, 'demo must state that it is public and free to inspect');
 assert.match(demo, /Illustrative built-in demo artwork/, 'demo must not pretend the sample is a customer property');
 assert.match(demo, /not a customer property/i, 'demo must preserve social-proof truthfulness');
+assert.match(demo, /href="\/about#contact">Contact<\/Link>/, 'public demo must expose the support/contact path');
 assert.doesNotMatch(demo, /getSupabaseBrowserAsync|signInWithOAuth|checkout\.sessions|\/api\/property-generation\/checkout/, 'public demo must not hide an auth or payment gate');
 
 assert.match(layout, /Turn a House Photo into a 3D Voxel/, 'site metadata must use the focused current promise');
 assert.match(layout, /house photo to 3D/, 'SEO keywords must focus on the shipping product');
 assert.doesNotMatch(layout, /real estate digital twin|NFT vault/i, 'metadata must not revive broad legacy positioning');
 assert.match(og, /house photo into a movable 3D voxel/i, 'social preview must show the current product story');
+
+for (const route of ['/', '/demo', '/property', '/world', '/vault', '/about', '/privacy', '/terms']) {
+  assert.ok(sitemap.includes(`path: '${route}'`), `sitemap must expose current public route ${route}`);
+}
+assert.doesNotMatch(sitemap, /path: '\/studio'/, 'legacy Studio must not outrank the current VoxelPop funnel in search metadata');
+assert.match(sitemap, /path: '\/demo'[\s\S]*priority: 0\.95/, 'public no-login demo should be the highest-priority product route after Home');
+assert.match(sitemap, /path: '\/property'[\s\S]*priority: 0\.9/, 'paid property creator should remain a high-priority product route');
 
 for (const page of [privacy, terms, about]) {
   assert.match(page, /Voxel Vault|VOXEL VAULT/, 'trust pages must identify Voxel Vault');
@@ -42,6 +52,7 @@ assert.doesNotMatch(legacyPrivacy, /ToolMint/, 'root privacy HTML must no longer
 assert.doesNotMatch(legacyTerms, /ToolMint/, 'root terms HTML must no longer expose ToolMint');
 assert.match(privacy, /source photo/i, 'privacy page must explain source-photo handling');
 assert.match(terms, /\$4\.99 DIGITAL/, 'terms must state what the creation purchase means');
+assert.match(about, /id="contact"/, 'about page must provide a directly linkable contact section');
 assert.match(about, /Contact and feedback/, 'about page must provide a real feedback/contact route');
 
 assert.match(readme, /What this repo currently ships/, 'README must lead with the shipping product');
@@ -50,4 +61,4 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public VoxelPop positioning checks passed: no-login product proof, focused $4.99 story, corrected trust pages, richer social preview, and scoped README remain intact.');
+console.log('Public VoxelPop positioning checks passed: no-login product proof, focused $4.99 story, current sitemap, explicit trust/contact navigation, richer social preview, and scoped README remain intact.');


### PR DESCRIPTION
## Follow-up to #461

PR #461 landed the main product-positioning work: one focused $4.99 house-photo-to-voxel story, a real no-login sample using the production 3D viewers, updated About/Privacy/Terms, richer social metadata, a scoped README, and contribution guidance.

This PR was rebased onto that merged work and now contains **only the remaining non-overlapping cleanup** from the product critique.

### 1. Fix stale search-routing metadata

The sitemap still promoted the legacy `/studio` route at priority `0.9` and did not expose the new public demo or the current core product routes.

It now prioritizes:

`/ → /demo → /property → /world → /vault → /about → /privacy → /terms`

The live host fallback remains `https://www.voxelvault.io` because the apex `voxelvault.io` currently redirects to `www.voxelvault.io`.

### 2. Make Contact visibly distinct from About

The homepage and public demo now expose separate **About** and **Contact** links instead of combining them as “About + contact.” Contact deep-links to the existing feedback/support section on `/about`, which uses the public GitHub issue tracker and warns users not to publish sensitive data.

### 3. Prevent drift with regression coverage

`test-public-demo-positioning` now verifies that:

- the no-login demo remains real production-viewer product proof;
- the $4.99 positioning remains focused;
- About and Contact stay separately visible;
- the sitemap includes the current core routes;
- legacy `/studio` cannot regain high-priority search metadata;
- trust/privacy/terms boundaries stay intact.

## Deliberate non-goals

- no duplicate `/preview` route: #461’s built-in `/demo` already solves pre-login product proof without giving away a separate user-photo creation path;
- no rewrite of #461’s homepage, README, OG image, privacy, terms, or About positioning;
- no changes to checkout, property generation, Vault persistence, mapping, mint contracts, provider gates, or property-title logic;
- no GitHub repository-description/About metadata write because the connected repository API does not expose that mutation;
- no open-source license chosen on the owner’s behalf.

## Verification

All checks passed on head `1d76de6e`:

- Voxel Vault Quality Gate — **passed**
- dependency audit — **passed**
- Voxel Vault web build — **passed**
- Vercel preview deployment — **passed**
- Mobile WebGL Guard — **passed**
- Ethereum Contract Checks — **passed**
- Voxel Vault Contracts — **passed**

The quality workflow also completed the property-platform, Vault, provider-binding, claims, global-earth, commerce, route, mobile, and other regression suites before its final production build.