### PR TITLE
Finish catalog worker security from full-repo audit

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 22
       - run: npm install --no-audit --no-fund
+      - run: node scripts/test-catalog-worker-security.mjs
       - run: npm run test:collection
       - run: npm run test:commerce
       - run: npm run test:routes

--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -7,10 +7,14 @@ export const maxDuration = 60;
 
 const STALE_AFTER_MS = 25 * 60 * 1000;
 
-function authorized(request) {
+function cronAuthorizationHeader() {
   const secret = String(process.env.CRON_SECRET || '').trim();
-  if (!secret) return null;
-  return request.headers.get('authorization') === `Bearer ${secret}`;
+  return secret ? `Bearer ${secret}` : '';
+}
+
+function authorized(request) {
+  const expected = cronAuthorizationHeader();
+  return Boolean(expected && request.headers.get('authorization') === expected);
 }
 
 function terminalFailure(row) {
@@ -28,11 +32,11 @@ function isStale(row) {
 }
 
 export async function GET(request) {
-  const auth = authorized(request);
-  if (auth === null) {
-    return NextResponse.json({ error: 'Cron authentication is not configured.' }, { status: 503 });
+  const authHeader = cronAuthorizationHeader();
+  if (!authHeader) {
+    return NextResponse.json({ error: 'Catalog cron is not configured.' }, { status: 503 });
   }
-  if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const health = await catalog3DStoreHealth();
   if (!health.ready) {
@@ -49,10 +53,12 @@ export async function GET(request) {
   const rows = await listCatalog3D();
   const byItem = new Map(rows.map(row => [row.item_id, row]));
   const operations = [];
+  const internalHeaders = { authorization: authHeader };
 
   for (const row of rows) {
     if (!row.task_id || hasFinishedModel(row) || terminalFailure(row) || isStale(row)) continue;
     operations.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, {
+      headers: internalHeaders,
       cache: 'no-store',
     }).then(async response => ({ kind: 'poll', itemId: row.item_id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -70,8 +76,8 @@ export async function GET(request) {
   for (const item of toRestart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item, forceRestart: true }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id, forceRestart: true }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'restart', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -79,8 +85,8 @@ export async function GET(request) {
   for (const item of toStart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'start', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }

--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cjProductImages, getCjProductBySku } from '../../../lib/cjApi';
 import { persistModelBinary, readCatalog3D, readCatalog3DByTask, saveCatalog3D } from '../../../lib/catalog3dStore';
+import { REAL_WORLD_CATALOG } from '../../../lib/realWorldCatalog';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -8,6 +9,17 @@ export const maxDuration = 60;
 const IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MULTI_IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/multi-image-to-3d';
 const MAX_TEXTURE_PROMPT = 560;
+
+function authorized(request) {
+  const secret = String(process.env.CRON_SECRET || '').trim();
+  return Boolean(secret && request.headers.get('authorization') === `Bearer ${secret}`);
+}
+
+function trustedCatalogItem(body = {}) {
+  const requestedId = String(body?.item?.id || body?.itemId || '').trim();
+  if (!requestedId) return null;
+  return REAL_WORLD_CATALOG.find((item) => item.id === requestedId) || null;
+}
 
 function buildPrompt(item = {}) {
   const name = [item.name, item.type].filter(Boolean).join(' / ') || 'the product';
@@ -45,9 +57,8 @@ async function scrapeProductImage(sourceUrl) {
   return '';
 }
 
-async function resolveProductImages(requestedImageUrl, item) {
+async function resolveProductImages(item) {
   const images = [];
-  if (requestedImageUrl && !isPlaceholderImage(requestedImageUrl)) images.push(requestedImageUrl);
   if (item?.supplierSku) {
     try {
       const product = await getCjProductBySku(item.supplierSku);
@@ -65,15 +76,17 @@ function parseTaskId(value = '') {
 }
 
 export async function POST(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });
   try {
     const body = await request.json();
-    const item = body?.item && typeof body.item === 'object' ? body.item : {};
-    const itemId = String(item?.id || body?.itemId || '').trim();
+    const item = trustedCatalogItem(body);
+    if (!item) return NextResponse.json({ error: 'Trusted catalog item is required.' }, { status: 404 });
+    const itemId = item.id;
     const forceRestart = body?.forceRestart === true;
 
-    if (itemId && !forceRestart) {
+    if (!forceRestart) {
       const saved = await readCatalog3D(itemId);
       if (saved?.model_url || saved?.model_storage_path) {
         return NextResponse.json({ configured: true, reused: true, modelUrl: saved.model_url || null, stored: Boolean(saved.model_storage_path), taskId: saved.task_id || null, progress: 100 });
@@ -83,8 +96,7 @@ export async function POST(request) {
       }
     }
 
-    const requestedImageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    const imageUrls = await resolveProductImages(requestedImageUrl, item);
+    const imageUrls = await resolveProductImages(item);
     if (!imageUrls.length) return NextResponse.json({ error: 'Public product media could not be resolved.' }, { status: 400 });
 
     const useMultiView = imageUrls.length >= 2;
@@ -133,7 +145,7 @@ export async function POST(request) {
 
     const rawTaskId = data?.result || data?.id || null;
     const taskId = rawTaskId ? `${useMultiView ? 'multi' : 'image'}:${rawTaskId}` : null;
-    if (itemId && taskId) {
+    if (taskId) {
       await saveCatalog3D(itemId, {
         supplier_sku: item?.supplierSku || null,
         task_id: taskId,
@@ -156,6 +168,7 @@ export async function POST(request) {
 }
 
 export async function GET(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   const taskId = new URL(request.url).searchParams.get('taskId');
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });

--- a/scripts/test-catalog-worker-security.mjs
+++ b/scripts/test-catalog-worker-security.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const worker = read('app/api/image-to-3d/route.js');
+const cron = read('app/api/cron/catalog-3d/route.js');
+
+assert.match(worker, /process\.env\.CRON_SECRET/, 'catalog Meshy worker must require CRON_SECRET');
+assert.ok((worker.match(/if \(!authorized\(request\)\)/g) || []).length >= 2, 'catalog Meshy worker must authenticate both POST and GET');
+assert.match(worker, /REAL_WORLD_CATALOG/, 'catalog Meshy worker must resolve items from the trusted repository catalog');
+assert.match(worker, /trustedCatalogItem/, 'catalog Meshy worker must reject arbitrary caller-supplied catalog objects');
+assert.doesNotMatch(worker, /requestedImageUrl|body\?\.imageUrl/, 'catalog Meshy worker must not accept arbitrary public image URLs');
+
+assert.match(cron, /process\.env\.CRON_SECRET/, 'catalog cron must require CRON_SECRET');
+assert.doesNotMatch(cron, /vercel-cron|user-agent/i, 'catalog cron must never authenticate by spoofable user-agent');
+assert.match(cron, /Catalog cron is not configured/, 'catalog cron must fail closed when CRON_SECRET is missing');
+assert.match(cron, /authorization:\s*authHeader/, 'catalog cron must forward its secret to internal Meshy worker calls');
+assert.match(cron, /headers:\s*internalHeaders/, 'catalog polling must forward authorization too');
+assert.match(cron, /JSON\.stringify\(\{ itemId: item\.id/, 'catalog cron must send trusted item ids rather than caller-controlled item objects');
+
+console.log('Catalog worker security guard passed: metered Meshy generation is secret-authenticated, catalog-bound, and no longer accepts arbitrary source/image URLs.');


### PR DESCRIPTION
Superseded by a clean rebase onto the newer `main` after #470 landed deterministic CI/lockfile enforcement. The replacement keeps the same four security changes without carrying older workflow lines.