### PR TITLE
Make the preview a real 3D voxel photo

### DIFF
--- a/app/components/HomeProductPreview.js
+++ b/app/components/HomeProductPreview.js
@@ -12,18 +12,18 @@ export default function HomeProductPreview() {
   const [voxelReady, setVoxelReady] = useState(false);
   return <div className={styles.card}>
     <div className={styles.topline}>
-      <div><small>REAL PRODUCT VIEWER</small><b>{stage === 'preview' ? 'Photo-faithful 3D preview' : 'Movable voxel'}</b></div>
+      <div><small>REAL PRODUCT VIEWER</small><b>{stage === 'preview' ? '3D voxel photo' : 'Movable 3D voxel'}</b></div>
       <span className={styles.price}>$4.99</span>
     </div>
-    <div className={styles.viewer} aria-label={stage === 'preview' ? 'Interactive photo-faithful 3D house preview' : 'Interactive movable voxel sample'}>
+    <div className={styles.viewer} aria-label={stage === 'preview' ? 'Interactive 3D voxel photo preview' : 'Interactive movable 3D voxel sample'}>
       {stage === 'preview'
         ? <PhotoReliefModelViewer imageUrl={SAMPLE}/>
         : <LocalVoxelModelViewer imageUrl={SAMPLE} sourceImageUrl={SAMPLE} onReady={() => setVoxelReady(true)}/>}
     </div>
     <div className={styles.controls} role="group" aria-label="Choose VoxelPop sample stage">
-      <button type="button" className={stage === 'preview' ? styles.active : ''} aria-pressed={stage === 'preview'} onClick={() => setStage('preview')}><span>1</span>3D preview</button>
-      <button type="button" className={stage === 'voxel' ? styles.active : ''} aria-pressed={stage === 'voxel'} onClick={() => setStage('voxel')}><span>2</span>{stage === 'voxel' && !voxelReady ? 'Building voxel…' : '3D voxel'}</button>
+      <button type="button" className={stage === 'preview' ? styles.active : ''} aria-pressed={stage === 'preview'} onClick={() => setStage('preview')}><span>1</span>3D voxel photo</button>
+      <button type="button" className={stage === 'voxel' ? styles.active : ''} aria-pressed={stage === 'voxel'} onClick={() => setStage('voxel')}><span>2</span>{stage === 'voxel' && !voxelReady ? 'Building voxel…' : 'Movable voxel'}</button>
     </div>
-    <p>{stage === 'preview' ? 'First: your original photo stays intact while real depth, perspective, lighting, and shadow make it inspectable in 3D.' : 'Second: approve that recognizable preview, then build the separate blocky voxel.'}</p>
+    <p>{stage === 'preview' ? 'First: VoxelPop turns your house photo into a block-by-block 3D voxel photo you can inspect and approve.' : 'Second: approve the voxel photo, then build the separate movable 3D voxel model.'}</p>
   </div>;
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -10,14 +10,14 @@ import './voxelpop-cute-system.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 
-const TITLE = 'Voxel Vault | Turn a House Photo into a 3D Voxel';
-const DESCRIPTION = 'Your 3D Asset Vault for turning an authorized house photo into a textured 3D preview and movable VoxelPop voxel for $4.99. Source photo stays on your device; minting is optional.';
+const TITLE = 'Voxel Vault | Turn a House Photo into a 3D Voxel Photo';
+const DESCRIPTION = 'Turn an authorized house photo into a block-by-block 3D VoxelPop photo for $4.99, approve it, then create a separate movable 3D voxel. Source photo stays on your device; minting is optional.';
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
   title: { default: TITLE, template: '%s | Voxel Vault' },
   description: DESCRIPTION,
-  keywords: ['house photo to 3D', 'voxel house creator', '3D house photo', 'VoxelPop', 'voxel creator', 'Voxel Vault'],
+  keywords: ['house photo to voxel', '3D voxel photo', 'voxel house creator', 'VoxelPop', '3D voxel creator', 'Voxel Vault'],
   robots: { index: true, follow: true },
   icons: { icon: '/voxelpop/voxelpop-logo.png', apple: '/voxelpop/voxelpop-logo.png' },
   openGraph: {
@@ -26,7 +26,7 @@ export const metadata = {
     type: 'website',
     url: SITE_URL,
     siteName: 'Voxel Vault',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'VoxelPop house photo to 3D voxel preview' }],
+    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'VoxelPop house photo to 3D voxel photo preview' }],
   },
   twitter: { card: 'summary_large_image', title: TITLE, description: DESCRIPTION, images: ['/opengraph-image'] },
 };

