### PR TITLE
Make VoxelPop’s real 3D outputs unmistakable

### DIFF
--- a/app/components/HomeProductPreview.js
+++ b/app/components/HomeProductPreview.js
@@ -13,16 +13,16 @@ const STAGES = {
     copy: 'Start with one clear property photo or reuse a photo from a saved property.',
   },
   preview: {
-    label: '3D preview',
-    copy: 'VoxelPop builds a photo-based 3D preview first so you can inspect it before voxeling.',
+    label: '3D voxel photo',
+    copy: 'VoxelPop rebuilds the visible photo as high-fidelity source-colored cubes so you can approve the likeness before the movable model starts.',
   },
   voxel: {
     label: 'Movable 3D voxel',
-    copy: 'Approve the 3D preview, then VoxelPop creates the separate movable voxel model.',
+    copy: 'Approve the 3D voxel photo, then VoxelPop builds the separate stacked-cube voxel model you can rotate.',
   },
   nft: {
     label: 'Optional NFT',
-    copy: 'After the 3D voxel is finished, you can keep it in Vault or mint that digital voxel as an NFT.',
+    copy: 'After the movable 3D voxel is finished, you can keep it in Vault or mint that digital voxel as an NFT.',
   },
 };
 
@@ -48,7 +48,7 @@ export default function HomeProductPreview() {
           : <div className={styles.nftStage}>
               <div className={styles.nftToken}>
                 <div className={styles.nftModel}><LocalVoxelModelViewer imageUrl={SAMPLE} sourceImageUrl={SAMPLE}/></div>
-                <div className={styles.nftMeta}><small>VOXELPOP NFT</small><b>My Property Voxel</b><span>Finished 3D voxel · mint optional</span></div>
+                <div className={styles.nftMeta}><small>VOXELPOP NFT</small><b>My Property Voxel</b><span>Finished movable 3D voxel · mint optional</span></div>
               </div>
               <span className={styles.nftBadge}>4 · NFT AFTER VOXEL</span>
             </div>}
