### PR TITLE
Protect the real Stage 3 voxel-photo flow

### DIFF
--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -26,11 +26,16 @@ assert.match(property, /Demo property slice · not real-property ownership/, 'sa
 assert.match(property, /setMessage\('Payment verified\. Loading your 3D voxel photo first\.'\)/,
   'a verified paid session stops at the 3D voxel-photo review stage first');
 assert.match(property, /PhotoReliefModelViewer/, '3D voxel photo is a distinct stage');
-assert.match(photoPreview, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, 'the review stage preserves the selected house photo itself');
-assert.match(photoPreview, /3D VOXEL PHOTO/, 'the review stage is identified as the 3D voxel-photo step');
-assert.match(photoPreview, /PHOTO-MATCHED/, 'the review stage makes likeness preservation explicit');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'the review stage samples the selected house photo into voxel data');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, 'the review stage renders actual voxel instances');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'the review stage is built from real 3D cubes');
+assert.match(photoPreview, /const depth = 0\.42/, 'the review stage has meaningful inspectable voxel depth');
+assert.match(photoPreview, /edge \* 0\.34/, 'the review stage uses visible image structure to shape block depth');
+assert.match(photoPreview, /voxels\.setColorAt\(instance, color\)/, 'the review stage keeps cube color tied to the house photo');
+assert.match(photoPreview, /PHOTO-MATCHED BLOCKS/, 'the review stage makes likeness-preserving real blocks explicit');
 assert.match(photoPreview, /ORIGINAL PHOTO/, 'the review stage keeps the original image visible for comparison');
-assert.doesNotMatch(photoPreview, /InstancedMesh|getImageData|BoxGeometry/, 'the approval preview must not fabricate unseen cube geometry from one photo');
+assert.doesNotMatch(photoPreview, /backingGeometry/, 'the review stage must not fall back to a flat picture backing');
+assert.match(photoPreview, /targetY = clamp/, 'the review stage limits rotation so a single photo does not imply known hidden walls');
 assert.match(property, /Looks good → Create Movable 3D Voxel/, 'user approval is required before movable-voxel generation');
 assert.match(property, /async function approvePreviewAndBuildVoxel\(\)/, 'movable-voxel generation has an explicit post-preview gate');
 assert.match(property, /const poster = await createVoxelPoster\(pendingPhoto\)/, 'voxel image is not created until after preview approval');
@@ -83,4 +88,4 @@ assert.match(mintPage, /Mint Later/, 'final mint page keeps minting optional');
 assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal paid creation flow does not lead into another paid collectible funnel');
 assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided property flow does not call metered provider generation routes');
 
-console.log('Property journey regression passed: saved/reusable property photo or new photo -> one paid unlock -> photo-matched 3D voxel-photo review -> explicit user approval -> separate local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with optional map/World, resilient persistence, and no Meshy credits or second paywall.');
+console.log('Property journey regression passed: saved/reusable property photo or new photo -> one paid unlock -> real photo-matched 3D voxel-photo review -> explicit user approval -> separate local movable voxel -> auto-save to Vault -> Mint Now or Mint Later, with optional map/World, resilient persistence, and no Meshy credits or second paywall.');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -31,16 +31,19 @@ assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');
 assert.match(home, /About/, 'home footer must expose About/contact information');
 
