### PR TITLE
Secure internal catalog Meshy worker

### DIFF
--- a/app/api/cron/catalog-3d/route.js
+++ b/app/api/cron/catalog-3d/route.js
@@ -7,10 +7,15 @@ export const maxDuration = 60;
 
 const STALE_AFTER_MS = 25 * 60 * 1000;
 
-function authorized(request) {
+function cronAuthorizationHeader() {
   const secret = String(process.env.CRON_SECRET || '').trim();
-  if (!secret) return null;
-  return request.headers.get('authorization') === `Bearer ${secret}`;
+  return secret ? `Bearer ${secret}` : '';
+}
+
+function authorized(request) {
+  const expected = cronAuthorizationHeader();
+  if (!expected) return null;
+  return request.headers.get('authorization') === expected;
 }
 
 function terminalFailure(row) {
@@ -28,6 +33,7 @@ function isStale(row) {
 }
 
 export async function GET(request) {
+  const authHeader = cronAuthorizationHeader();
   const auth = authorized(request);
   if (auth === null) {
     return NextResponse.json({ error: 'Cron authentication is not configured.' }, { status: 503 });
@@ -49,10 +55,12 @@ export async function GET(request) {
   const rows = await listCatalog3D();
   const byItem = new Map(rows.map(row => [row.item_id, row]));
   const operations = [];
+  const internalHeaders = { authorization: authHeader };
 
   for (const row of rows) {
     if (!row.task_id || hasFinishedModel(row) || terminalFailure(row) || isStale(row)) continue;
     operations.push(fetch(`${origin}/api/image-to-3d?taskId=${encodeURIComponent(row.task_id)}`, {
+      headers: internalHeaders,
       cache: 'no-store',
     }).then(async response => ({ kind: 'poll', itemId: row.item_id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -70,8 +78,8 @@ export async function GET(request) {
   for (const item of toRestart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item, forceRestart: true }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id, forceRestart: true }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'restart', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }
@@ -79,8 +87,8 @@ export async function GET(request) {
   for (const item of toStart) {
     operations.push(fetch(`${origin}/api/image-to-3d`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ item }),
+      headers: { 'content-type': 'application/json', authorization: authHeader },
+      body: JSON.stringify({ itemId: item.id }),
       cache: 'no-store',
     }).then(async response => ({ kind: 'start', itemId: item.id, ok: response.ok, data: await response.json().catch(() => ({})) })));
   }

--- a/app/api/image-to-3d/route.js
+++ b/app/api/image-to-3d/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cjProductImages, getCjProductBySku } from '../../../lib/cjApi';
 import { persistModelBinary, readCatalog3D, readCatalog3DByTask, saveCatalog3D } from '../../../lib/catalog3dStore';
+import { REAL_WORLD_CATALOG } from '../../../lib/realWorldCatalog';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -8,6 +9,17 @@ export const maxDuration = 60;
 const IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-3d';
 const MULTI_IMAGE_ENDPOINT = 'https://api.meshy.ai/openapi/v1/multi-image-to-3d';
 const MAX_TEXTURE_PROMPT = 560;
+
+function authorized(request) {
+  const secret = String(process.env.CRON_SECRET || '').trim();
+  return Boolean(secret && request.headers.get('authorization') === `Bearer ${secret}`);
+}
+
+function trustedCatalogItem(body = {}) {
+  const requestedId = String(body?.item?.id || body?.itemId || '').trim();
+  if (!requestedId) return null;
+  return REAL_WORLD_CATALOG.find((item) => item.id === requestedId) || null;
+}
 
 function buildPrompt(item = {}) {
   const name = [item.name, item.type].filter(Boolean).join(' / ') || 'the product';
@@ -45,9 +57,8 @@ async function scrapeProductImage(sourceUrl) {
   return '';
 }
 
-async function resolveProductImages(requestedImageUrl, item) {
+async function resolveProductImages(item) {
   const images = [];
-  if (requestedImageUrl && !isPlaceholderImage(requestedImageUrl)) images.push(requestedImageUrl);
   if (item?.supplierSku) {
     try {
       const product = await getCjProductBySku(item.supplierSku);
@@ -65,15 +76,17 @@ function parseTaskId(value = '') {
 }
 
 export async function POST(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });
   try {
     const body = await request.json();
-    const item = body?.item && typeof body.item === 'object' ? body.item : {};
-    const itemId = String(item?.id || body?.itemId || '').trim();
+    const item = trustedCatalogItem(body);
+    if (!item) return NextResponse.json({ error: 'Trusted catalog item is required.' }, { status: 404 });
+    const itemId = item.id;
     const forceRestart = body?.forceRestart === true;
 
-    if (itemId && !forceRestart) {
+    if (!forceRestart) {
       const saved = await readCatalog3D(itemId);
       if (saved?.model_url || saved?.model_storage_path) {
         return NextResponse.json({ configured: true, reused: true, modelUrl: saved.model_url || null, stored: Boolean(saved.model_storage_path), taskId: saved.task_id || null, progress: 100 });
@@ -83,8 +96,7 @@ export async function POST(request) {
       }
     }
 
-    const requestedImageUrl = typeof body?.imageUrl === 'string' ? body.imageUrl.trim() : '';
-    const imageUrls = await resolveProductImages(requestedImageUrl, item);
+    const imageUrls = await resolveProductImages(item);
     if (!imageUrls.length) return NextResponse.json({ error: 'Public product media could not be resolved.' }, { status: 400 });
 
     const useMultiView = imageUrls.length >= 2;
@@ -133,7 +145,7 @@ export async function POST(request) {
 
     const rawTaskId = data?.result || data?.id || null;
     const taskId = rawTaskId ? `${useMultiView ? 'multi' : 'image'}:${rawTaskId}` : null;
-    if (itemId && taskId) {
+    if (taskId) {
       await saveCatalog3D(itemId, {
         supplier_sku: item?.supplierSku || null,
         task_id: taskId,
@@ -156,6 +168,7 @@ export async function POST(request) {
 }
 
 export async function GET(request) {
+  if (!authorized(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const apiKey = process.env.MESHY_API_KEY;
   const taskId = new URL(request.url).searchParams.get('taskId');
   if (!apiKey) return NextResponse.json({ configured: false, error: 'Model generation is not configured.' }, { status: 503 });

--- a/scripts/test-route-integrity.mjs
+++ b/scripts/test-route-integrity.mjs
@@ -39,6 +39,8 @@ for(const required of [
  'app/admin/neural-core/list/page.js',
  'app/admin/neural-core/setup/page.js',
  'app/admin/neural-core/whatsapp/page.js',
+ 'app/api/image-to-3d/route.js',
+ 'app/api/cron/catalog-3d/route.js',
  'app/api/voxelflip/trader/route.ts',
  'app/api/voxelflip/factory/route.ts',
  'app/api/admin/neural-core/route.ts',
@@ -114,6 +116,17 @@ if(/eth_sendTransaction|eth_signTypedData|personal_sign|signTypedData\s*\(/.test
 const adminAuth=fs.readFileSync(path.join(root,'lib/neural-core-auth.ts'),'utf8');
 if(!adminAuth.includes('NEURAL_CORE_ADMIN_EMAILS')&&!adminAuth.includes('NEURAL_CORE_ADMIN_USER_IDS'))failures.push('Neural Core admin auth has no explicit allowlist.');
 
+const catalogWorker=fs.readFileSync(path.join(root,'app/api/image-to-3d/route.js'),'utf8');
+if(!catalogWorker.includes('process.env.CRON_SECRET'))failures.push('Catalog Meshy worker must require CRON_SECRET.');
+if((catalogWorker.match(/if \(!authorized\(request\)\)/g)||[]).length<2)failures.push('Catalog Meshy worker must authenticate both POST and GET.');
+if(!catalogWorker.includes('REAL_WORLD_CATALOG')||!catalogWorker.includes('trustedCatalogItem'))failures.push('Catalog Meshy worker must bind generation to the trusted repository catalog.');
+if(/requestedImageUrl|body\?\.imageUrl/.test(catalogWorker))failures.push('Catalog Meshy worker may not accept an arbitrary caller-supplied image URL.');
+const catalogCron=fs.readFileSync(path.join(root,'app/api/cron/catalog-3d/route.js'),'utf8');
+if(!catalogCron.includes('process.env.CRON_SECRET'))failures.push('Catalog cron must require CRON_SECRET.');
+if(/user-agent|vercel-cron/i.test(catalogCron))failures.push('Catalog cron may not trust a spoofable User-Agent.');
+if(!/authorization:\s*authHeader/.test(catalogCron)||!/headers:\s*internalHeaders/.test(catalogCron))failures.push('Catalog cron must forward authorization to internal Meshy worker calls.');
+if(!/JSON\.stringify\(\{ itemId: item\.id/.test(catalogCron))failures.push('Catalog cron must pass trusted catalog item ids rather than whole caller-shaped item objects.');
+
 const sitemap=fs.readFileSync(path.join(root,'app/sitemap.js'),'utf8');
 if(sitemap.includes("'/marketplace'")||sitemap.includes('CATALOG_SIZE'))failures.push('Sitemap still advertises the legacy marketplace/catalog instead of the VoxelPop launch surface.');
 if(sitemap.includes('/admin/neural-core'))failures.push('Private Neural Core route must not appear in the sitemap.');
@@ -127,4 +140,4 @@ if(failures.length){
  for(const failure of failures)console.error(`- ${failure}`);
  process.exit(1);
 }
-console.log('Route integrity passed: no duplicate route handlers, critical VoxelFlip/Neural Core/WhatsApp routes exist, the production deployment is pinned, admin auth, ownership, webhook signatures and private database controls are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');
+console.log('Route integrity passed: no duplicate route handlers, critical VoxelPop/VoxelFlip/catalog/Neural Core/WhatsApp routes exist, the production deployment is pinned, admin and catalog worker auth, ownership, webhook signatures and private database controls are present, automatic signing/buying/listing remain disabled, and private admin routes stay out of indexing.');


### PR DESCRIPTION
Superseded by #479, which merged first into `main` with the same blocking repository-audit fix: CRON_SECRET authentication on the internal `/api/image-to-3d` worker, trusted `REAL_WORLD_CATALOG` binding, no arbitrary caller image URL, cron authorization forwarding, and a dedicated Quality Gate regression. Closing this duplicate avoids reapplying/conflicting with code that is already live on `main`.