--- a/app/page.js
+++ b/app/page.js
@@ -11,23 +11,23 @@ export default function Home() {
     <div className={styles.shell}>
       <section className={styles.hero}>
         <div className={styles.heroCopy}>
-          <p className={styles.kicker}>VOXELPOP · PHOTO → 3D PREVIEW → VOXEL</p>
-          <h1>Turn your house photo<br/><em>into a 3D voxel.</em></h1>
-          <p className={styles.lead}>Upload one house photo, see the 3D preview first, approve it, then create the separate movable voxel. Minting is optional.</p>
+          <p className={styles.kicker}>VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL</p>
+          <h1>Turn your house photo<br/><em>into a 3D voxel photo.</em></h1>
+          <p className={styles.lead}>Upload one house photo and VoxelPop rebuilds the visible photo as a block-by-block 3D voxel photo. Approve it, then create the separate movable 3D voxel. Minting is optional.</p>
           <div className={styles.heroActions}>
             <Link className={styles.primaryAction} href="/property">Create mine · $4.99</Link>
-            <Link className={styles.secondaryAction} href="/demo">Try the free 3D demo</Link>
+            <Link className={styles.secondaryAction} href="/demo">Try the free voxel demo</Link>
           </div>
           <div className={styles.trustRow} aria-label="VoxelPop creation facts">
-            <span>Preview before voxel</span><span>Photo stays on device</span><span>Mint only if you want</span>
+            <span>Voxel photo before model</span><span>Photo stays on device</span><span>Mint only if you want</span>
           </div>
         </div>
         <div className={styles.heroVisual}><HomeProductPreview/></div>
       </section>
 
       <section className={styles.flowCard} id="how-it-works" aria-label="VoxelPop creation steps">
-        <div className={styles.flowIntro}><p>THE WHOLE FLOW</p><h2>Photo. Preview. Voxel.</h2></div>
-        <div className={styles.microFlow}><b>PHOTO</b><i>→</i><b>3D PREVIEW</b><i>→</i><b>APPROVE</b><i>→</i><b>3D VOXEL</b></div>
+        <div className={styles.flowIntro}><p>THE WHOLE FLOW</p><h2>Photo. Voxel photo. Movable voxel.</h2></div>
+        <div className={styles.microFlow}><b>PHOTO</b><i>→</i><b>3D VOXEL PHOTO</b><i>→</i><b>APPROVE</b><i>→</i><b>MOVABLE 3D VOXEL</b></div>
         <Link className={styles.startButton} href="/property">Start my VoxelPop →</Link>
       </section>
 
@@ -36,7 +36,7 @@ export default function Home() {
         <div className={styles.afterCreate}>
           <p><b>Vault</b> keeps your finished VoxelPop so you can reopen it later.</p>
           <p><b>World</b> can pair the finished voxel with map and building context.</p>
-          <p><b>Mint</b> is optional and comes after the voxel is finished. No wallet is required to create.</p>
+          <p><b>Mint</b> is optional and comes after the movable voxel is finished. No wallet is required to create.</p>
           <div className={styles.afterLinks}><Link href="/vault">Open Vault →</Link><Link href="/world">Open World →</Link><Link href="/more">More tools →</Link></div>
         </div>
       </details>
@@ -44,13 +44,13 @@ export default function Home() {
       <details className={styles.inclusion}>
         <summary><span><small>WHAT YOU'RE BUYING</small><b>One digital VoxelPop creation · $4.99</b></span><i>+</i></summary>
         <div>
-          <p>Sign in, choose a house photo, and complete the $4.99 creation checkout. You then see the 3D preview before the separate voxel is built.</p>
+          <p>Sign in, choose a house photo, and complete the $4.99 creation checkout. You then see the 3D voxel photo before the separate movable voxel is built.</p>
           <p>Your source photo stays on your device in the normal creation flow. One photo can represent the visible view, but it cannot prove hidden sides or survey-grade dimensions.</p>
           <p><b>Voxel Vault is not a bank, brokerage, title company, or real-estate marketplace.</b> A VoxelPop item, NFT, map marker, payment, or Property Passport does not create physical-property ownership, rent, occupancy, investment, or appreciation rights.</p>
         </div>
       </details>
 
-      <footer className={styles.footer}><span>Voxel Vault is a digital creation product. Physical-property and regulated financial rights remain separate.</span><span><Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link> · <Link href="/about">About</Link> · <Link href="/demo">3D demo</Link></span></footer>
+      <footer className={styles.footer}><span>Voxel Vault is a digital creation product. Physical-property and regulated financial rights remain separate.</span><span><Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link> · <Link href="/about">About</Link> · <Link href="/demo">Voxel demo</Link></span></footer>
     </div>
   </main>;
 }

--- a/app/property/PhotoReliefModelViewer.js
+++ b/app/property/PhotoReliefModelViewer.js
@@ -28,6 +28,7 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
       try {
         const THREE = await import('three');
         if (dead || !mountRef.current) return;
+
         const mount = mountRef.current;
         const initialWidth = Math.max(280, mount.clientWidth || 360);
         const initialHeight = Math.max(280, mount.clientHeight || 360);
@@ -35,17 +36,17 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches === true;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.25 : 1.7));
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, compact ? 1.2 : 1.55));
         renderer.setSize(initialWidth, initialHeight);
         renderer.outputColorSpace = THREE.SRGBColorSpace;
         renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        renderer.toneMappingExposure = 1.04;
