### PR TITLE
Add Voxel Maker subscriptions up to $99

### DIFF
--- a/app/api/property-generation/confirm/route.ts
+++ b/app/api/property-generation/confirm/route.ts
@@ -49,17 +49,18 @@ export async function POST(request: Request) {
       }, { status: 402 });
     }
 
-    const alreadyCounted = await hasVoxelMakerGeneration(auth.user.id, draftId);
-    const usedThisMonth = await countVoxelMakerGenerations(auth.user.id);
-    if (!alreadyCounted && usedThisMonth >= entitlement.plan.monthlyVoxels) {
+    const periodStart = entitlement.record?.currentPeriodStart || null;
+    const alreadyCounted = await hasVoxelMakerGeneration(auth.user.id, draftId, periodStart);
+    const usedThisPeriod = await countVoxelMakerGenerations(auth.user.id, periodStart);
+    if (!alreadyCounted && usedThisPeriod >= entitlement.plan.monthlyVoxels) {
       return privateJson({
         ok: false,
         code: 'VOXEL_MAKER_MONTHLY_LIMIT_REACHED',
         monthlyLimitReached: true,
         plan: entitlement.plan.id,
-        used: usedThisMonth,
+        used: usedThisPeriod,
         limit: entitlement.plan.monthlyVoxels,
-        error: `You have used all ${entitlement.plan.monthlyVoxels} Voxel Maker creations included in your ${entitlement.plan.name} plan this month.`,
+        error: `You have used all ${entitlement.plan.monthlyVoxels} Voxel Maker creations included in your ${entitlement.plan.name} billing period.`,
       }, { status: 429 });
     }
 
@@ -126,8 +127,9 @@ export async function POST(request: Request) {
       next: 'voxel-image',
       subscription: {
         plan: entitlement.plan.id,
-        used: alreadyCounted ? usedThisMonth : usedThisMonth + 1,
+        used: alreadyCounted ? usedThisPeriod : usedThisPeriod + 1,
         limit: entitlement.plan.monthlyVoxels,
+        currentPeriodEnd: entitlement.record?.currentPeriodEnd || null,
       },
     });
   } catch (error) {

--- a/app/api/property-generation/confirm/route.ts
+++ b/app/api/property-generation/confirm/route.ts
@@ -7,6 +7,12 @@ import {
   propertyCollectibleIdentity,
   releasePropertyCollectibleReservation,
 } from '../../../../lib/property-collectible-commerce';
+import {
+  countVoxelMakerGenerations,
+  getVoxelMakerEntitlement,
+  hasVoxelMakerGeneration,
+  registerVoxelMakerGeneration,
+} from '../../../../lib/voxel-maker-subscriptions';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -32,6 +38,30 @@ export async function POST(request: Request) {
     const draftId = normalizePropertyDraftId(clean(body?.draftId, 100));
     const address = clean(body?.address, 220);
     if (!address) return privateJson({ ok: false, error: 'Enter the house address to confirm this property.' }, { status: 400 });
+
+    const entitlement = await getVoxelMakerEntitlement(auth.user.id);
+    if (!entitlement.active || !entitlement.plan) {
+      return privateJson({
+        ok: false,
+        code: 'VOXEL_MAKER_SUBSCRIPTION_REQUIRED',
+        subscriptionRequired: true,
+        error: 'Choose a Voxel Maker plan before creating a new house voxel.',
+      }, { status: 402 });
+    }
+
+    const alreadyCounted = await hasVoxelMakerGeneration(auth.user.id, draftId);
+    const usedThisMonth = await countVoxelMakerGenerations(auth.user.id);
+    if (!alreadyCounted && usedThisMonth >= entitlement.plan.monthlyVoxels) {
+      return privateJson({
+        ok: false,
+        code: 'VOXEL_MAKER_MONTHLY_LIMIT_REACHED',
+        monthlyLimitReached: true,
+        plan: entitlement.plan.id,
+        used: usedThisMonth,
+        limit: entitlement.plan.monthlyVoxels,
+        error: `You have used all ${entitlement.plan.monthlyVoxels} Voxel Maker creations included in your ${entitlement.plan.name} plan this month.`,
+      }, { status: 429 });
+    }
 
     const atlas = await inspectWorldAtlas({ address, radiusMeters: 180 });
     const selectedBuilding = atlas?.selectedBuilding || null;
@@ -77,6 +107,15 @@ export async function POST(request: Request) {
       return privateJson({ ok: false, reserved: true, ownedByYou: true, error: 'You already started this property in another Voxel Vault creation. Finish that one or wait for the temporary hold to expire.' }, { status: 409 });
     }
 
+    if (!alreadyCounted) {
+      await registerVoxelMakerGeneration({
+        userId: auth.user.id,
+        draftId,
+        planId: entitlement.plan.id,
+        address: canonicalAddress,
+      });
+    }
+
     return privateJson({
       ok: true,
       confirmed: true,
@@ -85,6 +124,11 @@ export async function POST(request: Request) {
       address: canonicalAddress,
       onePropertyOneMint: true,
       next: 'voxel-image',
+      subscription: {
+        plan: entitlement.plan.id,
+        used: alreadyCounted ? usedThisMonth : usedThisMonth + 1,
+        limit: entitlement.plan.monthlyVoxels,
+      },
     });
   } catch (error) {
     return privateJson({ ok: false, error: error instanceof Error ? error.message : 'The property address could not be confirmed.' }, { status: 500 });

--- a/app/api/property-voxel-photo/route.ts
+++ b/app/api/property-voxel-photo/route.ts
@@ -58,7 +58,7 @@ async function verifyConfirmedDraft(userId: string, draftId: string, identityKey
   const identityKey = clean(identityKeyRaw, 96);
   if (!identityKey) throw new Error('Confirm the property address before generating the voxel.');
   const reservation = await readPropertyCollectibleReservation(identityKey);
-  if (!reservation || reservation.buyerUserId !== userId || reservation.draftId !== draftId) {
+  if (!reservation || reservation.buyerId !== userId || reservation.draftId !== draftId) {
     throw new Error('That confirmed property does not belong to this signed-in creation.');
   }
   if (!['reserved', 'paid', 'minted'].includes(reservation.state)) {

--- a/app/api/voxel-maker/subscription/checkout/route.ts
+++ b/app/api/voxel-maker/subscription/checkout/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '../../../../../lib/stripe-server';
+import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
+import { beginVoxelMakerCheckout, getVoxelMakerEntitlement } from '../../../../../lib/voxel-maker-subscriptions';
+import { voxelMakerPlan } from '../../../../../lib/voxel-maker-plans';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const plan = voxelMakerPlan(body?.planId);
+    if (!plan) return NextResponse.json({ ok: false, error: 'Choose a valid Voxel Maker plan.' }, { status: 400 });
+
+    const current = await getVoxelMakerEntitlement(auth.user.id);
+    if (current.active) {
+      return NextResponse.json({ ok: false, active: true, plan: current.plan, error: 'You already have an active Voxel Maker subscription. Manage billing to change or cancel it.' }, { status: 409 });
+    }
+
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const email = typeof auth.user.email === 'string' && auth.user.email.includes('@') ? auth.user.email : undefined;
+    const metadata = {
+      kind: 'voxel_maker_subscription',
+      plan_id: plan.id,
+      voxelpop_user_id: auth.user.id,
+    };
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      client_reference_id: auth.user.id,
+      ...(email ? { customer_email: email } : {}),
+      allow_promotion_codes: true,
+      line_items: [{
+        quantity: 1,
+        price_data: {
+          currency: 'usd',
+          unit_amount: plan.priceCents,
+          recurring: { interval: 'month' },
+          product_data: {
+            name: `Voxel Maker ${plan.name}`,
+            description: `${plan.monthlyVoxels} house-to-voxel creations each month, saved to Voxel Vault inventory.`,
+          },
+        },
+      }],
+      metadata,
+      subscription_data: { metadata },
+      success_url: `${origin}/property?subscription=success`,
+      cancel_url: `${origin}/property?subscription=cancelled`,
+    });
+
+    if (!session.url) throw new Error('Stripe did not return a checkout URL.');
+    await beginVoxelMakerCheckout({ userId: auth.user.id, planId: plan.id, checkoutSessionId: session.id });
+    return NextResponse.json({ ok: true, url: session.url, plan });
+  } catch (error) {
+    console.error('Voxel Maker subscription checkout failed', error);
+    return NextResponse.json({ ok: false, error: 'Subscription checkout is temporarily unavailable.' }, { status: 500 });
+  }
+}

--- a/app/api/voxel-maker/subscription/portal/route.ts
+++ b/app/api/voxel-maker/subscription/portal/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { stripe } from '../../../../../lib/stripe-server';
+import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
+import { refreshVoxelMakerSubscription } from '../../../../../lib/voxel-maker-subscriptions';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const record = await refreshVoxelMakerSubscription(auth.user.id);
+    if (!record?.stripeCustomerId) {
+      return NextResponse.json({ ok: false, error: 'Billing management is not available for this account yet.' }, { status: 409 });
+    }
+    const origin = (process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL || new URL(request.url).origin).replace(/\/$/, '');
+    const session = await stripe.billingPortal.sessions.create({
+      customer: record.stripeCustomerId,
+      return_url: `${origin}/property`,
+    });
+    return NextResponse.json({ ok: true, url: session.url });
+  } catch (error) {
+    console.error('Voxel Maker billing portal failed', error);
+    return NextResponse.json({ ok: false, error: 'Billing management is temporarily unavailable.' }, { status: 500 });
+  }
+}

