### PR TITLE
Condense VoxelPop into a one-action experience

### DIFF
--- a/app/components/FinancialOSNav.js
+++ b/app/components/FinancialOSNav.js
@@ -3,50 +3,44 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import styles from './FinancialOSNav.module.css';
-import {
-  APP_DOCK,
-  SIMPLE_PROPERTY_DOCK,
-  dockItemForPath,
-  isOrganizedUserRoute,
-  isSimplePropertyRoute,
-  simplePropertyDockItemForPath,
-} from '../../lib/product-map';
+import { isOrganizedUserRoute } from '../../lib/product-map';
 
-const DOCK_ORDER = ['home', 'world', 'create', 'vault', 'more'];
+const DOCK = [
+  { id: 'home', href: '/', icon: '⌂', label: 'Home' },
+  { id: 'create', href: '/property', icon: 'V', label: 'VoxelPop' },
+  { id: 'vault', href: '/vault', icon: '▣', label: 'Vault' },
+];
 
-function centerVoxelPop(items) {
-  return [...items].sort((a, b) => DOCK_ORDER.indexOf(a.id) - DOCK_ORDER.indexOf(b.id));
+function activeDockItem(pathname) {
+  if (pathname === '/property' || pathname.startsWith('/property/')) return 'create';
+  if (pathname === '/vault' || pathname.startsWith('/vault/') || pathname === '/world' || pathname.startsWith('/world/')) return 'vault';
+  return 'home';
 }
 
 export default function FinancialOSNav() {
   const pathname = usePathname() || '/';
   if (!isOrganizedUserRoute(pathname)) return null;
 
-  // Home and the paid VoxelPop creator have a focused product header. Do not
-  // stack a second navigation system underneath those two core surfaces.
+  // Home and the paid creator already have the focused top navigation.
   if (pathname === '/' || pathname === '/property') return null;
 
-  const simple = isSimplePropertyRoute(pathname);
-  const sourceDock = simple ? SIMPLE_PROPERTY_DOCK.filter((item) => item.id !== 'more') : APP_DOCK;
-  const dock = centerVoxelPop(sourceDock);
-  const active = simple ? simplePropertyDockItemForPath(pathname) : dockItemForPath(pathname);
+  const active = activeDockItem(pathname);
 
   return <>
     <div className={styles.spacer} aria-hidden="true" />
-    <nav className={styles.nav} aria-label="Voxel Vault primary navigation" style={{ gridTemplateColumns: `repeat(${dock.length}, minmax(0, 1fr))` }}>
-      {dock.map((item) => {
-        const selected = item.id === active.id;
+    <nav className={styles.nav} aria-label="VoxelPop primary navigation" style={{ gridTemplateColumns: `repeat(${DOCK.length}, minmax(0, 1fr))` }}>
+      {DOCK.map((item) => {
+        const selected = item.id === active;
         const voxelPop = item.id === 'create';
-        const label = voxelPop ? 'VoxelPop' : item.label;
         return <Link
           key={item.id}
           href={item.href}
-          aria-label={voxelPop ? 'VoxelPop 3D voxel and optional NFT creator' : undefined}
+          aria-label={voxelPop ? 'Create a VoxelPop' : undefined}
           aria-current={selected ? 'page' : undefined}
           className={`${styles.item} ${voxelPop ? styles.voxelPopItem : ''} ${selected ? styles.itemActive : ''}`}
         >
-          <span className={`${styles.icon} ${voxelPop ? styles.voxelPopIcon : ''} ${selected ? styles.iconActive : ''}`}>{voxelPop ? 'V' : item.icon}</span>
-          <b className={`${styles.label} ${voxelPop ? styles.voxelPopLabel : ''} ${selected ? styles.labelActive : ''}`}>{label}</b>
+          <span className={`${styles.icon} ${voxelPop ? styles.voxelPopIcon : ''} ${selected ? styles.iconActive : ''}`}>{item.icon}</span>
+          <b className={`${styles.label} ${voxelPop ? styles.voxelPopLabel : ''} ${selected ? styles.labelActive : ''}`}>{item.label}</b>
         </Link>;
       })}
     </nav>

--- a/app/components/ProductTopNav.js
+++ b/app/components/ProductTopNav.js
@@ -8,7 +8,6 @@ import styles from './ProductTopNav.module.css';
 const ITEMS = [
   { href: '/property', label: 'Create · $4.99' },
   { href: '/vault', label: 'Vault' },
-  { href: '/world', label: 'World' },
 ];
 
 function activeFor(pathname, href) {
@@ -30,7 +29,6 @@ export default function ProductTopNav({ className = '' }) {
         const active = activeFor(pathname, item.href);
         return <Link key={item.href} className={active ? styles.active : ''} href={item.href} aria-current={active ? 'page' : undefined}>{item.label}</Link>;
       })}
-      <Link className={styles.demo} href="/demo" aria-current={pathname === '/demo' ? 'page' : undefined}>Demo</Link>
     </div>
   </nav>;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -11,7 +11,7 @@ export default function Home() {
     <div className={styles.shell}>
       <section className={styles.hero}>
         <p className={styles.kicker}>VOXELPOP · ONE PHOTO · ONE SIMPLE FLOW</p>
-        <h1><em>MAKE YOUR HOUSE A VOXEL.</em></h1>
+        <h1><em>HOUSE → VOXEL.</em></h1>
         <p className={styles.heroLine}>Choose a photo. Pay once. Approve the 3D voxel photo. Your movable voxel is built and saved automatically.</p>
 
         <div className={styles.centerMachine}>
@@ -37,7 +37,7 @@ export default function Home() {
           <h2>Photo → approve → done.</h2>
           <span>VoxelPop keeps the technical steps in the background so each screen has one obvious next action.</span>
         </div>
-        <div className={styles.flowSteps}>
+        <div className={styles.flowSteps} style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
           <div><i>1</i><b>Choose photo</b><small>Use a clear house photo.</small></div>
           <div><i>2</i><b>Approve voxel photo</b><small>Confirm the photo-matched 3D voxel view looks right.</small></div>
           <div><i>3</i><b>Done</b><small>Your movable 3D voxel is built and saved to Vault. Mint only if you want.</small></div>

--- a/app/page.js
+++ b/app/page.js
@@ -10,64 +10,44 @@ export default function Home() {
     <ProductTopNav/>
     <div className={styles.shell}>
       <section className={styles.hero}>
-        <p className={styles.kicker}>VOXELPOP · PHOTO → 3D VOXEL PHOTO → MOVABLE VOXEL → NFT</p>
-        <h1><em>VOXELPOP</em></h1>
-        <p className={styles.heroLine}>Turn your property photo into a high-fidelity 3D voxel photo. Approve the likeness, then VoxelPop builds the separate movable 3D voxel. Minting is optional.</p>
+        <p className={styles.kicker}>VOXELPOP · ONE PHOTO · ONE SIMPLE FLOW</p>
+        <h1><em>MAKE YOUR HOUSE A VOXEL.</em></h1>
+        <p className={styles.heroLine}>Choose a photo. Pay once. Approve the 3D voxel photo. Your movable voxel is built and saved automatically.</p>
 
         <div className={styles.centerMachine}>
-          <div className={styles.machineLabel}><span>●</span> VOXELPOP CREATOR</div>
+          <div className={styles.machineLabel}><span>●</span> VOXELPOP</div>
           <HomeProductPreview/>
           <div className={styles.heroActions}>
-            <Link className={styles.primaryAction} href="/property">Start VoxelPop · $4.99</Link>
-            <Link className={styles.secondaryAction} href="/demo">Try voxel sample · no login</Link>
+            <Link className={styles.primaryAction} href="/property">Create my VoxelPop · $4.99</Link>
+            <Link className={styles.secondaryAction} href="/demo">See the 3D sample</Link>
           </div>
         </div>
 
-        <div className={styles.pipeline} aria-label="VoxelPop creation flow">
-          <div><i>1</i><b>Photo</b><small>Use your house or saved property image.</small></div>
-          <span>→</span>
-          <div><i>2</i><b>3D Voxel Photo</b><small>Photo-matched cubes preserve the visible house for approval.</small></div>
-          <span>→</span>
-          <div><i>3</i><b>Movable 3D Voxel</b><small>After approval, build the separate stacked voxel model.</small></div>
-          <span>→</span>
-          <div><i>4</i><b>Optional NFT</b><small>Mint only after the voxel is finished.</small></div>
-        </div>
-
         <div className={styles.trustRow} aria-label="VoxelPop creation facts">
-          <span>Voxel photo first</span>
-          <span>Movable voxel second</span>
-          <span>NFT optional</span>
-          <span>No wallet until mint</span>
+          <span>1 photo</span>
+          <span>$4.99 once</span>
+          <span>Saved automatically</span>
+          <span>Mint optional</span>
         </div>
       </section>
 
       <section className={styles.flowCard} id="how-it-works" aria-label="How VoxelPop works">
         <div className={styles.flowHeading}>
-          <p>THE VOXELPOP FLOW</p>
-          <h2>See the likeness before building the model.</h2>
-          <span>Your finished NFT represents the digital voxel only. Minting never changes ownership of the physical property.</span>
+          <p>ONE SIMPLE FLOW</p>
+          <h2>Photo → approve → done.</h2>
+          <span>VoxelPop keeps the technical steps in the background so each screen has one obvious next action.</span>
         </div>
         <div className={styles.flowSteps}>
-          <div><i>1</i><b>Choose photo</b><small>Upload a clear property image or reuse one already saved in your Vault.</small></div>
-          <div><i>2</i><b>Review 3D voxel photo</b><small>Compare the high-fidelity voxel blocks against the original photo before continuing.</small></div>
-          <div><i>3</i><b>Build movable voxel</b><small>Approve the voxel photo, then create the separate rotatable stacked-cube model.</small></div>
-          <div><i>4</i><b>Mint if you want</b><small>Save it normally or mint the completed digital voxel as an NFT.</small></div>
+          <div><i>1</i><b>Choose photo</b><small>Use a clear house photo.</small></div>
+          <div><i>2</i><b>Approve voxel photo</b><small>Confirm the photo-matched 3D voxel view looks right.</small></div>
+          <div><i>3</i><b>Done</b><small>Your movable 3D voxel is built and saved to Vault. Mint only if you want.</small></div>
         </div>
-        <Link className={styles.startButton} href="/property">Open VoxelPop Creator →</Link>
-      </section>
-
-      <section className={styles.valueSection} aria-label="What VoxelPop creates">
-        <div className={styles.sectionTitle}><p>VOXELPOP OUTPUT</p><h2>Voxel photo first. Movable voxel second. NFT last.</h2></div>
-        <div className={styles.valueGrid}>
-          <article><span>01</span><b>3D voxel photo</b><p>A high-fidelity field of real source-colored cubes that keeps the photographed house recognizable while adding shallow inspectable depth.</p></article>
-          <article><span>02</span><b>Movable 3D voxel</b><p>The separate finished VoxelPop asset uses stacked voxel volume so you can rotate, save, reopen, and keep it in your Vault.</p></article>
-          <article><span>03</span><b>Optional NFT</b><p>Mint the finished digital voxel only when you choose. The wallet step stays out of creation until then.</p></article>
-        </div>
+        <Link className={styles.startButton} href="/property">Start →</Link>
       </section>
 
       <section className={styles.truthCard}>
-        <div><b>One photo. Two different 3D outputs.</b><span>Photo → 3D voxel photo → movable 3D voxel → optional NFT.</span></div>
-        <p>VoxelPop is a digital creation product. A VoxelPop, payment, map marker, or NFT does not create ownership, deed/title, rent, occupancy, investment, appreciation, or other rights in a physical property.</p>
+        <div><b>One photo. One purchase. One finished voxel.</b><span>3D voxel photo approval stays separate from the final movable voxel so you can check the likeness first.</span></div>
+        <p>VoxelPop is a digital creation product. A VoxelPop, payment, map marker, or NFT does not create ownership or other rights in a physical property.</p>
       </section>
 
       <footer className={styles.footer}>

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -102,10 +102,56 @@ function VaultPropertyHandoff() {
   return null;
 }
 
+function SimpleJourneyPresentation() {
+  useEffect(() => {
+    const root = document.getElementById('voxelpop-journey');
+    if (!root) return undefined;
+
+    const simplify = () => {
+      const actions = Array.from(root.querySelectorAll('button, a'));
+      for (const action of actions) {
+        const text = String(action.textContent || '').trim();
+        if (!text) continue;
+
+        if (text === 'Choose photo') action.setAttribute('data-vv-hide-duplicate', 'true');
+        if (text === 'Upload / Photos' || text === 'My Properties') action.setAttribute('data-vv-compact-choice', 'true');
+
+        if (
+          text.startsWith('Choose another photo') ||
+          text.startsWith('Use a different photo') ||
+          text.startsWith('Start over') ||
+          text === 'Mint Now'
+        ) action.setAttribute('data-vv-secondary-action', 'true');
+
+        if (text.includes('Mint Later · Saved to Vault') || text === 'Done · Open Vault') {
+          if (text !== 'Done · Open Vault') action.textContent = 'Done · Open Vault';
+          action.setAttribute('data-vv-primary-finish', 'true');
+        }
+      }
+    };
+
+    simplify();
+    const observer = new MutationObserver(simplify);
+    observer.observe(root, { childList: true, subtree: true, characterData: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return <style>{`
+    #voxelpop-journey [data-vv-hide-duplicate="true"] { display: none !important; }
+    #voxelpop-journey [data-vv-compact-choice="true"] { min-height: 44px !important; font-size: 13px !important; box-shadow: none !important; }
+    #voxelpop-journey [data-vv-secondary-action="true"] { box-shadow: none !important; opacity: .76; }
+    #voxelpop-journey [data-vv-primary-finish="true"] { order: -1; background: #7138f5 !important; color: #fff !important; border-color: transparent !important; box-shadow: 0 8px 20px rgba(113,56,245,.17) !important; }
+  `}</style>;
+}
+
 export default function PropertyJourneyPage() {
   return <>
     <OAuthRecovery/>
     <ProductTopNav/>
-    <div id="voxelpop-journey"><VaultPropertyHandoff/><PropertyJourneyExact/></div>
+    <div id="voxelpop-journey">
+      <SimpleJourneyPresentation/>
+      <VaultPropertyHandoff/>
+      <PropertyJourneyExact/>
+    </div>
   </>;
 }

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -108,12 +108,16 @@ function SimpleJourneyPresentation() {
     if (!root) return undefined;
 
     const simplify = () => {
+      for (const control of Array.from(root.querySelectorAll('[role="button"]'))) {
+        const text = String(control.textContent || '').trim();
+        if (text.includes('Choose a property photo')) control.setAttribute('data-vv-hide-duplicate', 'true');
+      }
+
       const actions = Array.from(root.querySelectorAll('button, a'));
       for (const action of actions) {
         const text = String(action.textContent || '').trim();
         if (!text) continue;
 
-        if (text === 'Choose photo') action.setAttribute('data-vv-hide-duplicate', 'true');
         if (text === 'Upload / Photos' || text === 'My Properties') action.setAttribute('data-vv-compact-choice', 'true');
 
         if (

--- a/scripts/audit-ui-system.mjs
+++ b/scripts/audit-ui-system.mjs
@@ -47,24 +47,29 @@ const footer = read('app/components/ConsumerFooter.js');
 const system = read('app/ui-system.css');
 const demo = read('app/demo/page.js');
 const property = read('app/property/PropertyJourneyExact.js');
+const propertyPage = read('app/property/page.js');
 
 must(/HomeProductPreview/.test(home), 'Homepage must use real production 3D proof.');
 must(!/voxelHouse/.test(home), 'Homepage must not regress to a decorative CSS house.');
 must(/className=\{styles\.primaryAction\} href="\/property"/.test(home), 'Create must be the single visual primary hero action.');
-must(/className=\{styles\.secondaryAction\} href="\/demo"/.test(home), 'No-login demo must be the secondary proof action.');
-must(/VOXELPOP OUTPUT/.test(home) && /3D voxel photo/i.test(home) && /Movable 3D voxel/.test(home) && /Optional NFT/.test(home), 'Homepage must explain the real voxel-photo, movable-voxel and optional-NFT outputs without restoring dense product clutter.');
+must(/className=\{styles\.secondaryAction\} href="\/demo"/.test(home), 'No-login demo must remain the secondary proof action.');
+must(/ONE SIMPLE FLOW/.test(home) && /Photo → approve → done\./.test(home), 'Homepage must keep the condensed one-flow explanation.');
+must(/Saved automatically/.test(home) && /Mint optional/.test(home), 'Homepage must keep automatic-save and optional-mint facts visible.');
 must(/VoxelPop is a digital creation product\./.test(home) && /does not create ownership[\s\S]*physical property/i.test(home), 'Homepage must keep the digital-only physical-property boundary visible.');
 must(/PhotoReliefModelViewer/.test(preview) && /LocalVoxelModelViewer/.test(preview), 'Home product proof must use the actual voxel-photo and movable-voxel viewers.');
 
-must(/Create · \$4\.99[\s\S]*Vault[\s\S]*World/.test(topNav), 'Desktop product nav must keep Create, Vault, and World in the focused product order.');
-must(!/href: '\/more', label: 'More'/.test(topNav), 'Advanced More tools must stay out of the primary VoxelPop header.');
+must(/Create · \$4\.99[\s\S]*Vault/.test(topNav), 'Primary product nav must keep only Create and Vault as the focused choices.');
+must(!/label: 'World'/.test(topNav) && !/className=\{styles\.demo\}/.test(topNav), 'World and Demo must stay out of the primary header.');
 must(/focusedFunnel/.test(topNav) && /mobileDocked/.test(topNav) && /isOrganizedUserRoute/.test(topNav), 'Shared top nav must distinguish the focused Home/Create funnel from routes owned by the mobile dock.');
 must(/\.mobileDocked \.links\{display:none\}/.test(topCss), 'Organized mobile routes must let the bottom dock own navigation instead of duplicating header links.');
-must(/\.focusedFunnel \.links a:nth-child\(2\)\{display:inline-flex\}/.test(topCss) && /\.focusedFunnel \.links \.demo\{display:none\}/.test(topCss), 'Focused Home/Create mobile header must keep Create + Vault visible without a duplicate Demo control.');
 must(/pathname === '\/' \|\| pathname === '\/property'/.test(dock), 'Home and the paid creator must suppress the duplicate bottom dock.');
-must(/SIMPLE_PROPERTY_DOCK\.filter\(\(item\) => item\.id !== 'more'\)/.test(dock), 'Simple secondary routes must keep the condensed dock without More.');
+must(/const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/.test(dock), 'Mobile dock must be condensed to Home, VoxelPop, and Vault.');
+must(!/id: 'world'/.test(dock) && !/id: 'more'/.test(dock), 'World and More must not compete in the primary mobile dock.');
 must(/@media\(max-width:720px\)/.test(dockCss) && /\.nav\{display:none\}/.test(dockCss), 'Bottom dock must be mobile-only.');
 must(/FinancialOSNav\.module\.css/.test(dock), 'Bottom dock must use responsive stylesheet rather than always-on inline chrome.');
+
+must(/SimpleJourneyPresentation/.test(propertyPage), 'Property creator page must apply the one-action presentation layer.');
+must(/data-vv-hide-duplicate/.test(propertyPage) && /Done · Open Vault/.test(propertyPage), 'Creator must hide duplicate actions and make Vault the default finished action.');
 
 must(!/fontSize:\s*7\.8/.test(footer), 'Shared footer must not use unreadable 7.8px legal text.');
 must(/\/demo/.test(footer) && /\/privacy/.test(footer) && /\/about/.test(footer), 'Shared footer must cover demo and trust surfaces.');
@@ -117,5 +122,5 @@ if (failures.length) {
   for (const failure of failures) console.error(`  ERROR ${failure}`);
   process.exitCode = 1;
 } else {
-  console.log('\nUI system invariants passed: real high-fidelity 3D voxel-photo proof, concise VoxelPop value messaging, focused Home/Create navigation, condensed secondary mobile dock, readable shared trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
+  console.log('\nUI system invariants passed: real 3D proof, one clear homepage flow, Create/Vault primary navigation, compact Home/VoxelPop/Vault mobile dock, one-action creator presentation, readable trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
 }


### PR DESCRIPTION
## Goal
Make Voxel Vault feel much simpler and more iPhone-like without touching the working payment, source-photo privacy, 3D voxel-photo renderer, movable voxel builder, Vault persistence, or optional mint logic.

## What changed
- reduced the homepage to one promise, one primary CTA, and one short 3-step explanation
- condensed the primary header to **Create + Vault**
- condensed the mobile dock to **Home + VoxelPop + Vault**
- removed the duplicate `Choose photo` button from the creator presentation while keeping the large photo picker itself
- de-emphasized restart/change-photo/mint-now controls so each stage has one obvious next action
- makes the completed creator default to **Done · Open Vault** while keeping Mint optional
- keeps the explicit photo-permission confirmation and explicit 3D voxel-photo approval intact
- updated UI regression checks to enforce the simpler product hierarchy

## User flow
**Choose photo → confirm permission/pay → approve 3D voxel photo → movable voxel builds automatically → Done/Open Vault**

Mint remains optional and can be done later from the saved result.

## Safety / product truth preserved
- $4.99 remains one digital VoxelPop creation
- source photo behavior is unchanged
- 3D voxel photo remains a distinct likeness-approval stage before the movable voxel
- physical-property ownership/rights are not implied
- no payment, auth, WebGL, storage, map, wallet, contract, or mint transaction implementation was changed

## Validation
The branch is directly based on current `main` and is 5 commits ahead / 0 behind. Local clone/testing is unavailable in the current execution environment because outbound GitHub DNS is blocked, so GitHub CI is the release gate for this PR.