+        renderer.toneMappingExposure = 1.03;
         renderer.shadowMap.enabled = true;
         renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         renderer.setClearColor(0x000000, 0);
         renderer.domElement.style.touchAction = 'none';
         renderer.domElement.tabIndex = 0;
-        renderer.domElement.setAttribute('aria-label', 'Interactive photo-faithful 3D preview. Drag or use the arrow keys to inspect the depth.');
+        renderer.domElement.setAttribute('aria-label', 'Interactive 3D voxel photo preview. Drag or use the arrow keys to inspect the voxel depth.');
         mount.innerHTML = '';
         mount.appendChild(renderer.domElement);
 
@@ -54,28 +55,21 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         const objectGroup = new THREE.Group();
         scene.add(objectGroup);
 
-        const hemisphere = new THREE.HemisphereLight(0xfffcf3, 0x1b1220, 2.25);
-        scene.add(hemisphere);
-        const key = new THREE.DirectionalLight(0xfff7eb, 3.2);
-        key.position.set(4.5, 5.5, 6.5);
+        scene.add(new THREE.HemisphereLight(0xfffcf3, 0x211529, 2.15));
+        const key = new THREE.DirectionalLight(0xfff7eb, 3.15);
+        key.position.set(4.8, 5.8, 7.2);
         key.castShadow = true;
         key.shadow.mapSize.set(compact ? 512 : 1024, compact ? 512 : 1024);
-        key.shadow.camera.near = 0.5;
-        key.shadow.camera.far = 24;
-        key.shadow.camera.left = -8;
-        key.shadow.camera.right = 8;
-        key.shadow.camera.top = 8;
-        key.shadow.camera.bottom = -8;
         scene.add(key);
-        const fill = new THREE.DirectionalLight(0xded5ff, 1.25);
-        fill.position.set(-4.5, 1.8, 4);
+        const fill = new THREE.DirectionalLight(0xded5ff, 1.2);
+        fill.position.set(-4.4, 2.2, 4.4);
         scene.add(fill);
-        const rim = new THREE.DirectionalLight(0xe8ffc0, 0.85);
-        rim.position.set(1.5, 4, -3);
+        const rim = new THREE.DirectionalLight(0xe8ffc0, 0.8);
+        rim.position.set(2, 4.2, -3.2);
         scene.add(rim);
 
-        const ratio = Math.max(0.32, Math.min(3.2, (image.naturalWidth || 1) / (image.naturalHeight || 1)));
-        const maxWidth = compact ? 4.8 : 5.45;
+        const ratio = clamp((image.naturalWidth || 1) / (image.naturalHeight || 1), 0.4, 2.8);
+        const maxWidth = compact ? 4.75 : 5.45;
         const maxHeight = compact ? 3.8 : 4.25;
         let photoWidth = maxWidth;
         let photoHeight = photoWidth / ratio;
