### PR TITLE
Prevent account check from hanging

### DIFF
--- a/lib/supabase-browser.js
+++ b/lib/supabase-browser.js
@@ -3,6 +3,8 @@ import { createClient } from '@supabase/supabase-js';
 let browserClient;
 let runtimeConfigPromise;
 
+const CONFIG_TIMEOUT_MS = 8000;
+
 function bundledConfig() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
   const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
@@ -24,6 +26,29 @@ function createBrowserClient(url, key) {
   return browserClient;
 }
 
+async function fetchRuntimeConfig() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CONFIG_TIMEOUT_MS);
+  try {
+    const response = await fetch('/api/account/public-config', {
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data?.configured || !data?.url || !data?.key) {
+      throw new Error('Google sign-in still needs a Supabase publishable/anon key configured on the server.');
+    }
+    return data;
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error('Account setup took too long to respond. Please try Google sign-in again.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export function getSupabaseBrowser() {
   if (browserClient) return browserClient;
   const { url, key } = bundledConfig();
@@ -37,18 +62,10 @@ export async function getSupabaseBrowserAsync() {
   if (typeof window === 'undefined') throw new Error('Vault accounts are available in the browser only.');
 
   if (!runtimeConfigPromise) {
-    runtimeConfigPromise = fetch('/api/account/public-config', { cache: 'no-store' })
-      .then(async response => {
-        const data = await response.json().catch(() => ({}));
-        if (!response.ok || !data?.configured || !data?.url || !data?.key) {
-          throw new Error('Google sign-in still needs a Supabase publishable/anon key configured on the server.');
-        }
-        return data;
-      })
-      .catch(error => {
-        runtimeConfigPromise = undefined;
-        throw error;
-      });
+    runtimeConfigPromise = fetchRuntimeConfig().catch(error => {
+      runtimeConfigPromise = undefined;
+      throw error;
+    });
   }
 
   const runtime = await runtimeConfigPromise;
@@ -61,9 +78,8 @@ export async function supabaseBrowserConfigured() {
   if (bundled.url && bundled.key) return true;
   if (typeof window === 'undefined') return false;
   try {
-    const response = await fetch('/api/account/public-config', { cache: 'no-store' });
-    const data = await response.json().catch(() => ({}));
-    return Boolean(response.ok && data?.configured);
+    const data = await fetchRuntimeConfig();
+    return Boolean(data?.configured);
   } catch {
     return false;
   }


### PR DESCRIPTION
Adds a timeout to the public account configuration request so the property page cannot remain indefinitely on Checking your account. Existing Google OAuth and PKCE behavior is unchanged.