### PR TITLE
Fix stale VoxelPop v2 Meshy guard

### DIFF
--- a/scripts/test-meshy-polycount-limit.mjs
+++ b/scripts/test-meshy-polycount-limit.mjs
@@ -6,14 +6,15 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), '
 const paidPhotoRoute = read('app/api/property-photo-upload/route.ts');
 const property3dRoute = read('app/api/property-voxel-3d/route.ts');
 
-// The guided paid Property maker is deliberately local now. Keep this guard
-// explicit so a future change cannot silently reconnect its paid photo resume
-// route to a metered Meshy generation request.
-assert.match(paidPhotoRoute, /provider:\s*'voxelpop-local-webgl-v1'/, 'paid photo resume must declare the local VoxelPop engine');
-assert.doesNotMatch(paidPhotoRoute, /ai_model:\s*'meshy-t2'|target_polycount|api\.meshy|image-to-3d/i, 'paid photo resume must not call the Meshy generation API');
+// The paid house flow may use the configured VoxelPop image provider for the
+// transient voxel-image review, but its final interactive 3D build stays on
+// the local WebGL v2 engine. Keep this guard explicit so a future change
+// cannot silently reconnect the paid resume route to metered Meshy 3D.
+assert.match(paidPhotoRoute, /provider:\s*'[^']*voxelpop-local-webgl-v2[^']*'/, 'paid photo resume must declare the local VoxelPop WebGL v2 engine');
+assert.doesNotMatch(paidPhotoRoute, /ai_model:\s*'meshy-t2'|target_polycount|api\.meshy|image-to-3d/i, 'paid photo resume must not call the Meshy 3D generation API');
 
 // Standalone/legacy provider-backed 3D routes still keep their Meshy contract
-// bounded correctly when they are used outside the no-credit guided flow.
+// bounded correctly when they are used outside the guided house flow.
 assert.match(property3dRoute, /ai_model:\s*'meshy-t2'/, 'standalone voxel image -> 3D must keep the intended Meshy model explicit');
 const polycounts = [...property3dRoute.matchAll(/target_polycount:\s*(\d+)/g)].map((match) => Number(match[1]));
 assert.ok(polycounts.length > 0, 'standalone Meshy 3D route must declare a target polycount');
@@ -22,4 +23,4 @@ for (const value of polycounts) {
 }
 assert.ok(polycounts.includes(15000), 'standalone Meshy 3D route should use the supported meshy-t2 maximum of 15000');
 
-console.log('Meshy/local generation guard passed: the paid guided photo flow stays local/no-credit, while standalone Meshy 3D requests remain within the meshy-t2 100..15000 range.');
+console.log('Meshy/local generation guard passed: the paid house flow keeps its final 3D build local/WebGL v2, while standalone Meshy 3D requests remain within the meshy-t2 100..15000 range.');


### PR DESCRIPTION
Updates the legacy Meshy polycount regression to recognize the current VoxelPop house flow: transient image-provider review plus `voxelpop-local-webgl-v2` for the final interactive 3D build. No app behavior changes. Keeps the guard that the paid resume route must not call Meshy 3D generation and keeps the standalone Meshy polycount bounds intact.