### PR TITLE
VoxelPop-simple product UI + fix local image sampling

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,23 +1,19 @@
 import { WalletIdentityProvider } from './components/WalletIdentity';
 import FinancialOSNav from './components/FinancialOSNav';
-import AppCommandCenter from './components/AppCommandCenter';
-import ConsumerFooter from './components/ConsumerFooter';
 import './vault-fallback.css';
-import './futuristic-vault.css';
-import './spatial-os-interactions.css';
 import './voxelpop-cute-system.css';
 import './ui-system.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 
-const TITLE = 'Voxel Vault | Turn a House Photo into a 3D Voxel Photo';
-const DESCRIPTION = 'Turn an authorized house photo into a block-by-block 3D VoxelPop photo for $4.99, approve it, then create a separate movable 3D voxel. Source photo stays on your device; minting is optional.';
+const TITLE = 'VoxelPop | Photo in. Voxel out.';
+const DESCRIPTION = 'Turn a house photo into a 3D VoxelPop for $4.99. Approve the voxel photo, then get a movable 3D voxel. Saved to Vault. Mint optional.';
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
-  title: { default: TITLE, template: '%s | Voxel Vault' },
+  title: { default: TITLE, template: '%s | VoxelPop' },
   description: DESCRIPTION,
-  keywords: ['house photo to voxel', '3D voxel photo', 'voxel house creator', 'VoxelPop', '3D voxel creator', 'Voxel Vault'],
+  keywords: ['VoxelPop', 'house photo to voxel', '3D voxel photo', 'voxel house creator', 'Voxel Vault'],
   robots: { index: true, follow: true },
   icons: { icon: '/voxelpop/voxelpop-logo.png', apple: '/voxelpop/voxelpop-logo.png' },
   openGraph: {
@@ -25,8 +21,8 @@ export const metadata = {
     description: DESCRIPTION,
     type: 'website',
     url: SITE_URL,
-    siteName: 'Voxel Vault',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'VoxelPop house photo to 3D voxel photo preview' }],
+    siteName: 'VoxelPop',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'VoxelPop photo to 3D voxel' }],
   },
   twitter: { card: 'summary_large_image', title: TITLE, description: DESCRIPTION, images: ['/opengraph-image'] },
 };
