### PR TITLE
Align Stage 3 regression guards with real 3D voxel photo

### DIFF
--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -26,11 +26,11 @@ assert.match(property, /Demo property slice · not real-property ownership/, 'sa
 assert.match(property, /setMessage\('Payment verified\. Loading your 3D voxel photo first\.'\)/,
   'a verified paid session stops at the 3D voxel-photo review stage first');
 assert.match(property, /PhotoReliefModelViewer/, '3D voxel photo is a distinct stage');
-assert.match(photoPreview, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, 'the review stage preserves the selected house photo itself');
-assert.match(photoPreview, /3D VOXEL PHOTO/, 'the review stage is identified as the 3D voxel-photo step');
-assert.match(photoPreview, /PHOTO-MATCHED/, 'the review stage makes likeness preservation explicit');
-assert.match(photoPreview, /ORIGINAL PHOTO/, 'the review stage keeps the original image visible for comparison');
-assert.doesNotMatch(photoPreview, /InstancedMesh|getImageData|BoxGeometry/, 'the approval preview must not fabricate unseen cube geometry from one photo');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'the selected source image supplies voxel color data');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, 'the 3D voxel photo uses real voxel instances');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'the 3D voxel photo uses physical cube geometry');
+assert.match(photoPreview, /voxels\.setColorAt\(instance, color\)/, 'voxel-photo colors remain tied to the source image');
+assert.match(photoPreview, /targetY = clamp/, '3D voxel-photo rotation remains deliberately bounded');
 assert.match(property, /Looks good → Create Movable 3D Voxel/, 'user approval is required before movable-voxel generation');
 assert.match(property, /async function approvePreviewAndBuildVoxel\(\)/, 'movable-voxel generation has an explicit post-preview gate');
 assert.match(property, /const poster = await createVoxelPoster\(pendingPhoto\)/, 'voxel image is not created until after preview approval');
@@ -83,4 +83,4 @@ assert.match(mintPage, /Mint Later/, 'final mint page keeps minting optional');
 assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal paid creation flow does not lead into another paid collectible funnel');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided property flow does not call metered provider generation routes');
 
