### PR TITLE
Add generated VoxelPop image to property creator

### DIFF
--- a/app/api/property-photo-upload/route.ts
+++ b/app/api/property-photo-upload/route.ts
@@ -61,10 +61,10 @@ export async function POST(request: Request) {
         rightsBasis: 'user-owned',
         rightsReference: 'Signed-in Voxel Vault user confirmed they took this photo or have permission to use it for this digital creation.',
         label: 'Selected property photo',
-        provider: 'voxelpop-local-webgl-v1',
+        provider: 'meshy-nano-banana-voxelpop + voxelpop-local-webgl-v2',
         storagePath: null,
       },
-      privacy: 'Payment is verified without uploading the source photo. The authorized source stays in this browser device storage while VoxelPop builds the image and interactive 3D locally.',
+      privacy: 'Payment verification does not upload the source photo. During the next review step, the browser sends a resized prepared reference transiently to the configured VoxelPop image provider; Voxel Vault does not save the original source photo in generation storage. The approved generated image then feeds the local interactive 3D voxel build.',
     });
   } catch (error) {
     return privateJson({

--- a/app/api/property-voxel-photo/route.ts
+++ b/app/api/property-voxel-photo/route.ts
@@ -1,0 +1,202 @@
+import { createHmac } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../lib/user-auth';
+import { normalizePropertyDraftId } from '../../../lib/property-generation-ids';
+import { listPaidPropertyCollectiblesForBuyer } from '../../../lib/property-collectible-commerce';
+import {
+  MESHY_PROPERTY_CREDITS,
+  meshyClientStatus,
+  meshyCreditError,
+  meshyCreditsSufficient,
+  meshyProviderFailure,
+  readMeshyCreditBalance,
+} from '../../../lib/meshy-credits';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+export const dynamic = 'force-dynamic';
+
+const ENDPOINT = 'https://api.meshy.ai/openapi/v1/image-to-image';
+const MAX_REFERENCE_BYTES = 4 * 1024 * 1024;
+const MAX_RESULT_BYTES = 7 * 1024 * 1024;
+
+function clean(value: unknown, max = 1200) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function privateJson(body: unknown, init: ResponseInit = {}) {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) },
+  });
+}
+
+function taskToken(apiKey: string, userId: string, draftId: string, taskId: string) {
+  return createHmac('sha256', apiKey)
+    .update(`voxelpop-property-photo-v1:${userId}:${draftId}:${taskId}`)
+    .digest('hex');
+}
+
+function parseReferenceDataUrl(input: unknown) {
+  const reference = String(input || '').trim();
+  const match = reference.match(/^data:(image\/(?:jpeg|png|webp));base64,([A-Za-z0-9+/=]+)$/i);
+  if (!match) throw new Error('A prepared JPG, PNG, or WebP house photo is required.');
+  const bytes = Buffer.from(match[2], 'base64');
+  if (!bytes.length || bytes.length > MAX_REFERENCE_BYTES) {
+    throw new Error('The prepared house photo is too large. Try a smaller photo or screenshot.');
+  }
+  return reference;
+}
+
+async function verifyPaidDraft(userId: string, draftId: string) {
+  const paid = await listPaidPropertyCollectiblesForBuyer(userId);
+  const reservation = paid.find((item) => item.draftId === draftId) || null;
+  if (!reservation) {
+    throw new Error('Finish the one-property checkout before generating the VoxelPop image.');
+  }
+  return reservation;
+}
+
+function generationPrompt(address: string) {
+  const place = clean(address, 220);
+  return [
+    'Transform the reference house photo into a premium VoxelPop voxel image.',
+    'The house must remain immediately recognizable as the same visible building in the reference.',
+    'Preserve visible roof shape and pitch, story count, facade proportions, window and door count and placement, porch or steps, attached structures, exterior materials, trim, and color relationships.',
+    'Render the house with crisp dimensional voxel blocks, colorful but faithful materials, clean edges, soft studio daylight, grounded contact shadows, and a polished collectible presentation.',
+    'Do not add or remove floors, doors, windows, garages, porches, or other permanent architectural features that contradict the reference.',
+    'Do not invent hidden rear geometry. Use a simple warm neutral background with no text, labels, logos, people, watermark, frame, or UI.',
+    place ? `The confirmed property label is ${place}; use it only as context and do not render the address as text.` : '',
+  ].filter(Boolean).join(' ');
+}
+
+async function imageDataUrl(imageUrl: string) {
+  const response = await fetch(imageUrl, { cache: 'no-store' });
+  if (!response.ok) throw new Error('The completed VoxelPop image could not be opened.');
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!bytes.length || bytes.length > MAX_RESULT_BYTES) {
+    throw new Error('The completed VoxelPop image is too large to prepare for the 3D voxel.');
+  }
+  const rawType = clean(response.headers.get('content-type'), 80).toLowerCase().split(';')[0];
+  const mime = ['image/jpeg', 'image/png', 'image/webp'].includes(rawType) ? rawType : 'image/png';
+  return `data:${mime};base64,${bytes.toString('base64')}`;
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!apiKey) return privateJson({ ok: false, error: 'VoxelPop image generation is not configured on this deployment.' }, { status: 503 });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const draftId = normalizePropertyDraftId(body?.draftId);
+    const reference = parseReferenceDataUrl(body?.reference);
+    const reservation = await verifyPaidDraft(auth.user.id, draftId);
+
+    const balance = await readMeshyCreditBalance(apiKey);
+    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.voxelImage)) {
+      return privateJson(
+        meshyCreditError('starting the VoxelPop house image', MESHY_PROPERTY_CREDITS.voxelImage),
+        { status: 503 },
+      );
+    }
+
+    const response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ai_model: 'nano-banana',
+        prompt: generationPrompt(reservation.address),
+        reference_image_urls: [reference],
+        aspect_ratio: '1:1',
+        remove_background: false,
+      }),
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return privateJson(
+        meshyProviderFailure(
+          response.status,
+          data,
+          `VoxelPop image provider returned ${response.status}.`,
+          'starting the VoxelPop house image',
+          MESHY_PROPERTY_CREDITS.voxelImage,
+        ),
+        { status: meshyClientStatus(response.status) },
+      );
+    }
+
+    const taskId = clean(data?.result || data?.id || data?.task_id, 240);
+    if (!taskId) throw new Error('The VoxelPop image provider did not return a task ID.');
+
+    return privateJson({
+      ok: true,
+      taskId,
+      taskToken: taskToken(apiKey, auth.user.id, draftId, taskId),
+      draftId,
+      atlasId: reservation.atlasId,
+      propertyAddress: reservation.address,
+      provider: 'meshy-nano-banana-voxelpop',
+    });
+  } catch (error) {
+    return privateJson({ ok: false, error: error instanceof Error ? error.message : 'VoxelPop image generation could not start.' }, { status: 400 });
+  }
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return privateJson({ ok: false, error: auth.error }, { status: auth.status });
+
+  const apiKey = process.env.MESHY_API_KEY?.trim();
+  if (!apiKey) return privateJson({ ok: false, error: 'VoxelPop image generation is not configured on this deployment.' }, { status: 503 });
+
+  try {
+    const url = new URL(request.url);
+    const draftId = normalizePropertyDraftId(url.searchParams.get('draftId'));
+    const taskId = clean(url.searchParams.get('taskId'), 240);
+    const suppliedToken = clean(url.searchParams.get('taskToken'), 128);
+    if (!taskId || suppliedToken !== taskToken(apiKey, auth.user.id, draftId, taskId)) {
+      return privateJson({ ok: false, error: 'That VoxelPop image job does not belong to this signed-in creation.' }, { status: 404 });
+    }
+
+    const response = await fetch(`${ENDPOINT}/${encodeURIComponent(taskId)}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      cache: 'no-store',
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return privateJson(
+        meshyProviderFailure(response.status, data, 'Could not read the VoxelPop image job.', 'reading the VoxelPop house image'),
+        { status: meshyClientStatus(response.status) },
+      );
+    }
+
+    const status = clean(data?.status || 'PENDING', 60).toUpperCase();
+    const progress = Math.max(0, Math.min(100, Number(data?.progress || 0)));
+    if (status === 'FAILED' || status === 'CANCELED' || status === 'CANCELLED') {
+      return privateJson({ ok: false, status, progress, error: clean(data?.task_error?.message || data?.error || data?.message, 600) || 'VoxelPop image generation failed.' }, { status: 502 });
+    }
+    if (status !== 'SUCCEEDED' && status !== 'COMPLETED') {
+      return privateJson({ ok: true, status, progress, ready: false });
+    }
+
+    const providerImageUrl = Array.isArray(data?.image_urls)
+      ? clean(data.image_urls[0], 2200)
+      : clean(data?.image_url || data?.output?.image_url || data?.result?.image_url, 2200);
+    if (!/^https?:\/\//i.test(providerImageUrl)) throw new Error('The completed VoxelPop image is unavailable.');
+
+    return privateJson({
+      ok: true,
+      status: 'SUCCEEDED',
+      progress: 100,
+      ready: true,
+      imageUrl: providerImageUrl,
+      imageDataUrl: await imageDataUrl(providerImageUrl),
+    });
+  } catch (error) {
+    return privateJson({ ok: false, error: error instanceof Error ? error.message : 'VoxelPop image generation status could not be read.' }, { status: 400 });
+  }
+}

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -9,23 +9,24 @@ export const metadata = {
 
 export default function PrivacyPage() {
   return <main className={styles.page}><ProductTopNav/><div className={styles.shell}>
-    <header className={styles.hero}><small>PRIVACY</small><h1>Your photo starts<br/>on your device.</h1><p>Voxel Vault is designed so the property source photo used by the current VoxelPop creation flow stays on the user’s device rather than becoming a public property-photo database.</p></header>
+    <header className={styles.hero}><small>PRIVACY</small><h1>Your original photo<br/>starts on your device.</h1><p>Voxel Vault keeps the source photo private from public property listings and does not intentionally publish the original photo as a property-photo database.</p></header>
     <section className={styles.card}>
-      <div className={styles.notice}><strong>Current product boundary:</strong> the normal $4.99 property creation flow uses local browser processing for the 3D preview and voxel creation and does not require Meshy credits.</div>
+      <div className={styles.notice}><strong>Current product boundary:</strong> after the $4.99 property creation is verified, the browser sends a resized prepared reference to the configured VoxelPop image provider to create the voxel image. The approved generated image then feeds the local interactive 3D voxel build.</div>
       <h2>Property photos</h2>
-      <p>The current VoxelPop property flow processes the selected source image in the browser. When supported by the browser, Voxel Vault may keep a private copy in on-device browser storage so the same paid creation can resume after checkout. If that local cache is unavailable, the user may be asked to choose the same photo again. The source photo is not intentionally published in NFT metadata.</p>
+      <p>The selected source image begins in the browser. When supported, Voxel Vault keeps a private copy in on-device browser storage so the same paid creation can resume after checkout. During the voxel-image step, a resized JPG reference is transmitted transiently to the configured image-generation provider. Voxel Vault does not intentionally write the original source photo to its generation storage or publish it in NFT metadata.</p>
+      <p>The generated voxel image is a visual interpretation of the visible reference. One photograph cannot verify hidden sides, the rear of a building, exact measurements, parcel boundaries, or legal property facts.</p>
       <h2>Accounts</h2>
       <p>Google sign-in may be used to associate saved property drafts, creation records, and other account-scoped product state with one Voxel Vault identity. The authentication provider and configured backend services process the information required for sign-in and account storage.</p>
       <h2>Payments</h2>
       <p>Paid checkouts are handled through the configured payment provider. Voxel Vault should not store complete card numbers in the application database. Payment-provider records may include transaction identifiers and the minimum metadata needed to verify the purchase.</p>
       <h2>Maps and property context</h2>
-      <p>If a user chooses to map a finished creation, Voxel Vault may request address, coordinate, building, parcel, or other source-backed place information. Map data is kept conceptually separate from the user’s private source photo and from legal ownership records.</p>
+      <p>The confirmed address is used to resolve a source-backed building identity and enforce the one-property purchase and one-mint limit. Map data remains conceptually separate from the user’s source photo, generated artwork, and legal ownership records.</p>
       <h2>Wallets and minting</h2>
       <p>A wallet is not required for the core creation flow. If a user explicitly chooses to mint a finished digital voxel, public blockchain transaction information may be visible on the relevant network. Voxel Vault does not ask users to commit private keys or seed phrases to the public repository.</p>
       <h2>Public sharing</h2>
       <p>Items are not meant to become public property claims merely because they appear in World, Vault, metadata, or an NFT. Public-facing coordinates may be reduced or transformed where the product intentionally limits precision.</p>
       <h2>Third-party services</h2>
-      <p>Authentication, payment, map, hosting, blockchain, analytics, or other providers may have their own privacy practices. Only services actually configured on the live deployment should be treated as active.</p>
+      <p>Authentication, payment, image generation, map, hosting, blockchain, analytics, or other providers may have their own privacy practices. Only services actually configured on the live deployment should be treated as active.</p>
       <h2>Questions</h2>
       <p>For privacy questions or data-handling concerns, use the project contact route on the About page or open a repository issue without posting passwords, payment credentials, private keys, identity documents, deeds, leases, or other sensitive personal information.</p>
       <div className={styles.links}><Link href="/about">About + contact</Link><Link href="/terms">Terms</Link><Link href="/demo">See public demo</Link></div>

--- a/app/property/rasterizeImageUrl.js
+++ b/app/property/rasterizeImageUrl.js
@@ -1,27 +1,204 @@
+import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+
 const MAX_EDGE = 1600;
 const PROBE_SIZE = 32;
+const REFERENCE_MAX_EDGE = 1536;
+const DEVICE_DB = 'voxelpop-property-device-v1';
+const DEVICE_STORE = 'pending-photos';
+const RENDER_MAP_KEY = '__VOXELPOP_PROPERTY_RENDER_MAP__';
+const RENDER_PROMISES_KEY = '__VOXELPOP_PROPERTY_RENDER_PROMISES__';
 
 function isLocalUrl(url) {
   const value = String(url || '');
   return value.startsWith('data:') || value.startsWith('blob:') || value.startsWith('/') || value.startsWith('./');
 }
 
+function renderMap() {
+  if (typeof window === 'undefined') return null;
+  if (!window[RENDER_MAP_KEY]) window[RENDER_MAP_KEY] = Object.create(null);
+  return window[RENDER_MAP_KEY];
+}
+
+function renderPromises() {
+  if (typeof window === 'undefined') return null;
+  if (!window[RENDER_PROMISES_KEY]) window[RENDER_PROMISES_KEY] = Object.create(null);
+  return window[RENDER_PROMISES_KEY];
+}
+
+async function openDeviceDb() {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') return reject(new Error('Private on-device photo storage is unavailable.'));
+    const request = indexedDB.open(DEVICE_DB, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(DEVICE_STORE)) request.result.createObjectStore(DEVICE_STORE, { keyPath: 'draftId' });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('Private photo storage could not open.'));
+  });
+}
+
+async function sha256(bytes) {
+  if (!globalThis.crypto?.subtle) return '';
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest)).map((value) => value.toString(16).padStart(2, '0')).join('');
+}
+
+async function findDraftIdForPhoto(url) {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  const bytes = await blob.arrayBuffer();
+  const digest = await sha256(bytes);
+  const db = await openDeviceDb();
+  try {
+    const records = await new Promise((resolve, reject) => {
+      const request = db.transaction(DEVICE_STORE, 'readonly').objectStore(DEVICE_STORE).getAll();
+      request.onsuccess = () => resolve(Array.isArray(request.result) ? request.result : []);
+      request.onerror = () => reject(request.error || new Error('Private photo storage could not be read.'));
+    });
+    const candidates = records
+      .filter((record) => String(record?.draftId || '').startsWith('vp-') && record?.bytes)
+      .filter((record) => Number(record.bytes.byteLength || 0) === Number(bytes.byteLength || 0))
+      .sort((a, b) => Number(b.savedAt || 0) - Number(a.savedAt || 0));
+
+    if (!candidates.length) throw new Error('VoxelPop could not reconnect this photo to its paid creation.');
+    if (!digest) return String(candidates[0].draftId);
+    for (const record of candidates) {
+      try {
+        if (await sha256(record.bytes) === digest) return String(record.draftId);
+      } catch {}
+    }
+    throw new Error('VoxelPop could not reconnect this photo to its paid creation.');
+  } finally {
+    db.close();
+  }
+}
+
+async function loadRawImage(url) {
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const response = await fetch(url);
+      const blob = await response.blob();
+      return await createImageBitmap(blob);
+    } catch {}
+  }
+
+  const image = new Image();
+  image.decoding = 'async';
+  if (!isLocalUrl(url)) image.crossOrigin = 'anonymous';
+  await new Promise((resolve, reject) => {
+    image.onload = resolve;
+    image.onerror = () => reject(new Error('The house photo could not be prepared for VoxelPop.'));
+    image.src = url;
+  });
+  try { await image.decode?.(); } catch {}
+  return image;
+}
+
+async function prepareReference(url) {
+  const image = await loadRawImage(url);
+  try {
+    const sourceW = Math.max(2, image.width || image.naturalWidth || 960);
+    const sourceH = Math.max(2, image.height || image.naturalHeight || 640);
+    const scale = Math.min(1, REFERENCE_MAX_EDGE / Math.max(sourceW, sourceH));
+    const width = Math.max(2, Math.round(sourceW * scale));
+    const height = Math.max(2, Math.round(sourceH * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('This browser cannot prepare the house photo for VoxelPop.');
+    context.drawImage(image, 0, 0, width, height);
+    for (const quality of [0.9, 0.82, 0.74, 0.66, 0.58]) {
+      const data = canvas.toDataURL('image/jpeg', quality);
+      if (data.length <= 5_200_000) return data;
+    }
+    throw new Error('This house photo is too large for VoxelPop. Try a screenshot or a smaller photo.');
+  } finally {
+    image.close?.();
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function generateVoxelPhoto(sourceUrl) {
+  const [draftId, reference, client] = await Promise.all([
+    findDraftIdForPhoto(sourceUrl),
+    prepareReference(sourceUrl),
+    getSupabaseBrowserAsync(),
+  ]);
+  const { data } = await client.auth.getSession();
+  const token = String(data?.session?.access_token || '');
+  if (!token) throw new Error('Sign in again before generating the VoxelPop image.');
+
+  const start = await fetch('/api/property-voxel-photo', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ draftId, reference }),
+  });
+  const started = await start.json().catch(() => ({}));
+  if (!start.ok || !started?.ok || !started?.taskId || !started?.taskToken) {
+    throw new Error(started?.error || 'VoxelPop image generation could not start.');
+  }
+
+  for (let attempt = 0; attempt < 90; attempt += 1) {
+    if (attempt > 0) await sleep(1500);
+    const params = new URLSearchParams({
+      draftId,
+      taskId: String(started.taskId),
+      taskToken: String(started.taskToken),
+    });
+    const response = await fetch(`/api/property-voxel-photo?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    });
+    const state = await response.json().catch(() => ({}));
+    if (!response.ok || !state?.ok) throw new Error(state?.error || 'VoxelPop image generation failed.');
+    if (state.ready && state.imageDataUrl) return String(state.imageDataUrl);
+  }
+  throw new Error('VoxelPop image generation took too long. Try the photo again; you will not be charged twice.');
+}
+
+async function resolvePropertyRender(url) {
+  const sourceUrl = String(url || '');
+  if (!sourceUrl.startsWith('blob:') || typeof window === 'undefined' || window.location.pathname !== '/property') {
+    return sourceUrl;
+  }
+
+  const map = renderMap();
+  if (map?.[sourceUrl]) return String(map[sourceUrl]);
+  const promises = renderPromises();
+  if (!promises) return sourceUrl;
+  if (!promises[sourceUrl]) {
+    promises[sourceUrl] = generateVoxelPhoto(sourceUrl)
+      .then((generated) => {
+        map[sourceUrl] = generated;
+        return generated;
+      })
+      .catch((error) => {
+        delete promises[sourceUrl];
+        throw error;
+      });
+  }
+  return promises[sourceUrl];
+}
+
 /**
- * Loads an image URL into a canvas raster, preferring createImageBitmap
- * (works for blob: and data: URLs and same-origin assets) and falling back to
- * HTMLImageElement + decode(). Caps the longest edge at MAX_EDGE for
- * performance, then probes a corner for near-black or empty pixels.
+ * Loads an image URL into a canvas raster. In the paid /property flow, a
+ * device-local house photo is first transformed into the approved VoxelPop
+ * image and cached in-memory for the later movable 3D voxel stage.
  *
  * @param {string} url - Any URL including blob: / data: object URLs.
  * @returns {Promise<{canvas: HTMLCanvasElement, width: number, height: number}>}
- * @throws {Error} If the image cannot be loaded or appears empty/black.
  */
 export async function rasterizeImageUrl(url) {
+  const resolvedUrl = await resolvePropertyRender(url);
   let bitmap = null;
 
   try {
     if (typeof createImageBitmap === 'function') {
-      const response = await fetch(url);
+      const response = await fetch(resolvedUrl);
       const blob = await response.blob();
       bitmap = await createImageBitmap(blob);
     }
@@ -31,13 +208,12 @@ export async function rasterizeImageUrl(url) {
 
   if (!bitmap) {
     const img = new Image();
-    // Never set crossOrigin for data:/blob:/relative paths — it can block decoding.
-    if (!isLocalUrl(url)) img.crossOrigin = 'anonymous';
+    if (!isLocalUrl(resolvedUrl)) img.crossOrigin = 'anonymous';
     img.decoding = 'async';
     await new Promise((resolve, reject) => {
-      img.onload = () => resolve();
-      img.onerror = () => reject(new Error('The photo could not be opened for the 3D voxel photo.'));
-      img.src = url;
+      img.onload = resolve;
+      img.onerror = () => reject(new Error('The VoxelPop image could not be opened for the 3D voxel.'));
+      img.src = resolvedUrl;
     });
     try { await img.decode?.(); } catch {}
     bitmap = img;
@@ -71,7 +247,7 @@ export async function rasterizeImageUrl(url) {
   const totalProbe = probeW * probeH;
   const avgLuma = opaqueCount > 0 ? lumaSum / opaqueCount : 0;
   if (opaqueCount < totalProbe * 0.05 || avgLuma < 4) {
-    throw new Error('The photo appears empty or black — please use a JPG or PNG photo and try again.');
+    throw new Error('The VoxelPop image appears empty or black — choose the photo again and retry.');
   }
 
   return { canvas: raster, width: rasterW, height: rasterH };

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const property = read('app/property/PropertyJourneySimple.js');
 const photoPreview = read('app/property/PhotoReliefModelViewer.js');
+const rasterizer = read('app/property/rasterizeImageUrl.js');
+const voxelPhotoRoute = read('app/api/property-voxel-photo/route.ts');
 const checkout = read('app/api/property-generation/checkout/route.ts');
 const paidVerify = read('app/api/property-photo-upload/route.ts');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
@@ -21,15 +23,24 @@ assert.match(property, /sourcePhotoRetainedOnDevice: true/, 'saved records keep 
 assert.match(property, /setPaidSessionId\('saved-property'\)/, 'a previously paid saved property is recognized as paid');
 assert.match(property, /No second creation charge|not be charged twice|no second charge/i, 'saved paid properties never require a duplicate creation payment');
 
+assert.match(rasterizer, /\/api\/property-voxel-photo/, 'the paid house photo is transformed through the dedicated VoxelPop image endpoint before review');
+assert.match(rasterizer, /RENDER_MAP_KEY/, 'the approved generated image is cached for the final movable-voxel stage');
+assert.match(rasterizer, /findDraftIdForPhoto/, 'the device photo is rebound to its paid property draft before provider generation');
+assert.match(voxelPhotoRoute, /listPaidPropertyCollectiblesForBuyer/, 'image generation requires a permanently paid one-property reservation');
+assert.match(voxelPhotoRoute, /MESHY_PROPERTY_CREDITS\.voxelImage/, 'the image stage uses only the bounded Meshy image-generation credit budget');
+assert.match(voxelPhotoRoute, /reference_image_urls: \[reference\]/, 'the generated image stays conditioned on the authorized house photo');
+assert.match(voxelPhotoRoute, /Preserve visible roof shape and pitch/, 'the generation prompt prioritizes the visible house identity');
+assert.match(voxelPhotoRoute, /imageDataUrl/, 'the completed provider image is returned as a sampling-safe data URL for local 3D conversion');
+
 assert.match(property, /PhotoReliefModelViewer/, 'the real 3D voxel photo remains a distinct review stage');
-assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'the source image supplies voxel color data');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'the generated VoxelPop image supplies voxel color data');
 assert.match(photoPreview, /new THREE\.InstancedMesh/, 'the review uses real voxel instances');
 assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'the review is physical cube geometry');
 assert.match(property, /Looks good · continue/, 'one explicit approval is required before movable-voxel generation');
 assert.match(property, /function approvePreviewAndBuildVoxel\(\)/, 'movable-voxel generation has an explicit post-preview gate');
-assert.doesNotMatch(property, /createVoxelPoster|voxelPoster/, 'no 2D voxel poster is inserted after approval');
+assert.doesNotMatch(property, /createVoxelPoster|voxelPoster/, 'no fake 2D voxel poster is inserted after approval');
 
-assert.match(property, /LocalVoxelModelViewer imageUrl=\{pendingPreview\} sourceImageUrl=\{pendingPreview\}/, 'movable voxel builds directly from the approved photo');
+assert.match(property, /LocalVoxelModelViewer imageUrl=\{pendingPreview\} sourceImageUrl=\{pendingPreview\}/, 'the movable voxel stays on the same approved creation handoff');
 assert.match(property, /\/api\/property-local-voxel/, 'the finished local voxel is registered for continuity and minting');
 assert.match(property, /const localSaved = savePropertyDraft\(finishedDraft\)/, 'the finished voxel is saved to Vault automatically');
 assert.match(property, /Open Vault/, 'completion sends the user to the saved result with one primary action');
@@ -37,22 +48,22 @@ assert.match(property, /Mint NFT · optional/, 'mint remains optional and second
 assert.match(vault, /directMintHref/, 'saved local voxels can recover their optional mint route from Vault');
 assert.match(vault, /MINT · OPTIONAL/, 'Vault keeps minting optional');
 
-assert.match(viewer, /sampleRecipe/, 'the interactive local voxel derives from the property photo');
+assert.match(viewer, /sampleRecipe/, 'the interactive local voxel derives from the approved creation image');
 assert.match(viewer, /rawMask/, 'the viewer separates the building from background');
 assert.match(viewer, /InstancedMesh/, 'the movable voxel uses actual Three.js voxel instances');
 assert.match(viewer, /DRAG BUILDING · PINCH TO ZOOM/, 'the local voxel stays interactive on iPhone');
 assert.match(localVoxel, /saveLocalVoxelRecord/, 'local voxel persists an account-bound record');
 assert.match(localVoxel, /buildGltf\(recipe\)/, 'saved local recipes remain reconstructable as glTF');
 
-assert.match(checkout, /generation_engine: PROPERTY_VOXEL_GENERATION_ENGINE/, 'checkout explicitly selects the local generation engine');
-assert.match(checkout, /source_storage: 'device-local'/, 'checkout does not imply source upload');
-assert.doesNotMatch(checkout, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|meshyCreditsSufficient|stagePaidPropertyPhoto/i, 'paid checkout never calls Meshy capacity checks');
-assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|api\.meshy|image-to-3d|storage\.from/i, 'paid resume never calls Meshy or source-photo cloud storage');
+assert.match(checkout, /generation_engine: PROPERTY_VOXEL_GENERATION_ENGINE/, 'checkout explicitly selects the paid creation entitlement');
+assert.match(checkout, /source_storage: 'device-local'/, 'checkout itself does not upload the source photo');
+assert.doesNotMatch(checkout, /MESHY_PROPERTY_CREDITS|readMeshyCreditBalance|meshyCreditsSufficient|stagePaidPropertyPhoto/i, 'paid checkout never calls provider capacity checks');
+assert.doesNotMatch(paidVerify, /MESHY_PROPERTY_CREDITS|api\.meshy|image-to-3d|storage\.from/i, 'paid resume only verifies payment and never starts provider generation');
 assert.doesNotMatch(property, /\/api\/property-collectible\/quote|\/api\/property-collectible\/checkout|collectAndSave/, 'normal creation has no second paid collectible funnel');
-assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided creation does not call metered provider routes');
+assert.doesNotMatch(property, /\/api\/property-voxel-3d|\/api\/property-voxel-image/, 'guided creation does not call the old multi-pass metered provider routes');
 
 assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint checks the exact account-owned finished voxel');
-assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint does not reintroduce Meshy');
+assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint does not reintroduce provider generation');
 assert.match(mintPage, /Mint Later/, 'the mint page keeps minting optional');
 
-console.log('VoxelPop creation regression passed: new or saved photo -> one paid unlock -> real 3D voxel-photo review -> one approval -> automatic movable voxel -> automatic Vault save -> optional mint.');
+console.log('VoxelPop creation regression passed: house photo + confirmed address -> one paid lock -> generated VoxelPop image -> real 3D voxel-photo review -> approval -> movable voxel -> automatic Vault save -> optional one-time mint.');


### PR DESCRIPTION
Adds the requested property creation sequence while preserving the current creator UI and existing address, Vault, and mint behavior.

Changes:
- add a house-photo to VoxelPop image route
- require the existing completed property creation entitlement before generation
- use the generated image in the existing review renderer
- reuse that same image in the final local 3D voxel builder
- keep the final voxel saved in Vault with the existing optional mint action
- update privacy copy and regression coverage

The final 3D model remains the existing local Three.js/glTF voxel rather than adding another provider 3D pass.