### PR TITLE
Lock down internal Meshy catalog worker

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm run test:media
       - run: npm run test:mobile
       - run: npm run test:voxel-flow
+      - run: node scripts/test-catalog-worker-security.mjs
       - run: npm run test:machine-revenue
       - run: npm run test:liquidity-engine
       - run: npm run test:multipair
@@ -67,7 +68,4 @@ jobs:
         with:
           node-version: 22
       - run: npm install --no-audit --no-fund
-      # Critical vulnerabilities remain a hard release blocker. High-severity
-      # findings are recorded in docs/SECURITY_REVIEW.md and require a separate
-      # dependency-upgrade release because the current fixes are breaking.
       - run: npm audit --omit=dev --audit-level=critical

--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -7,10 +7,15 @@ export const maxDuration = 60;
 
 const STALE_AFTER_MS = 25 * 60 * 1000;
 
-function authorized(request) {
+function cronAuthorizationHeader() {
   const secret = String(process.env.CRON_SECRET || '').trim();
-  if (!secret) return null;
-  return request.headers.get('authorization') === `Bearer ${secret}`;
+  return secret ? `Bearer ${secret}` : '';
+}
+
+function authorized(request) {
+  const expected = cronAuthorizationHeader();
+  if (!expected) return null;
+  return request.headers.get('authorization') === expected;
 }
 
 function terminalFailure(row) {
@@ -28,6 +33,7 @@ function isStale(row) {
 }
 
 export async function GET(request) {
+  const authHeader = cronAuthorizationHeader();
   const auth = authorized(request);
   if (auth === null) {
     return NextResponse.json({ error: 'Cron authentication is not configured.' }, { status: 503 });
@@ -49,10 +55,12 @@ export async function GET(request) {
   const rows = await listCatalog3D();
   const byItem = new Map(rows.map(row => [row.item_id, row]));
   const operations = [];
+  const internalHeaders = { authorization: authHeader };
 
   for (const row of rows) {
     if (!row.task_id || hasFinishedModel(row) || terminalFailure(row) || isStale(row)) continue;
     operations.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, {
+      headers: internalHeaders,
       cache: 'no-store',
     }).then(async response => ({ kind: 'poll', itemId: row.item_id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -70,8 +78,8 @@ export async function GET(request) {
   for (const item of toRestart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item, forceRestart: true }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id, forceRestart: true }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'restart', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -79,8 +87,8 @@ export async function GET(request) {
   for (const item of toStart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'start', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }

--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cjProductImages, getCjProductBySku } from '../../../lib/cjApi';
 import { persistModelBinary, readCatalog3D, readCatalog3DByTask, saveCatalog3D } from '../../../lib/catalog3dStore';
+import { REAL_WORLD_CATALOG } from '../../../lib/realWorldCatalog';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -8,6 +9,17 @@ export const maxDuration = 60;
 const IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MULTI_IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/multi-image-to-3d';
 const MAX_TEXTURE_PROMPT = 560;
+
+function authorized(request) {
+  const secret = String(process.env.CRON_SECRET || '').trim();
+  return Boolean(secret && request.headers.get('authorization') === `Bearer ${secret}`);
+}
+
+function trustedCatalogItem(body = {}) {
+  const requestedId = String(body?.item?.id || body?.itemId || '').trim();
+  if (!requestedId) return null;
+  return REAL_WORLD_CATALOG.find((item) => item.id === requestedId) || null;
+}
 
 function buildPrompt(item = {}) {
   const name = [item.name, item.type].filter(Boolean).join(' / ') || 'the product';
@@ -45,9 +57,8 @@ async function scrapeProductImage(sourceUrl) {
   return '';
 }
 
-async function resolveProductImages(requestedImageUrl, item) {
+async function resolveProductImages(item) {
   const images = [];
-  if (requestedImageUrl && !isPlaceholderImage(requestedImageUrl)) images.push(requestedImageUrl);
   if (item?.supplierSku) {
     try {
       const product = await getCjProductBySku(item.supplierSku);
@@ -65,15 +76,17 @@ function parseTaskId(value = '') {
 }
 
 export async function POST(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });
   try {
     const body = await request.json();
-    const item = body?.item && typeof body.item === 'object' ? body.item : {};
-    const itemId = String(item?.id || body?.itemId || '').trim();
+    const item = trustedCatalogItem(body);
+    if (!item) return NextResponse.json({ error: 'Trusted catalog item is required.' }, { status: 404 });
+    const itemId = item.id;
     const forceRestart = body?.forceRestart === true;
 
-    if (itemId && !forceRestart) {
+    if (!forceRestart) {
       const saved = await readCatalog3D(itemId);
       if (saved?.model_url || saved?.model_storage_path) {
         return NextResponse.json({ configured: true, reused: true, modelUrl: saved.model_url || null, stored: Boolean(saved.model_storage_path), taskId: saved.task_id || null, progress: 100 });
@@ -83,8 +96,7 @@ export async function POST(request) {
       }
     }
 
-    const requestedImageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    const imageUrls = await resolveProductImages(requestedImageUrl, item);
+    const imageUrls = await resolveProductImages(item);
     if (!imageUrls.length) return NextResponse.json({ error: 'Public product media could not be resolved.' }, { status: 400 });
 
     const useMultiView = imageUrls.length >= 2;
@@ -133,7 +145,7 @@ export async function POST(request) {
 
     const rawTaskId = data?.result || data?.id || null;
     const taskId = rawTaskId ? `${useMultiView ? 'multi' : 'image'}:${rawTaskId}` : null;
-    if (itemId && taskId) {
+    if (taskId) {
       await saveCatalog3D(itemId, {
         supplier_sku: item?.supplierSku || null,
         task_id: taskId,
@@ -156,6 +168,7 @@ export async function POST(request) {
 }
 
 export async function GET(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   const taskId = new URL(request.url).searchParams.get('taskId');
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -9,30 +9,35 @@ Security review is a separate gate from build success. A production release is n
 - **Wallet authority:** client proximity detection is treated as UX/eligibility input, not as permission to sign, mint, transfer, or grant ownership.
 - **Rewards:** USD rewards require verified payment state before crediting; reward transitions are state-gated and regression-tested.
 - **Checkout:** the client requests a server checkout URL and does not treat a client-side success flag as proof of payment.
+- **Property creation:** the $4.99 creation entitlement is verified server-side against Stripe amount, currency, payment status, generation kind and signed-in user before the paid flow resumes.
+- **Property voxel minting:** mint preparation is downstream of the reviewed local voxel and remains a separate wallet-approved action; a digital voxel/NFT is not deed/title, equity, rent, occupancy or an investment right.
+- **Catalog 3D worker:** metered Meshy catalog generation is internal-only, requires `CRON_SECRET`, and resolves generation inputs from the trusted repository catalog instead of accepting arbitrary caller-supplied source/image URLs. This worker is separate from the no-Meshy property creator.
 - **Marketplace payouts:** third-party marketplace checkout fails closed unless a server-only activation flag is enabled and Stripe itself confirms the connected account has charges, payouts and onboarding enabled. Browser/database readiness flags are not treated as payment authority.
 - **Seller payout row writes:** migration 017 removes authenticated-user insert/update policies from `seller_accounts`; payout routing fields are intended to be written only by trusted server/service-role onboarding after Stripe verification.
 - **Incomplete paid routes:** receipt collectible mint checkout is disabled until a durable post-payment fulfillment/mint consumer exists. The disabled route cannot create a Stripe Checkout Session.
 - **NFT media:** broken/unsupported media must degrade to a visible recovery state instead of silently producing an empty card.
 - **WebGL:** passive gallery rendering is subject to the mobile/WebGL guard; full inspection remains an explicit user action.
-- **CI mutation risk:** Mobile WebGL Guard is now read-only (`permissions: contents: read`) and has no repository write step.
-- **Release-test coverage:** the primary Quality Gate runs collection integrity, commerce hardening and route-integrity tests in addition to the existing product/security suites and production build.
+- **CI mutation risk:** Mobile WebGL Guard is read-only (`permissions: contents: read`) and has no repository write step.
+- **Repository-file integrity:** the dedicated full tracked-file audit reads every committed path, validates JSON/relative imports/local Markdown links, scans high-confidence secret patterns, fingerprints the repository, and enforces deployment-safety invariants.
+- **Release-test coverage:** the primary Quality Gate runs collection integrity, commerce hardening, route integrity, VoxelPop/property safety, financial-provider boundaries, contracts and the production build.
 
 ## External configuration that code cannot prove
 
 - A successful Supabase migration workflow run is not proof that migrations reached the database when the workflow skipped CLI/link/push steps because credentials were absent. Migration application must be verified against the target project before database-dependent features are called live.
-- Historical migration filenames include reused numeric prefixes. Do not rename or replay historical migrations until the target database migration history has been reconciled.
+- Historical migration filenames include reused numeric prefixes `002` and `003`. Do not rename or replay historical migrations until the target database migration history has been reconciled. The full-file audit treats these known collisions as warnings and blocks new duplicate migration prefixes.
 - The repository ruleset requires pull requests and blocks force-push/deletion of `main`, but it does not currently require approving reviews or CI status checks. Until that is changed in repository settings, release operators must verify all checks against the exact PR head SHA before merge.
+- GitHub/Vercel/Supabase/Stripe/provider dashboard settings and secret values cannot be proven correct by source review alone; capability endpoints must expose status only, never secret values.
 
 ## Dependency audit note
 
-The current dependency graph reports high-severity findings, including transitive development-tooling issues through Hardhat and vulnerabilities associated with the current Next/sharp/PostCSS chain. The available automated remediation includes breaking major-version upgrades.
+As of the August 29, 2026 repository-wide review, `npm audit --omit=dev --audit-level=critical` on the current production dependency graph reports **0 vulnerabilities**. The install still reports deprecation warnings from some transitive packages, so dependency maintenance remains normal technical debt rather than a current npm-audit security finding.
 
-For this release we do **not** silently run `npm audit fix --force`. Instead:
+Release policy remains:
 
-1. critical vulnerabilities remain a hard CI blocker;
-2. high findings are documented here;
-3. dependency-major upgrades receive their own branch and full regression cycle;
-4. production dependencies are audited separately from development tooling.
+1. critical vulnerabilities are a hard CI blocker;
+2. newly reported high/critical findings are reviewed before release rather than hidden or force-fixed;
+3. breaking dependency-major upgrades receive their own branch and full regression cycle;
+4. production dependencies and development tooling are kept distinguishable when assessing runtime exposure.
 
 ## Release rule
 

--- a/scripts/test-catalog-worker-security.mjs
+++ b/scripts/test-catalog-worker-security.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const worker = read('app/api/image-to-3d/route.js');
+const cron = read('app/api/cron/catalog-3d/route.js');
+
+assert.match(worker, /process\.env\.CRON_SECRET/, 'catalog Meshy worker must require CRON_SECRET');
+assert.ok((worker.match(/if \(!authorized\(request\)\)/g) || []).length >= 2, 'catalog Meshy worker must authenticate both POST and GET');
+assert.match(worker, /REAL_WORLD_CATALOG/, 'catalog Meshy worker must resolve items from the trusted repository catalog');
+assert.match(worker, /trustedCatalogItem/, 'catalog Meshy worker must reject arbitrary caller-supplied catalog objects');
+assert.doesNotMatch(worker, /requestedImageUrl|body\?\.imageUrl/, 'catalog Meshy worker must not accept arbitrary public image URLs');
+
+assert.match(cron, /process\.env\.CRON_SECRET/, 'catalog cron must require CRON_SECRET');
+assert.doesNotMatch(cron, /vercel-cron|user-agent/i, 'catalog cron must never authenticate by spoofable user-agent');
+assert.match(cron, /Cron authentication is not configured/, 'catalog cron must fail closed when CRON_SECRET is missing');
+assert.match(cron, /authorization:\s*authHeader/, 'catalog cron must forward its secret to internal Meshy worker calls');
+assert.match(cron, /headers:\s*internalHeaders/, 'catalog polling must forward authorization too');
+assert.match(cron, /JSON\.stringify\(\{ itemId: item\.id/, 'catalog cron must send trusted item ids rather than caller-controlled item objects');
+
+console.log('Catalog worker security guard passed: metered Meshy generation is secret-authenticated, catalog-bound, and no longer accepts arbitrary source/image URLs.');


### PR DESCRIPTION
Superseded by a smaller rebase onto current `main` after #470. The security finding remains valid, but this branch also touched CI/security-doc files that #470 improved with deterministic npm installs, Actions v6 and refreshed dependency documentation. Closing it prevents those newer audit improvements from being overwritten. The replacement keeps only the internal Meshy worker/cron changes and places the regression in the existing route-integrity suite.