@@ -40,5 +36,5 @@ export const viewport = {
 };
 
 export default function RootLayout({ children }) {
-  return <html lang="en"><body><WalletIdentityProvider>{children}<ConsumerFooter/><AppCommandCenter/><FinancialOSNav/></WalletIdentityProvider></body></html>;
+  return <html lang="en"><body><WalletIdentityProvider>{children}<FinancialOSNav/></WalletIdentityProvider></body></html>;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -10,31 +10,31 @@ export default function Home() {
     <ProductTopNav/>
     <div className={styles.shell}>
       <section className={styles.hero}>
-        <p className={styles.kicker}>ONE PHOTO → ONE VOXEL</p>
+        <p className={styles.kicker}>PHOTO → VOXEL · $4.99</p>
         <h1><em>VOXELPOP</em></h1>
-        <p className={styles.heroLine}>Upload a property photo. Approve the 3D voxel photo. Your movable voxel is built and saved.</p>
+        <p className={styles.heroLine}>Photo in. Voxel out. Approve the 3D match, then rotate your voxel.</p>
 
         <div className={styles.centerMachine}>
           <HomeProductPreview/>
-          <Link className={styles.primaryAction} href="/property">Create mine · $4.99</Link>
-          <p className={styles.microCopy}>Saved to Vault automatically · NFT optional · no wallet needed to create</p>
+          <Link className={styles.primaryAction} href="/property">Create · $4.99</Link>
+          <p className={styles.microCopy}>Saved to Vault · mint optional</p>
         </div>
 
-        <div className={styles.simpleSteps} aria-label="VoxelPop creation flow">
-          <div><i>1</i><span><b>Choose photo</b><small>Pick one clear house photo.</small></span></div>
+        <div className={styles.simpleSteps} aria-label="VoxelPop steps">
+          <div><i>1</i><span><b>Photo</b><small>One clear house shot.</small></span></div>
           <div><i>2</i><span><b>Approve</b><small>Check the 3D voxel photo.</small></span></div>
-          <div><i>3</i><span><b>Done</b><small>Rotate your voxel. It is saved.</small></span></div>
+          <div><i>3</i><span><b>Done</b><small>Rotate. Saved to Vault.</small></span></div>
         </div>
       </section>
 
       <section className={styles.truthCard}>
-        <div><b>Simple by design.</b><span>Photo → review → movable voxel → saved.</span></div>
-        <p>VoxelPop creates a digital asset only. It does not create or transfer ownership, deed/title, rent, occupancy, investment, appreciation, or other rights in a physical property.</p>
+        <div><b>Digital only.</b><span>Photo → review → voxel → Vault.</span></div>
+        <p>No deed, title, or physical-property rights.</p>
       </section>
 
       <footer className={styles.footer}>
-        <span>VoxelPop by Voxel Vault · digital creations only.</span>
-        <span><Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link> · <Link href="/about">About</Link></span>
+        <span>VoxelPop</span>
+        <span><Link href="/demo">Demo</Link> · <Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link></span>
       </footer>
     </div>
   </main>;

--- a/app/property/rasterizeImageUrl.js
+++ b/app/property/rasterizeImageUrl.js
@@ -1,13 +1,18 @@
 const MAX_EDGE = 1600;
 const PROBE_SIZE = 32;
 
+function isLocalUrl(url) {
+  const value = String(url || '');
+  return value.startsWith('data:') || value.startsWith('blob:') || value.startsWith('/') || value.startsWith('./');
+}
+
 /**
  * Loads an image URL into a canvas raster, preferring createImageBitmap
- * (works for blob: URLs and same-origin assets) and falling back to
+ * (works for blob: and data: URLs and same-origin assets) and falling back to
  * HTMLImageElement + decode(). Caps the longest edge at MAX_EDGE for
  * performance, then probes a corner for near-black or empty pixels.
  *
- * @param {string} url - Any URL including blob: object URLs.
+ * @param {string} url - Any URL including blob: / data: object URLs.
  * @returns {Promise<{canvas: HTMLCanvasElement, width: number, height: number}>}
  * @throws {Error} If the image cannot be loaded or appears empty/black.
  */
@@ -15,19 +20,31 @@ export async function rasterizeImageUrl(url) {
   let bitmap = null;
 
   try {
-    const response = await fetch(url);
-    const blob = await response.blob();
-    bitmap = await createImageBitmap(blob);
+    if (typeof createImageBitmap === 'function') {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      bitmap = await createImageBitmap(blob);
+    }
   } catch {
+    bitmap = null;
+  }
+
+  if (!bitmap) {
     const img = new Image();
-    img.crossOrigin = 'anonymous';
-    img.src = url;
-    await img.decode();
+    // Never set crossOrigin for data:/blob:/relative paths — it can block decoding.
+    if (!isLocalUrl(url)) img.crossOrigin = 'anonymous';
+    img.decoding = 'async';
+    await new Promise((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('The photo could not be opened for the 3D voxel photo.'));
+      img.src = url;
+    });
+    try { await img.decode?.(); } catch {}
     bitmap = img;
   }
 
-  const srcW = bitmap.width || bitmap.naturalWidth || 960;
-  const srcH = bitmap.height || bitmap.naturalHeight || 640;
+  const srcW = Math.max(2, bitmap.width || bitmap.naturalWidth || 960);
+  const srcH = Math.max(2, bitmap.height || bitmap.naturalHeight || 640);
   const scale = Math.min(1, MAX_EDGE / Math.max(srcW, srcH));
   const rasterW = Math.max(2, Math.round(srcW * scale));
   const rasterH = Math.max(2, Math.round(srcH * scale));


### PR DESCRIPTION
## VoxelPop-simple
- Root layout: remove AppCommandCenter + ConsumerFooter; keep FinancialOSNav dock only
- Metadata branded as VoxelPop
- Home condensed: Photo → Voxel, shorter steps, Demo link in footer
- rasterizeImageUrl: never set crossOrigin on data:/blob:/relative URLs so demo + user photos sample correctly

Payment/mint/identity unchanged.