### PR TITLE
Fix Google sign-in getting stuck

### DIFF
--- a/lib/supabase-browser.js
+++ b/lib/supabase-browser.js
@@ -15,7 +15,7 @@ function createBrowserClient(url, key) {
     browserClient = createClient(url, key, {
       auth: {
         flowType: 'pkce',
-        detectSessionInUrl: false,
+        detectSessionInUrl: true,
         persistSession: true,
         autoRefreshToken: true,
       },
@@ -69,9 +69,6 @@ export async function supabaseBrowserConfigured() {
   }
 }
 
-// Preserve the existing client-shaped API for older call sites that already
-// have build-time public environment variables. New mobile flows should use
-// getSupabaseBrowserAsync() so server-side publishable config can bootstrap them.
 export const supabaseBrowser = new Proxy({}, {
   get(_target, property) {
     const client = getSupabaseBrowser();


### PR DESCRIPTION
Fixes the property flow returning from Google OAuth but remaining on the sign-in screen. Supabase PKCE now detects the OAuth callback in the browser and exchanges it into the persisted session, including mobile/iPhone flows.