-console.log('Property journey regression passed: saved/reusable property photo or new photo -> one paid unlock -> photo-matched 3D voxel-photo review -> explicit user approval -> separate local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with optional map/World, resilient persistence, and no Meshy credits or second paywall.');
+console.log('Property journey regression passed: saved/reusable property photo or new photo -> one paid unlock -> 3D voxel photo -> explicit user approval -> separate local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with optional map/World, resilient persistence, and no Meshy credits or second paywall.');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -21,7 +21,7 @@ assert.match(home, /Try the sample · no login/, 'home must show product value b
 assert.match(home, /href="\/demo"/, 'home must link to the public product sample');
 assert.match(home, /Create my VoxelPop · \$4\.99/, 'home must keep the paid creation price visible');
 assert.match(home, /3D voxel photo[\s\S]*movable 3D voxel/i, 'home must preserve voxel-photo-before-model positioning');
-assert.match(home, /HomeProductPreview/, 'home hero must show the real product preview instead of decorative art');
+assert.match(home, /HomeProductPreview/, 'home hero must show the real interactive product preview instead of decorative art');
 assert.match(homePreview, /PhotoReliefModelViewer/, 'home product proof must use the production voxel-photo viewer');
 assert.match(homePreview, /LocalVoxelModelViewer/, 'home product proof must use the production local voxel viewer');
 assert.match(homePreview, /House photo/, 'home preview must expose the source-photo state');
@@ -31,17 +31,17 @@ assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');
 assert.match(home, /About/, 'home footer must expose About/contact information');
 
-// The first review surface now prioritizes likeness: it presents the exact
-// selected house image as a photo-matched voxel-photo preview before the
-// separate local Three.js movable voxel is built. It must not fabricate unseen
-// geometry merely to make this approval step look more "3D".
-assert.match(photoViewer, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, 'voxel-photo review must preserve the selected house image itself');
-assert.match(photoViewer, /3D VOXEL PHOTO/, 'review surface must identify the intermediate voxel-photo stage');
-assert.match(photoViewer, /PHOTO-MATCHED/, 'review surface must clearly describe its likeness-preserving behavior');
-assert.match(photoViewer, /ORIGINAL PHOTO/, 'voxel-photo review must keep the original source visible for comparison');
-assert.doesNotMatch(photoViewer, /InstancedMesh|getImageData|BoxGeometry/, 'the first review stage must not invent block geometry from a single view');
-assert.match(photoViewerStyles, /\.housePhoto\{/, 'photo-matched review must have a dedicated visible house-photo treatment');
-assert.match(photoViewerStyles, /\.sourceCard\{/, 'photo-matched review must keep an original-photo comparison card');
+assert.match(photoViewer, /getImageData\(0, 0, columns, rows\)/, 'voxel-photo stage must sample visible source-image colors');
+assert.match(photoViewer, /new THREE\.InstancedMesh/, 'voxel-photo stage must render actual voxel instances');
+assert.match(photoViewer, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'voxel-photo stage must use real block geometry');
+assert.match(photoViewer, /const depth = 0\.42/, 'voxel-photo blocks must have meaningful inspectable depth');
+assert.match(photoViewer, /edge \* 0\.34/, 'voxel depth should respond to visible image structure instead of staying paper-thin');
+assert.doesNotMatch(photoViewer, /backingGeometry/, 'the voxel photo must not be mounted to a rectangular picture backing');
+assert.match(photoViewer, /plinthGeometry/, 'the voxel object may stand on a small floor reference without becoming a backed picture');
+assert.match(photoViewer, /ORIGINAL PHOTO/, 'voxel-photo preview must keep the original source visible for comparison');
+assert.match(photoViewer, /PHOTO-MATCHED BLOCKS/, 'viewer must identify the source-faithful output as real blocks, not a styled image');
+assert.match(photoViewer, /ArrowLeft|ArrowRight/, '3D voxel photo must support keyboard inspection as well as drag input');
+assert.match(photoViewerStyles, /focus-visible/, '3D viewer must keep a visible keyboard focus treatment');
 
 assert.match(demo, /FREE SAMPLE · NO LOGIN · NO PAYMENT/, 'demo must state that it is public and free to inspect');
 assert.match(demo, /built-in demo artwork/i, 'demo must identify its built-in artwork');
@@ -74,5 +74,5 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public VoxelPop positioning checks passed: sample-first product proof, photo-matched voxel-photo review, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
+console.log('Public VoxelPop positioning checks passed: sample-first product proof, real photo-matched 3D voxel geometry without a picture backing, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
 await import('./test-public-surface-coherence.mjs');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -72,10 +72,11 @@ assert.match(property, /You see and approve the 3D voxel photo before VoxelPop c
 
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'source photo is kept privately on-device across checkout');
 assert.match(property, /PhotoReliefModelViewer/, '3D voxel photo is a first-class stage');
-assert.match(photoPreview, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, '3D voxel-photo review preserves the exact selected house image');
-assert.match(photoPreview, /PHOTO-MATCHED/, '3D voxel-photo review makes likeness preservation explicit');
-assert.match(photoPreview, /ORIGINAL PHOTO/, '3D voxel-photo review keeps the source visible for comparison');
-assert.doesNotMatch(photoPreview, /InstancedMesh|getImageData|BoxGeometry/, 'single-photo review must not fabricate unseen cube geometry');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, '3D voxel photo samples the actual uploaded image');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, '3D voxel photo is rendered as real voxel geometry');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'voxel-photo cells use physical cube geometry');
+assert.match(photoPreview, /voxels\.setColorAt\(instance, color\)/, 'voxel-photo cells retain source-image color');
+assert.match(photoPreview, /targetY = clamp/, '3D voxel-photo rotation stays deliberately bounded so unseen sides are not presented as known');
 assert.match(property, /Looks good → Create Movable 3D Voxel/, 'user explicitly approves the 3D voxel photo before movable-voxel creation');
 assert.match(property, /createVoxelPoster/, 'VoxelPop movable-voxel image is built only after preview approval');
 assert.match(property, /LocalVoxelModelViewer/, 'local interactive movable voxel is a separate later stage');
@@ -154,4 +155,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> photo-matched 3D voxel-photo review -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');
+console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> 3D voxel photo -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');


### PR DESCRIPTION
The real Stage 3 voxel renderer is already on `main` in `0cc5b1b`, and the paid-flow regression was separately corrected on `main` in `e348a26`.

This PR updates the three remaining regression suites that still required the retired flat `<img>` preview:
- `test-public-demo-positioning.mjs`
- `test-photo-to-voxel-autostart.mjs`
- `test-simple-property-world.mjs`

They now protect the shipped behavior instead: source-photo sampling into voxel color data, real Three.js `InstancedMesh` cube geometry, meaningful shallow/edge-aware block depth, bounded inspection, original-photo comparison, no rectangular picture backing, and explicit approval before the separate movable voxel.

No checkout, auth, $4.99 pricing, source-photo storage, Stage 4, Vault, or mint runtime behavior is changed.