--- a/app/api/voxel-maker/subscription/status/route.ts
+++ b/app/api/voxel-maker/subscription/status/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultUser } from '../../../../../lib/user-auth';
+import { countVoxelMakerGenerations, getVoxelMakerEntitlement } from '../../../../../lib/voxel-maker-subscriptions';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultUser(request);
+  if (auth.ok === false) return NextResponse.json({ ok: false, error: auth.error }, { status: auth.status });
+
+  try {
+    const entitlement = await getVoxelMakerEntitlement(auth.user.id);
+    const used = entitlement.active ? await countVoxelMakerGenerations(auth.user.id) : 0;
+    const limit = entitlement.plan?.monthlyVoxels || 0;
+    return NextResponse.json({
+      ok: true,
+      active: entitlement.active,
+      plan: entitlement.plan,
+      status: entitlement.record?.status || 'none',
+      cancelAtPeriodEnd: Boolean(entitlement.record?.cancelAtPeriodEnd),
+      currentPeriodEnd: entitlement.record?.currentPeriodEnd || null,
+      usage: { used, limit, remaining: Math.max(0, limit - used) },
+      canManageBilling: Boolean(entitlement.record?.stripeCustomerId),
+    }, { headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'Subscription status is unavailable.' }, { status: 500 });
+  }
+}

