### PR TITLE
Fix account checks getting stuck

### DIFF
--- a/lib/supabase-browser.js
+++ b/lib/supabase-browser.js
@@ -4,6 +4,7 @@ let browserClient;
 let runtimeConfigPromise;
 
 const CONFIG_TIMEOUT_MS = 8000;
+const SESSION_TIMEOUT_MS = 5000;
 
 function bundledConfig() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
@@ -11,17 +12,40 @@ function bundledConfig() {
   return { url, key };
 }
 
+function protectSessionLookup(client) {
+  const getSession = client.auth.getSession.bind(client.auth);
+  client.auth.getSession = (...args) => new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(result);
+    };
+    const timeout = setTimeout(() => finish({
+      data: { session: null },
+      error: new Error('Account check took too long. You can still continue with Google.'),
+    }), SESSION_TIMEOUT_MS);
+
+    Promise.resolve()
+      .then(() => getSession(...args))
+      .then(finish)
+      .catch((error) => finish({ data: { session: null }, error }));
+  });
+  return client;
+}
+
 function createBrowserClient(url, key) {
   if (!url || !key) throw new Error('Vault accounts are not configured yet.');
   if (!browserClient) {
-    browserClient = createClient(url, key, {
+    browserClient = protectSessionLookup(createClient(url, key, {
       auth: {
         flowType: 'pkce',
         detectSessionInUrl: true,
         persistSession: true,
         autoRefreshToken: true,
       },
-    });
+    }));
   }
   return browserClient;
 }


### PR DESCRIPTION
Stops account-gated Voxel Vault screens from hanging forever on “Checking your account…” if Supabase session recovery stalls.

- adds a 5-second safety timeout around browser `getSession()`
- falls back to a signed-out/actionable state instead of an infinite loader
- preserves the existing 8-second runtime-config timeout and OAuth/session behavior

This is a fresh branch from current `main` and changes only `lib/supabase-browser.js`.