@@ -83,39 +77,76 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
           photoHeight = maxHeight;
           photoWidth = photoHeight * ratio;
         }
-        const depth = clamp(Math.min(photoWidth, photoHeight) * 0.085, 0.22, 0.38);
 
-        const texture = new THREE.Texture(image);
-        texture.needsUpdate = true;
-        texture.colorSpace = THREE.SRGBColorSpace;
-        texture.anisotropy = Math.min(8, renderer.capabilities.getMaxAnisotropy?.() || 1);
-        texture.minFilter = THREE.LinearMipmapLinearFilter;
-        texture.magFilter = THREE.LinearFilter;
+        const columns = compact ? 24 : 32;
+        const rows = clamp(Math.round(columns / ratio), 14, compact ? 32 : 40);
+        const sample = document.createElement('canvas');
+        sample.width = columns;
+        sample.height = rows;
+        const sampleContext = sample.getContext('2d', { willReadFrequently: true });
+        if (!sampleContext) throw new Error('Voxel photo processing is unavailable in this browser.');
+        sampleContext.imageSmoothingEnabled = true;
+        sampleContext.drawImage(image, 0, 0, columns, rows);
+        const pixels = sampleContext.getImageData(0, 0, columns, rows).data;
 
-        const frameGeometry = new THREE.BoxGeometry(photoWidth + 0.18, photoHeight + 0.18, depth, 1, 1, 1);
-        const frameMaterial = new THREE.MeshStandardMaterial({ color: 0x1a111f, roughness: 0.62, metalness: 0.08 });
-        const frame = new THREE.Mesh(frameGeometry, frameMaterial);
-        frame.castShadow = true;
-        frame.receiveShadow = true;
-        objectGroup.add(frame);
+        const cellWidth = photoWidth / columns;
+        const cellHeight = photoHeight / rows;
+        const cubeGeometry = new THREE.BoxGeometry(1, 1, 1);
+        const cubeMaterial = new THREE.MeshStandardMaterial({ roughness: 0.72, metalness: 0.025, vertexColors: true });
+        const voxels = new THREE.InstancedMesh(cubeGeometry, cubeMaterial, columns * rows);
+        voxels.castShadow = true;
+        voxels.receiveShadow = true;
+        const dummy = new THREE.Object3D();
+        const color = new THREE.Color();
 
-        const photoGeometry = new THREE.PlaneGeometry(photoWidth, photoHeight, 1, 1);
-        const photoMaterial = new THREE.MeshBasicMaterial({ map: texture, side: THREE.FrontSide, toneMapped: false });
-        const photo = new THREE.Mesh(photoGeometry, photoMaterial);
-        photo.position.z = depth / 2 + 0.012;
-        photo.castShadow = true;
-        objectGroup.add(photo);
+        let instance = 0;
+        for (let y = 0; y < rows; y += 1) {
+          for (let x = 0; x < columns; x += 1) {
+            const offset = (y * columns + x) * 4;
+            const red = pixels[offset] / 255;
+            const green = pixels[offset + 1] / 255;
+            const blue = pixels[offset + 2] / 255;
+            const alpha = pixels[offset + 3] / 255;
+            const luminance = red * 0.2126 + green * 0.7152 + blue * 0.0722;
+            const chroma = Math.max(red, green, blue) - Math.min(red, green, blue);
+            const depth = 0.11 + (1 - luminance) * 0.24 + chroma * 0.1;
+            const xPos = -photoWidth / 2 + cellWidth * (x + 0.5);
+            const yPos = photoHeight / 2 - cellHeight * (y + 0.5);
 
-        const edgeGeometry = new THREE.EdgesGeometry(frameGeometry, 24);
-        const edgeMaterial = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.19 });
+            dummy.position.set(xPos, yPos, depth * 0.5);
+            dummy.scale.set(cellWidth * 0.94, cellHeight * 0.94, depth);
+            dummy.rotation.set(0, 0, 0);
+            dummy.updateMatrix();
+            voxels.setMatrixAt(instance, dummy.matrix);
+            color.setRGB(red * alpha + 0.16 * (1 - alpha), green * alpha + 0.12 * (1 - alpha), blue * alpha + 0.18 * (1 - alpha));
+            voxels.setColorAt(instance, color);
+            instance += 1;
+          }
+        }
+        voxels.instanceMatrix.needsUpdate = true;
+        if (voxels.instanceColor) voxels.instanceColor.needsUpdate = true;
+        objectGroup.add(voxels);
+
+        const backingDepth = 0.13;
+        const backingGeometry = new THREE.BoxGeometry(photoWidth + 0.16, photoHeight + 0.16, backingDepth);
+        const backingMaterial = new THREE.MeshStandardMaterial({ color: 0x1a111f, roughness: 0.7, metalness: 0.04 });
+        const backing = new THREE.Mesh(backingGeometry, backingMaterial);
+        backing.position.z = -backingDepth * 0.62;
+        backing.castShadow = true;
+        backing.receiveShadow = true;
+        objectGroup.add(backing);
+
+        const edgeGeometry = new THREE.EdgesGeometry(backingGeometry, 24);
+        const edgeMaterial = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.18 });
         const edges = new THREE.LineSegments(edgeGeometry, edgeMaterial);
