### PR TITLE
Finish full-repository audit with deployment hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,27 @@
+# Core public application URLs. These values are safe to expose in browser code.
+NEXT_PUBLIC_APP_URL=https://www.voxelvault.io
+NEXT_PUBLIC_SITE_URL=https://www.voxelvault.io
+
+# Supabase browser authentication. The anon key is public by design; never use a
+# service-role or sb_secret_ key in any NEXT_PUBLIC_ variable.
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Stripe server configuration. Server-only; never use NEXT_PUBLIC_ prefixes.
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Scheduled catalog maintenance. Vercel cron must call the route with
+# Authorization: Bearer <CRON_SECRET>. Leave unset only when the cron is intentionally disabled.
+CRON_SECRET=
+
+# Optional VoxelPop property NFT minting. Server-only signing material.
+# VOXELFLIP_MINT_SIGNER_PRIVATE_KEY must be a dedicated 32-byte EVM private key.
+# PROPERTY_VOXEL_METADATA_SECRET should be a separate strong random HMAC secret.
+VOXELFLIP_MINT_SIGNER_PRIVATE_KEY=
+PROPERTY_VOXEL_METADATA_SECRET=
+VOXELFLIP_RPC_URL=https://mainnet.base.org
+
 # Public Base RPC fallback. Flashblocks pending-state reads use the separate preconfirmation endpoint below.
 BASE_RPC_URL=https://mainnet.base.org
 BASE_FLASHBLOCKS_RPC_URL=https://mainnet-preconf.base.org

--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -8,9 +8,9 @@ export const maxDuration = 60;
 const STALE_AFTER_MS = 25 * 60 * 1000;
 
 function authorized(request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret) return request.headers.get('authorization') === `Bearer ${secret}`;