--- a/app/api/voxel-maker/subscription/status/route.ts
+++ b/app/api/voxel-maker/subscription/status/route.ts
@@ -11,7 +11,9 @@ export async function GET(request: Request) {
 
   try {
     const entitlement = await getVoxelMakerEntitlement(auth.user.id);
-    const used = entitlement.active ? await countVoxelMakerGenerations(auth.user.id) : 0;
+    const used = entitlement.active
+      ? await countVoxelMakerGenerations(auth.user.id, entitlement.record?.currentPeriodStart)
+      : 0;
     const limit = entitlement.plan?.monthlyVoxels || 0;
     return NextResponse.json({
       ok: true,
@@ -19,6 +21,7 @@ export async function GET(request: Request) {
       plan: entitlement.plan,
       status: entitlement.record?.status || 'none',
       cancelAtPeriodEnd: Boolean(entitlement.record?.cancelAtPeriodEnd),
+      currentPeriodStart: entitlement.record?.currentPeriodStart || null,
       currentPeriodEnd: entitlement.record?.currentPeriodEnd || null,
       usage: { used, limit, remaining: Math.max(0, limit - used) },
       canManageBilling: Boolean(entitlement.record?.stripeCustomerId),

--- a/app/property/VoxelMakerSubscriptionGate.js
+++ b/app/property/VoxelMakerSubscriptionGate.js
@@ -1,0 +1,205 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import { VOXEL_MAKER_PLANS, formatVoxelMakerPrice } from '../../lib/voxel-maker-plans';
+
+function clean(value) { return String(value || '').trim(); }
+
+export default function VoxelMakerSubscriptionGate({ children }) {
+  const [ready, setReady] = useState(false);
+  const [session, setSession] = useState(null);
+  const [subscription, setSubscription] = useState(null);
+  const [loadingStatus, setLoadingStatus] = useState(false);
+  const [busyPlan, setBusyPlan] = useState('');
+  const [message, setMessage] = useState('');
+  const clientRef = useRef(null);
+  const autoCheckoutRef = useRef(false);
+
+  const loadStatus = useCallback(async (accessToken) => {
+    if (!accessToken) {
+      setSubscription(null);
+      return null;
+    }
+    setLoadingStatus(true);
+    try {
+      const response = await fetch('/api/voxel-maker/subscription/status', {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        cache: 'no-store',
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data?.error || 'Could not check your Voxel Maker plan.');
+      setSubscription(data);
+      return data;
+    } catch (error) {
+      setMessage(clean(error?.message || error || 'Could not check your Voxel Maker plan.'));
+      return null;
+    } finally {
+      setLoadingStatus(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    let authSubscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      if (!active) return;
+      const nextSession = data.session || null;
+      setSession(nextSession);
+      setReady(true);
+      if (nextSession?.access_token) loadStatus(nextSession.access_token);
+      const auth = client.auth.onAuthStateChange((_event, next) => {
+        if (!active) return;
+        setSession(next || null);
+        setReady(true);
+        if (next?.access_token) loadStatus(next.access_token);
+        else setSubscription(null);
+      });
+      authSubscription = auth.data.subscription;
+    }).catch(() => {
+      if (active) {
+        setReady(true);
+        setMessage('Sign-in is unavailable on this deployment.');
+      }
+    });
+    return () => { active = false; authSubscription?.unsubscribe?.(); };
+  }, [loadStatus]);
+
+  async function signInForPlan(planId) {
+    setBusyPlan(planId);
+    setMessage('Opening secure sign-in…');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const redirect = new URL('/property', window.location.origin);
+      redirect.searchParams.set('choose', planId);
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: redirect.toString() } });
+      if (error) throw error;
+    } catch (error) {
+      setBusyPlan('');
+      setMessage(clean(error?.message || error || 'Could not sign in.'));
+    }
+  }
+
+  const checkout = useCallback(async (planId) => {
+    if (!session?.access_token) return signInForPlan(planId);
+    setBusyPlan(planId);
+    setMessage('Opening secure monthly checkout…');
+    try {
+      const response = await fetch('/api/voxel-maker/subscription/checkout', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ planId }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (data?.active) {
+        await loadStatus(session.access_token);
+        setBusyPlan('');
+        return;
+      }
+      if (!response.ok || !data?.url) throw new Error(data?.error || 'Checkout is unavailable.');
+      window.location.assign(data.url);
+    } catch (error) {
+      setBusyPlan('');
+      setMessage(clean(error?.message || error || 'Checkout is unavailable.'));
+    }
+  }, [session?.access_token, loadStatus]);
+
+  useEffect(() => {
+    if (!ready || !session?.access_token || loadingStatus || subscription?.active || autoCheckoutRef.current) return;
+    const params = new URLSearchParams(window.location.search);
+    const planId = clean(params.get('choose')).toLowerCase();
+    if (!VOXEL_MAKER_PLANS.some((plan) => plan.id === planId)) return;
+    autoCheckoutRef.current = true;
+    params.delete('choose');
+    const next = `${window.location.pathname}${params.toString() ? `?${params}` : ''}`;
+    window.history.replaceState({}, '', next);
+    checkout(planId);
+  }, [ready, session?.access_token, subscription?.active, loadingStatus, checkout]);
+
+  useEffect(() => {
+    if (!session?.access_token) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('subscription') !== 'success') return;
+    let cancelled = false;
+    let attempts = 0;
+    const refresh = async () => {
+      attempts += 1;
+      const result = await loadStatus(session.access_token);
+      if (cancelled || result?.active || attempts >= 4) return;
+      window.setTimeout(refresh, 900);
+    };
+    refresh();
+    params.delete('subscription');
+    const next = `${window.location.pathname}${params.toString() ? `?${params}` : ''}`;
+    window.history.replaceState({}, '', next);
+    return () => { cancelled = true; };
+  }, [session?.access_token, loadStatus]);
+
+  async function manageBilling() {
+    if (!session?.access_token) return;
+    setMessage('Opening billing…');
+    try {
+      const response = await fetch('/api/voxel-maker/subscription/portal', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.url) throw new Error(data?.error || 'Billing management is unavailable.');
+      window.location.assign(data.url);
+    } catch (error) {
+      setMessage(clean(error?.message || error || 'Billing management is unavailable.'));
+    }
+  }
+
+  if (!ready) return <main className="vmPage"><div className="vmLoading"><div className="vmCube">V</div><strong>Opening Voxel Maker…</strong></div><style jsx>{styles}</style></main>;
+
+  if (subscription?.active) {
+    const used = Number(subscription?.usage?.used || 0);
+    const limit = Number(subscription?.usage?.limit || subscription?.plan?.monthlyVoxels || 0);
+    return <>
+      <div className="vmPlanBar">
+        <div className="vmPlanIdentity"><span className="vmDot"/><strong>Voxel Maker {subscription.plan?.name}</strong><small>{used}/{limit} creations this month</small></div>
+        <div className="vmPlanActions"><span>{formatVoxelMakerPrice(subscription.plan?.priceCents || 0)}/mo</span>{subscription.canManageBilling ? <button type="button" onClick={manageBilling}>Manage</button> : null}</div>
+      </div>
+      {children}
+      <style jsx>{styles}</style>
+    </>;
+  }
+
+  return <main className="vmPage">
+    <section className="vmShell">
+      <header className="vmHero">
+        <div className="vmBrand"><div className="vmCube">V</div><span>VOXEL VAULT</span></div>
+        <p className="vmEyebrow">VOXEL MAKER</p>
+        <h1>Turn houses into<br/><em>collectible voxels.</em></h1>
+        <p className="vmLead">Upload a house photo, confirm its address, build the voxel, save it to your inventory, and mint it when you want.</p>
+        <div className="vmFlow"><span>PHOTO</span><b>→</b><span>ADDRESS</span><b>→</b><span>VOXEL</span><b>→</b><span>INVENTORY</span></div>
+      </header>
+
+      <div className="vmPricingHeading"><div><p className="vmEyebrow">MONTHLY PLANS</p><h2>Pick how much you create.</h2></div><p>Cancel anytime. Minting stays optional.</p></div>
+
+      <div className="vmPlans">
+        {VOXEL_MAKER_PLANS.map((plan) => <article key={plan.id} className={`vmPlan vmPlan-${plan.id}`}>
+          <div className="vmPlanTop"><div><p>{plan.name}</p>{plan.badge ? <span>{plan.badge}</span> : null}</div><strong>{formatVoxelMakerPrice(plan.priceCents)}<small>/mo</small></strong></div>
+          <h3>{plan.monthlyVoxels} voxels <small>each month</small></h3>
+          <p className="vmBlurb">{plan.blurb}</p>
+          <ul>{plan.features.map((feature) => <li key={feature}><span>✓</span>{feature}</li>)}</ul>
+          <button type="button" onClick={() => checkout(plan.id)} disabled={Boolean(busyPlan)}>{busyPlan === plan.id ? 'Opening…' : session?.user ? `Choose ${plan.name}` : `Start ${plan.name}`}</button>
+        </article>)}
+      </div>
+
+      {!session?.user ? <p className="vmSigninNote">Choosing a plan starts with Google sign-in so your voxels stay attached to your inventory.</p> : null}
+      {loadingStatus ? <p className="vmMessage">Checking your subscription…</p> : message ? <p className="vmMessage" role="status">{message}</p> : null}
+      <p className="vmFine">Each plan covers the Voxel Maker creation allowance shown above. A Voxel Vault mint represents the digital collectible only and does not create ownership rights in the physical property.</p>
+    </section>
+    <style jsx>{styles}</style>
+  </main>;
+}
+
+const styles = `
+:global(body){margin:0;background:#fff9f1;color:#251a2c;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.vmPage{min-height:100vh;padding:18px 14px calc(80px + env(safe-area-inset-bottom));background:radial-gradient(circle at 12% 2%,rgba(255,194,72,.38),transparent 27%),radial-gradient(circle at 92% 8%,rgba(111,54,245,.18),transparent 28%),radial-gradient(circle at 46% 100%,rgba(190,255,74,.24),transparent 30%),#fff9f1}.vmShell{width:min(1080px,100%);margin:0 auto}.vmLoading{min-height:70vh;display:grid;place-items:center;align-content:center;gap:16px;color:#6845b8}.vmCube{width:58px;height:58px;display:grid;place-items:center;border-radius:18px;background:linear-gradient(145deg,#8c59ff,#642eed);box-shadow:0 7px 0 #4f1bc9,0 16px 34px rgba(92,42,220,.23);color:#fff;font-size:28px;font-weight:1000}.vmBrand{display:flex;align-items:center;gap:13px}.vmBrand span,.vmEyebrow{font-size:9px;font-weight:1000;letter-spacing:.14em;color:#7653b7}.vmHero{padding:18px 4px 32px}.vmHero .vmEyebrow{margin:35px 0 9px}.vmHero h1{margin:0;max-width:820px;font-size:clamp(48px,8vw,86px);line-height:.88;letter-spacing:-.075em}.vmHero h1 em{font-style:normal;color:#7540f3}.vmLead{max-width:620px;margin:21px 0 18px;color:#756b75;font-size:14px;line-height:1.65}.vmFlow{display:flex;align-items:center;flex-wrap:wrap;gap:7px}.vmFlow span{padding:8px 10px;border:1px solid #ded2e5;border-radius:999px;background:rgba(255,255,255,.8);font-size:8px;font-weight:1000;letter-spacing:.06em}.vmFlow b{color:#9f8aaa}.vmPricingHeading{display:flex;align-items:end;justify-content:space-between;gap:18px;margin:8px 4px 15px}.vmPricingHeading h2{margin:5px 0 0;font-size:clamp(28px,4vw,42px);letter-spacing:-.055em}.vmPricingHeading>p{max-width:260px;margin:0;color:#887d87;font-size:11px;text-align:right}.vmPlans{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}.vmPlan{position:relative;overflow:hidden;min-height:390px;padding:18px;border:1px solid #e2d7e6;border-radius:27px;background:rgba(255,255,255,.92);box-shadow:0 18px 45px rgba(62,40,76,.08);display:flex;flex-direction:column}.vmPlan:before{content:"";position:absolute;inset:0 0 auto;height:7px;background:#ddd}.vmPlan-starter:before{background:#ffc44d}.vmPlan-creator:before{background:#8b53ff}.vmPlan-pro:before{background:#c8ff50}.vmPlan-studio{background:linear-gradient(160deg,#2a1c33,#17111f);border-color:#3b2b49;color:#fff;box-shadow:0 22px 55px rgba(39,20,54,.2)}.vmPlan-studio:before{background:linear-gradient(90deg,#c6ff4d,#8a50ff,#ffbf43)}.vmPlanTop{display:flex;align-items:start;justify-content:space-between;gap:8px;margin-top:4px}.vmPlanTop p{margin:0;font-size:13px;font-weight:1000}.vmPlanTop div span{display:inline-block;margin-top:6px;padding:5px 7px;border-radius:999px;background:#ede5ff;color:#7043d1;font-size:6px;font-weight:1000;letter-spacing:.08em}.vmPlan-studio .vmPlanTop div span{background:#c9ff52;color:#293a0c}.vmPlanTop>strong{font-size:26px;letter-spacing:-.055em}.vmPlanTop>strong small{font-size:9px;font-weight:800;letter-spacing:0;color:#8e828f}.vmPlan h3{margin:26px 0 6px;font-size:25px;letter-spacing:-.05em}.vmPlan h3 small{display:block;margin-top:2px;color:#8f8490;font-size:10px;letter-spacing:0}.vmBlurb{min-height:41px;margin:0;color:#837884;font-size:10px;line-height:1.5}.vmPlan-studio .vmBlurb,.vmPlan-studio h3 small{color:#b8aebb}.vmPlan ul{list-style:none;padding:0;margin:21px 0 24px;display:grid;gap:10px}.vmPlan li{display:flex;gap:8px;align-items:center;font-size:9px;font-weight:800;color:#5e545f}.vmPlan-studio li{color:#e2dbe5}.vmPlan li span{width:20px;height:20px;display:grid;place-items:center;border-radius:7px;background:#f0e9f3;color:#7446d5;font-size:9px}.vmPlan-studio li span{background:#392b45;color:#ccff5d}.vmPlan button{margin-top:auto;min-height:52px;border:0;border-radius:16px;background:#251a2c;color:#fff;font:950 12px inherit;cursor:pointer}.vmPlan-creator button{background:#7440f2;box-shadow:0 5px 0 #5523cb}.vmPlan-pro button{background:#c6ff4d;color:#344313;box-shadow:0 5px 0 #9fd42d}.vmPlan-studio button{background:#fff;color:#251a2c;box-shadow:0 5px 0 #cfc5d2}.vmPlan button:disabled{opacity:.55;box-shadow:none}.vmSigninNote,.vmMessage,.vmFine{max-width:700px;margin:18px auto 0;text-align:center;color:#776d77;font-size:10px;line-height:1.55}.vmMessage{color:#6942bc;font-weight:850}.vmFine{color:#9a9099;font-size:8px}.vmPlanBar{position:sticky;top:0;z-index:90;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:9px max(12px,calc((100vw - 720px)/2));border-bottom:1px solid #e2d8e5;background:rgba(255,250,243,.92);backdrop-filter:blur(18px);color:#332739}.vmPlanIdentity{display:flex;align-items:center;gap:8px;min-width:0}.vmDot{width:9px;height:9px;border-radius:50%;background:#aee63d;box-shadow:0 0 0 4px rgba(174,230,61,.18)}.vmPlanIdentity strong{font-size:10px;white-space:nowrap}.vmPlanIdentity small{color:#887d88;font-size:8px;white-space:nowrap}.vmPlanActions{display:flex;align-items:center;gap:8px}.vmPlanActions span{font-size:9px;font-weight:900;color:#7551b6}.vmPlanActions button{min-height:31px;padding:0 10px;border:1px solid #dbd1e1;border-radius:10px;background:#fff;color:#6442ae;font:900 8px inherit;cursor:pointer}@media(max-width:850px){.vmPlans{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:580px){.vmPage{padding-left:10px;padding-right:10px}.vmHero{padding-top:10px}.vmHero h1{font-size:49px}.vmPricingHeading{align-items:start;flex-direction:column}.vmPricingHeading>p{text-align:left}.vmPlans{grid-template-columns:1fr}.vmPlan{min-height:350px}.vmPlanIdentity small{display:none}.vmPlanActions span{display:none}}
+`;

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import ProductTopNav from '../components/ProductTopNav';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
 import HouseVoxelMintFlow from './HouseVoxelMintFlow';
+import VoxelMakerSubscriptionGate from './VoxelMakerSubscriptionGate';
 
 function cleanOAuthParams() {
   const url = new URL(window.location.href);
@@ -46,6 +47,8 @@ export default function PropertyJourneyPage() {
   return <>
     <OAuthRecovery/>
     <ProductTopNav/>
-    <HouseVoxelMintFlow/>
+    <VoxelMakerSubscriptionGate>
+      <HouseVoxelMintFlow/>
+    </VoxelMakerSubscriptionGate>
   </>;
 }

--- a/lib/voxel-maker-plans.ts
+++ b/lib/voxel-maker-plans.ts
@@ -1,0 +1,57 @@
+export type VoxelMakerPlanId = 'starter' | 'creator' | 'pro' | 'studio';
+
+export type VoxelMakerPlan = {
+  id: VoxelMakerPlanId;
+  name: string;
+  priceCents: number;
+  monthlyVoxels: number;
+  blurb: string;
+  badge?: string;
+  features: string[];
+};
+
+export const VOXEL_MAKER_PLANS: readonly VoxelMakerPlan[] = Object.freeze([
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceCents: 900,
+    monthlyVoxels: 3,
+    blurb: 'For trying the house-to-voxel maker.',
+    features: ['3 house voxels / month', 'Saved Voxel Vault inventory', 'Mint-ready 3D voxel'],
+  },
+  {
+    id: 'creator',
+    name: 'Creator',
+    priceCents: 2900,
+    monthlyVoxels: 12,
+    blurb: 'For regular creators and collectors.',
+    badge: 'MOST POPULAR',
+    features: ['12 house voxels / month', 'Saved Voxel Vault inventory', 'Mint-ready 3D voxel'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    priceCents: 5900,
+    monthlyVoxels: 30,
+    blurb: 'For high-volume property collections.',
+    features: ['30 house voxels / month', 'Saved Voxel Vault inventory', 'Mint-ready 3D voxel'],
+  },
+  {
+    id: 'studio',
+    name: 'Studio',
+    priceCents: 9900,
+    monthlyVoxels: 60,
+    blurb: 'For studios building large voxel collections.',
+    badge: 'MAX',
+    features: ['60 house voxels / month', 'Saved Voxel Vault inventory', 'Mint-ready 3D voxel'],
+  },
+]);
+
+export function voxelMakerPlan(planId: unknown): VoxelMakerPlan | null {
+  const normalized = String(planId || '').trim().toLowerCase();
+  return VOXEL_MAKER_PLANS.find((plan) => plan.id === normalized) || null;
+}
+
+export function formatVoxelMakerPrice(priceCents: number) {
+  return `$${Math.max(0, Math.round(priceCents / 100))}`;
+}

--- a/lib/voxel-maker-subscriptions.ts
+++ b/lib/voxel-maker-subscriptions.ts
@@ -22,6 +22,10 @@ function clean(value: unknown, max = 300) {
   return String(value || '').trim().slice(0, max);
 }
 
+function generationEventId(userId: string, draftId: string) {
+  return `${userId}:${clean(draftId, 120)}`;
+}
+
 function activeStatus(status: unknown) {
   return status === 'active' || status === 'trialing';
 }
@@ -116,7 +120,7 @@ async function recordFromStripeSubscription(userId: string, subscription: Stripe
 }
 
 export async function refreshVoxelMakerSubscription(userId: string) {
-  let record = await readVoxelMakerSubscription(userId);
+  const record = await readVoxelMakerSubscription(userId);
   if (!record) return null;
 
   try {
@@ -168,10 +172,23 @@ export async function countVoxelMakerGenerations(userId: string) {
   return Math.max(0, Number(count || 0));
 }
 
+export async function hasVoxelMakerGeneration(userId: string, draftId: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('commerce_webhook_events')
+    .select('event_id,processed_at')
+    .eq('provider', GENERATION_PROVIDER)
+    .eq('event_id', generationEventId(userId, draftId))
+    .maybeSingle();
+  if (error) throw error;
+  if (!data?.event_id) return false;
+  return String(data.processed_at || '') >= monthStartIso();
+}
+
 export async function registerVoxelMakerGeneration(input: { userId: string; draftId: string; planId: VoxelMakerPlanId; address?: string }) {
   const supabase = getSupabaseAdmin();
   const now = new Date().toISOString();
-  const eventId = `${input.userId}:${clean(input.draftId, 120)}`;
+  const eventId = generationEventId(input.userId, input.draftId);
   const { error } = await supabase.from('commerce_webhook_events').upsert({
     provider: GENERATION_PROVIDER,
     event_id: eventId,

--- a/lib/voxel-maker-subscriptions.ts
+++ b/lib/voxel-maker-subscriptions.ts
@@ -14,6 +14,7 @@ export type VoxelMakerSubscriptionRecord = {
   stripeSubscriptionId?: string;
   stripeCheckoutSessionId?: string;
   cancelAtPeriodEnd?: boolean;
+  currentPeriodStart?: string | null;
   currentPeriodEnd?: string | null;
   updatedAt: string;
 };
@@ -30,9 +31,19 @@ function activeStatus(status: unknown) {
   return status === 'active' || status === 'trialing';
 }
 
-function subscriptionPeriodEnd(subscription: Stripe.Subscription) {
-  const unix = Number((subscription as any)?.current_period_end || 0);
+function isoFromUnix(value: unknown) {
+  const unix = Number(value || 0);
   return Number.isFinite(unix) && unix > 0 ? new Date(unix * 1000).toISOString() : null;
+}
+
+function subscriptionPeriod(subscription: Stripe.Subscription) {
+  const items = Array.isArray(subscription.items?.data) ? subscription.items.data : [];
+  const starts = items.map((item: any) => Number(item?.current_period_start || 0)).filter((value) => Number.isFinite(value) && value > 0);
+  const ends = items.map((item: any) => Number(item?.current_period_end || 0)).filter((value) => Number.isFinite(value) && value > 0);
+  return {
+    start: starts.length ? isoFromUnix(Math.min(...starts)) : null,
+    end: ends.length ? isoFromUnix(Math.max(...ends)) : null,
+  };
 }
 
 function decodeRecord(userId: string, row: any): VoxelMakerSubscriptionRecord | null {
@@ -49,6 +60,7 @@ function decodeRecord(userId: string, row: any): VoxelMakerSubscriptionRecord | 
       stripeSubscriptionId: clean(parsed?.stripeSubscriptionId, 160) || undefined,
       stripeCheckoutSessionId: clean(parsed?.stripeCheckoutSessionId, 160) || undefined,
       cancelAtPeriodEnd: Boolean(parsed?.cancelAtPeriodEnd),
+      currentPeriodStart: clean(parsed?.currentPeriodStart, 80) || null,
       currentPeriodEnd: clean(parsed?.currentPeriodEnd, 80) || null,
       updatedAt: clean(parsed?.updatedAt, 80) || String(row.processed_at || ''),
     };
@@ -97,6 +109,7 @@ export async function beginVoxelMakerCheckout(input: {
     stripeSubscriptionId: current?.stripeSubscriptionId,
     stripeCheckoutSessionId: input.checkoutSessionId,
     cancelAtPeriodEnd: current?.cancelAtPeriodEnd || false,
+    currentPeriodStart: current?.currentPeriodStart || null,
     currentPeriodEnd: current?.currentPeriodEnd || null,
     updatedAt: new Date().toISOString(),
   });
@@ -106,6 +119,7 @@ async function recordFromStripeSubscription(userId: string, subscription: Stripe
   const plan = voxelMakerPlan(subscription.metadata?.plan_id || fallback?.planId);
   if (!plan) throw new Error('Voxel Maker subscription plan metadata is missing.');
   const customerId = typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id;
+  const period = subscriptionPeriod(subscription);
   return writeVoxelMakerSubscription({
     userId,
     planId: plan.id,
@@ -114,7 +128,8 @@ async function recordFromStripeSubscription(userId: string, subscription: Stripe
     stripeSubscriptionId: subscription.id,
     stripeCheckoutSessionId: fallback?.stripeCheckoutSessionId,
     cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
-    currentPeriodEnd: subscriptionPeriodEnd(subscription),
+    currentPeriodStart: period.start || fallback?.currentPeriodStart || null,
+    currentPeriodEnd: period.end || fallback?.currentPeriodEnd || null,
     updatedAt: new Date().toISOString(),
   });
 }
@@ -156,23 +171,28 @@ export async function getVoxelMakerEntitlement(userId: string) {
   };
 }
 
-function monthStartIso(now = new Date()) {
+function fallbackPeriodStart(now = new Date()) {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
 }
 
-export async function countVoxelMakerGenerations(userId: string) {
+function usagePeriodStart(value?: string | null) {
+  const parsed = Date.parse(String(value || ''));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallbackPeriodStart();
+}
+
+export async function countVoxelMakerGenerations(userId: string, periodStart?: string | null) {
   const supabase = getSupabaseAdmin();
   const { count, error } = await supabase
     .from('commerce_webhook_events')
     .select('event_id', { count: 'exact', head: true })
     .eq('provider', GENERATION_PROVIDER)
     .like('event_id', `${userId}:%`)
-    .gte('processed_at', monthStartIso());
+    .gte('processed_at', usagePeriodStart(periodStart));
   if (error) throw error;
   return Math.max(0, Number(count || 0));
 }
 
-export async function hasVoxelMakerGeneration(userId: string, draftId: string) {
+export async function hasVoxelMakerGeneration(userId: string, draftId: string, periodStart?: string | null) {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('commerce_webhook_events')
@@ -182,7 +202,7 @@ export async function hasVoxelMakerGeneration(userId: string, draftId: string) {
     .maybeSingle();
   if (error) throw error;
   if (!data?.event_id) return false;
-  return String(data.processed_at || '') >= monthStartIso();
+  return String(data.processed_at || '') >= usagePeriodStart(periodStart);
 }
 
 export async function registerVoxelMakerGeneration(input: { userId: string; draftId: string; planId: VoxelMakerPlanId; address?: string }) {
@@ -194,6 +214,6 @@ export async function registerVoxelMakerGeneration(input: { userId: string; draf
     event_id: eventId,
     event_type: JSON.stringify({ userId: input.userId, draftId: input.draftId, planId: input.planId, address: clean(input.address, 220) || null }),
     processed_at: now,
-  }, { onConflict: 'provider,event_id', ignoreDuplicates: true });
+  }, { onConflict: 'provider,event_id' });
   if (error) throw error;
 }

--- a/lib/voxel-maker-subscriptions.ts
+++ b/lib/voxel-maker-subscriptions.ts
@@ -1,0 +1,182 @@
+import type Stripe from 'stripe';
+import { getSupabaseAdmin } from './supabase-admin';
+import { stripe } from './stripe-server';
+import { voxelMakerPlan, type VoxelMakerPlanId } from './voxel-maker-plans';
+
+const SUBSCRIPTION_PROVIDER = 'voxel-maker-subscription';
+const GENERATION_PROVIDER = 'voxel-maker-generation';
+
+export type VoxelMakerSubscriptionRecord = {
+  userId: string;
+  planId: VoxelMakerPlanId;
+  status: string;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  stripeCheckoutSessionId?: string;
+  cancelAtPeriodEnd?: boolean;
+  currentPeriodEnd?: string | null;
+  updatedAt: string;
+};
+
+function clean(value: unknown, max = 300) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function activeStatus(status: unknown) {
+  return status === 'active' || status === 'trialing';
+}
+
+function subscriptionPeriodEnd(subscription: Stripe.Subscription) {
+  const unix = Number((subscription as any)?.current_period_end || 0);
+  return Number.isFinite(unix) && unix > 0 ? new Date(unix * 1000).toISOString() : null;
+}
+
+function decodeRecord(userId: string, row: any): VoxelMakerSubscriptionRecord | null {
+  if (!row?.event_type) return null;
+  try {
+    const parsed = JSON.parse(String(row.event_type));
+    const plan = voxelMakerPlan(parsed?.planId);
+    if (!plan) return null;
+    return {
+      userId,
+      planId: plan.id,
+      status: clean(parsed?.status, 40) || 'unknown',
+      stripeCustomerId: clean(parsed?.stripeCustomerId, 160) || undefined,
+      stripeSubscriptionId: clean(parsed?.stripeSubscriptionId, 160) || undefined,
+      stripeCheckoutSessionId: clean(parsed?.stripeCheckoutSessionId, 160) || undefined,
+      cancelAtPeriodEnd: Boolean(parsed?.cancelAtPeriodEnd),
+      currentPeriodEnd: clean(parsed?.currentPeriodEnd, 80) || null,
+      updatedAt: clean(parsed?.updatedAt, 80) || String(row.processed_at || ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function readVoxelMakerSubscription(userId: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('commerce_webhook_events')
+    .select('event_type,processed_at')
+    .eq('provider', SUBSCRIPTION_PROVIDER)
+    .eq('event_id', userId)
+    .maybeSingle();
+  if (error) throw error;
+  return decodeRecord(userId, data);
+}
+
+export async function writeVoxelMakerSubscription(record: VoxelMakerSubscriptionRecord) {
+  const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
+  const payload = { ...record, updatedAt: now };
+  const { error } = await supabase.from('commerce_webhook_events').upsert({
+    provider: SUBSCRIPTION_PROVIDER,
+    event_id: record.userId,
+    event_type: JSON.stringify(payload),
+    processed_at: now,
+  }, { onConflict: 'provider,event_id' });
+  if (error) throw error;
+  return payload;
+}
+
+export async function beginVoxelMakerCheckout(input: {
+  userId: string;
+  planId: VoxelMakerPlanId;
+  checkoutSessionId: string;
+}) {
+  const current = await readVoxelMakerSubscription(input.userId);
+  return writeVoxelMakerSubscription({
+    userId: input.userId,
+    planId: input.planId,
+    status: current && activeStatus(current.status) ? current.status : 'checkout_pending',
+    stripeCustomerId: current?.stripeCustomerId,
+    stripeSubscriptionId: current?.stripeSubscriptionId,
+    stripeCheckoutSessionId: input.checkoutSessionId,
+    cancelAtPeriodEnd: current?.cancelAtPeriodEnd || false,
+    currentPeriodEnd: current?.currentPeriodEnd || null,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+async function recordFromStripeSubscription(userId: string, subscription: Stripe.Subscription, fallback?: VoxelMakerSubscriptionRecord | null) {
+  const plan = voxelMakerPlan(subscription.metadata?.plan_id || fallback?.planId);
+  if (!plan) throw new Error('Voxel Maker subscription plan metadata is missing.');
+  const customerId = typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id;
+  return writeVoxelMakerSubscription({
+    userId,
+    planId: plan.id,
+    status: subscription.status,
+    stripeCustomerId: customerId || fallback?.stripeCustomerId,
+    stripeSubscriptionId: subscription.id,
+    stripeCheckoutSessionId: fallback?.stripeCheckoutSessionId,
+    cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+    currentPeriodEnd: subscriptionPeriodEnd(subscription),
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export async function refreshVoxelMakerSubscription(userId: string) {
+  let record = await readVoxelMakerSubscription(userId);
+  if (!record) return null;
+
+  try {
+    if (record.stripeSubscriptionId) {
+      const subscription = await stripe.subscriptions.retrieve(record.stripeSubscriptionId);
+      return await recordFromStripeSubscription(userId, subscription, record);
+    }
+
+    if (record.stripeCheckoutSessionId) {
+      const checkout = await stripe.checkout.sessions.retrieve(record.stripeCheckoutSessionId);
+      const checkoutUser = clean(checkout.client_reference_id || checkout.metadata?.voxelpop_user_id, 100);
+      if (checkoutUser !== userId) return record;
+      const subscriptionId = typeof checkout.subscription === 'string' ? checkout.subscription : checkout.subscription?.id;
+      if (subscriptionId) {
+        const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+        return await recordFromStripeSubscription(userId, subscription, record);
+      }
+    }
+  } catch (error) {
+    console.warn('Voxel Maker subscription refresh failed', error);
+  }
+
+  return record;
+}
+
+export async function getVoxelMakerEntitlement(userId: string) {
+  const record = await refreshVoxelMakerSubscription(userId);
+  const plan = record ? voxelMakerPlan(record.planId) : null;
+  return {
+    active: Boolean(record && plan && activeStatus(record.status)),
+    record,
+    plan,
+  };
+}
+
+function monthStartIso(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)).toISOString();
+}
+
+export async function countVoxelMakerGenerations(userId: string) {
+  const supabase = getSupabaseAdmin();
+  const { count, error } = await supabase
+    .from('commerce_webhook_events')
+    .select('event_id', { count: 'exact', head: true })
+    .eq('provider', GENERATION_PROVIDER)
+    .like('event_id', `${userId}:%`)
+    .gte('processed_at', monthStartIso());
+  if (error) throw error;
+  return Math.max(0, Number(count || 0));
+}
+
+export async function registerVoxelMakerGeneration(input: { userId: string; draftId: string; planId: VoxelMakerPlanId; address?: string }) {
+  const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
+  const eventId = `${input.userId}:${clean(input.draftId, 120)}`;
+  const { error } = await supabase.from('commerce_webhook_events').upsert({
+    provider: GENERATION_PROVIDER,
+    event_id: eventId,
+    event_type: JSON.stringify({ userId: input.userId, draftId: input.draftId, planId: input.planId, address: clean(input.address, 220) || null }),
+    processed_at: now,
+  }, { onConflict: 'provider,event_id', ignoreDuplicates: true });
+  if (error) throw error;
+}

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -100,6 +100,6 @@ assert.match(mintConfirm, /markPropertyCollectibleMinted/, 'verified mint uses t
 assert.match(mintState, /state: 'minted'/, 'verified mint permanently records the minted property state');
 assert.match(mintConfirm, /onePropertyOneMint: true/, 'mint confirmation records the one-property-one-mint result');
 assert.match(mintMetadata, /animation_url/, 'NFT metadata points to the finished 3D model');
-assert.match(mintPage, /Mint Later/, 'mint page still lets the user leave without minting');
+assert.match(mintPage, /Keep in inventory/, 'mint page still lets the user leave without minting');
 
 console.log('Legacy paid VoxelPop compatibility passed alongside the live no-checkout house flow: the old paid component remains internally coherent, while /property uses photo -> address -> voxel image -> automatic 3D voxel -> Inventory -> optional one-time mint.');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -49,6 +49,6 @@ assert.match(finalize, /updatePropertyCollectibleReservation/, 'a completed voxe
 assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint checks the exact account-owned finished voxel');
 assert.match(mintPrepare, /already been minted|duplicate mint/i, 'mint blocks a second NFT for the same property');
 assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint does not reintroduce Meshy');
-assert.match(mintPage, /Mint Later/, 'the mint page keeps inventory ownership useful without immediate minting');
+assert.match(mintPage, /Keep in inventory/, 'the mint page keeps inventory ownership useful without immediate minting');
 
 console.log('House voxel regression passed: photo -> address -> voxel image -> automatic movable 3D voxel -> automatic Inventory save -> optional one-of-one mint.');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -78,7 +78,7 @@ assert.match(finalize, /state: 'paid'/, 'finished lock is promoted to the existi
 assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint preparation verifies ownership of the exact finished local voxel');
 assert.match(mintPrepare, /already been minted|duplicate mint/i, 'mint preparation blocks duplicate minting');
 assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'property mint does not require Meshy');
-assert.match(mintPage, /Mint Later/, 'mint page still allows keeping the voxel without minting immediately');
+assert.match(mintPage, /Keep in inventory/, 'mint page still allows keeping the voxel without minting immediately');
 assert.match(vault, /directMintHref/, 'Inventory can recover the direct mint route');
 
 assert.doesNotMatch(property, /PropertyWorldMap|mapBuilding|saveToMyWorld|Add to My World/, 'World/map controls stay out of the core creation funnel');


### PR DESCRIPTION
Adds real monthly Stripe subscriptions to the Voxel Maker with four tiers: Starter $9 (3 creations), Creator $29 (12), Pro $59 (30), and Studio $99 (60). The property maker is gated behind an active subscription, monthly creation limits are enforced server-side against the Stripe billing period, and active subscribers get usage visibility plus Stripe Billing Portal access. Existing one-property/one-mint behavior remains intact.

Implementation notes:
- Stripe Checkout uses recurring monthly billing.
- Entitlement state is refreshed against Stripe rather than trusted from the client.
- Usage is idempotent per draft and resets with the Stripe billing period.
- Pricing UI is mobile-first and matches the current Voxel Vault/VoxelPop visual language.
- No database migration is introduced; existing commerce event storage is reused.