+        edges.position.copy(backing.position);
         objectGroup.add(edges);
 
         const groundGeometry = new THREE.PlaneGeometry(Math.max(8, photoWidth * 1.8), 6);
-        const groundMaterial = new THREE.ShadowMaterial({ color: 0x000000, transparent: true, opacity: compact ? 0.16 : 0.23 });
+        const groundMaterial = new THREE.ShadowMaterial({ color: 0x000000, transparent: true, opacity: compact ? 0.16 : 0.22 });
         const ground = new THREE.Mesh(groundGeometry, groundMaterial);
         ground.rotation.x = -Math.PI / 2;
-        ground.position.set(0, -photoHeight / 2 - 0.5, 0.25);
+        ground.position.set(0, -photoHeight / 2 - 0.52, 0.2);
         ground.receiveShadow = true;
         scene.add(ground);
 
@@ -126,14 +157,14 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
           const horizontalFov = 2 * Math.atan(Math.tan(verticalFov / 2) * camera.aspect);
           const distanceForHeight = (photoHeight * 0.62) / Math.tan(verticalFov / 2);
           const distanceForWidth = (photoWidth * 0.62) / Math.tan(Math.max(0.12, horizontalFov / 2));
-          const distance = Math.max(distanceForHeight, distanceForWidth, 5.2) + 0.65;
+          const distance = Math.max(distanceForHeight, distanceForWidth, 5.2) + 0.8;
           camera.position.set(0, 0.18, distance);
-          camera.lookAt(0, -0.05, 0);
+          camera.lookAt(0, -0.05, 0.05);
         };
         fitCamera(initialWidth, initialHeight);
 
-        let targetX = -0.035;
-        let targetY = 0.09;
+        let targetX = -0.045;
+        let targetY = 0.13;
         let pointerId = null;
         let lastX = 0;
         let lastY = 0;
@@ -158,8 +189,8 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
           const dy = event.clientY - lastY;
           lastX = event.clientX;
           lastY = event.clientY;
