### PR TITLE
Audit every tracked file and add repository-wide integrity guard

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -56,7 +56,7 @@ jobs:
       - run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: '1'
-          NEXT_PUBLIC_SITE_URL: https://voxel-vault.vercel.app
+          NEXT_PUBLIC_SITE_URL: https://www.voxelvault.io
 
   dependency-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/repository-file-audit.yml
+++ b/.github/workflows/repository-file-audit.yml
@@ -1,0 +1,27 @@
+name: Full Repository File Audit
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+concurrency:
+  group: voxel-vault-file-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit-all-tracked-files:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Read and audit every tracked file
+        run: node scripts/audit-all-files.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 *.tsbuildinfo
 .DS_Store
 coverage/
+deployed-mainnet-addresses.json

--- a/DEPLOY_TRIGGER.md
+++ b/DEPLOY_TRIGGER.md
@@ -1,5 +1,16 @@
-# Voxel Vault deployment trigger
+# Voxel Vault deployment marker
 
-This file intentionally triggers a fresh Vercel production deployment from `main` after the verified collectible-pipeline hardening release.
+This is a historical no-op deployment marker. It is **not** the source of truth for release readiness.
 
-Verified baseline: durable background model prebuild, persistent model storage, stable model delivery, iPhone-friendly loading, simplified storefront copy, and fail-closed checkout safety.
+The current public product baseline is:
+
+- public no-login VoxelPop sample;
+- authorized house photo → **$4.99 digital creation**;
+- textured 3D preview shown before voxel conversion;
+- explicit user approval before the movable voxel is built;
+- normal property creation works without Meshy credits;
+- source photo remains device-local in the normal flow;
+- World, Vault, and minting are optional downstream actions;
+- demo, financial/provider, and real-property title workflows remain clearly separate and fail closed when their required rails are unavailable.
+
+Use `docs/ARCHITECTURE.md`, `docs/SECURITY_REVIEW.md`, the current CI checks, and the exact deployed commit—not this marker—to decide whether a release is ready.

--- a/MAINNET_DEPLOY.md
+++ b/MAINNET_DEPLOY.md
@@ -1,19 +1,22 @@
-# Ethereum mainnet deployment (Voxel Vault)
+# Ethereum mainnet deployment (advanced / optional)
 
-This deploys **real** contracts on **Ethereum mainnet** (chainId 1). Gas is paid in **real ETH**.
+This guide is for **advanced optional blockchain infrastructure**. It is not required for the core Voxel Vault product: an authorized house photo → $4.99 digital VoxelPop creation → textured 3D preview → approval → movable voxel works without an Ethereum mainnet deployment.
+
+If you intentionally use this guide, it deploys **real contracts on Ethereum mainnet** (chainId 1), and gas is paid in **real ETH**.
 
 ## Before you start
 
-1. Contracts were hardened (pause, auction fix, public-mint gate) but **are not a substitute for an audit**.
-2. Prefer a **multisig** as `MULTISIG_OWNER` and `FEE_RECIPIENT`.
-3. Never put `DEPLOYER_PRIVATE_KEY` in Vercel, GitHub, or chat.
-4. Fund the deployer with enough ETH for deploy + `setMinter` / `setPublicMintEnabled` (often ~0.05+ ETH depending on gas).
+1. Treat the contracts as unaudited unless the exact commit and deployed bytecode have received an independent security review. Existing hardening and tests are **not a substitute for an audit**.
+2. Prefer a hardware-backed **multisig** as `MULTISIG_OWNER` and `FEE_RECIPIENT`.
+3. Never put `DEPLOYER_PRIVATE_KEY` in Vercel, GitHub, chat, screenshots, logs, or shared shell history. Use a dedicated, minimally funded deployment key only when a local scripted deployment is truly necessary.
+4. Keep public mint disabled unless a separately reviewed product decision intentionally enables it.
+5. Verify the exact git commit, chain ID, constructor arguments, owner/fee-recipient addresses, and contract source before signing any transaction.
 
 ## Local `.env` (do not commit)
 
 ```bash
 MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_KEY
-DEPLOYER_PRIVATE_KEY=0xYOUR_HOT_WALLET_KEY
+DEPLOYER_PRIVATE_KEY=0xYOUR_DEDICATED_DEPLOYMENT_KEY
 CONFIRM_MAINNET=yes
 
 # Strongly recommended:
@@ -36,9 +39,11 @@ npm run chain:deploy:mainnet
 
 The script refuses to run if:
 
-- `CONFIRM_MAINNET` is not `yes`
-- RPC chainId is not `1`
-- Deployer has 0 ETH
+- `CONFIRM_MAINNET` is not `yes`;
+- RPC chainId is not `1`;
+- the deployer has 0 ETH.
+
+Those checks reduce obvious mistakes; they do not prove the deployment is safe or appropriate.
 
 Output includes:
 
@@ -47,16 +52,18 @@ NEXT_PUBLIC_VOXEL_NFT_ADDRESS=0x...
 NEXT_PUBLIC_VOXEL_MARKET_ADDRESS=0x...
 ```
 
