### PR TITLE
Align VoxelPop regression guards with the current product

### DIFF
--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -15,146 +15,114 @@ const integrationsPage = fs.readFileSync(new URL('../app/admin/integrations/page
 const integrationsApi = fs.readFileSync(new URL('../app/api/admin/integrations/status/route.ts', import.meta.url), 'utf8');
 const layout = fs.readFileSync(new URL('../app/layout.js', import.meta.url), 'utf8');
 const vaultLayout = fs.readFileSync(new URL('../app/vault/layout.js', import.meta.url), 'utf8');
-const home = fs.readFileSync(new URL('../app/real-estate/page.js', import.meta.url), 'utf8');
+const realEstateHome = fs.readFileSync(new URL('../app/real-estate/page.js', import.meta.url), 'utf8');
 
-// One consumer navigation everywhere: Home -> Create -> World -> Vault -> More.
+// Canonical route map keeps advanced tools organized, while the simple iPhone dock hides More.
 for (const label of ['Home', 'Create', 'World', 'Vault', 'More']) {
-  assert.match(productMap, new RegExp(`label: '${label}'`), `canonical product dock should include ${label}`);
+  assert.match(productMap, new RegExp(`label: '${label}'`), `canonical product map should include ${label}`);
 }
 assert.match(productMap, /SIMPLE_PROPERTY_DOCK/, 'simple property routes should use the canonical consumer dock');
-assert.doesNotMatch(productMap.split('export const APP_DOCK')[0], /label: '\$1\.99'|label: 'Rented'|label: 'Add'/, 'sandbox/rental shortcuts must not clutter the primary dock');
-assert.match(productMap, /APP_SECTIONS/);
-for (const route of ['/property', '/vault/earth', '/geo', '/studio', '/capture', '/receipt', '/avatar', '/room', '/trade', '/marketplace', '/ai', '/ai-licensing', '/hunt', '/real-estate/reits', '/vault/income', '/real-estate/acquire', '/vault/properties/claim', '/forge/mainnet', '/admin/integrations']) {
-  assert.ok(productMap.includes(`'${route}'`), `canonical product map should organize ${route}`);
-}
-assert.match(productMap, /\$1\.99 Property Sandbox/, 'the tiny property comparison must remain explicitly sandboxed under More');
+assert.match(productMap, /APP_SECTIONS/, 'advanced routes should remain organized outside the core creation flow');
+assert.match(productMap, /Authorized photo → \$4\.99 3D voxel photo → approval → movable voxel → optional World\/map\/mint\./, 'property directory copy must preserve voxel-photo-before-movable-voxel ordering');
+assert.match(productMap, /\$1\.99 Property Sandbox/, 'the property comparison must stay explicitly sandboxed');
 assert.match(productMap, /No real funds or property rights move/, 'sandbox description must preserve the no-rights boundary');
-assert.match(productMap, /Authorized photo → \$4\.99 textured 3D preview → approval → movable voxel/, 'property creator directory entry must disclose the paid preview-before-voxel creation sequence');
-assert.match(productMap, /badge: 'PROVIDER-GATED'/, 'regulated investment tools must be visibly provider-gated');
+assert.match(productMap, /badge: 'PROVIDER-GATED'/, 'regulated investment tools must remain visibly provider-gated');
 assert.match(productMap, /A token or VoxelPop item is never the deed/, 'direct ownership path must keep title separate from the token');
-assert.match(productMap, /APP_USER_PREFIXES[\s\S]*'\/admin'/, 'owner routes should keep the global app shell');
-assert.match(productMap, /isOrganizedUserRoute/);
-assert.match(productMap, /isSimplePropertyRoute/);
-assert.match(productMap, /dockItemForPath/);
 
-assert.match(nav, /APP_DOCK/);
-assert.match(nav, /SIMPLE_PROPERTY_DOCK/);
-assert.match(nav, /Voxel Vault primary navigation/);
-assert.match(nav, /isOrganizedUserRoute/);
-assert.match(nav, /isSimplePropertyRoute/);
-assert.match(nav, /FinancialOSNav\.module\.css/, 'consumer dock should use its responsive stylesheet');
+assert.match(nav, /APP_DOCK/, 'mobile navigation must use the canonical app dock');
+assert.match(nav, /SIMPLE_PROPERTY_DOCK/, 'core VoxelPop routes must use the simple dock');
+assert.match(nav, /SIMPLE_PROPERTY_DOCK\.filter\(\(item\) => item\.id !== 'more'\)/, 'core mobile navigation must stay condensed to Home, Create, World, and Vault');
+assert.match(nav, /isOrganizedUserRoute/, 'navigation should render only on organized product routes');
 assert.match(navCss, /safe-area-inset-bottom/, 'consumer dock must respect the iPhone safe area');
 assert.match(navCss, /@media\(max-width:720px\)/, 'consumer dock must stay mobile-only when desktop top navigation is present');
-assert.doesNotMatch(nav, /FINANCIAL_PREFIXES|financialRoute/, 'global app shell should not be restricted to finance-only routes');
-assert.match(layout, /FinancialOSNav/);
-assert.match(layout, /AppCommandCenter/);
-assert.match(layout, /spatial-os-interactions\.css/);
-assert.match(layout, /Your 3D Asset Vault/, 'public metadata should describe the understandable product rather than internal architecture jargon');
-assert.doesNotMatch(vaultLayout, /VaultPortalNav/);
+assert.doesNotMatch(nav, /FINANCIAL_PREFIXES|financialRoute/, 'global app shell must not be restricted to finance-only routes');
+
+assert.match(layout, /FinancialOSNav/, 'root layout must include the shared mobile dock');
+assert.match(layout, /AppCommandCenter/, 'root layout must keep advanced tool discovery available off the simple routes');
+assert.match(layout, /spatial-os-interactions\.css/, 'shared interaction accessibility must remain loaded');
+assert.match(layout, /Turn a House Photo into a 3D Voxel Photo/, 'public metadata must describe the focused current VoxelPop product');
+assert.match(layout, /3D voxel photo/, 'metadata must distinguish the reviewable voxel-photo stage');
+assert.doesNotMatch(vaultLayout, /VaultPortalNav/, 'Vault must not restore a competing legacy navigation shell');
 
 assert.match(interactions, /--vv-tap-min:\s*44px/, 'coarse-pointer controls should keep an iPhone-friendly minimum target');
 assert.match(interactions, /@media \(pointer: coarse\)/, 'shared interactions should adapt to touch devices');
 assert.match(interactions, /:focus-visible/, 'keyboard focus must stay visible across the app shell');
 assert.match(interactions, /prefers-reduced-motion: reduce/, 'shared shell must respect reduced motion');
 assert.match(interactions, /-webkit-text-size-adjust:\s*100%/, 'iPhone text resizing should remain stable');
-assert.doesNotMatch(interactions, /background:\s*#(?:000|05060b)|color-scheme:/i, 'shared interaction polish must not force one visual theme onto every subsystem');
+assert.doesNotMatch(interactions, /background:\s*#(?:000|05060b)|color-scheme:/i, 'shared interaction helpers must not force a dark visual theme onto every subsystem');
 
 assert.match(commandCenter, /APP_DOCK, APP_SECTIONS/, 'tool finder should index the canonical product map instead of maintaining another route list');
 assert.match(commandCenter, /metaKey \|\| event\.ctrlKey/, 'tool finder should support desktop keyboard invocation');
-assert.match(commandCenter, /event\.key === '\/'/, 'tool finder should support fast slash invocation outside text fields');
+assert.match(commandCenter, /event\.key === '\/'/, 'tool finder should support slash invocation outside text fields');
 assert.match(commandCenter, /safe-area-inset-bottom/, 'tool finder trigger must respect iPhone safe area');
 assert.match(commandCenter, /!isSimplePropertyRoute\(pathname\)/, 'advanced tool search must disappear from the simple core routes');
 assert.match(commandCenter, /never automatically spends money, mints an NFT, or starts a paid 3D generation/, 'tool finder must disclose its non-execution boundary');
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
-// Consumer Home describes the actual demo-first, account-gated, paid preview-before-voxel flow.
-assert.match(rootHome, /START → SIGN IN \+ UPLOAD PHOTO/, 'root Home should accurately disclose sign-in before the upload picker');
-assert.match(rootHome, /href="\/demo"/, 'root Home should let visitors inspect real 3D interaction before sign-in');
-assert.match(rootHome, /href="\/property"/, 'root Home should route creation into the account-gated maker');
-assert.match(rootHome, /Upload a picture\./, 'root Home should keep one photo as the obvious creation source');
-assert.match(rootHome, /After sign-in and the \$4\.99 creation checkout/, 'root Home should disclose the exact paid creation gate without implying hidden charging');
-assert.match(rootHome, /One VoxelPop creation costs \$4\.99/i, 'root Home must disclose the generation price');
-assert.match(rootHome, /source photo stays on your device/i, 'root Home must explain the device-local source-photo boundary');
-assert.match(rootHome, /without Meshy credits/i, 'root Home must accurately describe the local generation engine');
-assert.match(rootHome, /Optional Collect later is a separate digital-item purchase/i, 'root Home must distinguish generation from the later collectible checkout');
-assert.match(rootHome, /HomeProductPreview/, 'root Home should prove the product with the production visual stages rather than a decorative CSS house');
-assert.match(rootHome, /<b>PHOTO<\/b>/, 'root Home should show the photo stage');
-assert.match(rootHome, /<b>\$4\.99<\/b>/, 'root Home should disclose the paid creation stage in the flow');
-assert.match(rootHome, /<b>3D PREVIEW<\/b>/, 'root Home should expose the preview before voxelization');
-assert.match(rootHome, /<b>APPROVE<\/b>/, 'root Home should require explicit preview approval');
-assert.match(rootHome, /<b>VOXEL<\/b>/, 'root Home should expose the separate movable voxel stage');
-assert.match(rootHome, /<b>OPTIONAL MINT<\/b>/, 'root Home should make minting explicitly optional');
-assert.match(rootHome, /href="\/world"/, 'source-backed map context should remain reachable after creation');
-assert.match(rootHome, /href="\/vault"/, 'finished creations should have a clear Vault destination');
-assert.match(rootHome, /Collection and minting remain separate optional actions/, 'paid and blockchain actions must never appear automatic');
-assert.match(rootHome, /no wallet is required to create/i, 'wallet must remain optional for creation');
-assert.match(rootHome, /Voxel Vault is not a bank/i, 'root Home must not imply bank status');
-assert.match(rootHome, /VoxelPop item is not a deed/i, 'root Home must distinguish a digital item from title');
-assert.match(rootHome, /\$1\.99 property comparison is a sandbox/i, 'root Home must label the property slice as sandbox');
-assert.match(rootHome, /financial products remain provider-gated/i, 'root Home must label regulated financial tools as provider-gated');
-assert.match(rootHome, /href="\/more"/, 'optional and advanced tools must remain deliberately reachable');
+// Consumer Home: one photo, one paid creation, voxel-photo review first, movable voxel second.
+assert.match(rootHome, /ONE HOUSE PHOTO · \$4\.99/, 'root Home must present one photo and one clear creation price');
+assert.match(rootHome, /Create my VoxelPop · \$4\.99/, 'root Home must keep one clear paid creation CTA');
+assert.match(rootHome, /Try the free demo/, 'root Home must let visitors inspect the product before sign-in or payment');
+assert.match(rootHome, /Photo stays on your device/i, 'root Home must explain the device-local source-photo boundary');
+assert.match(rootHome, /No wallet to create/i, 'wallet must remain optional for creation');
+assert.match(rootHome, /3D VOXEL PHOTO/, 'root Home must expose the voxel-photo review stage');
+assert.match(rootHome, /MOVABLE VOXEL/, 'root Home must expose the separate movable voxel stage');
+assert.match(rootHome, /SAVE \/ OPTIONAL MINT/, 'root Home must keep minting downstream and optional');
+assert.match(rootHome, /HomeProductPreview/, 'root Home must prove the flow with the production visual stages');
+assert.match(rootHome, /does not create ownership or financial rights in a physical property/i, 'root Home must preserve the physical-property boundary');
 assert.doesNotMatch(rootHome, /YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT|TRY THE \$1\.99 SLICE/, 'bank-like and sandbox-heavy language must not dominate the front door');
 assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING|guaranteed returns|guaranteed yield|risk[- ]free/i, 'unverified physical-property purchase or return claims must stay out of the consumer front door');
-assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root home must not alias an older real-estate subsystem');
+assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root Home must not alias the advanced real-estate subsystem');
 
-// The $1.99 comparison is intentionally a pure sandbox, not a faux bank/wallet surface.
+// The $1.99 comparison remains a pure sandbox, not a faux bank/wallet surface.
 assert.match(slice, /PROPERTY SLICE · SANDBOX/, 'slice page must identify itself as a sandbox before the demo interaction');
 assert.match(slice, /DEMO BALANCE · NOT MONEY/, 'demo balance must never look like settled cash');
 assert.match(slice, /Simulation only · no checkout · no wallet · no ownership/, 'slice CTA must disclose that it cannot execute a real transaction');
 assert.match(slice, /no real funds, deed, equity, security, rent rights, or NFT moved/, 'demo completion must preserve the full legal/financial boundary');
-assert.doesNotMatch(slice, /useWalletIdentity|Connect wallet|Crypto estimated value|NFT estimated value|Make the NFT useful|PROPERTY · USD · CRYPTO · NFT/, 'the property sandbox must not imitate live wallet, crypto, NFT or banking execution');
+assert.doesNotMatch(slice, /useWalletIdentity|Connect wallet|Crypto estimated value|NFT estimated value|Make the NFT useful|PROPERTY · USD · CRYPTO · NFT/, 'the property sandbox must not imitate live wallet, crypto, NFT, or banking execution');
 
-// Capability status remains safe even though it is not on the consumer front door.
-assert.match(homeCapabilities, /\/api\/world-atlas\/capabilities/, 'capability strip must use the safe public readiness endpoint wherever it is surfaced');
+// Capability status can exist without crowding the consumer front door.
+assert.match(homeCapabilities, /\/api\/world-atlas\/capabilities/, 'capability strip must use the safe public readiness endpoint wherever surfaced');
 for (const label of ['WORLD DATA', 'OPEN STREET', 'MESHY 7', 'MARKET FEEDS']) assert.match(homeCapabilities, new RegExp(label));
 assert.match(homeCapabilities, /READY · MANUAL/, 'Meshy readiness must remain explicitly manual');
 assert.match(homeCapabilities, /no auto-spend/, 'capabilities must explain that Meshy does not spend credits automatically');
-assert.match(homeCapabilities, /Readiness is configuration status, not a promise of market inventory, legal ownership, investment availability or AI-generation rights/, 'readiness must preserve truth boundaries');
 assert.match(homeCapabilities, /No API keys or secret values are exposed here/, 'capability display must state the secret-value boundary');
 assert.doesNotMatch(homeCapabilities, /process\.env|MESHY_API_KEY|BRIDGE_ACCESS_TOKEN|DOMAIN_CLIENT_SECRET/, 'client capability strip must never reference raw secret environment variables');
 assert.match(capabilitiesApi, /automaticGeneration:\s*false/, 'server capability contract must keep Meshy automatic generation disabled');
 assert.match(capabilitiesApi, /Boolean\(process\.env\.MESHY_API_KEY\?\.trim\(\)\)/, 'Meshy readiness may expose only a boolean');
 
-// More keeps the core app short while surfacing useful property actions first and advanced rails second.
-assert.match(more, /More tools\.[\s\S]*Less confusion\./i, 'More must explain its simplified purpose');
-assert.match(more, /Bought or saved a property\?/i, 'More must lead with the reusable property workflow');
-assert.match(more, /3D preview → approve → 3D voxel → optional mint/i, 'More must state the actual property creation order');
-assert.match(more, /Create from My Properties →/, 'More must link directly to the reusable property picker');
-assert.match(more, /\$1\.99 Property Sandbox/, 'More must keep the demo property tool clearly labeled');
-assert.match(more, /ADVANCED \+ PROVIDER-GATED/, 'provider and legal rails must stay visibly advanced');
-assert.match(more, /A demo, NFT, investment security, lease record, and property deed are different things/, 'More must preserve the legal and financial separation');
-assert.match(more, /A VoxelPop model or NFT can represent a digital creation/, 'More must preserve the digital-not-deed boundary');
+// Extras remain reachable but secondary to VoxelPop Property.
+assert.match(more, /Keep VoxelPop simple\./i, 'Extras page must state its simplified purpose');
+assert.match(more, /The main product is Create → 3D voxel photo → movable voxel → Vault/i, 'Extras page must preserve the core product order');
+assert.match(more, /Create VoxelPop · \$4\.99 →/, 'Extras page must route back to the main paid creator');
+assert.match(more, /See free sample →/, 'Extras page must keep the no-login proof reachable');
+assert.match(more, /OWNER \/ PROVIDER TOOLS/, 'provider and owner rails must remain visibly advanced');
+assert.match(more, /not part of the \$4\.99 VoxelPop product/i, 'regulated/provider tools must remain separate from the creation purchase');
+assert.match(more, /A VoxelPop model or NFT is a digital creation/, 'Extras page must preserve the digital-not-deed boundary');
 
 assert.match(integrationsApi, /requireVoxelVaultAdmin/, 'integration status must be owner-authenticated');
-assert.match(integrationsApi, /MESHY_API_KEY/);
-assert.match(integrationsApi, /STRIPE_SECRET_KEY/);
-assert.match(integrationsApi, /BRIDGE_DATASET_ID/);
-assert.match(integrationsApi, /DOMAIN_CLIENT_ID/);
-assert.match(integrationsApi, /DINARI_API_KEY_ID/);
-assert.match(integrationsApi, /ALGORAND_INDEXER_BASE_URL/);
-assert.match(integrationsApi, /CDP_API_KEY_ID/);
-assert.match(integrationsApi, /secretsReturned:\s*false/);
-assert.match(integrationsApi, /valuesReturned:\s*false/);
-assert.doesNotMatch(integrationsApi, /return process\.env\[[^\]]+\]/, 'integration API must never return raw env values');
-assert.match(integrationsPage, /OWNER · INTEGRATIONS CENTER/);
-assert.match(integrationsPage, /getSupabaseBrowserAsync/);
-assert.match(integrationsPage, /\/api\/admin\/integrations\/status/);
-assert.match(integrationsPage, /SIGN IN WITH GOOGLE/);
+for (const key of ['MESHY_API_KEY','STRIPE_SECRET_KEY','BRIDGE_DATASET_ID','DOMAIN_CLIENT_ID','DINARI_API_KEY_ID','ALGORAND_INDEXER_BASE_URL','CDP_API_KEY_ID']) assert.match(integrationsApi, new RegExp(key));
+assert.match(integrationsApi, /secretsReturned:\s*false/, 'integration API must never claim to return secrets');
+assert.match(integrationsApi, /valuesReturned:\s*false/, 'integration API must never claim to return raw values');
+assert.doesNotMatch(integrationsApi, /return process\.env\[[^\]]+\]/, 'integration API must never return raw environment values');
+assert.match(integrationsPage, /OWNER · INTEGRATIONS CENTER/, 'owner integration page must identify its restricted purpose');
+assert.match(integrationsPage, /getSupabaseBrowserAsync/, 'owner integration page must use authenticated account state');
+assert.match(integrationsPage, /\/api\/admin\/integrations\/status/, 'owner integration page must call the protected status endpoint');
+assert.match(integrationsPage, /SIGN IN WITH GOOGLE/, 'owner integration page must expose its sign-in gate');
 
-// Detailed real-estate stays advanced, status-driven, and fail-closed without finance-dashboard theater.
-assert.match(home, /Explore · sandbox · invest through providers · own through title/);
-assert.match(home, /Real estate,[\s\S]*without pretending\./);
-assert.match(home, /Try \$1\.99 property math/);
-assert.match(home, /LIVE DIGITAL/);
-assert.match(home, /DEMO/);
-assert.match(home, /PARTNER REQUIRED/);
-assert.match(home, /TITLE REQUIRED/);
-assert.match(home, /Map ≠ collectible ≠ investment ≠ deed/);
-assert.match(home, /Live investing is locked until provider requirements are satisfied/);
-assert.match(home, /Demo data only · no real purchase/);
-assert.match(home, /recorded title/i);
-assert.match(home, /Voxel Vault is not itself a bank, broker, exchange, custodian, escrow service, or deed registry/);
-assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
-assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
+// Advanced real-estate surfaces stay truthful and fail closed.
+assert.match(realEstateHome, /Explore · sandbox · invest through providers · own through title/);
+assert.match(realEstateHome, /Real estate,[\s\S]*without pretending\./);
+assert.match(realEstateHome, /LIVE DIGITAL/);
+assert.match(realEstateHome, /DEMO/);
+assert.match(realEstateHome, /PARTNER REQUIRED/);
+assert.match(realEstateHome, /TITLE REQUIRED/);
+assert.match(realEstateHome, /Map ≠ collectible ≠ investment ≠ deed/);
+assert.match(realEstateHome, /Live investing is locked until provider requirements are satisfied/);
+assert.match(realEstateHome, /Demo data only · no real purchase/);
+assert.match(realEstateHome, /recorded title/i);
+assert.match(realEstateHome, /Voxel Vault is not itself a bank, broker, exchange, custodian, escrow service, or deed registry/);
+assert.doesNotMatch(realEstateHome, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
+assert.doesNotMatch(realEstateHome, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault demo-first photo -> $4.99 -> 3D preview -> approve -> movable voxel -> optional World/Vault/mint + unambiguous $1.99 sandbox + fail-closed advanced rails coherence checks passed');
+console.log('Voxel Vault coherence checks passed: focused photo -> $4.99 -> 3D voxel photo -> approval -> movable voxel -> optional save/mint, with condensed mobile navigation, sandbox separation, and fail-closed advanced rails.');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -17,7 +17,7 @@ const legacyTerms = read('terms.html');
 const readme = read('README.md');
 const og = read('app/opengraph-image.js');
 
-assert.match(home, /Try the sample · no login/, 'home must show product value before Google sign-in');
+assert.match(home, /Try the free demo/, 'home must show product value before Google sign-in');
 assert.match(home, /href="\/demo"/, 'home must link to the public product sample');
 assert.match(home, /Create my VoxelPop · \$4\.99/, 'home must keep the paid creation price visible');
 assert.match(home, /3D voxel photo[\s\S]*movable 3D voxel/i, 'home must preserve voxel-photo-before-model positioning');
@@ -70,5 +70,5 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public VoxelPop positioning checks passed: sample-first product proof, real 3D voxel-photo semantics, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
+console.log('Public VoxelPop positioning checks passed: free demo-first product proof, real 3D voxel-photo semantics, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
 await import('./test-public-surface-coherence.mjs');


### PR DESCRIPTION
Updates stale regression checks so they protect the product that is actually shipping now: one house photo → $4.99 → 3D voxel photo → approval → separate movable voxel → save / optional mint. Also keeps the sandbox, provider-gated finance, title, and secret-handling boundaries fail-closed. No production payment, generation, save, wallet, or mint logic is changed.