### PR TITLE
Finish repo-wide public-surface cleanup

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,1 +1,15 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Privacy | Voxel Vault</title><style>body{margin:0;background:#fffaf0;color:#241820;font:15px/1.7 system-ui,sans-serif}.wrap{max-width:820px;margin:auto;padding:40px 20px}.card{background:#fff;border:1px solid #e3dce6;border-radius:24px;padding:26px}a{color:#6f3df4}.muted{color:#7c727b}.note{background:#f2ffe0;border-radius:14px;padding:12px 14px;color:#50672f}</style></head><body><main class="wrap"><a href="https://www.voxelvault.io/">← Voxel Vault</a><div class="card"><h1>Privacy</h1><p class="muted">Current VoxelPop property-photo privacy summary.</p><p class="note"><b>Core flow:</b> the normal $4.99 VoxelPop property creation is designed to process the source photo in the browser and does not require Meshy credits.</p><h2>Property photos</h2><p>The selected source image is processed locally for the current 3D preview and voxel flow. When browser storage is available, an on-device copy may be retained so a paid creation can resume after checkout. The source photo is not intentionally published in NFT metadata.</p><h2>Accounts and payments</h2><p>Google sign-in may associate saved product state with an account. Payments are handled by the configured payment provider; the application should not store complete card numbers.</p><h2>Maps and wallets</h2><p>Map data is separate from the private source photo and from legal ownership records. A wallet is optional and is requested only for explicit blockchain actions such as minting.</p><h2>Questions</h2><p>See the live <a href="https://www.voxelvault.io/privacy">Privacy page</a> and <a href="https://www.voxelvault.io/about">About/contact page</a> for the current product notice. Do not post passwords, payment credentials, private keys, identity documents, deeds, leases, or other sensitive information in public issues.</p></div></main></body></html>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="0;url=https://www.voxelvault.io/privacy">
+  <link rel="canonical" href="https://www.voxelvault.io/privacy">
+  <meta name="robots" content="noindex,follow">
+  <title>Voxel Vault Privacy</title>
+  <script>window.location.replace('https://www.voxelvault.io/privacy');</script>
+</head>
+<body style="margin:0;background:#fffaf0;color:#241820;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:grid;place-items:center;min-height:100vh;padding:24px;box-sizing:border-box">
+  <p>Opening the current <a href="https://www.voxelvault.io/privacy">Voxel Vault Privacy Policy</a>…</p>
+</body>
+</html>

--- a/scripts/test-public-surface-coherence.mjs
+++ b/scripts/test-public-surface-coherence.mjs
@@ -6,6 +6,8 @@ const read = (file) => fs.readFileSync(new URL(`../${file}`, import.meta.url), '
 const staticIndex = read('index.html');
 const staticSitemap = read('sitemap.xml');
 const staticRobots = read('robots.txt');
+const staticPrivacy = read('privacy.html');
+const staticTerms = read('terms.html');
 const appSitemap = read('app/sitemap.js');
 const appRobots = read('app/robots.js');
 const layout = read('app/layout.js');
@@ -20,6 +22,17 @@ for (const [name, source] of [
   ['static robots', staticRobots],
 ]) {
   assert.match(source, /https:\/\/www\.voxelvault\.io/, `${name} must point to the canonical Voxel Vault domain.`);
+  assert.doesNotMatch(source, /Ad-Revenue|voxel-vault\.vercel\.app|VoxelForge/, `${name} must not preserve an obsolete public identity.`);
+}
+
+for (const [name, source, path] of [
+  ['static privacy', staticPrivacy, '/privacy'],
+  ['static terms', staticTerms, '/terms'],
+]) {
+  const url = `https://www.voxelvault.io${path}`;
+  assert.ok(source.includes(`rel="canonical" href="${url}"`), `${name} must canonicalize to the live policy route.`);
+  assert.ok(source.includes(`window.location.replace('${url}')`), `${name} must redirect to the live policy route.`);
+  assert.match(source, /name="robots" content="noindex,follow"/, `${name} must not compete with the live policy in search results.`);
   assert.doesNotMatch(source, /Ad-Revenue|voxel-vault\.vercel\.app|VoxelForge/, `${name} must not preserve an obsolete public identity.`);
 }
 
@@ -44,4 +57,4 @@ for (const [name, source] of [['checkout', checkout], ['secure checkout', secure
 assert.match(productMap, /Authorized photo → \$4\.99 textured 3D preview → approval → movable voxel → optional World\/map\/mint\./, 'Canonical product-map copy must preserve preview-before-voxel ordering.');
 assert.match(productMap, /included voxel for eligible purchases/, 'Product-map Digital Twin copy must preserve the purchased-twin voxel entitlement.');
 
-console.log('Public-surface coherence passed: canonical domain, sitemap/robots, checkout fallbacks, canonical scoping, and preview-before-voxel positioning are aligned.');
+console.log('Public-surface coherence passed: canonical domain, static legal redirects, sitemap/robots, checkout fallbacks, canonical scoping, and preview-before-voxel positioning are aligned.');

--- a/terms.html
+++ b/terms.html
@@ -1,1 +1,15 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Terms | Voxel Vault</title><style>body{margin:0;background:#fffaf0;color:#241820;font:15px/1.7 system-ui,sans-serif}.wrap{max-width:820px;margin:auto;padding:40px 20px}.card{background:#fff;border:1px solid #e3dce6;border-radius:24px;padding:26px}a{color:#6f3df4}.muted{color:#7c727b}.note{background:#f2ffe0;border-radius:14px;padding:12px 14px;color:#50672f}</style></head><body><main class="wrap"><a href="https://www.voxelvault.io/">← Voxel Vault</a><div class="card"><h1>Terms</h1><p class="muted">Current VoxelPop product summary.</p><p class="note"><b>$4.99 DIGITAL:</b> the creation payment buys one digital VoxelPop creation. It does not buy the physical house or land or create title, equity, rent, occupancy, investment, or appreciation rights.</p><h2>Source content</h2><p>Only use a property photo or other content you took, own, or have permission to use.</p><h2>Creation accuracy</h2><p>A single photograph cannot establish unseen walls, exact dimensions, roof geometry, survey accuracy, appraisal value, structural condition, or legal ownership. VoxelPop results are digital representations and can vary with source quality and device capability.</p><h2>Maps, demo tools and blockchain</h2><p>Map geometry is not title evidence. The $1.99 Property Sandbox uses demo credit only. A wallet is optional for core creation; blockchain transactions are separate user-approved actions and can be public and irreversible.</p><h2>Current version</h2><p>See the live <a href="https://www.voxelvault.io/terms">Terms page</a> for the current product notice.</p></div></main></body></html>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="0;url=https://www.voxelvault.io/terms">
+  <link rel="canonical" href="https://www.voxelvault.io/terms">
+  <meta name="robots" content="noindex,follow">
+  <title>Voxel Vault Terms</title>
+  <script>window.location.replace('https://www.voxelvault.io/terms');</script>
+</head>
+<body style="margin:0;background:#fffaf0;color:#241820;font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;display:grid;place-items:center;min-height:100vh;padding:24px;box-sizing:border-box">
+  <p>Opening the current <a href="https://www.voxelvault.io/terms">Voxel Vault Terms</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
## What this finishes

This is the narrow cleanup left after the repository-wide audit and the newer main-branch hardening work.

- make legacy root `privacy.html` redirect/canonicalize to the live `/privacy` policy
- make legacy root `terms.html` redirect/canonicalize to the live `/terms` policy
- mark both legacy static copies `noindex,follow` so they do not compete with the live Next.js policies
- extend public-surface regression coverage so these redirects cannot silently drift

## What was deliberately preserved

- newest photo → $4.99 → 3D picture → approval → voxel → Vault → optional mint flow
- current canonical-domain sitemap/robots/checkout changes already on main
- full tracked-file audit workflow already on main
- all contracts, migrations, provider integrations, payment logic, and property-rights safety gates
- legacy prototype files were reviewed but not deleted in this PR

## Validation

PR CI should run the existing full tracked-file audit, quality gate, web build, mobile WebGL guard, and contract checks. The public-surface test is reached through the existing public-demo/property-platform regression chain.