@@ -56,8 +56,8 @@ export default function HomeProductPreview() {
 
     <div className={styles.controls} role="group" aria-label="Choose VoxelPop sample stage">
       <button type="button" className={stage === 'source' ? styles.active : ''} aria-pressed={stage === 'source'} onClick={() => setStage('source')}><span>1</span>Photo</button>
-      <button type="button" className={stage === 'preview' ? styles.active : ''} aria-pressed={stage === 'preview'} onClick={() => setStage('preview')}><span>2</span>3D</button>
-      <button type="button" className={stage === 'voxel' ? styles.active : ''} aria-pressed={stage === 'voxel'} onClick={() => setStage('voxel')}><span>3</span>{stage === 'voxel' && !voxelReady ? 'Building…' : 'Voxel'}</button>
+      <button type="button" className={stage === 'preview' ? styles.active : ''} aria-pressed={stage === 'preview'} onClick={() => setStage('preview')}><span>2</span>Voxel photo</button>
+      <button type="button" className={stage === 'voxel' ? styles.active : ''} aria-pressed={stage === 'voxel'} onClick={() => setStage('voxel')}><span>3</span>{stage === 'voxel' && !voxelReady ? 'Building…' : 'Movable'}</button>
       <button type="button" className={stage === 'nft' ? styles.active : ''} aria-pressed={stage === 'nft'} onClick={() => setStage('nft')}><span>4</span>NFT</button>
     </div>
     <p>{current.copy}</p>

--- a/app/page.js
+++ b/app/page.js
@@ -10,32 +10,32 @@ export default function Home() {
     <ProductTopNav/>
     <div className={styles.shell}>
       <section className={styles.hero}>
-        <p className={styles.kicker}>VOXELPOP · PHOTO → 3D → VOXEL → NFT</p>
+        <p className={styles.kicker}>VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL → NFT</p>
         <h1><em>VOXELPOP</em></h1>
-        <p className={styles.heroLine}>Turn your property photo into a 3D preview, then a movable 3D voxel, then mint that finished voxel as an NFT if you want.</p>
+        <p className={styles.heroLine}>Turn your property photo into a high-fidelity 3D voxel photo. Approve the likeness, then VoxelPop builds the separate movable 3D voxel. Minting is optional.</p>
 
         <div className={styles.centerMachine}>
           <div className={styles.machineLabel}><span>●</span> VOXELPOP CREATOR</div>
           <HomeProductPreview/>
           <div className={styles.heroActions}>
             <Link className={styles.primaryAction} href="/property">Start VoxelPop · $4.99</Link>
-            <Link className={styles.secondaryAction} href="/demo">Try 3D sample · no login</Link>
+            <Link className={styles.secondaryAction} href="/demo">Try voxel sample · no login</Link>
           </div>
         </div>
 
         <div className={styles.pipeline} aria-label="VoxelPop creation flow">
           <div><i>1</i><b>Photo</b><small>Use your house or saved property image.</small></div>
           <span>→</span>
-          <div><i>2</i><b>3D Preview</b><small>Inspect the 3D result before voxeling.</small></div>
+          <div><i>2</i><b>3D Voxel Photo</b><small>Photo-matched cubes preserve the visible house for approval.</small></div>
           <span>→</span>
-          <div><i>3</i><b>3D Voxel</b><small>Create the movable VoxelPop model.</small></div>
+          <div><i>3</i><b>Movable 3D Voxel</b><small>After approval, build the separate stacked voxel model.</small></div>
           <span>→</span>
-          <div><i>4</i><b>NFT</b><small>Optional mint after the voxel is finished.</small></div>
+          <div><i>4</i><b>Optional NFT</b><small>Mint only after the voxel is finished.</small></div>
         </div>
 
         <div className={styles.trustRow} aria-label="VoxelPop creation facts">
-          <span>3D first</span>
-          <span>Voxel second</span>
+          <span>Voxel photo first</span>
+          <span>Movable voxel second</span>
           <span>NFT optional</span>
           <span>No wallet until mint</span>
         </div>
@@ -44,29 +44,29 @@ export default function Home() {
       <section className={styles.flowCard} id="how-it-works" aria-label="How VoxelPop works">
         <div className={styles.flowHeading}>
           <p>THE VOXELPOP FLOW</p>
-          <h2>One centered creator. Four clear stages.</h2>
+          <h2>See the likeness before building the model.</h2>
           <span>Your finished NFT represents the digital voxel only. Minting never changes ownership of the physical property.</span>
         </div>
         <div className={styles.flowSteps}>
           <div><i>1</i><b>Choose photo</b><small>Upload a clear property image or reuse one already saved in your Vault.</small></div>
-          <div><i>2</i><b>Build 3D preview</b><small>See the 3D photo-based result before the voxel conversion starts.</small></div>
-          <div><i>3</i><b>Voxel it</b><small>Approve the preview, then create the separate movable 3D voxel.</small></div>
+          <div><i>2</i><b>Review 3D voxel photo</b><small>Compare the high-fidelity voxel blocks against the original photo before continuing.</small></div>
+          <div><i>3</i><b>Build movable voxel</b><small>Approve the voxel photo, then create the separate rotatable stacked-cube model.</small></div>
           <div><i>4</i><b>Mint if you want</b><small>Save it normally or mint the completed digital voxel as an NFT.</small></div>
         </div>
         <Link className={styles.startButton} href="/property">Open VoxelPop Creator →</Link>
       </section>
 
       <section className={styles.valueSection} aria-label="What VoxelPop creates">
-        <div className={styles.sectionTitle}><p>VOXELPOP OUTPUT</p><h2>3D first. Voxel second. NFT last.</h2></div>
+        <div className={styles.sectionTitle}><p>VOXELPOP OUTPUT</p><h2>Voxel photo first. Movable voxel second. NFT last.</h2></div>
         <div className={styles.valueGrid}>
-          <article><span>01</span><b>3D preview</b><p>A photo-based 3D view you can inspect before converting it into the final voxel model.</p></article>
-          <article><span>02</span><b>Movable 3D voxel</b><p>The finished interactive VoxelPop asset you can rotate, save, reopen, and keep in your Vault.</p></article>
-          <article><span>03</span><b>Optional NFT</b><p>Mint the finished digital voxel only when you choose. The wallet step stays out of the creation flow until then.</p></article>
+          <article><span>01</span><b>3D voxel photo</b><p>A high-fidelity field of real source-colored cubes that keeps the photographed house recognizable while adding shallow inspectable depth.</p></article>
+          <article><span>02</span><b>Movable 3D voxel</b><p>The separate finished VoxelPop asset uses stacked voxel volume so you can rotate, save, reopen, and keep it in your Vault.</p></article>
+          <article><span>03</span><b>Optional NFT</b><p>Mint the finished digital voxel only when you choose. The wallet step stays out of creation until then.</p></article>
         </div>
       </section>
 
       <section className={styles.truthCard}>
-        <div><b>VoxelPop stays in the middle.</b><span>Photo → 3D → Voxel → optional NFT.</span></div>
+        <div><b>One photo. Two different 3D outputs.</b><span>Photo → 3D voxel photo → movable 3D voxel → optional NFT.</span></div>
         <p>VoxelPop is a digital creation product. A VoxelPop, payment, map marker, or NFT does not create ownership, deed/title, rent, occupancy, investment, appreciation, or other rights in a physical property.</p>
       </section>
 

--- a/scripts/audit-ui-system.mjs
+++ b/scripts/audit-ui-system.mjs
@@ -52,7 +52,7 @@ must(/HomeProductPreview/.test(home), 'Homepage must use real production 3D proo
 must(!/voxelHouse/.test(home), 'Homepage must not regress to a decorative CSS house.');
 must(/className=\{styles\.primaryAction\} href="\/property"/.test(home), 'Create must be the single visual primary hero action.');
 must(/className=\{styles\.secondaryAction\} href="\/demo"/.test(home), 'No-login demo must be the secondary proof action.');
-must(/VOXELPOP OUTPUT/.test(home) && /3D preview/.test(home) && /Movable 3D voxel/.test(home) && /Optional NFT/.test(home), 'Homepage must explain the three useful VoxelPop outputs without restoring dense product clutter.');
+must(/VOXELPOP OUTPUT/.test(home) && /3D voxel photo/i.test(home) && /Movable 3D voxel/.test(home) && /Optional NFT/.test(home), 'Homepage must explain the real voxel-photo, movable-voxel and optional-NFT outputs without restoring dense product clutter.');
 must(/VoxelPop is a digital creation product\./.test(home) && /does not create ownership[\s\S]*physical property/i.test(home), 'Homepage must keep the digital-only physical-property boundary visible.');
 must(/PhotoReliefModelViewer/.test(preview) && /LocalVoxelModelViewer/.test(preview), 'Home product proof must use the actual voxel-photo and movable-voxel viewers.');
 
@@ -117,5 +117,5 @@ if (failures.length) {
   for (const failure of failures) console.error(`  ERROR ${failure}`);
   process.exitCode = 1;
 } else {
-  console.log('\nUI system invariants passed: real 3D proof, concise VoxelPop value messaging, focused Home/Create navigation, condensed secondary mobile dock, readable shared trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
+  console.log('\nUI system invariants passed: real high-fidelity 3D voxel-photo proof, concise VoxelPop value messaging, focused Home/Create navigation, condensed secondary mobile dock, readable shared trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
 }

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -72,18 +72,18 @@ assert.match(commandCenter, /never automatically spends money, mints an NFT, or 
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
 // The consumer Home is intentionally concise: product proof, one paid CTA,
-// one no-login sample, the actual photo -> 3D -> voxel -> optional NFT order,
+// one no-login sample, the actual photo -> 3D voxel photo -> movable voxel -> optional NFT order,
 // and a visible digital-only rights boundary. Advanced property/financial tooling stays off it.
-assert.match(rootHome, /VOXELPOP · PHOTO → 3D → VOXEL → NFT/, 'root Home must state the centered product sequence');
+assert.match(rootHome, /VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL → NFT/, 'root Home must state the centered product sequence');
 assert.match(rootHome, /Start VoxelPop · \$4\.99/, 'root Home must keep one clear paid creation CTA and price');
-assert.match(rootHome, /Try 3D sample · no login/, 'root Home must expose a no-login product sample');
+assert.match(rootHome, /Try voxel sample · no login/, 'root Home must expose a no-login product sample');
 assert.match(rootHome, /href="\/demo"/, 'root Home must link to the public sample');
 assert.match(rootHome, /href="\/property"/, 'root Home must route creation into the maker');
-assert.match(rootHome, /3D preview[\s\S]*movable 3D voxel/i, 'root Home must keep the 3D review before the separate movable model');
+assert.match(rootHome, /3D voxel photo[\s\S]*movable 3D voxel/i, 'root Home must keep the voxel-photo review before the separate movable model');
 assert.match(rootHome, /NFT optional/, 'minting must remain explicitly downstream and optional');
 assert.match(rootHome, /No wallet until mint/, 'wallet must remain outside the creation flow until optional minting');
 assert.match(rootHome, /VOXELPOP OUTPUT/, 'root Home must explain the useful outputs without restoring dense product clutter');
-assert.match(rootHome, /3D preview/, 'root Home must name the intermediate 3D review output');
+assert.match(rootHome, /3D voxel photo/i, 'root Home must name the intermediate 3D voxel-photo output');
 assert.match(rootHome, /Movable 3D voxel/, 'root Home must name the separate final interactive model');
 assert.match(rootHome, /Optional NFT/, 'root Home must name minting as an optional output');
 assert.match(rootHome, /VoxelPop is a digital creation product\./, 'root Home must identify the product as digital');
@@ -158,4 +158,4 @@ assert.match(home, /Voxel Vault is not itself a bank, broker, exchange, custodia
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault checks passed: focused photo -> $4.99 -> 3D review -> movable voxel -> Vault/optional mint, with optional extras, sandbox boundaries, and fail-closed advanced rails kept distinct.');
+console.log('Voxel Vault checks passed: focused photo -> $4.99 -> high-fidelity 3D voxel photo -> approval -> stacked movable voxel -> Vault/optional mint, with optional extras, sandbox boundaries, and fail-closed advanced rails kept distinct.');

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -116,9 +116,9 @@ requireMarkers(distribution, 'distribution vault', [
 // while the front door must still preserve price clarity, optional minting and
 // the digital-only physical-property rights boundary.
 requireMarkers(root, 'simple root homepage', [
-  'VOXELPOP · PHOTO → 3D → VOXEL → NFT',
+  'VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL → NFT',
   'Start VoxelPop · $4.99',
-  '3D preview',
+  '3D voxel photo',
   'Movable 3D voxel',
   'NFT optional',
   'No wallet until mint',
@@ -245,4 +245,4 @@ assert.equal(regulatedLaunchPacket.liveMoneyMovement, 'blocked', 'direct-propert
 assert.equal(regulatedLaunchPacket.liveOwnershipMinting, 'blocked', 'direct-property ownership minting must remain blocked');
 assert.ok(regulatedLaunchPacket.reviewDocuments.some((doc) => doc.path === 'docs/REGULATED_LAUNCH_PACKET.md'), 'launch packet doc should be listed for review');
 
-console.log('Property-platform safety checks passed: the clear $4.99 VoxelPop flow remains separate from regulated rails; provider-backed investment routes remain gated, legal clearance is never claimed, Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment remains Base Sepolia-only.');
+console.log('Property-platform safety checks passed: the clear $4.99 high-fidelity 3D voxel-photo -> separate movable-voxel flow remains separate from regulated rails; provider-backed investment routes remain gated, legal clearance is never claimed, Property Passport cannot act as a transferable deed proxy, direct-property investing and auto-reinvestment remain fail-closed, and property deployment remains Base Sepolia-only.');

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -17,15 +17,15 @@ const legacyTerms = read('terms.html');
 const readme = read('README.md');
 const og = read('app/opengraph-image.js');
 
-assert.match(home, /Try 3D sample · no login/, 'home must show product value before Google sign-in');
+assert.match(home, /Try voxel sample · no login/, 'home must show product value before Google sign-in');
 assert.match(home, /href="\/demo"/, 'home must link to the public product sample');
 assert.match(home, /Start VoxelPop · \$4\.99/, 'home must keep the paid creation price visible');
-assert.match(home, /3D preview[\s\S]*movable 3D voxel/i, 'home must preserve preview-before-model positioning');
+assert.match(home, /3D voxel photo[\s\S]*movable 3D voxel/i, 'home must preserve voxel-photo-before-movable-model positioning');
 assert.match(home, /HomeProductPreview/, 'home hero must show the real interactive product preview instead of decorative art');
 assert.match(homePreview, /PhotoReliefModelViewer/, 'home product proof must use the production voxel-photo viewer');
 assert.match(homePreview, /LocalVoxelModelViewer/, 'home product proof must use the production local voxel viewer');
 assert.match(homePreview, /House photo/, 'home preview must expose the source-photo state');
-assert.match(homePreview, /3D preview/, 'home preview must name the intermediate preview state');
+assert.match(homePreview, /3D voxel photo/, 'home preview must name the intermediate voxel-photo state');
 assert.match(homePreview, /Movable 3D voxel/, 'home preview must name the final movable-model state');
 assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');
@@ -76,5 +76,5 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public VoxelPop positioning checks passed: sample-first product proof, high-fidelity source-matched 3D voxel geometry without a backing or plaque, movable voxel separation, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
+console.log('Public VoxelPop positioning checks passed: explicit 3D voxel-photo approval, high-fidelity source-matched cube geometry without a backing or plaque, separate stacked movable voxel, focused $4.99 story, corrected trust pages, and current social preview remain aligned.');
 await import('./test-public-surface-coherence.mjs');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -39,14 +39,14 @@ const dock = read('app/components/FinancialOSNav.js');
 const command = read('app/components/AppCommandCenter.js');
 
 assert.match(propertyRoute, /PropertyJourneyExact/, '/property must use the strict voxel-photo -> movable-voxel -> optional-mint journey');
-assert.match(home, /VOXELPOP · PHOTO → 3D → VOXEL → NFT/, 'home clearly presents the centered creation sequence');
-assert.match(home, /3D preview/, 'home names the intermediate 3D review stage');
+assert.match(home, /VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL → NFT/, 'home clearly presents the centered creation sequence');
+assert.match(home, /3D voxel photo/i, 'home names the intermediate high-fidelity 3D voxel-photo review stage');
 assert.match(home, /Start VoxelPop · \$4\.99/, 'home has one clear paid creation CTA');
 assert.match(home, /NFT optional/, 'home keeps minting downstream and optional');
 assert.match(home, /No wallet until mint/, 'wallet must not block core creation');
 assert.match(home, /does not create ownership, deed\/title, rent, occupancy, investment, appreciation, or other rights in a physical property/i, 'home separates the digital product from physical-property rights');
 assert.match(homePreview, /source:\s*\{[\s\S]*label: 'House photo'/, 'home preview includes the original source-photo stage');
-assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D preview'/, 'home preview includes the real Stage 3 review state');
+assert.match(homePreview, /preview:\s*\{[\s\S]*label: '3D voxel photo'/, 'home preview includes the real high-fidelity Stage 3 voxel-photo review state');
 assert.match(homePreview, /voxel:\s*\{[\s\S]*label: 'Movable 3D voxel'/, 'home preview includes the separate movable-voxel stage');
 assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed|guaranteed returns|guaranteed yield/i, 'unverified property-purchase or return language stays out of the simple home');
 assert.doesNotMatch(layout, /property-create-polish\.css/, 'legacy Create progress overrides stay unloaded');


### PR DESCRIPTION
## Upgrade
VoxelPop already has the stronger engines on `main`: a high-fidelity photo-matched 3D voxel photo and a separate stacked movable voxel. The remaining problem was the customer-facing shell still calling the first output a generic “3D Preview,” which made the product look like the wrong thing.

## What changes
- makes the homepage sequence explicit: **Photo → 3D Voxel Photo → Movable 3D Voxel → Optional NFT**
- explains that the voxel photo is the likeness-approval step and the movable voxel is a separate stacked-cube output
- renames the live homepage sample controls to `Voxel photo` and `Movable`
- keeps the $4.99 price, no-login sample, device-local photo model, optional minting and physical-property rights boundary intact
- updates release/safety guards so they protect the correct terminology instead of forcing the old `3D preview` label

## Deliberately preserved
This branch starts from the newest `main` (`cb849ef...`) and does **not** replace the upgraded `PhotoReliefModelViewer` or the new stacked `LocalVoxelModelViewer` / persisted voxel volume. It only fixes the product shell and its matching regression assertions.

## Target flow
**Photo → high-fidelity 3D voxel photo → approve likeness → stacked movable 3D voxel → save → optional NFT**