### PR TITLE
Guard the real Stage 3 voxel-photo renderer

### DIFF
--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -61,11 +61,15 @@ assert.doesNotMatch(property, /\/api\/property-collectible\/checkout|collectAndS
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided paid property creation must not call metered Meshy endpoints');
 assert.doesNotMatch(property, /insufficient funds|needs credits|add Meshy credits/i, 'guided UI must not expose provider-credit dead ends');
 
-assert.match(photoPreview, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, 'recognizable voxel-photo review keeps the real source house visible');
-assert.match(photoPreview, /3D VOXEL PHOTO/, 'the review surface must identify the current voxel-photo stage');
-assert.match(photoPreview, /PHOTO-MATCHED/, 'the review surface must prioritize likeness to the selected house');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, '3D voxel photo samples the selected source image into voxel data');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, '3D voxel photo renders real block geometry');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, '3D voxel photo is composed of physical cubes');
+assert.match(photoPreview, /const depth = 0\.42/, '3D voxel photo has meaningful edge-aware block depth instead of a flat picture body');
+assert.match(photoPreview, /voxels\.setColorAt\(instance, color\)/, 'voxel-photo colors stay tied to the selected photo');
 assert.match(photoPreview, /ORIGINAL PHOTO/, 'the source photo remains visible for direct comparison');
-assert.doesNotMatch(photoPreview, /getImageData|InstancedMesh|BoxGeometry|PlaneGeometry|THREE\./, 'the first approval surface must not fabricate 3D geometry from a single visible view');
+assert.doesNotMatch(photoPreview, /backingGeometry/, '3D voxel photo must not be mounted to a rectangular picture backing');
+assert.match(photoPreview, /plinthGeometry/, 'voxel photo may use a floor reference without becoming a backed picture');
+assert.match(photoPreview, /targetY = clamp/, 'voxel-photo rotation is deliberately bounded so unseen sides are not presented as known');
 
 assert.match(viewer, /const GRID = 32/, 'photo-matched building uses the higher-detail 32-cell local voxel grid');
 assert.match(viewer, /COLOR_STEP = 12/, 'photo-matched voxel keeps finer facade color differences');
@@ -99,4 +103,4 @@ assert.match(mintPage, /Mint your voxel\./, 'mint UI centers the digital voxel a
 assert.match(mintPage, /Mint Later/, 'mint UI keeps minting optional');
 assert.match(mintPage, /The NFT represents the finished digital VoxelPop voxel only/, 'mint UI clearly distinguishes the digital voxel from real-estate title');
 
-console.log('Paid VoxelPop property regression passed: sign in -> photo -> one $4.99 payment -> recognizable photo-matched 3D voxel-photo review -> explicit approval -> separate higher-detail local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with no Meshy credits, hidden second paywall, or physical-property claim.');
+console.log('Paid VoxelPop property regression passed: sign in -> photo -> one $4.99 payment -> real photo-matched 3D voxel-photo review -> explicit approval -> separate higher-detail local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with no Meshy credits, hidden second paywall, or physical-property claim.');


### PR DESCRIPTION
Superseded by current `main` commit `e348a26c` (`Protect real 3D voxel-photo stage`), which already contains this regression guard on top of the real Stage 3 renderer from `0cc5b1b`.

Closing this duplicate PR to avoid conflicts with the already-landed fix.