### PR TITLE
Finish one-click navigation with three core actions

### DIFF
--- a/app/components/FinancialOSNav.js
+++ b/app/components/FinancialOSNav.js
@@ -3,50 +3,44 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import styles from './FinancialOSNav.module.css';
-import {
-  APP_DOCK,
-  SIMPLE_PROPERTY_DOCK,
-  dockItemForPath,
-  isOrganizedUserRoute,
-  isSimplePropertyRoute,
-  simplePropertyDockItemForPath,
-} from '../../lib/product-map';
+import { isOrganizedUserRoute } from '../../lib/product-map';
 
-const DOCK_ORDER = ['home', 'world', 'create', 'vault', 'more'];
+const DOCK = [
+  { id: 'home', href: '/', icon: '⌂', label: 'Home' },
+  { id: 'create', href: '/property', icon: 'V', label: 'VoxelPop' },
+  { id: 'vault', href: '/vault', icon: '▣', label: 'Vault' },
+];
 
-function centerVoxelPop(items) {
-  return [...items].sort((a, b) => DOCK_ORDER.indexOf(a.id) - DOCK_ORDER.indexOf(b.id));
+function activeDockItem(pathname) {
+  if (pathname === '/property' || pathname.startsWith('/property/')) return 'create';
+  if (pathname === '/vault' || pathname.startsWith('/vault/') || pathname === '/world' || pathname.startsWith('/world/')) return 'vault';
+  return 'home';
 }
 
 export default function FinancialOSNav() {
   const pathname = usePathname() || '/';
   if (!isOrganizedUserRoute(pathname)) return null;
 
-  // Home and the paid VoxelPop creator have a focused product header. Do not
-  // stack a second navigation system underneath those two core surfaces.
+  // Home and the paid creator already use the focused top navigation.
   if (pathname === '/' || pathname === '/property') return null;
 
-  const simple = isSimplePropertyRoute(pathname);
-  const sourceDock = simple ? SIMPLE_PROPERTY_DOCK.filter((item) => item.id !== 'more') : APP_DOCK;
-  const dock = centerVoxelPop(sourceDock);
-  const active = simple ? simplePropertyDockItemForPath(pathname) : dockItemForPath(pathname);
+  const active = activeDockItem(pathname);
 
   return <>
     <div className={styles.spacer} aria-hidden="true" />
-    <nav className={styles.nav} aria-label="Voxel Vault primary navigation" style={{ gridTemplateColumns: `repeat(${dock.length}, minmax(0, 1fr))` }}>
-      {dock.map((item) => {
-        const selected = item.id === active.id;
+    <nav className={styles.nav} aria-label="VoxelPop primary navigation" style={{ gridTemplateColumns: `repeat(${DOCK.length}, minmax(0, 1fr))` }}>
+      {DOCK.map((item) => {
+        const selected = item.id === active;
         const voxelPop = item.id === 'create';
-        const label = voxelPop ? 'VoxelPop' : item.label;
         return <Link
           key={item.id}
           href={item.href}
-          aria-label={voxelPop ? 'VoxelPop 3D voxel and optional NFT creator' : undefined}
+          aria-label={voxelPop ? 'Create a VoxelPop' : undefined}
           aria-current={selected ? 'page' : undefined}
           className={`${styles.item} ${voxelPop ? styles.voxelPopItem : ''} ${selected ? styles.itemActive : ''}`}
         >
-          <span className={`${styles.icon} ${voxelPop ? styles.voxelPopIcon : ''} ${selected ? styles.iconActive : ''}`}>{voxelPop ? 'V' : item.icon}</span>
-          <b className={`${styles.label} ${voxelPop ? styles.voxelPopLabel : ''} ${selected ? styles.labelActive : ''}`}>{label}</b>
+          <span className={`${styles.icon} ${voxelPop ? styles.voxelPopIcon : ''} ${selected ? styles.iconActive : ''}`}>{item.icon}</span>
+          <b className={`${styles.label} ${voxelPop ? styles.voxelPopLabel : ''} ${selected ? styles.labelActive : ''}`}>{item.label}</b>
         </Link>;
       })}
     </nav>

--- a/scripts/audit-ui-system.mjs
+++ b/scripts/audit-ui-system.mjs
@@ -63,7 +63,8 @@ must(/focusedFunnel/.test(topNav) && /mobileDocked/.test(topNav) && /isOrganized
 must(/\.mobileDocked \.links\{display:none\}/.test(topCss), 'Organized mobile routes must let the bottom dock own navigation instead of duplicating header links.');
 must(/\.focusedFunnel \.links a:nth-child\(2\)\{display:inline-flex\}/.test(topCss), 'Focused Home/Create mobile header must keep Vault reachable without restoring extra header choices.');
 must(/pathname === '\/' \|\| pathname === '\/property'/.test(dock), 'Home and the paid creator must suppress the duplicate bottom dock.');
-must(/SIMPLE_PROPERTY_DOCK\.filter\(\(item\) => item\.id !== 'more'\)/.test(dock), 'Simple secondary routes must keep the condensed dock without More.');
+must(/const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/.test(dock), 'Mobile dock must be condensed to Home, VoxelPop, and Vault.');
+must(!/id: 'world'/.test(dock) && !/id: 'more'/.test(dock), 'World and More must not compete in the primary mobile dock.');
 must(/@media\(max-width:720px\)/.test(dockCss) && /\.nav\{display:none\}/.test(dockCss), 'Bottom dock must be mobile-only.');
 must(/FinancialOSNav\.module\.css/.test(dock), 'Bottom dock must use responsive stylesheet rather than always-on inline chrome.');
 
@@ -123,5 +124,5 @@ if (failures.length) {
   for (const failure of failures) console.error(`  ERROR ${failure}`);
   process.exitCode = 1;
 } else {
-  console.log('\nUI system invariants passed: real high-fidelity 3D voxel-photo proof, one-click-focused Home/Create UX, two-destination product header, readable trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
+  console.log('\nUI system invariants passed: real high-fidelity 3D voxel-photo proof, one-click-focused Home/Create UX, two-destination header, three-action mobile dock, readable trust chrome, optional minting, focus visibility, and reduced-motion support are enforced.');
 }


### PR DESCRIPTION
## Final simplification
Current main already includes the one-click homepage/sample work from #532 and creator cleanup from #535. This PR removes the last competing primary navigation choices.

### Mobile dock
Before:
**Home · World · VoxelPop · Vault · More**

After:
**Home · VoxelPop · Vault**

World remains available from the relevant product flows, but it no longer competes as a primary mobile action. Advanced surfaces remain reachable outside the core dock.

### Regression guard
Updates the UI audit so the three-action dock is enforced and World/More cannot silently return to the primary mobile navigation.

## Preserved
- $4.99 paid creation flow
- device-local source photo behavior
- real 3D voxel-photo approval
- separate movable 3D voxel
- automatic Vault save
- optional minting
- existing creator simplification from #535

This branch is based directly on current main and is 0 commits behind.