-          targetY = clamp(targetY + dx * 0.0048, -0.36, 0.36);
-          targetX = clamp(targetX + dy * 0.0035, -0.14, 0.14);
+          targetY = clamp(targetY + dx * 0.0048, -0.42, 0.42);
+          targetX = clamp(targetX + dy * 0.0035, -0.17, 0.17);
           applyReducedMotionRotation();
         };
         const up = (event) => {
@@ -170,10 +201,10 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         };
         const keydown = (event) => {
           let handled = true;
-          if (event.key === 'ArrowLeft') targetY = clamp(targetY - 0.055, -0.36, 0.36);
-          else if (event.key === 'ArrowRight') targetY = clamp(targetY + 0.055, -0.36, 0.36);
-          else if (event.key === 'ArrowUp') targetX = clamp(targetX - 0.04, -0.14, 0.14);
-          else if (event.key === 'ArrowDown') targetX = clamp(targetX + 0.04, -0.14, 0.14);
+          if (event.key === 'ArrowLeft') targetY = clamp(targetY - 0.055, -0.42, 0.42);
+          else if (event.key === 'ArrowRight') targetY = clamp(targetY + 0.055, -0.42, 0.42);
+          else if (event.key === 'ArrowUp') targetX = clamp(targetX - 0.04, -0.17, 0.17);
+          else if (event.key === 'ArrowDown') targetX = clamp(targetX + 0.04, -0.17, 0.17);
           else handled = false;
           if (handled) {
             event.preventDefault();
@@ -187,9 +218,8 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
         renderer.domElement.addEventListener('keydown', keydown);
 
         objectGroup.rotation.set(targetX, targetY, 0);
-        if (reducedMotion) {
-          renderOnce();
-        } else {
+        if (reducedMotion) renderOnce();
+        else {
           const render = () => {
             if (dead) return;
             objectGroup.rotation.x += (targetX - objectGroup.rotation.x) * 0.085;
@@ -224,13 +254,12 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
           renderer.domElement.removeEventListener('pointerup', up);
           renderer.domElement.removeEventListener('pointercancel', up);
           renderer.domElement.removeEventListener('keydown', keydown);
-          photoGeometry.dispose();
-          photoMaterial.dispose();
-          texture.dispose();
+          cubeGeometry.dispose();
+          cubeMaterial.dispose();
+          backingGeometry.dispose();
+          backingMaterial.dispose();
           edgeGeometry.dispose();
           edgeMaterial.dispose();
-          frameGeometry.dispose();
-          frameMaterial.dispose();
           groundGeometry.dispose();
           groundMaterial.dispose();
           renderer.dispose();
@@ -240,14 +269,14 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
       } catch (previewError) {
         if (!dead) {
           setStatus('error');
-          setError(String(previewError?.message || previewError || 'The 3D photo preview could not open.'));
+          setError(String(previewError?.message || previewError || 'The 3D voxel photo preview could not open.'));
         }
       }
     };
     image.onerror = () => {
       if (!dead) {
         setStatus('error');
-        setError('The selected photo could not be opened for the 3D preview.');
+        setError('The selected photo could not be opened for the 3D voxel photo preview.');
       }
     };
 
@@ -261,15 +290,15 @@ export default function PhotoReliefModelViewer({ imageUrl, onReady }) {
 
   return <div className={`viewerShell ${styles.shell}`}>
     <div ref={mountRef} className={styles.canvasMount}/>
-    {status === 'loading' ? <div className={styles.loading}><span>PREPARING PHOTO-FAITHFUL 3D…</span></div> : null}
+    {status === 'loading' ? <div className={styles.loading}><span>BUILDING 3D VOXEL PHOTO…</span></div> : null}
     {!error ? <>
-      <div className={styles.qualityBadge} aria-hidden="true"><span>PHOTO-FAITHFUL 3D</span><b>NO WARPING</b></div>
-      <div className={styles.hint} aria-hidden="true">DRAG TO INSPECT DEPTH</div>
-      <div className={styles.sourceCard} aria-hidden="true"><img src={imageUrl} alt=""/><span>ORIGINAL REFERENCE</span></div>
+      <div className={styles.qualityBadge} aria-hidden="true"><span>3D VOXEL PHOTO</span><b>PHOTO-MATCHED</b></div>
+      <div className={styles.hint} aria-hidden="true">DRAG TO INSPECT VOXEL DEPTH</div>
+      <div className={styles.sourceCard} aria-hidden="true"><img src={imageUrl} alt=""/><span>ORIGINAL PHOTO</span></div>
     </> : null}
     {error ? <div className={styles.error} role="status">
       <img src={imageUrl} alt="Original property reference"/>
-      <p>{error} The original reference is still shown so the property is never replaced by a misleading render.</p>
+      <p>{error} Your original photo is still shown so you can retry without losing the reference.</p>
     </div> : null}
   </div>;
 }


### PR DESCRIPTION
## Correction
The product preview is a **3D voxel photo**, not a generic 3D picture.

## What changed
- Rebuilt `PhotoReliefModelViewer` as a block-by-block voxel renderer sampled from the uploaded/source house photo.
- The preview now uses hundreds of colored 3D voxel blocks with per-block depth and remains draggable/keyboard-inspectable.
- Kept the original photo visible as the reference so the voxel photo remains tied to the user's house.
- Updated the homepage flow to: **Photo → 3D voxel photo → approve → movable 3D voxel**.
- Updated the homepage sample controls and metadata to use the corrected product language.

## What stays the same
- $4.99 creation price.
- Source-photo privacy behavior.
- Existing sign-in, checkout, save, World, Vault, and optional mint behavior.
- The separate final movable 3D voxel step remains after approval of the voxel-photo preview.