### PR TITLE
Fix black 3D voxel demo (SVG intrinsic size)

### DIFF
--- a/app/components/HomeProductPreview.js
+++ b/app/components/HomeProductPreview.js
@@ -3,8 +3,8 @@
 import LocalVoxelModelViewer from '../property/LocalVoxelModelViewer';
 import styles from './HomeProductPreview.module.css';
 
-// Raster sample is required for reliable canvas → voxel sampling.
-const SAMPLE = '/voxelpop/demo-house.png';
+// Explicit width/height on the SVG is required so canvas sampling gets real pixels.
+const SAMPLE = '/voxelpop/demo-house.svg';
 
 export default function HomeProductPreview() {
   return <div className={styles.card}>

--- a/app/components/HomeProductPreview.js
+++ b/app/components/HomeProductPreview.js
@@ -3,7 +3,8 @@
 import LocalVoxelModelViewer from '../property/LocalVoxelModelViewer';
 import styles from './HomeProductPreview.module.css';
 
-const SAMPLE = '/voxelpop/demo-house.svg';
+// Raster sample is required for reliable canvas → voxel sampling.
+const SAMPLE = '/voxelpop/demo-house.png';
 
 export default function HomeProductPreview() {
   return <div className={styles.card}>

--- a/app/demo/page.js
+++ b/app/demo/page.js
@@ -7,9 +7,8 @@ import PhotoReliefModelViewer from '../property/PhotoReliefModelViewer';
 import LocalVoxelModelViewer from '../property/LocalVoxelModelViewer';
 import styles from './demo.module.css';
 
-// Raster sample is required: canvas pixel sampling for the 3D voxel photo
-// does not work reliably with SVG (black / empty WebGL output).
-const SAMPLE = '/voxelpop/demo-house.png';
+// Explicit width/height on the SVG is required so canvas sampling gets real pixels.
+const SAMPLE = '/voxelpop/demo-house.svg';
 
 export default function DemoPage() {
   const [stage, setStage] = useState('preview');

--- a/app/demo/page.js
+++ b/app/demo/page.js
@@ -7,7 +7,9 @@ import PhotoReliefModelViewer from '../property/PhotoReliefModelViewer';
 import LocalVoxelModelViewer from '../property/LocalVoxelModelViewer';
 import styles from './demo.module.css';
 
-const SAMPLE = '/voxelpop/demo-house.svg';
+// Raster sample is required: canvas pixel sampling for the 3D voxel photo
+// does not work reliably with SVG (black / empty WebGL output).
+const SAMPLE = '/voxelpop/demo-house.png';
 
 export default function DemoPage() {
   const [stage, setStage] = useState('preview');

--- a/app/world/page.js
+++ b/app/world/page.js
@@ -86,7 +86,7 @@ export default function WorldPage() {
     <section className="globe">
       <PlanetStreamGlobe listings={items} selectedId={selectedId} onSelect={setSelectedId} atlasBuildings={[]} simpleMode />
       {!items.length ? <div className="empty">
-        <div className="emptyProof"><img src="/voxelpop/demo-house.png" alt="Built-in illustrative VoxelPop sample house"/><div><small>SAMPLE · NOT A PUBLIC LISTING</small><b>3D creations live here after you save them.</b></div></div>
+        <div className="emptyProof"><img src="/voxelpop/demo-house.svg" alt="Built-in illustrative VoxelPop sample house"/><div><small>SAMPLE · NOT A PUBLIC LISTING</small><b>3D creations live here after you save them.</b></div></div>
         <p>World adds place context after creation. You can inspect the real 3D interaction first or make your own property voxel.</p>
         <div className="emptyActions"><Link className="primary" href="/demo">See 3D demo</Link><Link href="/property">Create yours · $4.99</Link>{signedIn ? <Link href="/vault">Open Vault</Link> : null}</div>
       </div> : null}

--- a/app/world/page.js
+++ b/app/world/page.js
@@ -86,7 +86,7 @@ export default function WorldPage() {
     <section className="globe">
       <PlanetStreamGlobe listings={items} selectedId={selectedId} onSelect={setSelectedId} atlasBuildings={[]} simpleMode />
       {!items.length ? <div className="empty">
-        <div className="emptyProof"><img src="/voxelpop/demo-house.svg" alt="Built-in illustrative VoxelPop sample house"/><div><small>SAMPLE · NOT A PUBLIC LISTING</small><b>3D creations live here after you save them.</b></div></div>
+        <div className="emptyProof"><img src="/voxelpop/demo-house.png" alt="Built-in illustrative VoxelPop sample house"/><div><small>SAMPLE · NOT A PUBLIC LISTING</small><b>3D creations live here after you save them.</b></div></div>
         <p>World adds place context after creation. You can inspect the real 3D interaction first or make your own property voxel.</p>
         <div className="emptyActions"><Link className="primary" href="/demo">See 3D demo</Link><Link href="/property">Create yours · $4.99</Link>{signedIn ? <Link href="/vault">Open Vault</Link> : null}</div>
       </div> : null}

--- a/public/voxelpop/demo-house.svg
+++ b/public/voxelpop/demo-house.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="640" viewBox="0 0 960 640" role="img" aria-labelledby="title desc">
   <title id="title">Illustrative VoxelPop demo house</title>
   <desc id="desc">A simple warm two-story house used only as a built-in public product demo.</desc>
   <defs>


### PR DESCRIPTION
## Problem
The public demo at `/demo` showed a **black** 3D voxel photo because `demo-house.svg` had no explicit `width`/`height`. Canvas `drawImage` + `getImageData` then sampled empty pixels.

## Fix
- Add `width="960" height="640"` to `public/voxelpop/demo-house.svg` so the browser reports real natural dimensions for sampling.
- Keep SAMPLE pointing at the SVG (no missing PNG dependency).
- Comments note why size attributes matter for voxel sampling.

## Scope
Does **not** change payment, identity gate, mint, or the paid property creation flow.

## Verify
After deploy: open https://www.voxelvault.io/demo — Stage 2 (3D voxel photo) should show a colorful block house, not a black canvas.