### PR TITLE
Polish Create flow stages and 3D review

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -7,6 +7,7 @@ import './vault-fallback.css';
 import './futuristic-vault.css';
 import './spatial-os-interactions.css';
 import './voxelpop-cute-system.css';
+import './property-create-polish.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 

--- a/app/property-create-polish.css
+++ b/app/property-create-polish.css
@@ -1,0 +1,201 @@
+/* Presentation-only polish for the signed-in VoxelPop Create flow. */
+main:has([aria-label^="Step "]) [aria-label^="Step "]{
+  width:min(620px,100%);
+  margin:2px auto 12px;
+  padding:0;
+  display:grid;
+  grid-template-columns:repeat(5,minmax(0,1fr));
+  gap:7px;
+}
+
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span{
+  position:relative;
+  min-width:0;
+  height:58px;
+  border:1px solid #e4dce8;
+  border-radius:16px;
+  background:rgba(255,255,255,.86);
+  color:#8e838f;
+  box-shadow:0 7px 18px rgba(72,49,88,.045);
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:5px;
+  transform:none;
+}
+
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:before{
+  width:21px;
+  height:21px;
+  border-radius:999px;
+  display:grid;
+  place-items:center;
+  background:#eee8ef;
+  color:#756b78;
+  font-size:9px;
+  line-height:1;
+  font-weight:1000;
+}
+
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:after{
+  display:block;
+  max-width:100%;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+  font-size:8px;
+  line-height:1;
+  font-weight:1000;
+  letter-spacing:.045em;
+}
+
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(1):before{content:"1"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(2):before{content:"2"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(3):before{content:"3"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(4):before{content:"4"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(5):before{content:"5"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(1):after{content:"PHOTO"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(2):after{content:"PAY"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(3):after{content:"3D PIC"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(4):after{content:"VOXEL"}
+main:has([aria-label^="Step "]) [aria-label^="Step "]>span:nth-child(5):after{content:"MINT"}
+
+main:has([aria-label="Step 2 of 5"]) [aria-label="Step 2 of 5"]>span:nth-child(1),
+main:has([aria-label="Step 3 of 5"]) [aria-label="Step 3 of 5"]>span:nth-child(-n+2),
+main:has([aria-label="Step 4 of 5"]) [aria-label="Step 4 of 5"]>span:nth-child(-n+3),
+main:has([aria-label="Step 5 of 5"]) [aria-label="Step 5 of 5"]>span:nth-child(-n+4){
+  border-color:#d6e9af;
+  background:linear-gradient(180deg,#fbfff2,#f1ffda);
+  color:#58712d;
+}
+
+main:has([aria-label="Step 2 of 5"]) [aria-label="Step 2 of 5"]>span:nth-child(1):before,
+main:has([aria-label="Step 3 of 5"]) [aria-label="Step 3 of 5"]>span:nth-child(-n+2):before,
+main:has([aria-label="Step 4 of 5"]) [aria-label="Step 4 of 5"]>span:nth-child(-n+3):before,
+main:has([aria-label="Step 5 of 5"]) [aria-label="Step 5 of 5"]>span:nth-child(-n+4):before{
+  content:"✓";
+  background:#c9ff54;
+  color:#3f5719;
+}
+
+main:has([aria-label="Step 1 of 5"]) [aria-label="Step 1 of 5"]>span:nth-child(1),
+main:has([aria-label="Step 2 of 5"]) [aria-label="Step 2 of 5"]>span:nth-child(2),
+main:has([aria-label="Step 3 of 5"]) [aria-label="Step 3 of 5"]>span:nth-child(3),
+main:has([aria-label="Step 4 of 5"]) [aria-label="Step 4 of 5"]>span:nth-child(4),
+main:has([aria-label="Step 5 of 5"]) [aria-label="Step 5 of 5"]>span:nth-child(5){
+  border-color:#7540ef;
+  background:linear-gradient(180deg,#8250ff,#6a32ed);
+  color:#fff;
+  box-shadow:0 5px 0 #5120d0,0 13px 24px rgba(105,48,237,.17);
+}
+
+main:has([aria-label="Step 1 of 5"]) [aria-label="Step 1 of 5"]>span:nth-child(1):before,
+main:has([aria-label="Step 2 of 5"]) [aria-label="Step 2 of 5"]>span:nth-child(2):before,
+main:has([aria-label="Step 3 of 5"]) [aria-label="Step 3 of 5"]>span:nth-child(3):before,
+main:has([aria-label="Step 4 of 5"]) [aria-label="Step 4 of 5"]>span:nth-child(4):before,
+main:has([aria-label="Step 5 of 5"]) [aria-label="Step 5 of 5"]>span:nth-child(5):before{
+  background:#fff;
+  color:#6730ec;
+}
+
+main:has([aria-label^="Step "]) [aria-label^="Step "]+p{
+  margin:0 auto 20px;
+  padding:7px 12px;
+  border:1px solid #e2d8f4;
+  border-radius:999px;
+  background:#f4efff;
+  color:#6536ce;
+  font-size:10px;
+  font-weight:1000;
+  letter-spacing:.1em;
+}
+
+/* Stage 3 is a deliberate approval gate before voxelization. */
+main:has([aria-label="Step 3 of 5"]) div:has(> .viewerShell){
+  outline:2px solid rgba(113,56,245,.24);
+  outline-offset:3px;
+  box-shadow:0 24px 62px rgba(72,49,88,.17);
+}
+
+main:has([aria-label="Step 3 of 5"]) div:has(> .viewerShell):before{
+  content:"REVIEW BEFORE VOXEL";
+  position:absolute;
+  z-index:10;
+  top:13px;
+  right:13px;
+  width:max-content;
+  max-width:calc(100% - 26px);
+  padding:8px 10px;
+  border:1px solid rgba(255,255,255,.7);
+  border-radius:999px;
+  background:rgba(245,239,255,.94);
+  color:#6730ec;
+  font-size:8px;
+  line-height:1;
+  font-weight:1000;
+  letter-spacing:.09em;
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
+  pointer-events:none;
+}
+
+/* The viewer already contains the source image. Enlarge it for an actual phone-size comparison. */
+main:has([aria-label="Step 3 of 5"]) div[aria-hidden="true"]:has(>img){
+  right:14px;
+  bottom:14px;
+  width:126px;
+  padding:7px;
+  border-radius:17px;
+  border-width:2px;
+}
+
+main:has([aria-label="Step 3 of 5"]) div[aria-hidden="true"]:has(>img)>span{
+  margin-top:6px;
+  font-size:8px;
+  letter-spacing:.08em;
+}
+
+@media(max-width:640px){
+  main:has([aria-label^="Step "]) [aria-label^="Step "]{
+    width:100%;
+    gap:5px;
+    margin-bottom:10px;
+  }
+  main:has([aria-label^="Step "]) [aria-label^="Step "]>span{
+    height:54px;
+    border-radius:13px;
+    gap:4px;
+  }
+  main:has([aria-label^="Step "]) [aria-label^="Step "]>span:before{
+    width:19px;
+    height:19px;
+    font-size:8px;
+  }
+  main:has([aria-label^="Step "]) [aria-label^="Step "]>span:after{
+    font-size:7px;
+    letter-spacing:.025em;
+  }
+  main:has([aria-label^="Step "]) [aria-label^="Step "]+p{
+    margin-bottom:16px;
+    font-size:9px;
+  }
+  main:has([aria-label="Step 3 of 5"]) div:has(> .viewerShell):before{
+    top:10px;
+    right:10px;
+    padding:7px 9px;
+    font-size:7px;
+  }
+  main:has([aria-label="Step 3 of 5"]) div[aria-hidden="true"]:has(>img){
+    width:106px;
+    right:10px;
+    bottom:10px;
+  }
+}
+
+@media(max-width:380px){
+  main:has([aria-label^="Step "]) [aria-label^="Step "]{gap:4px}
+  main:has([aria-label^="Step "]) [aria-label^="Step "]>span{height:51px;border-radius:12px}
+  main:has([aria-label^="Step "]) [aria-label^="Step "]>span:after{font-size:6.5px}
+  main:has([aria-label="Step 3 of 5"]) div[aria-hidden="true"]:has(>img){width:98px}
+}


### PR DESCRIPTION
## What changed
- Replaces the anonymous five-bar Create progress indicator with labeled step cards: Photo, Pay, 3D Pic, Voxel, Mint.
- Visually distinguishes completed, current, and upcoming stages.
- Makes the paid 3D-preview step feel like an explicit approval gate before voxelization.
- Enlarges the existing original-photo reference inside the 3D viewer on iPhone so users can compare the 3D result to the source photo more easily.
- Adds a clear `REVIEW BEFORE VOXEL` marker to Stage 3.

## Safety / scope
Presentation-only. No checkout, auth, photo handling, generation, persistence, map, mint, wallet, or contract logic changed.

## Why
The underlying journey is now correct, but the UI still made the five stages look like generic progress bars and made the source-photo comparison too small on phones. This makes the intended Photo → Pay → 3D Picture → Voxel → Mint sequence immediately understandable.