### PR TITLE
Finish house photo → voxel image → generated 3D → inventory → mint

### DIFF
--- a/app/api/property-generation/finalize/route.ts
+++ b/app/api/property-generation/finalize/route.ts
@@ -4,12 +4,13 @@ import { normalizePropertyDraftId } from '../../../../lib/property-generation-id
 import {
   readPropertyCollectibleReservation,
   updatePropertyCollectibleReservation,
+  verifyOwnedFinalVoxelModel,
 } from '../../../../lib/property-collectible-commerce';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-function clean(value: unknown, max = 300) {
+function clean(value: unknown, max = 420) {
   return String(value || '').trim().slice(0, max);
 }
 
@@ -28,22 +29,33 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const draftId = normalizePropertyDraftId(body?.draftId);
     const identityKey = clean(body?.identityKey, 100);
-    const taskId = clean(body?.taskId, 260);
-    if (!identityKey || !taskId.startsWith('local-v1:')) {
-      return privateJson({ ok: false, error: 'A confirmed property and finished voxel are required.' }, { status: 400 });
+    const modelTaskId = clean(body?.modelTaskId || body?.taskId, 420);
+    if (!identityKey || !modelTaskId) {
+      return privateJson({ ok: false, error: 'A confirmed property and finished generated 3D voxel are required.' }, { status: 400 });
     }
 
     const reservation = await readPropertyCollectibleReservation(identityKey);
     if (!reservation) return privateJson({ ok: false, error: 'The property confirmation expired. Confirm the address again.' }, { status: 409 });
     if (reservation.buyerId !== auth.user.id) return privateJson({ ok: false, error: 'This property confirmation belongs to another account.' }, { status: 403 });
     if (reservation.draftId !== draftId) return privateJson({ ok: false, error: 'This property confirmation belongs to another creation.' }, { status: 409 });
+    if (reservation.state === 'minted') return privateJson({ ok: false, alreadyMinted: true, error: 'This property has already been minted.' }, { status: 409 });
+
+    const owned = await verifyOwnedFinalVoxelModel({
+      userId: auth.user.id,
+      draftId,
+      modelTaskId,
+      atlasId: reservation.atlasId,
+    });
+    if (!owned.savedModel || !owned.modelUrl) {
+      return privateJson({ ok: false, error: 'Finish the generated 3D voxel before saving it to your Vault.' }, { status: 409 });
+    }
 
     const finalized = await updatePropertyCollectibleReservation({
       identityKey,
       buyerId: auth.user.id,
       state: 'paid',
-      source: 'photo-voxel-complete',
-      sourceId: taskId,
+      source: 'photo-voxel-generated-3d-complete',
+      sourceId: modelTaskId,
     });
 
     return privateJson({
@@ -52,8 +64,13 @@ export async function POST(request: Request) {
       identityKey,
       atlasId: finalized.atlasId,
       address: finalized.address,
-      taskId,
+      taskId: modelTaskId,
+      modelTaskId,
+      modelUrl: owned.modelUrl,
+      modelProvider: clean(owned.savedModel.provider, 120),
+      onePropertyOnePurchase: true,
       onePropertyOneMint: true,
+      digitalOnly: true,
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'The finished property voxel could not be locked.' }, { status: 500 });

--- a/app/api/property-voxel-nft/metadata/route.ts
+++ b/app/api/property-voxel-nft/metadata/route.ts
@@ -1,24 +1,18 @@
 import { NextResponse } from 'next/server';
 import { readCatalog3DByTask } from '../../../../lib/catalog3dStore';
 import { normalizePropertyDraftId } from '../../../../lib/property-generation-ids';
+import { propertyGenerationModelUrl } from '../../../../lib/property-generation-model';
 import { verifyPropertyVoxelMetadataSignature } from '../../../../lib/property-voxel-mint';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const PROVIDER = 'voxelpop-local-webgl-v1';
+const LOCAL_PROVIDER = 'voxelpop-local-webgl-v1';
 const RECIPE_PREFIX = 'local-voxel-recipe-v1:';
 
-function clean(value: unknown, max = 300) {
-  return String(value || '').trim().slice(0, max);
-}
+function clean(value: unknown, max = 300) { return String(value || '').trim().slice(0, max); }
 function escapeXml(value: unknown) {
-  return String(value ?? '')
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&apos;');
+  return String(value ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&apos;');
 }
 function decodeRecipe(value: unknown) {
   const text = clean(value, 12000);
@@ -30,10 +24,10 @@ function decodeRecipe(value: unknown) {
   const colors = Array.isArray(parsed?.colors) ? parsed.colors.slice(0, count).map((item: unknown) => clean(item, 6).toLowerCase()) : [];
   const depths = Array.isArray(parsed?.depths) ? parsed.depths.slice(0, count).map((item: unknown) => Math.max(0, Math.min(9, Math.trunc(Number(item) || 0)))) : [];
   if (Number(parsed?.version) !== 1 || width < 8 || height < 8 || width > 24 || height > 24 || colors.length !== count || depths.length !== count) throw new Error('Local voxel recipe is invalid.');
-  if (colors.some((value: string) => !/^[a-f0-9]{6}$/.test(value))) throw new Error('Local voxel colors are invalid.');
+  if (colors.some((entry: string) => !/^[a-f0-9]{6}$/.test(entry))) throw new Error('Local voxel colors are invalid.');
   return { width, height, colors, depths };
 }
-function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
+function localThumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
   const cell = 34;
   const artWidth = recipe.width * cell;
   const artHeight = recipe.height * cell;
@@ -58,7 +52,7 @@ function thumbnail(recipe: ReturnType<typeof decodeRecipe>, name: string) {
     <g>${blocks.join('')}</g>
     <text x="70" y="86" fill="#c9ff54" font-family="Arial,sans-serif" font-size="25" font-weight="800" letter-spacing="6">VOXELPOP · PROPERTY VOXEL</text>
     <text x="70" y="1060" fill="#ffffff" font-family="Arial,sans-serif" font-size="62" font-weight="800">${escapeXml(name)}</text>
-    <text x="70" y="1115" fill="#cfc4dc" font-family="Arial,sans-serif" font-size="23">PHOTO-APPROVED 3D → LOCAL VOXEL → DIGITAL NFT</text>
+    <text x="70" y="1115" fill="#cfc4dc" font-family="Arial,sans-serif" font-size="23">PHOTO → VOXEL IMAGE → 3D VOXEL → DIGITAL NFT</text>
     <text x="70" y="1150" fill="#9286a0" font-family="Arial,sans-serif" font-size="18">DIGITAL COLLECTIBLE ONLY · NOT A DEED OR PHYSICAL-PROPERTY RIGHT</text>
   </svg>`;
 }
@@ -67,48 +61,65 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const draftId = normalizePropertyDraftId(clean(url.searchParams.get('draftId'), 100));
-    const taskId = clean(url.searchParams.get('taskId'), 260);
+    const taskId = clean(url.searchParams.get('taskId'), 420);
     const name = clean(url.searchParams.get('name'), 72) || 'VoxelPop Property';
     const sig = clean(url.searchParams.get('sig'), 128);
-    if (!taskId.startsWith('local-v1:') || !verifyPropertyVoxelMetadataSignature(draftId, taskId, name, sig)) {
+    if (!taskId || !verifyPropertyVoxelMetadataSignature(draftId, taskId, name, sig)) {
       return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
     }
+
     const model = await readCatalog3DByTask(taskId);
-    if (!model || model.provider !== PROVIDER || !model.source_image_url) {
+    if (!model || (!model.model_storage_path && !model.model_url && model.provider !== LOCAL_PROVIDER)) {
       return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
     }
-    const recipe = decodeRecipe(model.source_image_url);
-    const svg = thumbnail(recipe, name);
-    const image = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
-    const animationUrl = `${url.origin}/api/property-local-voxel?taskId=${encodeURIComponent(taskId)}`;
+
+    let image = '';
+    let animationUrl = '';
+    let engine = 'VoxelPop AI 3D';
+    const local = model.provider === LOCAL_PROVIDER && taskId.startsWith('local-v1:');
+
+    if (local) {
+      if (!model.source_image_url) return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
+      const svg = localThumbnail(decodeRecipe(model.source_image_url), name);
+      image = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+      animationUrl = `${url.origin}/api/property-local-voxel?taskId=${encodeURIComponent(taskId)}`;
+      engine = 'VoxelPop Local WebGL';
+    } else {
+      const apiKey = process.env.MESHY_API_KEY?.trim();
+      if (!apiKey) return NextResponse.json({ error: 'Property voxel metadata is temporarily unavailable.' }, { status: 503 });
+      const modelPath = propertyGenerationModelUrl(apiKey, taskId);
+      if (!modelPath) return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });
+      const absoluteModel = new URL(modelPath, url.origin);
+      const preview = new URL(absoluteModel);
+      preview.searchParams.set('preview', '1');
+      animationUrl = absoluteModel.toString();
+      image = preview.toString();
+    }
+
     return NextResponse.json({
       name: `${name} · VoxelPop`,
-      description: 'A photo-approved VoxelPop digital property voxel. The user saw the source-faithful 3D preview before creating this local voxel. This NFT is a digital collectible only and does not convey deed/title, occupancy, rent, investment, appraisal, or other rights in physical real estate.',
+      description: 'A one-of-one VoxelPop digital property voxel created from an authorized house photo after confirming the property address. The NFT represents the finished digital 3D voxel only and does not convey deed/title, occupancy, rent, investment, appraisal, or other rights in physical real estate.',
       image,
       animation_url: animationUrl,
       external_url: `${url.origin}/property`,
       attributes: [
         { trait_type: 'Asset Type', value: 'VoxelPop Property Voxel' },
-        { trait_type: 'Creation Flow', value: 'Photo → 3D Preview → Voxel' },
-        { trait_type: '3D Engine', value: 'VoxelPop Local WebGL' },
-        { trait_type: 'Meshy Credits', value: 'Not used' },
-        { trait_type: 'Source Preview Approved', value: 'Yes' },
+        { trait_type: 'Creation Flow', value: local ? 'Photo → Voxel → 3D' : 'Photo → Voxel Image → Generated 3D Voxel' },
+        { trait_type: '3D Engine', value: engine },
+        { trait_type: 'Property Identity', value: 'Address Confirmed' },
+        { trait_type: 'Mint Limit', value: 'One per property' },
         { trait_type: 'Real Property Rights', value: 'None' },
         { trait_type: 'Deed / Title', value: 'None' },
-        { trait_type: 'Rent / Occupancy Rights', value: 'None' },
       ],
       properties: {
         digital_only: true,
-        photo_source_stored_in_metadata: false,
-        source_photo_uploaded_for_generation: false,
+        one_property_one_mint: true,
+        source_photo_in_metadata: false,
         real_property_rights: false,
         deed_or_title: false,
       },
     }, {
-      headers: {
-        'Cache-Control': 'public, max-age=300, s-maxage=3600',
-        'X-Robots-Tag': 'noindex',
-      },
+      headers: { 'Cache-Control': 'public, max-age=300, s-maxage=3600', 'X-Robots-Tag': 'noindex' },
     });
   } catch {
     return NextResponse.json({ error: 'Property voxel metadata is unavailable.' }, { status: 404 });

--- a/app/api/property-voxel-nft/prepare/route.ts
+++ b/app/api/property-voxel-nft/prepare/route.ts
@@ -8,7 +8,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
-const LOCAL_PROVIDER = 'voxelpop-local-webgl-v1';
 
 function clean(value: unknown, max = 300) { return String(value || '').trim().slice(0, max); }
 function privateJson(body: unknown, init: ResponseInit = {}) { return NextResponse.json(body, { ...init, headers: { 'Cache-Control': 'private, no-store, max-age=0', ...(init.headers || {}) } }); }
@@ -19,17 +18,19 @@ export async function POST(request: Request) {
   try {
     const body = await request.json().catch(() => ({}));
     const draftId = clean(body?.draftId, 100);
-    const taskId = clean(body?.taskId, 260);
+    const taskId = clean(body?.taskId, 420);
     const wallet = clean(body?.wallet, 60);
     const name = clean(body?.name, 72) || 'VoxelPop Property';
     if (!draftId || !taskId || !ADDRESS_RE.test(wallet)) return privateJson({ ok: false, error: 'A finished property voxel and connected wallet are required.' }, { status: 400 });
 
+    // Only the signed-in user's account-owned final `voxel` phase model can mint.
+    // The UI cannot substitute an arbitrary model URL or task ID.
     const owned = await verifyOwnedFinalVoxelModel({ userId: auth.user.id, draftId, modelTaskId: taskId });
-    if (!owned.savedModel || owned.savedModel.provider !== LOCAL_PROVIDER || !taskId.startsWith('local-v1:')) return privateJson({ ok: false, error: 'Finish the local photo-approved voxel before minting.' }, { status: 409 });
+    if (!owned.savedModel || !owned.modelUrl) return privateJson({ ok: false, error: 'Finish and save the generated 3D voxel before minting.' }, { status: 409 });
 
     const reservations = await listPaidPropertyCollectiblesForBuyer(auth.user.id);
     const reservation = reservations.find((item) => item.draftId === owned.draftId) || null;
-    if (!reservation) return privateJson({ ok: false, error: 'This property does not have a paid one-of-one purchase lock for this account.' }, { status: 403 });
+    if (!reservation) return privateJson({ ok: false, error: 'This property does not have a finalized one-of-one collectible lock for this account.' }, { status: 403 });
     if (reservation.state === 'minted') return privateJson({ ok: false, alreadyMinted: true, error: 'This property has already been minted. A second NFT for the same property is blocked.' }, { status: 409 });
     const propertyIdentity = reservation.identityKey;
 
@@ -43,7 +44,28 @@ export async function POST(request: Request) {
     catch { return privateJson({ ok: false, error: 'Base could not be checked safely. No mint was sent. Try again before approving a wallet transaction.' }, { status: 503 }); }
     if (used) return privateJson({ ok: false, alreadyMinted: true, error: 'This property has already used its one-time VoxelFlip mint voucher. A duplicate mint is blocked.' }, { status: 409 });
 
-    return privateJson({ ok: true, ready: true, mintConfigured: true, wallet, draftId: owned.draftId, taskId, propertyIdentity, atlasId: reservation.atlasId, propertyAddress: reservation.address, modelUrl: owned.modelUrl, metadataUrl: voucher.metadataUrl, voucherId: voucher.voucherId, signature: voucher.signature, signer: voucher.signer, contractAddress: deployment.address, chainId: deployment.chainId, network: deployment.network, onePropertyOneMint: true, digitalOnly: true, noMeshy: true });
+    return privateJson({
+      ok: true,
+      ready: true,
+      mintConfigured: true,
+      wallet,
+      draftId: owned.draftId,
+      taskId,
+      propertyIdentity,
+      atlasId: reservation.atlasId,
+      propertyAddress: reservation.address,
+      modelUrl: owned.modelUrl,
+      modelProvider: clean(owned.savedModel.provider, 120),
+      metadataUrl: voucher.metadataUrl,
+      voucherId: voucher.voucherId,
+      signature: voucher.signature,
+      signer: voucher.signer,
+      contractAddress: deployment.address,
+      chainId: deployment.chainId,
+      network: deployment.network,
+      onePropertyOneMint: true,
+      digitalOnly: true,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Property voxel mint could not be prepared.';
     return privateJson({ ok: false, error: message }, { status: /does not belong|signed-in|valid|required/i.test(message) ? 403 : 500 });

--- a/app/api/property-voxel-photo/route.ts
+++ b/app/api/property-voxel-photo/route.ts
@@ -2,7 +2,7 @@ import { createHmac } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultUser } from '../../../lib/user-auth';
 import { normalizePropertyDraftId } from '../../../lib/property-generation-ids';
-import { listPaidPropertyCollectiblesForBuyer } from '../../../lib/property-collectible-commerce';
+import { readPropertyCollectibleReservation } from '../../../lib/property-collectible-commerce';
 import {
   MESHY_PROPERTY_CREDITS,
   meshyClientStatus,
@@ -37,6 +37,12 @@ function taskToken(apiKey: string, userId: string, draftId: string, taskId: stri
     .digest('hex');
 }
 
+function final3dTaskToken(apiKey: string, userId: string, taskId: string) {
+  return createHmac('sha256', apiKey)
+    .update(`property-voxel-image-v1:${userId}:${taskId}`)
+    .digest('hex');
+}
+
 function parseReferenceDataUrl(input: unknown) {
   const reference = String(input || '').trim();
   const match = reference.match(/^data:(image\/(?:jpeg|png|webp));base64,([A-Za-z0-9+/=]+)$/i);
@@ -48,11 +54,15 @@ function parseReferenceDataUrl(input: unknown) {
   return reference;
 }
 
-async function verifyPaidDraft(userId: string, draftId: string) {
-  const paid = await listPaidPropertyCollectiblesForBuyer(userId);
-  const reservation = paid.find((item) => item.draftId === draftId) || null;
-  if (!reservation) {
-    throw new Error('Finish the one-property checkout before generating the VoxelPop image.');
+async function verifyConfirmedDraft(userId: string, draftId: string, identityKeyRaw: unknown) {
+  const identityKey = clean(identityKeyRaw, 96);
+  if (!identityKey) throw new Error('Confirm the property address before generating the voxel.');
+  const reservation = await readPropertyCollectibleReservation(identityKey);
+  if (!reservation || reservation.buyerUserId !== userId || reservation.draftId !== draftId) {
+    throw new Error('That confirmed property does not belong to this signed-in creation.');
+  }
+  if (!['reserved', 'paid', 'minted'].includes(reservation.state)) {
+    throw new Error('Confirm the property address before generating the voxel.');
   }
   return reservation;
 }
@@ -93,12 +103,14 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const draftId = normalizePropertyDraftId(body?.draftId);
     const reference = parseReferenceDataUrl(body?.reference);
-    const reservation = await verifyPaidDraft(auth.user.id, draftId);
+    const reservation = await verifyConfirmedDraft(auth.user.id, draftId, body?.identityKey);
 
+    // The user asked for one uninterrupted flow. Do not spend the image credits
+    // unless there are enough provider credits left to also create the final GLB.
     const balance = await readMeshyCreditBalance(apiKey);
-    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.voxelImage)) {
+    if (!meshyCreditsSufficient(balance, MESHY_PROPERTY_CREDITS.afterSource)) {
       return privateJson(
-        meshyCreditError('starting the VoxelPop house image', MESHY_PROPERTY_CREDITS.voxelImage),
+        meshyCreditError('starting the VoxelPop image and final 3D build', MESHY_PROPERTY_CREDITS.afterSource),
         { status: 503 },
       );
     }
@@ -136,10 +148,14 @@ export async function POST(request: Request) {
       ok: true,
       taskId,
       taskToken: taskToken(apiKey, auth.user.id, draftId, taskId),
+      voxelImageTaskToken: final3dTaskToken(apiKey, auth.user.id, taskId),
       draftId,
       atlasId: reservation.atlasId,
+      identityKey: reservation.identityKey,
       propertyAddress: reservation.address,
       provider: 'meshy-nano-banana-voxelpop',
+      onePropertyOnePurchase: true,
+      onePropertyOneMint: true,
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'VoxelPop image generation could not start.' }, { status: 400 });
@@ -195,6 +211,7 @@ export async function GET(request: Request) {
       ready: true,
       imageUrl: providerImageUrl,
       imageDataUrl: await imageDataUrl(providerImageUrl),
+      voxelImageTaskToken: final3dTaskToken(apiKey, auth.user.id, taskId),
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'VoxelPop image generation status could not be read.' }, { status: 400 });

--- a/app/property/mint/page.js
+++ b/app/property/mint/page.js
@@ -14,16 +14,14 @@ function storageKey(draftId, taskId) { return `voxelpop:property-mint:${draftId}
 export default function PropertyVoxelMintPage() {
   const [authReady, setAuthReady] = useState(false);
   const [session, setSession] = useState(null);
-  const [params, setParams] = useState({ draftId: '', taskId: '', name: 'VoxelPop Property' });
+  const [params, setParams] = useState({ draftId: '', taskId: '', name: 'VoxelPop Property', modelUrl: '' });
   const [wallet, setWallet] = useState('');
   const [busy, setBusy] = useState('');
   const [message, setMessage] = useState('Opening your finished voxel…');
   const [minted, setMinted] = useState(null);
   const clientRef = useRef(null);
 
-  const modelUrl = useMemo(() => params.taskId?.startsWith('local-v1:')
-    ? `/api/property-local-voxel?taskId=${encodeURIComponent(params.taskId)}`
-    : '', [params.taskId]);
+  const modelUrl = useMemo(() => clean(params.modelUrl), [params.modelUrl]);
 
   useEffect(() => {
     const query = new URLSearchParams(window.location.search);
@@ -31,6 +29,7 @@ export default function PropertyVoxelMintPage() {
       draftId: clean(query.get('draftId')),
       taskId: clean(query.get('taskId')),
       name: clean(query.get('name')) || 'VoxelPop Property',
+      modelUrl: clean(query.get('modelUrl')),
     };
     setParams(next);
     try {
@@ -97,12 +96,10 @@ export default function PropertyVoxelMintPage() {
         body: JSON.stringify({ draftId: params.draftId, taskId: params.taskId, wallet: connected.address, name: params.name }),
       });
       const prepared = await response.json().catch(() => ({}));
-      if (!response.ok || !prepared?.ready || !prepared?.signature) {
-        throw new Error(prepared?.error || 'This finished voxel could not be prepared for minting.');
-      }
+      if (!response.ok || !prepared?.ready || !prepared?.signature) throw new Error(prepared?.error || 'This finished voxel could not be prepared for minting.');
 
       setBusy('mint');
-      setMessage('Confirm the VoxelFlip mint in your wallet. This is the only blockchain transaction in this step.');
+      setMessage('Confirm the one-of-one mint in your wallet.');
       const result = await mintVoxelFlip({ metadataUrl: prepared.metadataUrl, voucherId: prepared.voucherId, signature: prepared.signature });
       if (!result?.tokenId || !result?.hash) throw new Error('The wallet transaction completed, but the token ID could not be read.');
 
@@ -121,9 +118,7 @@ export default function PropertyVoxelMintPage() {
         }),
       });
       const verified = await confirm.json().catch(() => ({}));
-      if (!confirm.ok || !verified?.verified) {
-        throw new Error(verified?.error || `VoxelFlip #${result.tokenId} was submitted, but Base verification is not complete. Do not mint it again.`);
-      }
+      if (!confirm.ok || !verified?.verified) throw new Error(verified?.error || `VoxelFlip #${result.tokenId} was submitted, but verification is not complete. Do not mint it again.`);
       const finalResult = { ...result, ...verified, verified: true };
       setMinted(finalResult);
       setWallet(finalResult.owner || connected.address);
@@ -140,36 +135,34 @@ export default function PropertyVoxelMintPage() {
     }
   }
 
-  const invalid = !params.draftId || !params.taskId?.startsWith('local-v1:');
+  const invalid = !params.draftId || !params.taskId || !modelUrl;
   if (!authReady) return <main className="page"><section className="shell"><div className="mark">V</div><h1>Opening mint…</h1><p className="status">{message}</p><style jsx>{styles}</style></section></main>;
 
   return <main className="page"><section className="shell">
-    <nav><Link href="/property">← CREATE</Link><span>VOXELPOP · MINT</span><Link href="/vault/property-drafts">VAULT</Link></nav>
+    <nav><Link href="/property">← CREATE</Link><span>VOXELPOP · MINT</span><Link href="/vault/property-drafts">INVENTORY</Link></nav>
 
-    {invalid ? <section className="notice"><b>Open Mint from a finished VoxelPop voxel.</b><Link href="/property">Create a voxel</Link></section> : <>
+    {invalid ? <section className="notice"><b>Open Mint from a finished VoxelPop 3D voxel.</b><Link href="/property">Create a voxel</Link></section> : <>
       <header>
-        <div className="paid">✓ 3D PICTURE APPROVED · 3D VOXEL READY</div>
+        <div className="ready">✓ 3D VOXEL SAVED · ONE MINT MAX</div>
         <h1>{minted ? 'Mint complete.' : 'Mint your voxel.'}</h1>
-        <p>{minted ? 'Your finished digital voxel is verified on Base.' : 'Your voxel is already saved in Vault. Minting is optional.'}</p>
+        <p>{minted ? 'Your digital voxel is verified on Base.' : 'It is already safe in your Voxel Vault inventory. Minting is optional.'}</p>
       </header>
 
-      <div className="viewer"><MeshyModelViewer modelUrl={modelUrl}/><span>{minted ? `VOXELFLIP #${minted.tokenId}` : 'FINAL 3D VOXEL'}</span></div>
+      <div className="viewer"><MeshyModelViewer modelUrl={modelUrl}/><span>{minted ? `VOXELFLIP #${minted.tokenId}` : 'YOUR GENERATED 3D VOXEL'}</span></div>
 
       {minted ? <section className="done">
         <div className="doneMark">✓</div>
         <b>VoxelFlip #{minted.tokenId}</b>
         <span>Verified owner · {short(minted.owner)}</span>
-        <div className="links">{minted.openSeaUrl ? <a href={minted.openSeaUrl} target="_blank" rel="noreferrer">View on OpenSea ↗</a> : null}{minted.explorerUrl ? <a href={minted.explorerUrl} target="_blank" rel="noreferrer">View transaction ↗</a> : null}<Link href="/vault/property-drafts">Open Vault</Link></div>
+        <div className="links">{minted.openSeaUrl ? <a href={minted.openSeaUrl} target="_blank" rel="noreferrer">OpenSea ↗</a> : null}{minted.explorerUrl ? <a href={minted.explorerUrl} target="_blank" rel="noreferrer">Transaction ↗</a> : null}<Link href="/vault/property-drafts">Open inventory</Link></div>
       </section> : <section className="actions">
-        {!session?.user ? <button className="primary" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Sign in to Mint'}</button> : <button className="primary" type="button" onClick={mint} disabled={Boolean(busy)}>{busy === 'wallet' ? 'Connecting wallet…' : busy === 'prepare' ? 'Checking voxel…' : busy === 'mint' ? 'Confirm in wallet…' : busy === 'verify' ? 'Verifying on Base…' : 'Mint Now'}</button>}
-        <Link className="later" href="/vault/property-drafts">Mint Later</Link>
-        <small>Optional minting · no wallet is required to keep the voxel in Vault.</small>
+        {!session?.user ? <button className="primary" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Sign in to mint'}</button> : <button className="primary" type="button" onClick={mint} disabled={Boolean(busy)}>{busy === 'wallet' ? 'Connecting wallet…' : busy === 'prepare' ? 'Checking voxel…' : busy === 'mint' ? 'Confirm in wallet…' : busy === 'verify' ? 'Verifying…' : 'Mint this voxel'}</button>}
+        <Link className="later" href="/vault/property-drafts">Keep in inventory</Link>
+        <small>One property can mint only one VoxelPop NFT.</small>
       </section>}
 
       {wallet && !minted ? <p className="wallet">Wallet · {short(wallet)}</p> : null}
       <p className="status" role="status">{message}</p>
-
-      <details className="details"><summary>Mint details</summary><div className="facts"><div><small>NETWORK</small><b>Base</b></div><div><small>MODEL</small><b>Photo-approved voxel</b></div><div><small>MESHY</small><b>Not used</b></div><div><small>PHYSICAL PROPERTY</small><b>No rights transferred</b></div></div><p>Your wallet approves the transaction itself; Voxel Vault does not auto-sign or auto-spend. The one-time voucher blocks a duplicate mint of the same finished voxel. The original property photo is not placed in NFT metadata.</p></details>
       <p className="truth">The NFT represents the finished digital VoxelPop voxel only. It is not the deed, title, equity, rent, occupancy, investment rights, or ownership of the physical property.</p>
     </>}
     <style jsx>{styles}</style>
@@ -177,4 +170,5 @@ export default function PropertyVoxelMintPage() {
 }
 
 const styles = `
-:global(body){margin:0;background:#fffaf2;color:#281b12;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.page{min-height:100vh;padding:12px 12px calc(108px + env(safe-area-inset-bottom));background:radial-gradient(circle at 10% 7%,rgba(255,224,166,.42),transparent 28%),radial-gradient(circle at 91% 9%,rgba(113,56,245,.13),transparent 29%),radial-gradient(circle at 50% 94%,rgba(201,255,84,.18),transparent 27%),#fffaf2}.shell{width:min(680px,100%);margin:auto;text-align:center}nav{height:48px;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:0 3px;font-size:8px;font-weight:1000;letter-spacing:.11em;color:#8c8179}nav a{color:#6b4db2;text-decoration:none;padding:8px}header{margin:30px auto 16px}.paid{display:inline-flex;padding:7px 10px;border:1px solid #cce99b;border-radius:999px;background:#f5ffe4;color:#527025;font-size:8px;font-weight:1000;letter-spacing:.09em}header h1{font-size:clamp(38px,8vw,54px);line-height:.95;letter-spacing:-.055em;margin:14px 0 9px}header p{margin:0 auto;color:#786e67;font-size:13px;line-height:1.5}.viewer{position:relative;width:100%;height:min(62vh,560px);min-height:390px;overflow:hidden;border:1px solid #e4dacf;border-radius:30px;background:#21172c;box-shadow:0 22px 54px rgba(70,47,87,.14)}.viewer>div{height:100%!important;min-height:100%!important}.viewer :global(.viewerShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.viewer>span{position:absolute;z-index:7;left:13px;top:13px;padding:8px 10px;border:1px solid rgba(255,255,255,.56);border-radius:999px;background:rgba(32,23,39,.76);color:#fff;font-size:7px;font-weight:1000;letter-spacing:.09em;backdrop-filter:blur(10px)}.actions{display:grid;gap:10px;margin-top:14px;padding:16px;border:1px solid #e7ded4;border-radius:24px;background:rgba(255,255,255,.94);box-shadow:0 14px 34px rgba(74,52,88,.07)}.primary,.later{width:100%;min-height:59px;border-radius:19px;display:flex;align-items:center;justify-content:center;font:950 17px inherit;text-decoration:none}.primary{border:0;background:linear-gradient(180deg,#7d43ff,#6730ec);color:#fff;box-shadow:0 6px 0 #5120d0,0 14px 27px rgba(113,56,245,.17);cursor:pointer}.primary:disabled{opacity:.55;box-shadow:none}.later{border:1px solid #ddd2eb;background:#fff;color:#6846b7;box-shadow:0 8px 20px rgba(76,54,91,.06)}.actions small{color:#938a83;font-size:9px;line-height:1.45}.status{min-height:18px;margin:13px auto 0;max-width:590px;color:#6f655e;font-size:10.5px;font-weight:700;line-height:1.5}.wallet{margin:12px 0 0;font-size:8px;color:#8c8179}.details{margin-top:13px;border:1px solid #e7ded4;border-radius:18px;background:rgba(255,255,255,.72);text-align:left;overflow:hidden}.details summary{cursor:pointer;padding:13px 15px;color:#716569;font-size:9px;font-weight:1000;letter-spacing:.06em;list-style:none}.details summary::-webkit-details-marker{display:none}.details[open] summary{border-bottom:1px solid #eee5dc}.details>p{margin:0;padding:12px 15px 15px;color:#8c8179;font-size:8px;line-height:1.55}.facts{display:grid;grid-template-columns:1fr 1fr;gap:7px;padding:12px}.facts div{padding:10px;border:1px solid #eee5dc;border-radius:13px;background:#fff}.facts small{display:block;color:#9a8e85;font-size:6.5px;font-weight:1000;letter-spacing:.07em}.facts b{display:block;margin-top:4px;font-size:8.5px;line-height:1.3}.truth{max-width:610px;margin:12px auto;color:#9c938c;font-size:8px;line-height:1.55}.done{display:grid;gap:9px;margin-top:14px;padding:20px;border:1px solid #d8edac;border-radius:24px;background:#f7ffe8}.doneMark,.mark{width:56px;height:56px;margin:auto;border-radius:18px;background:#c9ff54;color:#456318;display:grid;place-items:center;font-size:26px;font-weight:1000;box-shadow:0 6px 0 #aada35}.done>b{font-size:20px}.done>span{font-size:10px;color:#6f7b59}.links{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:4px}.links a{min-height:48px;display:grid;place-items:center;border:1px solid #dfd7e4;border-radius:14px;background:#fff;color:#614fa2;text-decoration:none;font-size:9px;font-weight:950}.links a:last-child{grid-column:1/-1;background:#21172c;color:#fff;border:0}.notice{margin-top:70px;display:grid;gap:13px;padding:28px;border:1px dashed #d9ccff;border-radius:25px;background:#fff}.notice a{padding:14px;border-radius:14px;background:#7138f5;color:#fff;text-decoration:none;font-weight:900}@media(max-width:620px){.page{padding:8px 9px calc(102px + env(safe-area-inset-bottom))}header{margin-top:22px}.viewer{height:54vh;min-height:360px;border-radius:25px}.actions{padding:14px;border-radius:21px}.primary,.later{min-height:56px;border-radius:18px;font-size:16px}.facts{grid-template-columns:1fr 1fr}.links{grid-template-columns:1fr}.links a:last-child{grid-column:auto}}@media(prefers-reduced-motion:reduce){*{animation-duration:.01ms!important;transition-duration:.01ms!important}}`;
+:global(body){margin:0;background:#fffaf2;color:#281b12;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.page{min-height:100vh;padding:10px 12px calc(92px + env(safe-area-inset-bottom));background:radial-gradient(circle at 90% 8%,rgba(113,56,245,.12),transparent 30%),radial-gradient(circle at 10% 88%,rgba(201,255,84,.18),transparent 28%),#fffaf2}.shell{width:min(680px,100%);margin:auto;text-align:center}nav{height:48px;display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:8px;font-weight:1000;letter-spacing:.1em;color:#8c8179}nav a{color:#6b4db2;text-decoration:none;padding:8px}header{margin:26px auto 14px}.ready{display:inline-flex;padding:7px 10px;border:1px solid #cce99b;border-radius:999px;background:#f5ffe4;color:#527025;font-size:8px;font-weight:1000;letter-spacing:.08em}header h1{font-size:clamp(39px,8vw,56px);line-height:.94;letter-spacing:-.055em;margin:14px 0 8px}header p{max-width:520px;margin:0 auto;color:#786e67;font-size:12px;line-height:1.5}.viewer{position:relative;width:100%;height:min(58vh,520px);min-height:350px;overflow:hidden;border:1px solid #e4dacf;border-radius:26px;background:#21172c;box-shadow:0 20px 48px rgba(70,47,87,.13)}.viewer>div{height:100%!important;min-height:100%!important}.viewer :global(.viewerShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.viewer>span{position:absolute;z-index:7;left:12px;top:12px;padding:8px 10px;border:1px solid rgba(255,255,255,.5);border-radius:999px;background:rgba(32,23,39,.76);color:#fff;font-size:7px;font-weight:1000;letter-spacing:.08em;backdrop-filter:blur(10px)}.actions{display:grid;gap:9px;margin-top:12px;padding:14px;border:1px solid #e7ded4;border-radius:21px;background:#fff}.primary,.later{width:100%;min-height:57px;border-radius:17px;display:flex;align-items:center;justify-content:center;font:950 16px inherit;text-decoration:none}.primary{border:0;background:#7138f5;color:#fff;box-shadow:0 6px 0 #5120d0;cursor:pointer}.primary:disabled{opacity:.5;box-shadow:none}.later{border:1px solid #ddd2eb;background:#fff;color:#6846b7}.actions small{color:#938a83;font-size:9px}.status{min-height:18px;margin:12px auto 0;max-width:590px;color:#6f655e;font-size:10px;font-weight:700;line-height:1.5}.wallet{margin:10px 0 0;font-size:8px;color:#8c8179}.truth{max-width:610px;margin:11px auto;color:#9c938c;font-size:8px;line-height:1.55}.done{display:grid;gap:9px;margin-top:12px;padding:19px;border:1px solid #d8edac;border-radius:21px;background:#f7ffe8}.doneMark,.mark{width:54px;height:54px;margin:auto;border-radius:17px;background:#c9ff54;color:#456318;display:grid;place-items:center;font-size:25px;font-weight:1000;box-shadow:0 6px 0 #aada35}.done>b{font-size:20px}.done>span{font-size:10px;color:#6f7b59}.links{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:3px}.links a{min-height:47px;display:grid;place-items:center;border:1px solid #dfd7e4;border-radius:13px;background:#fff;color:#614fa2;text-decoration:none;font-size:9px;font-weight:950}.links a:last-child{grid-column:1/-1;background:#21172c;color:#fff;border:0}.notice{margin-top:70px;display:grid;gap:14px;padding:28px;border:1px solid #e6ddd5;border-radius:22px;background:#fff}.notice b{font-size:20px}.notice a{color:#7138f5;font-weight:900}.mark{margin-top:70px}.shell>.mark+h1{font-size:36px;letter-spacing:-.04em}.page button:focus-visible,.page a:focus-visible{outline:3px solid rgba(113,56,245,.24);outline-offset:3px}@media(max-width:520px){.page{padding:8px 8px calc(78px + env(safe-area-inset-bottom))}.viewer{min-height:330px;border-radius:21px}.links{grid-template-columns:1fr}.links a:last-child{grid-column:auto}}
+`;


### PR DESCRIPTION
## VoxelPop core flow

**House photo → confirm address → generated voxel image → generated 3D GLB → Voxel Vault inventory → optional one-property mint**

This PR is based on the latest main and preserves the newer persistent property reservation/finalization lifecycle while replacing the old local-only 3D approximation.

### What changed
- The address confirmation remains the one-property identity lock.
- A confirmed property can start the provider-backed voxel-image job without a broken paid-only dependency.
- The voxel-image job preflights enough provider capacity to also finish the final GLB.
- The completed voxel-image task gets a signed account-scoped handoff into the existing verified image-to-3D route.
- The active creator automatically runs voxel image → final 3D with no manual approval screen and no local voxel approximation.
- Finalization verifies the account-owned final `voxel` phase model instead of accepting a browser/local model.
- The generated GLB is saved into Voxel Vault inventory locally and to the signed-in account.
- Mint preparation verifies the same account-owned generated GLB and the one-property reservation.
- The mint page renders the real generated GLB.
- NFT metadata points to the generated 3D model/preview and excludes the source house photo.

### Removed from the core path
- Local-only final voxel generation.
- Preview approval step between voxel image and 3D.
- Arbitrary browser model URL trust.

### Product boundary
The collectible is digital only. Saving or minting does not convey deed, title, equity, occupancy, rent, investment, or other rights in the physical property.