-Addresses are also written to `deployed-mainnet-addresses.json` (gitignored if you add it).
+The deployment script may also write `deployed-mainnet-addresses.json`; the repository ignores that generated local file. Contract addresses are public information, but the generated file should not become an accidental source of stale deployment configuration.
 
 ## If owner is a multisig
 
-From the multisig, execute:
+From the multisig, verify the target addresses and calldata, then execute:
 
 1. `nft.setMinter(marketAddress, true)`
 2. `nft.setPublicMintEnabled(false)` (recommended)
 
 ## Vercel production env
+
+Only after the deployment has been reviewed and intentionally connected to the product:
 
 ```bash
 NEXT_PUBLIC_EVM_CHAIN_ID=0x1
@@ -66,18 +73,21 @@ NEXT_PUBLIC_VOXEL_NFT_ADDRESS=0x...
 NEXT_PUBLIC_VOXEL_MARKET_ADDRESS=0x...
 ```
 
-Redeploy the Next.js app after setting these.
+Redeploy the Next.js app after changing public contract configuration and verify the exact production commit.
 
-## Verify on Etherscan (optional)
+## Verify on Etherscan
 
 ```bash
 npx hardhat verify --network mainnet <NFT_ADDRESS> <OWNER_ADDRESS>
 npx hardhat verify --network mainnet <MARKET_ADDRESS> <OWNER_ADDRESS> <NFT_ADDRESS> <FEE_RECIPIENT>
 ```
 
-## After deploy canary
+Verification is strongly recommended for any intentional production deployment.
 
-1. Connect MetaMask to Ethereum mainnet on the live site.
-2. Mint or marketplace action with a **small** amount of ETH.
-3. Confirm explorer links and `withdraw()` for fees if applicable.
-4. Monitor contract balances and pause if something is wrong: `market.pause()`.
+## After-deploy canary
+
+1. Confirm the deployed bytecode, owner, fee recipient, mint permissions, and network in an explorer before using the UI.
+2. Test only the smallest practical explicit user-approved action.
+3. Confirm explorer links, event data, fee accounting, and any withdrawal path.
+4. Monitor balances and permissions; pause the market if something is wrong.
+5. Keep the core VoxelPop creator independent from this optional blockchain path.

--- a/app/api/checkout-secure/route.ts
+++ b/app/api/checkout-secure/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
     }
 
     const fee = platformFee(asset.price_cents);
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxel-vault.vercel.app';
+    const appUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       customer_email: user.email || undefined,

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
     }
 
     const fee = platformFee(asset.price_cents);
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://voxel-vault.vercel.app';
+    const appUrl = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       customer_email: user.email || undefined,