-// The first review surface now prioritizes likeness: it presents the exact
-// selected house image as a photo-matched voxel-photo preview before the
-// separate local Three.js movable voxel is built. It must not fabricate unseen
-// geometry merely to make this approval step look more "3D".
-assert.match(photoViewer, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, 'voxel-photo review must preserve the selected house image itself');
-assert.match(photoViewer, /3D VOXEL PHOTO/, 'review surface must identify the intermediate voxel-photo stage');
-assert.match(photoViewer, /PHOTO-MATCHED/, 'review surface must clearly describe its likeness-preserving behavior');
-assert.match(photoViewer, /ORIGINAL PHOTO/, 'voxel-photo review must keep the original source visible for comparison');
-assert.doesNotMatch(photoViewer, /InstancedMesh|getImageData|BoxGeometry/, 'the first review stage must not invent block geometry from a single view');
-assert.match(photoViewerStyles, /\.housePhoto\{/, 'photo-matched review must have a dedicated visible house-photo treatment');
+assert.match(photoViewer, /getImageData\(0, 0, columns, rows\)/, 'voxel-photo stage must sample visible source-image colors');
+assert.match(photoViewer, /new THREE\.InstancedMesh/, 'voxel-photo stage must render actual voxel instances');
+assert.match(photoViewer, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'voxel-photo stage must use real block geometry');
+assert.match(photoViewer, /const depth = 0\.42/, 'voxel-photo blocks must have meaningful inspectable depth');
+assert.match(photoViewer, /edge \* 0\.34/, 'voxel depth should respond to visible image structure instead of staying paper-thin');
+assert.match(photoViewer, /voxels\.setColorAt\(instance, color\)/, 'voxel-photo colors must remain tied to the source image');
+assert.doesNotMatch(photoViewer, /backingGeometry/, 'the voxel photo must not be mounted to a rectangular picture backing');
+assert.match(photoViewer, /plinthGeometry/, 'the voxel object may stand on a small floor reference without becoming a backed picture');
+assert.match(photoViewer, /ORIGINAL PHOTO/, 'voxel-photo preview must keep the original source visible for comparison');
+assert.match(photoViewer, /PHOTO-MATCHED BLOCKS/, 'viewer must identify the source-faithful output as real blocks, not a styled image');
+assert.match(photoViewer, /ArrowLeft|ArrowRight/, '3D voxel photo must support keyboard inspection as well as drag input');
+assert.match(photoViewerStyles, /\.canvasMount\{/, 'real voxel-photo review must have a dedicated WebGL canvas surface');
+assert.match(photoViewerStyles, /focus-visible/, '3D viewer must keep a visible keyboard focus treatment');
 assert.match(photoViewerStyles, /\.sourceCard\{/, 'photo-matched review must keep an original-photo comparison card');
 
 assert.match(demo, /FREE SAMPLE · NO LOGIN · NO PAYMENT/, 'demo must state that it is public and free to inspect');
@@ -74,5 +77,5 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public VoxelPop positioning checks passed: sample-first product proof, photo-matched voxel-photo review, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
+console.log('Public VoxelPop positioning checks passed: sample-first product proof, real photo-matched 3D voxel geometry without a picture backing, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
 await import('./test-public-surface-coherence.mjs');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -72,10 +72,16 @@ assert.match(property, /You see and approve the 3D voxel photo before VoxelPop c
 
 assert.match(property, /indexedDB\.open\(DEVICE_DB/, 'source photo is kept privately on-device across checkout');
 assert.match(property, /PhotoReliefModelViewer/, '3D voxel photo is a first-class stage');
-assert.match(photoPreview, /className=\{styles\.housePhoto\} src=\{imageUrl\}/, '3D voxel-photo review preserves the exact selected house image');
-assert.match(photoPreview, /PHOTO-MATCHED/, '3D voxel-photo review makes likeness preservation explicit');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, '3D voxel-photo review samples the selected house image into voxel data');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, '3D voxel-photo review uses real instanced WebGL geometry');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, '3D voxel-photo review is built from physical cubes');
+assert.match(photoPreview, /const depth = 0\.42/, '3D voxel-photo review has meaningful physical block depth');
+assert.match(photoPreview, /edge \* 0\.34/, 'visible facade structure contributes to voxel depth');
+assert.match(photoPreview, /voxels\.setColorAt\(instance, color\)/, '3D voxel-photo review preserves source-photo colors');
+assert.match(photoPreview, /PHOTO-MATCHED BLOCKS/, '3D voxel-photo review makes likeness-preserving real blocks explicit');
 assert.match(photoPreview, /ORIGINAL PHOTO/, '3D voxel-photo review keeps the source visible for comparison');
-assert.doesNotMatch(photoPreview, /InstancedMesh|getImageData|BoxGeometry/, 'single-photo review must not fabricate unseen cube geometry');
+assert.doesNotMatch(photoPreview, /backingGeometry/, '3D voxel-photo review must not fall back to a picture-wall backing');
+assert.match(photoPreview, /targetY = clamp/, 'single-photo inspection remains bounded instead of pretending hidden sides are known');
 assert.match(property, /Looks good → Create Movable 3D Voxel/, 'user explicitly approves the 3D voxel photo before movable-voxel creation');
 assert.match(property, /createVoxelPoster/, 'VoxelPop movable-voxel image is built only after preview approval');
 assert.match(property, /LocalVoxelModelViewer/, 'local interactive movable voxel is a separate later stage');
@@ -154,4 +160,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> photo-matched 3D voxel-photo review -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');
+console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> real photo-matched 3D voxel-photo review -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');


### PR DESCRIPTION
Superseded by `adea798667b47102ff71b72177ed91d3ee147946` on `main`, which landed the same three Stage 3 regression-guard updates while this PR was being opened.

No merge needed. The real Three.js Stage 3 renderer is already on `main`, and the remaining stale regression guards are now aligned there too.