### PR TITLE
Match VoxelPop home to the house photo flow

### DIFF
--- a/app/components/HomeProductPreview.js
+++ b/app/components/HomeProductPreview.js
@@ -16,8 +16,8 @@ export default function HomeProductPreview() {
     </div>
     <div className={styles.facts} aria-label="VoxelPop facts">
       <span>Photo</span>
-      <span>3D review</span>
-      <span>Saved</span>
+      <span>3D voxel photo review</span>
+      <span>Movable voxel</span>
     </div>
   </div>;
 }

--- a/app/demo/page.js
+++ b/app/demo/page.js
@@ -16,9 +16,9 @@ export default function DemoPage() {
     <ProductTopNav/>
     <div className={styles.shell}>
       <header className={styles.hero}>
-        <small>FREE SAMPLE</small>
+        <small>FREE SAMPLE · NO LOGIN · NO PAYMENT</small>
         <h1>Photo in.<br/><em>Voxel out.</em></h1>
-        <p>One photo becomes a 3D voxel photo, then a movable voxel you can rotate.</p>
+        <p>Built-in demo artwork shows how one photo becomes a 3D voxel photo, then a movable voxel you can rotate.</p>
       </header>
 
       <section className={styles.demoCard}>
@@ -29,7 +29,7 @@ export default function DemoPage() {
 
         <div className={styles.viewerSide}>
           <div className={styles.viewerHead}>
-            <div><small>{stage === 'preview' ? '3D VOXEL PHOTO' : 'MOVABLE VOXEL'}</small><h2>{stage === 'preview' ? 'Match the photo.' : 'Rotate it.'}</h2></div>
+            <div><small>{stage === 'preview' ? '3D VOXEL PHOTO' : 'MOVABLE 3D VOXEL'}</small><h2>{stage === 'preview' ? 'Match the photo.' : 'Rotate it.'}</h2></div>
             <div className={styles.switcher} role="tablist" aria-label="Demo stage">
               <button type="button" role="tab" aria-selected={stage === 'preview'} className={stage === 'preview' ? styles.active : ''} onClick={() => setStage('preview')}>Voxel photo</button>
               <button type="button" role="tab" aria-selected={stage === 'voxel'} className={stage === 'voxel' ? styles.active : ''} onClick={() => setStage('voxel')}>Movable</button>
@@ -44,6 +44,10 @@ export default function DemoPage() {
             ? 'Colored blocks from the photo — drag to inspect depth.'
             : voxelReady ? 'Same photo, movable 3D voxel. Drag to rotate.' : 'Building movable voxel…'}</div>
         </div>
+      </section>
+
+      <section className={styles.flow}>
+        <div><small>BUILT-IN DEMO ARTWORK</small><h2>One-photo truth.</h2><p>A single photo guides the visible likeness. It is not a fake reconstruction of unseen walls and cannot prove hidden sides.</p></div>
       </section>
 
       <section className={styles.flow}>

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,13 +1,15 @@
 import { WalletIdentityProvider } from './components/WalletIdentity';
 import FinancialOSNav from './components/FinancialOSNav';
+import AppCommandCenter from './components/AppCommandCenter';
 import './vault-fallback.css';
 import './voxelpop-cute-system.css';
 import './ui-system.css';
+import './spatial-os-interactions.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 
-const TITLE = 'VoxelPop | Photo in. Voxel out.';
-const DESCRIPTION = 'Turn a house photo into a 3D VoxelPop for $4.99. Approve the voxel photo, then get a movable 3D voxel. Saved to Vault. Mint optional.';
+const TITLE = 'VoxelPop | Turn a House Photo into a 3D Voxel Photo';
+const DESCRIPTION = 'Turn a House Photo into a 3D Voxel Photo for $4.99. Approve the voxel photo, then get a movable 3D voxel. Source photo stays on your device; minting is optional. Saved to Vault.';
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
@@ -36,5 +38,5 @@ export const viewport = {
 };
 
 export default function RootLayout({ children }) {
-  return <html lang="en"><body><WalletIdentityProvider>{children}<FinancialOSNav/></WalletIdentityProvider></body></html>;
+  return <html lang="en"><body><WalletIdentityProvider>{children}<FinancialOSNav/><AppCommandCenter/></WalletIdentityProvider></body></html>;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -16,8 +16,8 @@ export default function Home() {
 
         <div className={styles.centerMachine}>
           <HomeProductPreview/>
-          <Link className={styles.primaryAction} href="/property">Create · $4.99</Link>
-          <p className={styles.microCopy}>Saved to Vault automatically · NFT optional · no wallet needed to create</p>
+          <Link className={styles.primaryAction} href="/property">Create mine · $4.99</Link>
+          <p className={styles.microCopy}>Saved to Vault automatically · Your movable voxel is built and saved. · NFT optional · no wallet needed to create</p>
         </div>
 
         <div className={styles.simpleSteps} aria-label="VoxelPop house steps">
@@ -30,8 +30,8 @@ export default function Home() {
       </section>
 
       <section className={styles.truthCard}>
-        <div><b>Digital asset only.</b><span>One confirmed property can have one VoxelPop collectible.</span></div>
-        <p>Creating, saving, or minting the voxel does not create or transfer ownership of the physical property.</p>
+        <div><b>VoxelPop creates a digital asset only.</b><span>One confirmed property can have one VoxelPop collectible.</span></div>
+        <p>VoxelPop does not create or transfer ownership, deed/title, rent, occupancy, investment, appreciation, or other rights in a physical property.</p>
       </section>
 
       <footer className={styles.footer}>

--- a/app/page.js
+++ b/app/page.js
@@ -10,26 +10,28 @@ export default function Home() {
     <ProductTopNav/>
     <div className={styles.shell}>
       <section className={styles.hero}>
-        <p className={styles.kicker}>PHOTO → VOXEL · $4.99</p>
+        <p className={styles.kicker}>ONE PHOTO → ONE VOXEL</p>
         <h1><em>VOXELPOP</em></h1>
-        <p className={styles.heroLine}>Photo in. Voxel out. Approve the 3D match, then rotate your voxel.</p>
+        <p className={styles.heroLine}>House photo in. Confirm the address. Approve the 3D voxel photo, then get the movable voxel.</p>
 
         <div className={styles.centerMachine}>
           <HomeProductPreview/>
           <Link className={styles.primaryAction} href="/property">Create · $4.99</Link>
-          <p className={styles.microCopy}>Saved to Vault · mint optional</p>
+          <p className={styles.microCopy}>Saved to Vault automatically · NFT optional · no wallet needed to create</p>
         </div>
 
-        <div className={styles.simpleSteps} aria-label="VoxelPop steps">
-          <div><i>1</i><span><b>Photo</b><small>One clear house shot.</small></span></div>
-          <div><i>2</i><span><b>Approve</b><small>Check the 3D voxel photo.</small></span></div>
-          <div><i>3</i><span><b>Done</b><small>Rotate. Saved to Vault.</small></span></div>
+        <div className={styles.simpleSteps} aria-label="VoxelPop house steps">
+          <div><i>1</i><span><b>Photo</b><small>Upload one clear house photo.</small></span></div>
+          <div><i>2</i><span><b>Address</b><small>Confirm the property address.</small></span></div>
+          <div><i>3</i><span><b>Voxel</b><small>Approve the voxel image and 3D build.</small></span></div>
+          <div><i>4</i><span><b>Keep</b><small>Saved to your Vault inventory.</small></span></div>
+          <div><i>5</i><span><b>Mint</b><small>Mint the one-of-one NFT only if you want.</small></span></div>
         </div>
       </section>
 
       <section className={styles.truthCard}>
-        <div><b>Digital only.</b><span>Photo → review → voxel → Vault.</span></div>
-        <p>No deed, title, or physical-property rights.</p>
+        <div><b>Digital asset only.</b><span>One confirmed property can have one VoxelPop collectible.</span></div>
+        <p>Creating, saving, or minting the voxel does not create or transfer ownership of the physical property.</p>
       </section>
 
       <footer className={styles.footer}>

--- a/app/page.js
+++ b/app/page.js
@@ -36,7 +36,7 @@ export default function Home() {
 
       <footer className={styles.footer}>
         <span>VoxelPop</span>
-        <span><Link href="/demo">Demo</Link> · <Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link></span>
+        <span><Link href="/demo">Demo</Link> · <Link href="/about">About</Link> · <Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link></span>
       </footer>
     </div>
   </main>;


### PR DESCRIPTION
Follow-up to the canonical house-photo creator already on main. Aligns the public Home, product proof, global metadata/safe shell, and free demo with the focused flow: house photo → confirmed address → generated VoxelPop image → movable 3D voxel → Vault → optional one-time mint. Restores the required privacy/legal truth labels and the navigation-only command finder, which remains hidden on simple Home/Create routes. No creator, checkout, property-identity, mint, or inventory backend logic changes.