-  return /vercel-cron/i.test(request.headers.get('user-agent') || '');
+  const secret = String(process.env.CRON_SECRET || '').trim();
+  if (!secret) return null;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
 }
 
 function terminalFailure(row) {
@@ -28,7 +28,11 @@ function isStale(row) {
 }
 
 export async function GET(request) {
-  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = authorized(request);
+  if (auth === null) {
+    return NextResponse.json({ error: 'Cron authentication is not configured.' }, { status: 503 });
+  }
+  if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const health = await catalog3DStoreHealth();
   if (!health.ready) {

--- a/scripts/audit-all-files.mjs
+++ b/scripts/audit-all-files.mjs
@@ -113,11 +113,73 @@ function auditHighConfidenceSecrets(file, text) {
   const patterns = [
     [/-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/, 'embedded private key'],
     [/\bsk_live_[A-Za-z0-9]{20,}\b/, 'live Stripe secret key'],
+    [/\brk_live_[A-Za-z0-9]{20,}\b/, 'live Stripe restricted key'],
+    [/\bwhsec_[A-Za-z0-9]{24,}\b/, 'Stripe webhook secret'],
     [/\bgh(?:p|o|u|s|r)_[A-Za-z0-9]{30,}\b/, 'GitHub access token'],
+    [/\bgithub_pat_[A-Za-z0-9_]{40,}\b/, 'GitHub fine-grained access token'],
     [/\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{20,}\b/, 'Slack access token'],
     [/\bAKIA[0-9A-Z]{16}\b/, 'AWS access key ID'],
   ];
   for (const [pattern, label] of patterns) if (pattern.test(text)) record('error', file, label);
+}
+
+function auditDeploymentSafety() {
+  const committedEnvFiles = tracked.filter((file) => {
+    const basename = path.basename(file);
+    if (!basename.startsWith('.env')) return false;
+    return !basename.endsWith('.example') && !basename.endsWith('.sample') && !basename.endsWith('.template');
+  });
+  for (const file of committedEnvFiles) record('error', file, 'real environment files must never be committed');
+
+  const envPath = path.join(root, '.env.example');
+  if (!fs.existsSync(envPath)) {
+    record('error', '.env.example', 'core deployment example is missing');
+  } else {
+    const envText = fs.readFileSync(envPath, 'utf8');
+    for (const name of [
+      'NEXT_PUBLIC_APP_URL',
+      'NEXT_PUBLIC_SITE_URL',
+      'NEXT_PUBLIC_SUPABASE_URL',
+      'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+      'STRIPE_SECRET_KEY',
+      'STRIPE_WEBHOOK_SECRET',
+      'CRON_SECRET',
+      'VOXELFLIP_MINT_SIGNER_PRIVATE_KEY',
+      'PROPERTY_VOXEL_METADATA_SECRET',
+    ]) {
+      if (!new RegExp(`^${name}=`, 'm').test(envText)) record('error', '.env.example', `must document ${name}`);
+    }
+  }
+
+  const cronFile = 'app/api/cron/catalog-3d/route.js';
+  const cronPath = path.join(root, cronFile);
+  if (!fs.existsSync(cronPath)) {
+    record('error', cronFile, 'catalog maintenance route is missing');
+  } else {
+    const cronText = fs.readFileSync(cronPath, 'utf8');
+    if (!/CRON_SECRET/.test(cronText)) record('error', cronFile, 'must require CRON_SECRET');
+    if (!/authorization/i.test(cronText)) record('error', cronFile, 'must authenticate with the Authorization header');
+    if (/user-agent|vercel-cron/i.test(cronText)) record('error', cronFile, 'must not trust a spoofable User-Agent as authentication');
+    if (!/status:\s*503/.test(cronText)) record('error', cronFile, 'must fail closed when scheduled-job authentication is not configured');
+  }
+
+  const migrations = tracked.filter((file) => file.startsWith('supabase/migrations/') && file.endsWith('.sql'));
+  const byVersion = new Map();
+  for (const file of migrations) {
+    const version = path.basename(file).split('_')[0];
+    const files = byVersion.get(version) || [];
+    files.push(file);
+    byVersion.set(version, files);
+  }
+  const knownLegacyCollisions = new Set(['002', '003']);
+  for (const [version, files] of byVersion) {
+    if (files.length <= 1) continue;
+    if (knownLegacyCollisions.has(version)) {
+      record('warning', 'supabase/migrations', `reviewed legacy migration version ${version} is shared by ${files.map(path.basename).join(', ')}; do not rename already-applied migrations without reconciling production history`);
+    } else {
+      record('error', 'supabase/migrations', `new duplicate migration version ${version}: ${files.map(path.basename).join(', ')}`);
+    }
+  }
 }
 
 for (const file of tracked) {
@@ -179,6 +241,8 @@ for (const file of tracked) {
   }
 }
 
+auditDeploymentSafety();
+
 console.log(`Repository file audit read ${counts.files} tracked files (${counts.text} text, ${counts.binary} binary), ${counts.bytes.toLocaleString()} bytes total.`);
 console.log(`Validated ${counts.json} JSON files, ${counts.markdown} Markdown files, and relative imports in ${counts.source} source files.`);
 console.log(`Whole-repository content digest: ${manifest.digest('hex')}`);
@@ -194,5 +258,5 @@ if (errors.length) {
   for (const error of errors) console.error(`  ERROR ${error}`);
   process.exitCode = 1;
 } else {
-  console.log('\nFull tracked-file audit passed with no blocking file-integrity errors.');
+  console.log('\nFull tracked-file audit passed with no blocking file-integrity or deployment-safety errors.');
 }

--- a/scripts/audit-all-files.mjs
+++ b/scripts/audit-all-files.mjs
@@ -174,10 +174,11 @@ function auditDeploymentSafety() {
   const knownLegacyCollisions = new Set(['002', '003']);
   for (const [version, files] of byVersion) {
     if (files.length <= 1) continue;
+    const filenames = files.map((file) => path.basename(file)).join(', ');
     if (knownLegacyCollisions.has(version)) {
-      record('warning', 'supabase/migrations', `reviewed legacy migration version ${version} is shared by ${files.map(path.basename).join(', ')}; do not rename already-applied migrations without reconciling production history`);
+      record('warning', 'supabase/migrations', `reviewed legacy migration version ${version} is shared by ${filenames}; do not rename already-applied migrations without reconciling production history`);
     } else {
-      record('error', 'supabase/migrations', `new duplicate migration version ${version}: ${files.map(path.basename).join(', ')}`);
+      record('error', 'supabase/migrations', `new duplicate migration version ${version}: ${filenames}`);
     }
   }
 }


### PR DESCRIPTION
Superseded by merged PR #469, which landed the same corrected fail-closed cron authentication, deployment environment documentation, and enhanced all-files safety invariants on the newer `main`. Closing this duplicate so it cannot reapply stale overlapping changes.