--- a/app/layout.js
+++ b/app/layout.js
@@ -16,7 +16,6 @@ export const metadata = {
   title: { default: TITLE, template: '%s | Voxel Vault' },
   description: DESCRIPTION,
   keywords: ['house photo to 3D', 'voxel house creator', '3D house photo', 'VoxelPop', 'voxel creator', 'Voxel Vault'],
-  alternates: { canonical: SITE_URL },
   robots: { index: true, follow: true },
   icons: { icon: '/voxelpop/voxelpop-logo.png', apple: '/voxelpop/voxelpop-logo.png' },
   openGraph: {

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import styles from './home.module.css';
 
+export const metadata = { alternates: { canonical: '/' } };
+
 // One public promise: authorized house photo -> $4.99 digital VoxelPop creation.
 // Visitors can inspect a built-in no-login demo before account/payment friction.
 // Paid creation remains account-bound and preserves preview -> approval -> voxel -> optional mint.

--- a/app/robots.js
+++ b/app/robots.js
@@ -4,7 +4,7 @@ export default function robots() {
     rules: [{
       userAgent: '*',
       allow: '/',
-      disallow: ['/admin/', '/api/', '/vault/', '/account/', '/checkout/', '/property/mint'],
+      disallow: ['/admin/', '/api/admin/', '/api/', '/vault/', '/account/', '/checkout/', '/property/mint'],
     }],
     sitemap: `${base}/sitemap.xml`,
     host: base,

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,7 +1,11 @@
 export default function robots() {
   const base = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
   return {
-    rules: [{ userAgent: '*', allow: '/', disallow: ['/admin/', '/api/admin/'] }],
+    rules: [{
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/admin/', '/api/', '/vault/', '/account/', '/checkout/', '/property/mint'],
+    }],
     sitemap: `${base}/sitemap.xml`,
     host: base,
   };

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,15 +1,17 @@
 export default function sitemap() {
   const base = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
-  const now = new Date();
   const routes = [
-    { path: '/', changeFrequency: 'daily', priority: 1 },
-    { path: '/studio', changeFrequency: 'daily', priority: 0.9 },
-    { path: '/privacy', changeFrequency: 'monthly', priority: 0.3 },
-    { path: '/terms', changeFrequency: 'monthly', priority: 0.3 },
+    { path: '/', changeFrequency: 'weekly', priority: 1 },
+    { path: '/demo', changeFrequency: 'monthly', priority: 0.9 },
+    { path: '/property', changeFrequency: 'weekly', priority: 0.9 },
+    { path: '/world', changeFrequency: 'weekly', priority: 0.7 },
+    { path: '/more', changeFrequency: 'monthly', priority: 0.5 },
+    { path: '/about', changeFrequency: 'monthly', priority: 0.5 },
+    { path: '/privacy', changeFrequency: 'monthly', priority: 0.4 },
+    { path: '/terms', changeFrequency: 'monthly', priority: 0.4 },
   ];
   return routes.map((route) => ({
     url: `${base}${route.path}`,
-    lastModified: now,
     changeFrequency: route.changeFrequency,
     priority: route.priority,
   }));

--- a/index.html
+++ b/index.html
@@ -3,11 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="refresh" content="0;url=https://voxel-vault.vercel.app/studio">
-  <title>VoxelForge · Voxel Vault</title>
-  <script>window.location.replace('https://voxel-vault.vercel.app/studio');</script>
+  <meta name="description" content="Voxel Vault turns an authorized house photo into a digital VoxelPop 3D preview and movable voxel.">
+  <link rel="canonical" href="https://www.voxelvault.io/">
+  <meta http-equiv="refresh" content="0;url=https://www.voxelvault.io/">
+  <title>Voxel Vault · House Photo to 3D Voxel</title>
+  <script>window.location.replace('https://www.voxelvault.io/');</script>
 </head>
-<body style="margin:0;background:#08080c;color:#f7f5ee;font-family:system-ui,sans-serif;display:grid;place-items:center;min-height:100vh">
-  <p>Opening <strong>VoxelForge at Voxel Vault</strong>…</p>
+<body style="margin:0;background:#fffaf0;color:#26190f;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:grid;place-items:center;min-height:100vh;padding:24px;box-sizing:border-box">
+  <main style="max-width:560px;text-align:center">
+    <p style="font-weight:800;letter-spacing:.08em;color:#7138f5">VOXEL VAULT · VOXELPOP</p>
+    <h1 style="margin:.4em 0">Turn a house photo into a 3D voxel.</h1>
+    <p>Opening the current Voxel Vault experience at <a href="https://www.voxelvault.io/">voxelvault.io</a>…</p>
+  </main>
 </body>
 </html>

--- a/lib/product-map.js
+++ b/lib/product-map.js
@@ -21,7 +21,7 @@ export const APP_SECTIONS = Object.freeze([
     { id: 'discover', href: '/discover', label: 'Discover', icon: '✦', description: 'Browse public Voxel Vault experiences and digital assets.', badge: 'BROWSE' },
   ]},
   { id: 'create', eyebrow: 'CREATE + COLLECT', title: 'Digital assets', description: 'Create and organize digital assets first. Wallets and minting stay optional.', items: [
-    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Authorized photo → $4.99 local VoxelPop image + interactive 3D → source-backed map → World → optional collection.', badge: 'LIVE' },
+    { id: 'property', href: '/property', label: 'VoxelPop Property', icon: '+', description: 'Authorized photo → $4.99 textured 3D preview → approval → movable voxel → optional World/map/mint.', badge: 'LIVE' },
     { id: 'studio', href: '/studio', label: 'Voxel Studio', icon: '+', description: 'Create and prepare other 3D voxel assets.', badge: 'CREATE' },
     { id: 'capture', href: '/capture', label: 'Capture', icon: '◉', description: 'Bring a real object or image into an asset workflow.', badge: 'SCAN' },
     { id: 'receipt', href: '/receipt', label: 'Receipt Scan', icon: '▣', description: 'Verify an eligible purchase before an optional collectible workflow.', badge: 'VERIFY' },
@@ -38,7 +38,7 @@ export const APP_SECTIONS = Object.freeze([
     { id: 'income', href: '/vault/income', label: 'Income Records', icon: '↗', description: 'Show provider-observed payment history without inventing yield, returns or spendable balances.', badge: 'OBSERVED' },
     { id: 'acquire', href: '/real-estate/acquire', label: 'Direct Property Path', icon: '⌂', description: 'Plan ordinary diligence, financing, closing and title steps. A token or VoxelPop item is never the deed.', badge: 'LEGAL PATH' },
     { id: 'verify', href: '/vault/properties/claim', label: 'Verify Property', icon: '✓', description: 'Create a Property Passport downstream of evidence; it is not a deed or investment security.', badge: 'VERIFY' },
-    { id: 'twins', href: '/vault/estates/mine', label: 'Digital Twins', icon: '◇', description: 'See account-secured digital twins and optional wallet bindings.', badge: 'DIGITAL' },
+    { id: 'twins', href: '/vault/estates/mine', label: 'Digital Twins', icon: '◇', description: 'See account-secured digital twins, create an included voxel for eligible purchases, and manage optional wallet bindings.', badge: 'DIGITAL' },
   ]},
   { id: 'intelligence', eyebrow: 'OPTIONAL EXPERIENCES', title: 'AI + playful tools', description: 'Useful extras stay available without crowding the core Create → World → Vault flow.', items: [
     { id: 'vault-ai', href: '/ai', label: 'Vault AI', icon: '✦', description: 'Research products, sources, provenance and collection context.', badge: 'AI' },

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://hartensteindominic.github.io/Ad-Revenue/sitemap.xml
+Sitemap: https://www.voxelvault.io/sitemap.xml

--- a/scripts/audit-all-files.mjs
+++ b/scripts/audit-all-files.mjs
@@ -46,7 +46,12 @@ function cleanSpecifier(specifier) {
   return specifier.split('?')[0].split('#')[0];
 }
 
+function expectedGeneratedImport(fromFile, specifier) {
+  return fromFile === 'next-env.d.ts' && cleanSpecifier(specifier).startsWith('./.next/types/');
+}
+
 function relativeTargetExists(fromFile, specifier) {
+  if (expectedGeneratedImport(fromFile, specifier)) return true;
   const cleaned = cleanSpecifier(specifier);
   const base = path.resolve(root, path.dirname(fromFile), cleaned);
   for (const ext of resolvableExtensions) {
@@ -96,7 +101,15 @@ function auditMarkdownLinks(file, text) {
 }
 
 function auditHighConfidenceSecrets(file, text) {
-  if (file === '.env.example' || file.startsWith('docs/') || file.startsWith('scripts/') || file.startsWith('test/') || file.startsWith('tests/')) return;
+  const basename = path.basename(file);
+  if (
+    file === '.env.example'
+    || file === 'scripts/audit-all-files.mjs'
+    || file.startsWith('docs/')
+    || file.startsWith('test/')
+    || file.startsWith('tests/')
+    || (file.startsWith('scripts/') && /^(?:test-|check-|smoke-test)/.test(basename))
+  ) return;
   const patterns = [
     [/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/, 'embedded private key'],
     [/\bsk_live_[A-Za-z0-9]{20,}\b/, 'live Stripe secret key'],
@@ -158,10 +171,10 @@ for (const file of tracked) {
     auditRelativeImports(file, text);
   }
 
-  if (buffer.length > 180_000 && !['package-lock.json'].includes(file)) {
+  if (buffer.length > 180_000 && file !== 'package-lock.json') {
     record('warning', file, `large tracked text file (${Math.round(buffer.length / 1024)} KiB); consider splitting for maintainability`);
   }
-  if (/\b(?:TODO|FIXME|HACK)\b/i.test(text) && !file.startsWith('docs/')) {
+  if (file !== 'scripts/audit-all-files.mjs' && /\b(?:TODO|FIXME|HACK)\b/i.test(text) && !file.startsWith('docs/')) {
     record('warning', file, 'contains TODO/FIXME/HACK marker');
   }
 }

--- a/scripts/audit-all-files.mjs
+++ b/scripts/audit-all-files.mjs
@@ -1,0 +1,185 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { TextDecoder } from 'node:util';
+
+const root = process.cwd();
+const decoder = new TextDecoder('utf-8', { fatal: true });
+const errors = [];
+const warnings = [];
+const counts = { files: 0, bytes: 0, text: 0, binary: 0, json: 0, markdown: 0, source: 0 };
+const byTopLevel = new Map();
+const manifest = crypto.createHash('sha256');
+
+const tracked = execFileSync('git', ['ls-files', '-z'], { cwd: root })
+  .toString('utf8')
+  .split('\0')
+  .filter(Boolean)
+  .sort();
+
+const binaryExtensions = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.pdf', '.zip', '.gz', '.woff', '.woff2', '.ttf', '.otf',
+  '.glb', '.gltf.bin', '.mp3', '.mp4', '.mov', '.webm', '.wasm', '.mapbox', '.pmtiles',
+]);
+const sourceExtensions = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx']);
+const resolvableExtensions = ['', '.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx', '.json', '.css', '.scss', '.svg'];
+const expectedEmpty = new Set(['.nojekyll']);
+
+function record(level, file, message) {
+  (level === 'error' ? errors : warnings).push(`${file}: ${message}`);
+}
+
+function topLevel(file) {
+  return file.includes('/') ? file.split('/')[0] : '(root)';
+}
+
+function isProbablyBinary(file, buffer) {
+  const lower = file.toLowerCase();
+  if ([...binaryExtensions].some((ext) => lower.endsWith(ext))) return true;
+  const sample = buffer.subarray(0, Math.min(buffer.length, 8000));
+  for (const byte of sample) if (byte === 0) return true;
+  return false;
+}
+
+function cleanSpecifier(specifier) {
+  return specifier.split('?')[0].split('#')[0];
+}
+
+function relativeTargetExists(fromFile, specifier) {
+  const cleaned = cleanSpecifier(specifier);
+  const base = path.resolve(root, path.dirname(fromFile), cleaned);
+  for (const ext of resolvableExtensions) {
+    if (fs.existsSync(`${base}${ext}`) && fs.statSync(`${base}${ext}`).isFile()) return true;
+  }
+  for (const ext of resolvableExtensions) {
+    const candidate = path.join(base, `index${ext}`);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return true;
+  }
+  return false;
+}
+
+function auditRelativeImports(file, text) {
+  const patterns = [
+    /\b(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.{1,2}\/[^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"](\.{1,2}\/[^'"]+)['"]\s*\)/g,
+    /\brequire\s*\(\s*['"](\.{1,2}\/[^'"]+)['"]\s*\)/g,
+  ];
+  const seen = new Set();
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const specifier = match[1];
+      if (!specifier || seen.has(specifier)) continue;
+      seen.add(specifier);
+      if (!relativeTargetExists(file, specifier)) record('error', file, `relative import does not resolve: ${specifier}`);
+    }
+  }
+}
+
+function auditMarkdownLinks(file, text) {
+  counts.markdown += 1;
+  const linkPattern = /!?\[[^\]]*\]\(([^)]+)\)/g;
+  for (const match of text.matchAll(linkPattern)) {
+    let target = String(match[1] || '').trim();
+    if (!target || target.startsWith('#') || /^(?:https?:|mailto:|tel:|data:)/i.test(target)) continue;
+    if (target.startsWith('<') && target.endsWith('>')) target = target.slice(1, -1);
+    target = target.split(/\s+["']/)[0].split('#')[0].split('?')[0];
+    try { target = decodeURIComponent(target); } catch {}
+    if (!target) continue;
+    const resolved = path.resolve(root, path.dirname(file), target);
+    if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+      record('error', file, `local Markdown link escapes repository: ${target}`);
+      continue;
+    }
+    if (!fs.existsSync(resolved)) record('error', file, `local Markdown link is missing: ${target}`);
+  }
+}
+
+function auditHighConfidenceSecrets(file, text) {
+  if (file === '.env.example' || file.startsWith('docs/') || file.startsWith('scripts/') || file.startsWith('test/') || file.startsWith('tests/')) return;
+  const patterns = [
+    [/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/, 'embedded private key'],
+    [/\bsk_live_[A-Za-z0-9]{20,}\b/, 'live Stripe secret key'],
+    [/\bgh(?:p|o|u|s|r)_[A-Za-z0-9]{30,}\b/, 'GitHub access token'],
+    [/\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{20,}\b/, 'Slack access token'],
+    [/\bAKIA[0-9A-Z]{16}\b/, 'AWS access key ID'],
+  ];
+  for (const [pattern, label] of patterns) if (pattern.test(text)) record('error', file, label);
+}
+
+for (const file of tracked) {
+  const full = path.join(root, file);
+  let stat;
+  try { stat = fs.lstatSync(full); } catch (error) {
+    record('error', file, `cannot stat tracked path: ${error.message}`);
+    continue;
+  }
+  if (!stat.isFile() && !stat.isSymbolicLink()) {
+    record('warning', file, 'tracked path is not a regular file or symlink');
+    continue;
+  }
+
+  let buffer;
+  try { buffer = fs.readFileSync(full); } catch (error) {
+    record('error', file, `cannot read tracked file: ${error.message}`);
+    continue;
+  }
+
+  counts.files += 1;
+  counts.bytes += buffer.length;
+  byTopLevel.set(topLevel(file), (byTopLevel.get(topLevel(file)) || 0) + 1);
+  manifest.update(file); manifest.update('\0'); manifest.update(buffer); manifest.update('\0');
+
+  if (buffer.length === 0 && !expectedEmpty.has(file)) record('warning', file, 'empty tracked file');
+  if (isProbablyBinary(file, buffer)) {
+    counts.binary += 1;
+    continue;
+  }
+
+  let text;
+  try { text = decoder.decode(buffer); } catch {
+    counts.binary += 1;
+    record('warning', file, 'non-binary extension contains non-UTF-8 bytes');
+    continue;
+  }
+  counts.text += 1;
+
+  if (/^<<<<<<< /m.test(text) || /^>>>>>>> /m.test(text)) record('error', file, 'unresolved merge-conflict marker');
+  auditHighConfidenceSecrets(file, text);
+
+  const ext = path.extname(file).toLowerCase();
+  if (ext === '.json') {
+    counts.json += 1;
+    try { JSON.parse(text); } catch (error) { record('error', file, `invalid JSON: ${error.message}`); }
+  }
+  if (ext === '.md' || ext === '.mdx') auditMarkdownLinks(file, text);
+  if (sourceExtensions.has(ext)) {
+    counts.source += 1;
+    auditRelativeImports(file, text);
+  }
+
+  if (buffer.length > 180_000 && !['package-lock.json'].includes(file)) {
+    record('warning', file, `large tracked text file (${Math.round(buffer.length / 1024)} KiB); consider splitting for maintainability`);
+  }
+  if (/\b(?:TODO|FIXME|HACK)\b/i.test(text) && !file.startsWith('docs/')) {
+    record('warning', file, 'contains TODO/FIXME/HACK marker');
+  }
+}
+
+console.log(`Repository file audit read ${counts.files} tracked files (${counts.text} text, ${counts.binary} binary), ${counts.bytes.toLocaleString()} bytes total.`);
+console.log(`Validated ${counts.json} JSON files, ${counts.markdown} Markdown files, and relative imports in ${counts.source} source files.`);
+console.log(`Whole-repository content digest: ${manifest.digest('hex')}`);
+console.log('Tracked files by top-level area:');
+for (const [area, count] of [...byTopLevel.entries()].sort((a, b) => a[0].localeCompare(b[0]))) console.log(`  ${area}: ${count}`);
+
+if (warnings.length) {
+  console.log(`\nWarnings (${warnings.length}):`);
+  for (const warning of warnings) console.log(`  WARN ${warning}`);
+}
+if (errors.length) {
+  console.error(`\nErrors (${errors.length}):`);
+  for (const error of errors) console.error(`  ERROR ${error}`);
+  process.exitCode = 1;
+} else {
+  console.log('\nFull tracked-file audit passed with no blocking file-integrity errors.');
+}

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -28,7 +28,7 @@ for (const route of ['/property', '/vault/earth', '/geo', '/studio', '/capture',
 }
 assert.match(productMap, /\$1\.99 Property Sandbox/, 'the tiny property comparison must remain explicitly sandboxed under More');
 assert.match(productMap, /No real funds or property rights move/, 'sandbox description must preserve the no-rights boundary');
-assert.match(productMap, /\$4\.99 local VoxelPop image \+ interactive 3D/, 'property creator directory entry must disclose the local paid creation');
+assert.match(productMap, /Authorized photo → \$4\.99 textured 3D preview → approval → movable voxel/, 'property creator directory entry must disclose the paid preview-before-voxel creation sequence');
 assert.match(productMap, /badge: 'PROVIDER-GATED'/, 'regulated investment tools must be visibly provider-gated');
 assert.match(productMap, /A token or VoxelPop item is never the deed/, 'direct ownership path must keep title separate from the token');
 assert.match(productMap, /APP_USER_PREFIXES[\s\S]*'\/admin'/, 'owner routes should keep the global app shell');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -51,3 +51,4 @@ assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidan
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
 console.log('Public VoxelPop positioning checks passed: no-login product proof, focused $4.99 story, corrected trust pages, richer social preview, and scoped README remain intact.');
+await import('./test-public-surface-coherence.mjs');

--- a/scripts/test-public-surface-coherence.mjs
+++ b/scripts/test-public-surface-coherence.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (file) => fs.readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+
+const staticIndex = read('index.html');
+const staticSitemap = read('sitemap.xml');
+const staticRobots = read('robots.txt');
+const appSitemap = read('app/sitemap.js');
+const appRobots = read('app/robots.js');
+const layout = read('app/layout.js');
+const home = read('app/page.js');
+const checkout = read('app/api/checkout/route.ts');
+const secureCheckout = read('app/api/checkout-secure/route.ts');
+const productMap = read('lib/product-map.js');
+
+for (const [name, source] of [
+  ['static index', staticIndex],
+  ['static sitemap', staticSitemap],
+  ['static robots', staticRobots],
+]) {
+  assert.match(source, /https:\/\/www\.voxelvault\.io/, `${name} must point to the canonical Voxel Vault domain.`);
+  assert.doesNotMatch(source, /Ad-Revenue|voxel-vault\.vercel\.app|VoxelForge/, `${name} must not preserve an obsolete public identity.`);
+}
+
+for (const route of ['/', '/demo', '/property', '/world', '/more', '/about', '/privacy', '/terms']) {
+  const escaped = route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  assert.match(appSitemap, new RegExp(`path:\\s*['"]${escaped}['"]`), `Next sitemap must include ${route}.`);
+}
+assert.doesNotMatch(appSitemap, /path:\s*['"]\/studio['"]/, 'The optional Studio route must not replace the current property product in the public sitemap.');
+
+for (const privatePath of ['/admin/', '/api/', '/vault/', '/account/', '/checkout/', '/property/mint']) {
+  assert.match(appRobots, new RegExp(privatePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `robots metadata must keep ${privatePath} out of search crawling.`);
+}
+
+assert.doesNotMatch(layout, /alternates:\s*\{\s*canonical:\s*SITE_URL/, 'The root layout must not force the homepage canonical onto every child route.');
+assert.match(home, /alternates:\s*\{\s*canonical:\s*['"]\/['"]\s*\}/, 'The homepage must own its own canonical URL.');
+
+for (const [name, source] of [['checkout', checkout], ['secure checkout', secureCheckout]]) {
+  assert.match(source, /NEXT_PUBLIC_SITE_URL[\s\S]*NEXT_PUBLIC_APP_URL[\s\S]*https:\/\/www\.voxelvault\.io/, `${name} must use the canonical domain as its safe fallback.`);
+  assert.doesNotMatch(source, /https:\/\/voxel-vault\.vercel\.app/, `${name} must not redirect a customer to the obsolete Vercel hostname.`);
+}
+
+assert.match(productMap, /Authorized photo → \$4\.99 textured 3D preview → approval → movable voxel → optional World\/map\/mint\./, 'Canonical product-map copy must preserve preview-before-voxel ordering.');
+assert.match(productMap, /included voxel for eligible purchases/, 'Product-map Digital Twin copy must preserve the purchased-twin voxel entitlement.');
+
+console.log('Public-surface coherence passed: canonical domain, sitemap/robots, checkout fallbacks, canonical scoping, and preview-before-voxel positioning are aligned.');

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,1 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://hartensteindominic.github.io/Ad-Revenue/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/tools/profit-margin/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/tools/discount-calculator/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/tools/break-even-calculator/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/tools/loan-payment/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/tools/hourly-rate/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/privacy.html</loc><priority>0.3</priority></url><url><loc>https://hartensteindominic.github.io/Ad-Revenue/terms.html</loc><priority>0.3</priority></url></urlset>
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.voxelvault.io/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://www.voxelvault.io/demo</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://www.voxelvault.io/property</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://www.voxelvault.io/world</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.voxelvault.io/more</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.voxelvault.io/about</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.voxelvault.io/privacy</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+  <url><loc>https://www.voxelvault.io/terms</loc><changefreq>monthly</changefreq><priority>0.4</priority></url>
+</urlset>


### PR DESCRIPTION
## Goal
Review the entire current Voxel Vault repository rather than only customer-facing pages, fix real inconsistencies found, and make the review repeatable in CI.

## Full repository audit
A new repository-wide audit uses `git ls-files` and **reads every tracked file**. On the current PR merged with the latest `main`, it successfully audited **816 tracked files**: 811 text and 5 binary, ~4.9 MB total.

It validates:
- file readability / UTF-8 text integrity;
- JSON parsing;
- local JS/TS relative-import resolution;
- local Markdown links;
- unresolved merge-conflict markers;
- high-confidence accidental credential patterns;
- empty/oversized/TODO maintainability signals;
- whole-repository content digest and inventory.

A dedicated `Full Repository File Audit` GitHub Actions workflow now runs this on future PRs and `main` pushes.

## Real issues found and fixed
- Replaced stale root `index.html` VoxelForge/old-Vercel redirect with the canonical Voxel Vault house-photo → 3D voxel entry point.
- Replaced old `Ad-Revenue` static sitemap/robots URLs with `https://www.voxelvault.io`.
- Updated Next.js sitemap to the current public product routes and kept private/account routes out of robots indexing.
- Removed the root-layout homepage canonical that could be inherited by child pages; homepage now owns its own canonical.
- Replaced old Vercel checkout fallback URLs with the canonical Voxel Vault domain.
- Updated product-map wording to the current **$4.99 textured 3D preview → approval → movable voxel** flow and preserved the included purchased-Digital-Twin voxel path.
- Updated outdated regression expectations instead of reintroducing stale product copy.
- Clarified the optional/mainnet deployment guide and replaced the stale deployment-marker baseline.
- Added the generated mainnet-address file to `.gitignore`.
- Updated the Quality Gate build environment to the canonical site URL.
- Preserved the newer consumer/mobile polish from `main`; the audit branch only makes targeted metadata/SEO/domain/copy/test/operational changes to those surfaces.

## Safety / release status
- Production dependency audit reports 0 vulnerabilities with `npm audit --omit=dev`.
- Mobile WebGL guard passes.
- Ethereum contract checks pass.
- Voxel Vault contract checks pass.
- Standalone production web build passes.
- Vercel preview deploys Ready.
- Full Quality Gate is required to be green before merge.

The five binary image assets are included in the read/inventory audit. The connector does not expose their bytes for pixel-level visual inspection, so this PR does not falsely claim a direct pixel review; their referenced paths and the rendered/build pipeline remain covered by code/build checks.