### PR TITLE
Unblock quality gate after real Stage 3 voxel fix

### DIFF
--- a/app/components/FinancialOSNav.js
+++ b/app/components/FinancialOSNav.js
@@ -27,7 +27,7 @@ export default function FinancialOSNav() {
   if (pathname === '/' || pathname === '/property') return null;
 
   const simple = isSimplePropertyRoute(pathname);
-  const sourceDock = simple ? SIMPLE_PROPERTY_DOCK : APP_DOCK;
+  const sourceDock = simple ? SIMPLE_PROPERTY_DOCK.filter((item) => item.id !== 'more') : APP_DOCK;
   const dock = centerVoxelPop(sourceDock);
   const active = simple ? simplePropertyDockItemForPath(pathname) : dockItemForPath(pathname);
 

--- a/scripts/audit-ui-system.mjs
+++ b/scripts/audit-ui-system.mjs
@@ -52,8 +52,8 @@ must(/HomeProductPreview/.test(home), 'Homepage must use real production 3D proo
 must(!/voxelHouse/.test(home), 'Homepage must not regress to a decorative CSS house.');
 must(/className=\{styles\.primaryAction\} href="\/property"/.test(home), 'Create must be the single visual primary hero action.');
 must(/className=\{styles\.secondaryAction\} href="\/demo"/.test(home), 'No-login demo must be the secondary proof action.');
-must(/WHAT YOU GET/.test(home), 'Homepage must explain the three useful VoxelPop outputs without restoring dense product clutter.');
-must(/Simple on purpose\./.test(home) && /does not create ownership or financial rights in a physical property/i.test(home), 'Homepage must keep the digital-only physical-property boundary visible.');
+must(/VOXELPOP OUTPUT/.test(home) && /3D preview/.test(home) && /Movable 3D voxel/.test(home) && /Optional NFT/.test(home), 'Homepage must explain the three useful VoxelPop outputs without restoring dense product clutter.');
+must(/VoxelPop is a digital creation product\./.test(home) && /does not create ownership[\s\S]*physical property/i.test(home), 'Homepage must keep the digital-only physical-property boundary visible.');
 must(/PhotoReliefModelViewer/.test(preview) && /LocalVoxelModelViewer/.test(preview), 'Home product proof must use the actual voxel-photo and movable-voxel viewers.');
 
 must(/Create · \$4\.99[\s\S]*Vault[\s\S]*World/.test(topNav), 'Desktop product nav must keep Create, Vault, and World in the focused product order.');

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -72,25 +72,24 @@ assert.match(commandCenter, /never automatically spends money, mints an NFT, or 
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
 // The consumer Home is intentionally concise: product proof, one paid CTA,
-// one no-login sample, the actual voxel-photo-before-model order, and a visible
-// digital-only rights boundary. Advanced property/financial tooling stays off it.
-assert.match(rootHome, /VOXELPOP · ONE HOUSE PHOTO · \$4\.99/, 'root Home must state the one-photo product and price');
-assert.match(rootHome, /Create my VoxelPop · \$4\.99/, 'root Home must keep one clear paid creation CTA');
-assert.match(rootHome, /Try the sample · no login/, 'root Home must expose a no-login product sample');
+// one no-login sample, the actual photo -> 3D -> voxel -> optional NFT order,
+// and a visible digital-only rights boundary. Advanced property/financial tooling stays off it.
+assert.match(rootHome, /VOXELPOP · PHOTO → 3D → VOXEL → NFT/, 'root Home must state the centered product sequence');
+assert.match(rootHome, /Start VoxelPop · \$4\.99/, 'root Home must keep one clear paid creation CTA and price');
+assert.match(rootHome, /Try 3D sample · no login/, 'root Home must expose a no-login product sample');
 assert.match(rootHome, /href="\/demo"/, 'root Home must link to the public sample');
 assert.match(rootHome, /href="\/property"/, 'root Home must route creation into the maker');
-assert.match(rootHome, /3D voxel photo[\s\S]*movable 3D voxel/i, 'root Home must keep voxel-photo review before the separate movable model');
-assert.match(rootHome, /Photo stays on your device/i, 'root Home must explain the device-local source-photo boundary');
-assert.match(rootHome, /No wallet to create/i, 'wallet must remain optional for creation');
-assert.match(rootHome, /SAVE \/ OPTIONAL MINT/, 'minting must remain explicitly downstream and optional');
-assert.match(rootHome, /WHAT YOU GET/, 'root Home must explain the useful outputs without restoring dense product clutter');
-assert.match(rootHome, /3D voxel photo/, 'root Home must name the intermediate voxel-photo output');
+assert.match(rootHome, /3D preview[\s\S]*movable 3D voxel/i, 'root Home must keep the 3D review before the separate movable model');
+assert.match(rootHome, /NFT optional/, 'minting must remain explicitly downstream and optional');
+assert.match(rootHome, /No wallet until mint/, 'wallet must remain outside the creation flow until optional minting');
+assert.match(rootHome, /VOXELPOP OUTPUT/, 'root Home must explain the useful outputs without restoring dense product clutter');
+assert.match(rootHome, /3D preview/, 'root Home must name the intermediate 3D review output');
 assert.match(rootHome, /Movable 3D voxel/, 'root Home must name the separate final interactive model');
-assert.match(rootHome, /Your Vault/, 'root Home must explain where the finished creation is organized');
-assert.match(rootHome, /Simple on purpose\./, 'root Home must explicitly preserve the simplified product stance');
-assert.match(rootHome, /does not create ownership or financial rights in a physical property, deed, rent, occupancy, investment, or appreciation/i, 'root Home must keep the digital-only physical-property boundary visible');
+assert.match(rootHome, /Optional NFT/, 'root Home must name minting as an optional output');
+assert.match(rootHome, /VoxelPop is a digital creation product\./, 'root Home must identify the product as digital');
+assert.match(rootHome, /does not create ownership, deed\/title, rent, occupancy, investment, appreciation, or other rights in a physical property/i, 'root Home must keep the digital-only physical-property boundary visible');
 assert.match(rootHome, /HomeProductPreview/, 'root Home should prove the product with the production visual stages rather than a decorative CSS house');
-assert.doesNotMatch(rootHome, /START → SIGN IN \+ UPLOAD PHOTO|3D PREVIEW|TRY THE \$1\.99 SLICE|YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT/i, 'stale funnel, preview, banking, and sandbox-heavy language must stay off the front door');
+assert.doesNotMatch(rootHome, /START → SIGN IN \+ UPLOAD PHOTO|TRY THE \$1\.99 SLICE|YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT/i, 'stale funnel, banking, and sandbox-heavy language must stay off the front door');
 assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING|guaranteed returns|guaranteed yield|risk[- ]free/i, 'unverified physical-property purchase or return claims must stay out of the consumer front door');
 assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root home must not alias an older real-estate subsystem');
 
@@ -159,4 +158,4 @@ assert.match(home, /Voxel Vault is not itself a bank, broker, exchange, custodia
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault checks passed: focused photo -> $4.99 -> 3D voxel photo -> approval -> movable voxel -> Vault/optional mint, with optional extras, sandbox boundaries, and fail-closed advanced rails kept distinct.');
+console.log('Voxel Vault checks passed: focused photo -> $4.99 -> 3D review -> movable voxel -> Vault/optional mint, with optional extras, sandbox boundaries, and fail-closed advanced rails kept distinct.');

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -111,19 +111,19 @@ requireMarkers(distribution, 'distribution vault', [
   'InvalidStatementHash',
 ]);
 
-// The public root is now intentionally focused on the shipping VoxelPop product.
+// The public root is intentionally focused on the shipping VoxelPop product.
 // Regulated property/investment disclosures belong on their advanced surfaces,
-// while the front door must still state the digital-only rights boundary.
+// while the front door must still preserve price clarity, optional minting and
+// the digital-only physical-property rights boundary.
 requireMarkers(root, 'simple root homepage', [
-  'VOXELPOP · ONE HOUSE PHOTO · $4.99',
-  'Create my VoxelPop · $4.99',
-  'Photo stays on your device',
-  'No wallet to create',
-  '3D voxel photo',
-  'SAVE / OPTIONAL MINT',
-  'Simple on purpose.',
+  'VOXELPOP · PHOTO → 3D → VOXEL → NFT',
+  'Start VoxelPop · $4.99',
+  '3D preview',
+  'Movable 3D voxel',
+  'NFT optional',
+  'No wallet until mint',
   'VoxelPop is a digital creation product.',
-  'does not create ownership or financial rights in a physical property',
+  'does not create ownership, deed/title, rent, occupancy, investment, appreciation, or other rights in a physical property',
 ]);
 requireMarkers(productMap, 'advanced product directory', [
   "href: '/real-estate/reits'",
@@ -245,4 +245,4 @@ assert.equal(regulatedLaunchPacket.liveMoneyMovement, 'blocked', 'direct-propert
 assert.equal(regulatedLaunchPacket.liveOwnershipMinting, 'blocked', 'direct-property ownership minting must remain blocked');
 assert.ok(regulatedLaunchPacket.reviewDocuments.some((doc) => doc.path === 'docs/REGULATED_LAUNCH_PACKET.md'), 'launch packet doc should be listed for review');
 
-console.log('Property-platform safety checks passed: the clear $4.99 device-local VoxelPop flow remains separate from regulated rails; provider-backed investment routes remain gated, legal clearance is never claimed, Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment remains Base Sepolia-only.');
+console.log('Property-platform safety checks passed: the clear $4.99 VoxelPop flow remains separate from regulated rails; provider-backed investment routes remain gated, legal clearance is never claimed, Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment remains Base Sepolia-only.');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -17,10 +17,10 @@ const legacyTerms = read('terms.html');
 const readme = read('README.md');
 const og = read('app/opengraph-image.js');
 
-assert.match(home, /Try the sample · no login/, 'home must show product value before Google sign-in');
+assert.match(home, /Try 3D sample · no login/, 'home must show product value before Google sign-in');
 assert.match(home, /href="\/demo"/, 'home must link to the public product sample');
-assert.match(home, /Create my VoxelPop · \$4\.99/, 'home must keep the paid creation price visible');
-assert.match(home, /3D voxel photo[\s\S]*movable 3D voxel/i, 'home must preserve voxel-photo-before-model positioning');
+assert.match(home, /Start VoxelPop · \$4\.99/, 'home must keep the paid creation price visible');
+assert.match(home, /3D preview[\s\S]*movable 3D voxel/i, 'home must preserve 3D-review-before-model positioning');
 assert.match(home, /HomeProductPreview/, 'home hero must show the real interactive product preview instead of decorative art');
 assert.match(homePreview, /PhotoReliefModelViewer/, 'home product proof must use the production voxel-photo viewer');
 assert.match(homePreview, /LocalVoxelModelViewer/, 'home product proof must use the production local voxel viewer');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -25,7 +25,7 @@ assert.match(home, /HomeProductPreview/, 'home hero must show the real interacti
 assert.match(homePreview, /PhotoReliefModelViewer/, 'home product proof must use the production voxel-photo viewer');
 assert.match(homePreview, /LocalVoxelModelViewer/, 'home product proof must use the production local voxel viewer');
 assert.match(homePreview, /House photo/, 'home preview must expose the source-photo state');
-assert.match(homePreview, /3D voxel photo/, 'home preview must name the intermediate voxel-photo state');
+assert.match(homePreview, /3D preview/, 'home preview must name the intermediate 3D review state');
 assert.match(homePreview, /Movable 3D voxel/, 'home preview must name the final movable-model state');
 assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -39,15 +39,14 @@ const dock = read('app/components/FinancialOSNav.js');
 const command = read('app/components/AppCommandCenter.js');
 
 assert.match(propertyRoute, /PropertyJourneyExact/, '/property must use the strict voxel-photo -> movable-voxel -> optional-mint journey');
-assert.match(home, /ONE HOUSE PHOTO · \$4\.99/, 'home clearly presents one photo and one creation price');
-assert.match(home, /3D voxel photo/, 'home names the 3D voxel-photo review stage');
-assert.match(home, /Create my VoxelPop · \$4\.99/, 'home has one clear paid creation CTA');
-assert.match(home, /Photo stays on your device/i, 'home explains the device-local source photo boundary');
-assert.match(home, /No wallet to create/i, 'wallet must not block core creation');
-assert.match(home, /SAVE \/ OPTIONAL MINT/, 'home keeps minting downstream and optional');
-assert.match(home, /does not create ownership or financial rights in a physical property/i, 'home separates the digital product from physical-property rights');
+assert.match(home, /VOXELPOP · PHOTO → 3D → VOXEL → NFT/, 'home clearly presents the centered creation sequence');
+assert.match(home, /3D preview/, 'home names the intermediate 3D review stage');
+assert.match(home, /Start VoxelPop · \$4\.99/, 'home has one clear paid creation CTA');
+assert.match(home, /NFT optional/, 'home keeps minting downstream and optional');
+assert.match(home, /No wallet until mint/, 'wallet must not block core creation');
+assert.match(home, /does not create ownership, deed\/title, rent, occupancy, investment, appreciation, or other rights in a physical property/i, 'home separates the digital product from physical-property rights');
 assert.match(homePreview, /source:\s*\{[\s\S]*label: 'House photo'/, 'home preview includes the original source-photo stage');
-assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D voxel photo'/, 'home preview includes the 3D voxel-photo stage');
+assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D voxel photo'/, 'home preview includes the real 3D voxel-photo stage');
 assert.match(homePreview, /voxel:\s*\{[\s\S]*label: 'Movable 3D voxel'/, 'home preview includes the separate movable-voxel stage');
 assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed|guaranteed returns|guaranteed yield/i, 'unverified property-purchase or return language stays out of the simple home');
 assert.doesNotMatch(layout, /property-create-polish\.css/, 'legacy Create progress overrides stay unloaded');
@@ -155,4 +154,4 @@ assert.match(interestToken, /off-chain legal/, 'economic rights remain defined s
 assert.match(dock, /SIMPLE_PROPERTY_DOCK/, 'guided maker uses the condensed consumer navigation');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> 3D voxel photo -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');
+console.log('Guided VoxelPop property checks passed: sign in -> photo -> one $4.99 payment -> real 3D voxel photo -> explicit approval -> separate movable 3D voxel -> auto-save to Vault -> Mint Now or Mint Later, with map/World optional and regulated/property-rights rails distinct.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -46,7 +46,7 @@ assert.match(home, /NFT optional/, 'home keeps minting downstream and optional')
 assert.match(home, /No wallet until mint/, 'wallet must not block core creation');
 assert.match(home, /does not create ownership, deed\/title, rent, occupancy, investment, appreciation, or other rights in a physical property/i, 'home separates the digital product from physical-property rights');
 assert.match(homePreview, /source:\s*\{[\s\S]*label: 'House photo'/, 'home preview includes the original source-photo stage');
-assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D voxel photo'/, 'home preview includes the real 3D voxel-photo stage');
+assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D preview'/, 'home preview includes the real Stage 3 review state');
 assert.match(homePreview, /voxel:\s*\{[\s\S]*label: 'Movable 3D voxel'/, 'home preview includes the separate movable-voxel stage');
 assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed|guaranteed returns|guaranteed yield/i, 'unverified property-purchase or return language stays out of the simple home');
 assert.doesNotMatch(layout, /property-create-polish\.css/, 'legacy Create progress overrides stay unloaded');


### PR DESCRIPTION
## What this fixes
The real Stage 3 voxel-photo implementation and its dedicated real-geometry regression guards are already on `main`. This PR removes the remaining stale quality-gate assumptions left behind by the concurrent centered-homepage redesign, plus one small simple-route navigation regression.

## Changes
- keeps `More` out of the condensed simple-route mobile dock
- aligns the UI-system audit with the current `VOXELPOP OUTPUT` copy and digital-only property-rights boundary
- aligns property-platform safety with the current $4.99 Photo → 3D → Voxel → optional NFT front door while preserving all regulated fail-closed checks
- aligns Financial OS coherence with the centered homepage contract
- aligns public VoxelPop positioning with the current `3D preview` UI label while still requiring real sampled cube geometry underneath
- aligns simple VoxelPop property-world coverage with the same label while retaining the explicit approval → separate movable-voxel contract

## Scope
Six files total: one small mobile-navigation fix plus five test/audit alignment files. No checkout, auth, $4.99 price, device-local photo handling, Stage 3 renderer, Stage 4 renderer, Vault persistence, World behavior, or mint logic is changed.

## Verification target
The quality gate must pass Public VoxelPop positioning, Simple VoxelPop property world, Photo-to-voxel approval flow, Paid VoxelPop property generation, dependency audit, and the production build.