### PR TITLE
Add Vault Bank digital cards prototype

### DIFF
--- a/app/bank/BankClient.js
+++ b/app/bank/BankClient.js
@@ -1,0 +1,406 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+const initialCards = [
+  {
+    id: 'everyday',
+    name: 'Everyday',
+    holder: 'DOMINIC H',
+    last4: '4821',
+    number: '4242 8301 7714 4821',
+    expiry: '08/30',
+    cvv: '731',
+    frozen: false,
+    limit: 3500,
+    spent: 1284.62,
+    network: 'VISA',
+    tone: 'violet',
+  },
+  {
+    id: 'online',
+    name: 'Online only',
+    holder: 'DOMINIC H',
+    last4: '1940',
+    number: '4000 7013 5218 1940',
+    expiry: '11/30',
+    cvv: '264',
+    frozen: false,
+    limit: 1200,
+    spent: 316.18,
+    network: 'VISA',
+    tone: 'blue',
+  },
+];
+
+const initialTransactions = [
+  { id: 1, merchant: 'Acme Hosting', detail: 'Software · Today', amount: -24, icon: 'A', category: 'Software' },
+  { id: 2, merchant: 'Coffee District', detail: 'Food & drink · Today', amount: -7.85, icon: 'C', category: 'Food' },
+  { id: 3, merchant: 'Demo payroll', detail: 'Income · Yesterday', amount: 2850, icon: '↗', category: 'Income' },
+  { id: 4, merchant: 'Metro Market', detail: 'Groceries · Aug 27', amount: -83.46, icon: 'M', category: 'Groceries' },
+  { id: 5, merchant: 'Cloudbox', detail: 'Software · Aug 26', amount: -18, icon: 'C', category: 'Software' },
+  { id: 6, merchant: 'Northstar Energy', detail: 'Utilities · Aug 25', amount: -121.32, icon: 'N', category: 'Utilities' },
+];
+
+const navItems = [
+  ['overview', '⌂', 'Overview'],
+  ['cards', '▤', 'Cards'],
+  ['activity', '↕', 'Activity'],
+  ['payments', '→', 'Payments'],
+];
+
+function money(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+}
+
+function CardArtwork({ card, compact = false }) {
+  return (
+    <div className={`vb-card vb-card-${card.tone} ${card.frozen ? 'is-frozen' : ''} ${compact ? 'is-compact' : ''}`}>
+      <div className="vb-card-glow vb-card-glow-one" />
+      <div className="vb-card-glow vb-card-glow-two" />
+      <div className="vb-card-topline">
+        <div className="vb-card-brand"><span className="vb-brand-mark">V</span><b>VAULT</b></div>
+        <span className="vb-card-chip" aria-hidden="true" />
+      </div>
+      <div className="vb-card-number">•••• &nbsp;•••• &nbsp;•••• &nbsp;{card.last4}</div>
+      <div className="vb-card-bottom">
+        <div><span>CARD HOLDER</span><b>{card.holder}</b></div>
+        <div><span>EXPIRES</span><b>{card.expiry}</b></div>
+        <strong>{card.network}</strong>
+      </div>
+      {card.frozen && <div className="vb-card-frozen-label">FROZEN</div>}
+    </div>
+  );
+}
+
+function TinySparkline() {
+  return (
+    <svg className="vb-sparkline" viewBox="0 0 260 76" role="img" aria-label="Balance trend rising over the last month">
+      <defs>
+        <linearGradient id="lineFill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="currentColor" stopOpacity="0.26" />
+          <stop offset="1" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path className="vb-spark-area" d="M2 62 C25 55 40 58 57 44 S92 56 111 38 S144 42 160 28 S190 35 207 18 S236 20 258 8 L258 76 L2 76 Z" />
+      <path className="vb-spark-line" d="M2 62 C25 55 40 58 57 44 S92 56 111 38 S144 42 160 28 S190 35 207 18 S236 20 258 8" />
+    </svg>
+  );
+}
+
+export default function BankClient() {
+  const [section, setSection] = useState('overview');
+  const [balance, setBalance] = useState(12486.32);
+  const [savings] = useState(8200);
+  const [cards, setCards] = useState(initialCards);
+  const [transactions, setTransactions] = useState(initialTransactions);
+  const [selectedCardId, setSelectedCardId] = useState('everyday');
+  const [revealed, setRevealed] = useState(false);
+  const [modal, setModal] = useState(null);
+  const [toast, setToast] = useState('');
+  const [transfer, setTransfer] = useState({ recipient: '', amount: '' });
+  const [newCard, setNewCard] = useState({ name: 'Virtual card', limit: '1000' });
+
+  const selectedCard = cards.find((card) => card.id === selectedCardId) || cards[0];
+  const total = balance + savings;
+  const monthlySpend = useMemo(
+    () => transactions.filter((tx) => tx.amount < 0).reduce((sum, tx) => sum + Math.abs(tx.amount), 0),
+    [transactions]
+  );
+
+  function notify(message) {
+    setToast(message);
+    window.setTimeout(() => setToast(''), 2200);
+  }
+
+  function toggleFreeze() {
+    setCards((current) => current.map((card) => card.id === selectedCard.id ? { ...card, frozen: !card.frozen } : card));
+    notify(selectedCard.frozen ? 'Card unfrozen' : 'Card frozen');
+  }
+
+  function addDemoFunds() {
+    const amount = 500;
+    setBalance((value) => value + amount);
+    setTransactions((current) => [
+      { id: Date.now(), merchant: 'Demo top up', detail: 'Demo funds · Just now', amount, icon: '+', category: 'Income' },
+      ...current,
+    ]);
+    notify('Added $500 in demo funds');
+  }
+
+  function sendTransfer(event) {
+    event.preventDefault();
+    const amount = Number(transfer.amount);
+    if (!transfer.recipient.trim() || !Number.isFinite(amount) || amount <= 0) {
+      notify('Enter a recipient and valid amount');
+      return;
+    }
+    if (amount > balance) {
+      notify('Demo balance is too low');
+      return;
+    }
+    setBalance((value) => value - amount);
+    setTransactions((current) => [
+      {
+        id: Date.now(),
+        merchant: transfer.recipient.trim(),
+        detail: 'Transfer · Just now',
+        amount: -amount,
+        icon: '→',
+        category: 'Transfer',
+      },
+      ...current,
+    ]);
+    setTransfer({ recipient: '', amount: '' });
+    setModal(null);
+    notify('Demo transfer completed');
+  }
+
+  function createVirtualCard(event) {
+    event.preventDefault();
+    const limit = Math.max(100, Number(newCard.limit) || 1000);
+    const last4 = String(Math.floor(1000 + Math.random() * 9000));
+    const id = `virtual-${Date.now()}`;
+    const card = {
+      id,
+      name: newCard.name.trim() || 'Virtual card',
+      holder: 'DOMINIC H',
+      last4,
+      number: `4000 7712 8406 ${last4}`,
+      expiry: '08/31',
+      cvv: String(Math.floor(100 + Math.random() * 900)),
+      frozen: false,
+      limit,
+      spent: 0,
+      network: 'VISA',
+      tone: cards.length % 2 ? 'violet' : 'blue',
+    };
+    setCards((current) => [...current, card]);
+    setSelectedCardId(id);
+    setNewCard({ name: 'Virtual card', limit: '1000' });
+    setModal(null);
+    setSection('cards');
+    notify('Demo virtual card created');
+  }
+
+  function updateLimit(event) {
+    const next = Number(event.target.value);
+    setCards((current) => current.map((card) => card.id === selectedCard.id ? { ...card, limit: next } : card));
+  }
+
+  return (
+    <main className="vb-shell">
+      <aside className="vb-sidebar">
+        <Link href="/" className="vb-logo" aria-label="Back to Voxel Vault">
+          <span className="vb-logo-mark">V</span>
+          <span><b>Vault</b><small>Bank</small></span>
+        </Link>
+
+        <div className="vb-demo-pill"><span /> DEMO BANKING</div>
+
+        <nav className="vb-nav" aria-label="Bank navigation">
+          {navItems.map(([id, icon, label]) => (
+            <button key={id} className={section === id ? 'active' : ''} onClick={() => setSection(id)}>
+              <span>{icon}</span>{label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="vb-sidebar-bottom">
+          <button onClick={() => notify('Support is a demo in this build')}><span>?</span>Help center</button>
+          <button onClick={() => notify('Settings are a demo in this build')}><span>⚙</span>Settings</button>
+          <div className="vb-user-chip">
+            <div className="vb-avatar">DH</div>
+            <div><b>Dominic</b><small>Personal account</small></div>
+            <span>⌄</span>
+          </div>
+        </div>
+      </aside>
+
+      <section className="vb-main">
+        <header className="vb-topbar">
+          <div>
+            <div className="vb-mobile-logo"><span className="vb-logo-mark">V</span><b>Vault Bank</b></div>
+            <h1>{section === 'overview' ? 'Welcome back, Dominic' : section[0].toUpperCase() + section.slice(1)}</h1>
+            <p>{section === 'overview' ? 'Here’s your money at a glance.' : 'Manage everything from one clean workspace.'}</p>
+          </div>
+          <div className="vb-top-actions">
+            <button className="vb-icon-button" onClick={() => notify('No new alerts')} aria-label="Notifications">♢</button>
+            <button className="vb-primary-button" onClick={() => setModal('new-card')}>+ New card</button>
+          </div>
+        </header>
+
+        <div className="vb-safety-note">
+          <span>i</span>
+          <p><b>Prototype mode.</b> Balances, cards and transfers on this page are simulated. Real deposits or card issuance require a regulated banking/card provider integration.</p>
+        </div>
+
+        {section === 'overview' && (
+          <>
+            <div className="vb-overview-grid">
+              <article className="vb-balance-card">
+                <div className="vb-panel-heading">
+                  <div><span>Total balance</span><h2>{money(total)}</h2></div>
+                  <button onClick={() => setSection('activity')}>•••</button>
+                </div>
+                <div className="vb-balance-trend"><b>+4.8%</b><span>this month</span></div>
+                <TinySparkline />
+                <div className="vb-account-strip">
+                  <div><span>Checking</span><b>{money(balance)}</b></div>
+                  <div><span>Savings</span><b>{money(savings)}</b></div>
+                </div>
+              </article>
+
+              <article className="vb-quick-card">
+                <div className="vb-panel-title"><div><span className="vb-kicker">QUICK ACTIONS</span><h3>Move money</h3></div></div>
+                <div className="vb-quick-grid">
+                  <button onClick={() => setModal('transfer')}><span>↗</span><b>Transfer</b><small>Send money</small></button>
+                  <button onClick={addDemoFunds}><span>＋</span><b>Add money</b><small>Demo top up</small></button>
+                  <button onClick={() => { setSection('cards'); notify('Choose a card to manage'); }}><span>▤</span><b>Cards</b><small>Manage cards</small></button>
+                  <button onClick={() => notify('Bank details are hidden in demo mode')}><span>⌁</span><b>Bank details</b><small>Routing & account</small></button>
+                </div>
+              </article>
+            </div>
+
+            <div className="vb-content-grid">
+              <article className="vb-panel vb-card-panel">
+                <div className="vb-panel-title">
+                  <div><span className="vb-kicker">DIGITAL CARD</span><h3>{selectedCard.name}</h3></div>
+                  <button className="vb-text-button" onClick={() => setSection('cards')}>Manage →</button>
+                </div>
+                <CardArtwork card={selectedCard} />
+                <div className="vb-card-actions">
+                  <button onClick={toggleFreeze}><span>{selectedCard.frozen ? '▶' : '❄'}</span>{selectedCard.frozen ? 'Unfreeze' : 'Freeze'}</button>
+                  <button onClick={() => { setRevealed((value) => !value); }}><span>◉</span>{revealed ? 'Hide' : 'Details'}</button>
+                  <button onClick={() => setModal('new-card')}><span>＋</span>New card</button>
+                </div>
+              </article>
+
+              <article className="vb-panel vb-spend-panel">
+                <div className="vb-panel-title">
+                  <div><span className="vb-kicker">AUGUST</span><h3>Spending</h3></div>
+                  <b className="vb-spend-total">{money(monthlySpend)}</b>
+                </div>
+                <div className="vb-budget-row"><span>Monthly budget</span><b>{Math.round((monthlySpend / 2500) * 100)}% of $2,500</b></div>
+                <div className="vb-progress"><span style={{ width: `${Math.min(100, monthlySpend / 25)}%` }} /></div>
+                <div className="vb-spend-list">
+                  <div><span className="vb-dot dot-one" /><p><b>Shopping</b><small>42% of spend</small></p><strong>$356</strong></div>
+                  <div><span className="vb-dot dot-two" /><p><b>Food & drink</b><small>31% of spend</small></p><strong>$262</strong></div>
+                  <div><span className="vb-dot dot-three" /><p><b>Bills & software</b><small>27% of spend</small></p><strong>$228</strong></div>
+                </div>
+              </article>
+            </div>
+
+            <TransactionPanel transactions={transactions.slice(0, 5)} onAll={() => setSection('activity')} />
+          </>
+        )}
+
+        {section === 'cards' && (
+          <div className="vb-cards-page">
+            <div className="vb-card-gallery">
+              {cards.map((card) => (
+                <button key={card.id} className={`vb-card-choice ${card.id === selectedCard.id ? 'selected' : ''}`} onClick={() => { setSelectedCardId(card.id); setRevealed(false); }}>
+                  <CardArtwork card={card} compact />
+                  <div><b>{card.name}</b><span>•••• {card.last4}</span></div>
+                </button>
+              ))}
+              <button className="vb-add-card-tile" onClick={() => setModal('new-card')}><span>＋</span><b>Create virtual card</b><small>Make a separate card for subscriptions, online shopping or a project.</small></button>
+            </div>
+
+            <div className="vb-card-detail-grid">
+              <article className="vb-panel vb-card-management">
+                <div className="vb-panel-title"><div><span className="vb-kicker">CARD CONTROLS</span><h3>{selectedCard.name}</h3></div><span className={`vb-status ${selectedCard.frozen ? 'frozen' : ''}`}>{selectedCard.frozen ? 'Frozen' : 'Active'}</span></div>
+                <div className="vb-details-box">
+                  <div><span>Card number</span><b>{revealed ? selectedCard.number : `•••• •••• •••• ${selectedCard.last4}`}</b></div>
+                  <div><span>Expires</span><b>{revealed ? selectedCard.expiry : '••/••'}</b></div>
+                  <div><span>CVV</span><b>{revealed ? selectedCard.cvv : '•••'}</b></div>
+                  <button onClick={() => setRevealed((value) => !value)}>{revealed ? 'Hide details' : 'Reveal demo details'}</button>
+                </div>
+                <div className="vb-control-list">
+                  <button onClick={toggleFreeze}><div><span>{selectedCard.frozen ? '▶' : '❄'}</span><p><b>{selectedCard.frozen ? 'Unfreeze card' : 'Freeze card'}</b><small>{selectedCard.frozen ? 'Allow demo card activity again' : 'Pause demo card activity instantly'}</small></p></div><strong>→</strong></button>
+                  <button onClick={() => notify('Replacement flow is demo-only')}><div><span>↻</span><p><b>Replace card</b><small>Create a fresh card number</small></p></div><strong>→</strong></button>
+                  <button onClick={() => notify('Merchant controls are demo-only')}><div><span>⌘</span><p><b>Merchant controls</b><small>Subscriptions, online purchases and categories</small></p></div><strong>→</strong></button>
+                </div>
+              </article>
+
+              <article className="vb-panel vb-limit-panel">
+                <span className="vb-kicker">SPENDING LIMIT</span>
+                <h3>{money(selectedCard.limit)} <small>/ month</small></h3>
+                <div className="vb-progress"><span style={{ width: `${Math.min(100, selectedCard.spent / selectedCard.limit * 100)}%` }} /></div>
+                <div className="vb-limit-labels"><span>{money(selectedCard.spent)} spent</span><span>{money(Math.max(0, selectedCard.limit - selectedCard.spent))} left</span></div>
+                <label>Monthly limit
+                  <input type="range" min="100" max="10000" step="100" value={selectedCard.limit} onChange={updateLimit} />
+                </label>
+                <div className="vb-limit-presets">
+                  {[500, 1000, 2500, 5000].map((value) => <button key={value} className={selectedCard.limit === value ? 'active' : ''} onClick={() => setCards((current) => current.map((card) => card.id === selectedCard.id ? { ...card, limit: value } : card))}>{money(value).replace('.00', '')}</button>)}
+                </div>
+                <div className="vb-wallet-note"><span>⌁</span><div><b>Apple / Google Wallet ready</b><small>Tokenized-wallet provisioning can be connected when a real issuer is configured.</small></div></div>
+              </article>
+            </div>
+          </div>
+        )}
+
+        {section === 'activity' && <TransactionPanel transactions={transactions} large />}
+
+        {section === 'payments' && (
+          <div className="vb-empty-page">
+            <div className="vb-empty-icon">→</div>
+            <span className="vb-kicker">PAYMENTS</span>
+            <h2>Send money without the clutter.</h2>
+            <p>Create a demo transfer to see how the finished payment flow behaves. Production transfers stay disabled until a real provider is connected.</p>
+            <button className="vb-primary-button" onClick={() => setModal('transfer')}>New transfer</button>
+          </div>
+        )}
+      </section>
+
+      {modal === 'transfer' && (
+        <div className="vb-modal-backdrop" onMouseDown={() => setModal(null)}>
+          <form className="vb-modal" onSubmit={sendTransfer} onMouseDown={(event) => event.stopPropagation()}>
+            <div className="vb-modal-head"><div><span className="vb-kicker">DEMO TRANSFER</span><h2>Send money</h2></div><button type="button" onClick={() => setModal(null)}>×</button></div>
+            <label>Recipient<input autoFocus value={transfer.recipient} onChange={(event) => setTransfer({ ...transfer, recipient: event.target.value })} placeholder="Name or email" /></label>
+            <label>Amount<div className="vb-money-input"><span>$</span><input inputMode="decimal" value={transfer.amount} onChange={(event) => setTransfer({ ...transfer, amount: event.target.value })} placeholder="0.00" /></div></label>
+            <div className="vb-modal-balance"><span>Available demo balance</span><b>{money(balance)}</b></div>
+            <button className="vb-primary-button vb-full" type="submit">Send demo transfer</button>
+            <p className="vb-modal-disclaimer">No real funds move in this prototype.</p>
+          </form>
+        </div>
+      )}
+
+      {modal === 'new-card' && (
+        <div className="vb-modal-backdrop" onMouseDown={() => setModal(null)}>
+          <form className="vb-modal" onSubmit={createVirtualCard} onMouseDown={(event) => event.stopPropagation()}>
+            <div className="vb-modal-head"><div><span className="vb-kicker">DIGITAL CARD</span><h2>Create a virtual card</h2></div><button type="button" onClick={() => setModal(null)}>×</button></div>
+            <div className="vb-mini-card-preview"><span className="vb-logo-mark">V</span><div><small>NEW VIRTUAL CARD</small><b>{newCard.name || 'Virtual card'}</b></div><strong>VISA</strong></div>
+            <label>Card name<input autoFocus maxLength="24" value={newCard.name} onChange={(event) => setNewCard({ ...newCard, name: event.target.value })} placeholder="Subscriptions" /></label>
+            <label>Monthly limit<div className="vb-money-input"><span>$</span><input inputMode="numeric" value={newCard.limit} onChange={(event) => setNewCard({ ...newCard, limit: event.target.value })} /></div></label>
+            <button className="vb-primary-button vb-full" type="submit">Create demo card</button>
+            <p className="vb-modal-disclaimer">This creates a simulated card only. Live card issuance requires an approved card-issuing provider.</p>
+          </form>
+        </div>
+      )}
+
+      {toast && <div className="vb-toast">✓ {toast}</div>}
+    </main>
+  );
+}
+
+function TransactionPanel({ transactions, onAll, large = false }) {
+  return (
+    <article className={`vb-panel vb-transactions ${large ? 'is-large' : ''}`}>
+      <div className="vb-panel-title">
+        <div><span className="vb-kicker">ACTIVITY</span><h3>{large ? 'All transactions' : 'Recent transactions'}</h3></div>
+        {onAll && <button className="vb-text-button" onClick={onAll}>View all →</button>}
+      </div>
+      <div className="vb-transaction-list">
+        {transactions.map((tx) => (
+          <div className="vb-transaction" key={tx.id}>
+            <span className="vb-merchant-icon">{tx.icon}</span>
+            <div><b>{tx.merchant}</b><small>{tx.detail}</small></div>
+            <strong className={tx.amount > 0 ? 'positive' : ''}>{tx.amount > 0 ? '+' : ''}{money(tx.amount)}</strong>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/app/bank/bank.css
+++ b/app/bank/bank.css
@@ -1,0 +1,395 @@
+.vb-shell {
+  --vb-ink: #17151f;
+  --vb-muted: #777382;
+  --vb-line: #eceaf0;
+  --vb-soft: #f7f6f9;
+  --vb-purple: #6545f5;
+  --vb-purple-dark: #4f32db;
+  --vb-green: #168f5b;
+  min-height: 100svh;
+  background: #f4f3f6;
+  color: var(--vb-ink);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+}
+
+.vb-shell *, .vb-shell *::before, .vb-shell *::after { box-sizing: border-box; }
+.vb-shell button, .vb-shell input { font: inherit; }
+.vb-shell button { color: inherit; }
+
+.vb-sidebar {
+  min-height: 100svh;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  padding: 28px 18px 20px;
+  background: #fff;
+  border-right: 1px solid var(--vb-line);
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.vb-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  text-decoration: none;
+  color: var(--vb-ink);
+  padding: 0 9px;
+}
+
+.vb-logo-mark {
+  width: 34px;
+  height: 34px;
+  display: inline-grid;
+  place-items: center;
+  color: #fff;
+  background: linear-gradient(145deg, #785bff, #4724da);
+  border-radius: 11px;
+  box-shadow: 0 8px 20px rgba(101, 69, 245, .25);
+  font-weight: 900;
+  letter-spacing: -.04em;
+}
+
+.vb-logo > span:last-child { display: flex; gap: 3px; align-items: baseline; }
+.vb-logo b { font-size: 17px; letter-spacing: -.02em; }
+.vb-logo small { font-size: 12px; color: var(--vb-muted); font-weight: 700; }
+
+.vb-demo-pill {
+  width: fit-content;
+  margin: 23px 9px 19px;
+  padding: 7px 9px;
+  border-radius: 999px;
+  background: #f2efff;
+  color: #5f42dc;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: .08em;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.vb-demo-pill span { width: 6px; height: 6px; border-radius: 50%; background: #7b5cff; box-shadow: 0 0 0 4px rgba(123, 92, 255, .13); }
+
+.vb-nav { display: grid; gap: 5px; }
+.vb-nav button,
+.vb-sidebar-bottom > button {
+  min-height: 46px;
+  border: 0;
+  background: transparent;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+  font-weight: 720;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0 12px;
+  transition: .18s ease;
+}
+
+.vb-nav button span,
+.vb-sidebar-bottom > button span {
+  width: 25px;
+  height: 25px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  color: #8a8494;
+  font-size: 15px;
+}
+
+.vb-nav button:hover,
+.vb-sidebar-bottom > button:hover { background: #f7f5fb; }
+.vb-nav button.active { background: #f0edff; color: #5537dc; }
+.vb-nav button.active span { background: #ded6ff; color: #5537dc; }
+
+.vb-sidebar-bottom { margin-top: auto; display: grid; gap: 4px; }
+.vb-user-chip {
+  margin-top: 14px;
+  padding: 14px 9px 0;
+  border-top: 1px solid var(--vb-line);
+  display: grid;
+  grid-template-columns: 35px 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+.vb-avatar { width: 35px; height: 35px; border-radius: 50%; background: #191720; color: #fff; display: grid; place-items: center; font-size: 11px; font-weight: 850; }
+.vb-user-chip div:nth-child(2) { min-width: 0; display: grid; gap: 2px; }
+.vb-user-chip b { font-size: 12px; }
+.vb-user-chip small { font-size: 10px; color: var(--vb-muted); }
+.vb-user-chip > span { color: #9a96a1; }
+
+.vb-main { min-width: 0; padding: 38px clamp(24px, 4vw, 58px) 64px; max-width: 1500px; width: 100%; margin: 0 auto; }
+.vb-topbar { display: flex; justify-content: space-between; align-items: flex-start; gap: 24px; margin-bottom: 24px; }
+.vb-topbar h1 { margin: 0; font-size: clamp(25px, 2.4vw, 34px); letter-spacing: -.045em; line-height: 1.05; }
+.vb-topbar p { margin: 8px 0 0; color: var(--vb-muted); font-size: 13px; }
+.vb-top-actions { display: flex; align-items: center; gap: 9px; }
+.vb-icon-button, .vb-primary-button {
+  min-height: 42px;
+  border-radius: 12px;
+  border: 1px solid #e4e1e8;
+  background: #fff;
+  cursor: pointer;
+  font-weight: 800;
+  transition: transform .16s ease, box-shadow .16s ease, background .16s ease;
+}
+.vb-icon-button { width: 42px; padding: 0; font-size: 17px; }
+.vb-primary-button { padding: 0 16px; border-color: #5d3be4; background: linear-gradient(145deg, #7657ff, #5735df); color: #fff !important; box-shadow: 0 9px 22px rgba(87, 53, 223, .2); }
+.vb-primary-button:hover, .vb-icon-button:hover { transform: translateY(-1px); box-shadow: 0 10px 24px rgba(31, 25, 47, .11); }
+.vb-primary-button:active, .vb-icon-button:active { transform: translateY(0); }
+.vb-mobile-logo { display: none; }
+
+.vb-safety-note {
+  min-height: 46px;
+  margin-bottom: 18px;
+  padding: 10px 14px;
+  border: 1px solid #ddd6ff;
+  border-radius: 13px;
+  background: #f7f5ff;
+  color: #514772;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.vb-safety-note > span { flex: 0 0 auto; width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center; background: #e8e1ff; color: #6545f5; font-weight: 900; font-size: 12px; }
+.vb-safety-note p { margin: 0; font-size: 11px; line-height: 1.45; }
+
+.vb-overview-grid { display: grid; grid-template-columns: minmax(0, 1.32fr) minmax(330px, .8fr); gap: 16px; }
+.vb-balance-card,
+.vb-quick-card,
+.vb-panel {
+  background: #fff;
+  border: 1px solid var(--vb-line);
+  border-radius: 21px;
+  box-shadow: 0 12px 30px rgba(27, 22, 36, .035);
+}
+
+.vb-balance-card { min-height: 260px; padding: 25px 26px 0; overflow: hidden; position: relative; }
+.vb-panel-heading { display: flex; justify-content: space-between; align-items: flex-start; }
+.vb-panel-heading > div { display: grid; gap: 7px; }
+.vb-panel-heading span { color: var(--vb-muted); font-size: 11px; font-weight: 700; }
+.vb-panel-heading h2 { margin: 0; font-size: clamp(29px, 3vw, 40px); letter-spacing: -.05em; }
+.vb-panel-heading button { border: 0; background: transparent; color: #918c98; cursor: pointer; font-weight: 900; }
+.vb-balance-trend { margin-top: 8px; display: flex; align-items: center; gap: 7px; font-size: 10px; }
+.vb-balance-trend b { color: var(--vb-green); background: #e9f8f0; padding: 4px 7px; border-radius: 999px; }
+.vb-balance-trend span { color: var(--vb-muted); }
+.vb-sparkline { width: 100%; height: 82px; color: #694bf0; display: block; margin-top: 7px; }
+.vb-spark-area { fill: url(#lineFill); }
+.vb-spark-line { fill: none; stroke: currentColor; stroke-width: 2.5; stroke-linecap: round; }
+.vb-account-strip { margin: 0 -26px; padding: 12px 26px; border-top: 1px solid var(--vb-line); display: grid; grid-template-columns: 1fr 1fr; }
+.vb-account-strip > div { display: flex; justify-content: space-between; gap: 12px; align-items: center; font-size: 11px; }
+.vb-account-strip > div + div { border-left: 1px solid var(--vb-line); padding-left: 22px; margin-left: 22px; }
+.vb-account-strip span { color: var(--vb-muted); }
+.vb-account-strip b { font-size: 12px; }
+
+.vb-quick-card { padding: 23px; }
+.vb-panel-title { display: flex; justify-content: space-between; align-items: flex-start; gap: 18px; }
+.vb-panel-title h3 { margin: 4px 0 0; font-size: 17px; letter-spacing: -.025em; }
+.vb-kicker { font-size: 9px; letter-spacing: .12em; font-weight: 900; color: #9a95a2; }
+.vb-quick-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; margin-top: 18px; }
+.vb-quick-grid button { min-height: 83px; border: 1px solid var(--vb-line); border-radius: 14px; background: #faf9fb; cursor: pointer; text-align: left; padding: 11px; display: grid; grid-template-columns: 28px 1fr; grid-template-rows: auto auto; column-gap: 9px; transition: .16s ease; }
+.vb-quick-grid button:hover { background: #f4f1ff; border-color: #dad1ff; transform: translateY(-1px); }
+.vb-quick-grid button > span { grid-row: 1 / span 2; width: 28px; height: 28px; border-radius: 9px; display: grid; place-items: center; background: #eee9ff; color: #5d3de0; font-weight: 900; }
+.vb-quick-grid b { font-size: 11px; align-self: end; }
+.vb-quick-grid small { font-size: 9px; color: var(--vb-muted); }
+
+.vb-content-grid { margin-top: 16px; display: grid; grid-template-columns: minmax(360px, 1.13fr) minmax(320px, .87fr); gap: 16px; }
+.vb-panel { padding: 23px; }
+.vb-text-button { border: 0; background: transparent; color: #6545f5; font-size: 10px; font-weight: 850; cursor: pointer; padding: 5px; }
+
+.vb-card { margin-top: 17px; width: min(100%, 385px); aspect-ratio: 1.59 / 1; min-height: 205px; border-radius: 20px; position: relative; overflow: hidden; color: white; padding: 21px; display: flex; flex-direction: column; justify-content: space-between; box-shadow: 0 19px 42px rgba(62, 37, 145, .2); isolation: isolate; }
+.vb-card-violet { background: linear-gradient(145deg, #2a1a58 0%, #5835c2 48%, #9c7bff 100%); }
+.vb-card-blue { background: linear-gradient(145deg, #10183c 0%, #2a4a9b 49%, #60a7ff 100%); }
+.vb-card::after { content: ''; position: absolute; inset: 0; z-index: -1; background-image: linear-gradient(120deg, rgba(255,255,255,.09), transparent 34%), repeating-linear-gradient(130deg, transparent 0 22px, rgba(255,255,255,.025) 22px 23px); }
+.vb-card-glow { position: absolute; border-radius: 50%; filter: blur(2px); z-index: -1; }
+.vb-card-glow-one { width: 170px; height: 170px; top: -85px; right: -35px; background: rgba(255,255,255,.18); }
+.vb-card-glow-two { width: 110px; height: 110px; bottom: -45px; left: 80px; background: rgba(173,141,255,.26); }
+.vb-card-topline, .vb-card-bottom { display: flex; justify-content: space-between; align-items: center; }
+.vb-card-brand { display: flex; align-items: center; gap: 7px; font-size: 12px; letter-spacing: .1em; }
+.vb-brand-mark { width: 23px; height: 23px; display: grid; place-items: center; border-radius: 7px; background: rgba(255,255,255,.17); border: 1px solid rgba(255,255,255,.22); font-weight: 900; }
+.vb-card-chip { width: 34px; height: 25px; border-radius: 7px; background: linear-gradient(135deg, #e8d78e, #fff1b2 55%, #b59e4a); position: relative; }
+.vb-card-chip::after, .vb-card-chip::before { content: ''; position: absolute; background: rgba(95,77,27,.25); }
+.vb-card-chip::after { height: 1px; left: 0; right: 0; top: 12px; }
+.vb-card-chip::before { width: 1px; top: 0; bottom: 0; left: 17px; }
+.vb-card-number { font-size: clamp(16px, 2vw, 21px); letter-spacing: .09em; font-weight: 650; text-shadow: 0 1px 8px rgba(0,0,0,.18); }
+.vb-card-bottom { align-items: flex-end; }
+.vb-card-bottom > div { display: grid; gap: 3px; }
+.vb-card-bottom span { font-size: 6px; letter-spacing: .13em; opacity: .67; }
+.vb-card-bottom b { font-size: 8px; letter-spacing: .08em; }
+.vb-card-bottom strong { font-size: 16px; font-style: italic; letter-spacing: -.06em; }
+.vb-card.is-frozen { filter: saturate(.25); }
+.vb-card-frozen-label { position: absolute; inset: 0; display: grid; place-items: center; background: rgba(10,8,18,.48); backdrop-filter: blur(3px); font-size: 12px; font-weight: 900; letter-spacing: .18em; }
+.vb-card.is-compact { width: 100%; min-height: 0; border-radius: 16px; padding: 15px; box-shadow: 0 13px 28px rgba(62, 37, 145, .14); }
+.vb-card.is-compact .vb-card-number { font-size: 12px; }
+.vb-card.is-compact .vb-card-bottom span { font-size: 5px; }
+.vb-card.is-compact .vb-card-bottom b { font-size: 6px; }
+.vb-card.is-compact .vb-card-brand { font-size: 8px; }
+.vb-card.is-compact .vb-brand-mark { width: 19px; height: 19px; font-size: 9px; }
+.vb-card.is-compact .vb-card-chip { width: 27px; height: 20px; }
+
+.vb-card-actions { display: flex; gap: 8px; margin-top: 15px; }
+.vb-card-actions button { flex: 1; min-height: 39px; border: 1px solid var(--vb-line); background: #faf9fb; border-radius: 11px; cursor: pointer; display: flex; justify-content: center; align-items: center; gap: 7px; font-size: 9px; font-weight: 800; }
+.vb-card-actions button span { color: #6545f5; }
+
+.vb-spend-total { font-size: 13px; }
+.vb-budget-row { margin-top: 24px; display: flex; justify-content: space-between; gap: 12px; color: var(--vb-muted); font-size: 9px; }
+.vb-budget-row b { color: #524f58; }
+.vb-progress { height: 7px; background: #efedf2; border-radius: 99px; overflow: hidden; margin-top: 9px; }
+.vb-progress span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #7758ff, #9a7dff); }
+.vb-spend-list { margin-top: 20px; display: grid; gap: 14px; }
+.vb-spend-list > div { display: grid; grid-template-columns: 8px 1fr auto; gap: 9px; align-items: center; }
+.vb-dot { width: 7px; height: 7px; border-radius: 50%; }
+.dot-one { background: #6a48ef; } .dot-two { background: #9e83ff; } .dot-three { background: #d1c7fb; }
+.vb-spend-list p { margin: 0; display: grid; gap: 2px; }
+.vb-spend-list b, .vb-spend-list strong { font-size: 10px; }
+.vb-spend-list small { color: var(--vb-muted); font-size: 8px; }
+
+.vb-transactions { margin-top: 16px; }
+.vb-transaction-list { margin-top: 13px; }
+.vb-transaction { min-height: 55px; display: grid; grid-template-columns: 34px minmax(0,1fr) auto; align-items: center; gap: 11px; border-top: 1px solid #f0eef2; }
+.vb-transaction:first-child { border-top: 0; }
+.vb-merchant-icon { width: 32px; height: 32px; display: grid; place-items: center; background: #f1eff5; border-radius: 10px; font-weight: 900; font-size: 10px; color: #514b5a; }
+.vb-transaction > div { display: grid; gap: 2px; }
+.vb-transaction b { font-size: 11px; }
+.vb-transaction small { font-size: 8px; color: var(--vb-muted); }
+.vb-transaction strong { font-size: 10px; }
+.vb-transaction strong.positive { color: var(--vb-green); }
+.vb-transactions.is-large { min-height: 540px; }
+.vb-transactions.is-large .vb-transaction { min-height: 66px; }
+.vb-transactions.is-large .vb-transaction b, .vb-transactions.is-large .vb-transaction strong { font-size: 12px; }
+.vb-transactions.is-large .vb-transaction small { font-size: 9px; }
+
+.vb-cards-page { display: grid; gap: 16px; }
+.vb-card-gallery { display: grid; grid-template-columns: repeat(3, minmax(220px, 1fr)); gap: 14px; }
+.vb-card-choice { border: 1px solid transparent; background: #fff; border-radius: 20px; padding: 10px; cursor: pointer; text-align: left; transition: .16s ease; }
+.vb-card-choice:hover { transform: translateY(-2px); }
+.vb-card-choice.selected { border-color: #aa98ff; box-shadow: 0 0 0 3px rgba(101,69,245,.08); }
+.vb-card-choice .vb-card { margin-top: 0; pointer-events: none; }
+.vb-card-choice > div:last-child { padding: 11px 5px 3px; display: flex; justify-content: space-between; gap: 10px; }
+.vb-card-choice > div:last-child b { font-size: 11px; }
+.vb-card-choice > div:last-child span { color: var(--vb-muted); font-size: 9px; }
+.vb-add-card-tile { min-height: 210px; border: 1px dashed #cfc8dd; border-radius: 20px; background: rgba(255,255,255,.56); cursor: pointer; padding: 30px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 7px; }
+.vb-add-card-tile > span { width: 38px; height: 38px; border-radius: 13px; background: #eee9ff; color: #6243e9; display: grid; place-items: center; font-size: 20px; }
+.vb-add-card-tile b { font-size: 11px; margin-top: 5px; }
+.vb-add-card-tile small { max-width: 210px; color: var(--vb-muted); font-size: 8px; line-height: 1.45; }
+.vb-card-detail-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(300px, .85fr); gap: 16px; }
+.vb-status { font-size: 9px; font-weight: 850; color: #13754d; background: #e6f7ee; padding: 6px 9px; border-radius: 999px; }
+.vb-status.frozen { color: #6b6170; background: #efedf2; }
+.vb-details-box { margin-top: 19px; border: 1px solid var(--vb-line); background: #faf9fb; border-radius: 14px; padding: 14px; display: grid; grid-template-columns: 1.8fr .6fr .45fr auto; gap: 12px; align-items: end; }
+.vb-details-box > div { display: grid; gap: 4px; min-width: 0; }
+.vb-details-box span { color: var(--vb-muted); font-size: 7px; text-transform: uppercase; letter-spacing: .09em; }
+.vb-details-box b { font-size: 9px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.vb-details-box button { min-height: 34px; border: 0; border-radius: 9px; background: #eee9ff; color: #5d3de0; font-size: 8px; font-weight: 850; cursor: pointer; padding: 0 10px; }
+.vb-control-list { margin-top: 16px; display: grid; }
+.vb-control-list > button { min-height: 65px; border: 0; border-top: 1px solid var(--vb-line); background: transparent; cursor: pointer; padding: 10px 2px; display: flex; align-items: center; justify-content: space-between; text-align: left; }
+.vb-control-list > button:first-child { border-top: 0; }
+.vb-control-list > button > div { display: flex; align-items: center; gap: 11px; }
+.vb-control-list > button > div > span { width: 31px; height: 31px; border-radius: 10px; background: #f1eefc; color: #6747ea; display: grid; place-items: center; }
+.vb-control-list p { margin: 0; display: grid; gap: 3px; }
+.vb-control-list b { font-size: 10px; }
+.vb-control-list small { color: var(--vb-muted); font-size: 8px; }
+.vb-control-list > button > strong { color: #a5a0aa; }
+.vb-limit-panel h3 { margin: 11px 0 0; font-size: 24px; letter-spacing: -.04em; }
+.vb-limit-panel h3 small { font-size: 10px; color: var(--vb-muted); font-weight: 700; }
+.vb-limit-labels { margin-top: 7px; display: flex; justify-content: space-between; color: var(--vb-muted); font-size: 8px; }
+.vb-limit-panel label { display: grid; gap: 8px; margin-top: 23px; color: var(--vb-muted); font-size: 8px; font-weight: 800; }
+.vb-limit-panel input[type="range"] { width: 100%; accent-color: #6545f5; }
+.vb-limit-presets { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin-top: 8px; }
+.vb-limit-presets button { min-height: 31px; border: 1px solid var(--vb-line); border-radius: 9px; background: #fff; cursor: pointer; font-size: 8px; font-weight: 800; }
+.vb-limit-presets button.active { border-color: #b9aaff; background: #f0edff; color: #5c3ee0; }
+.vb-wallet-note { margin-top: 22px; padding: 12px; border-radius: 12px; background: #f7f5fb; display: flex; gap: 10px; align-items: center; }
+.vb-wallet-note > span { width: 31px; height: 31px; border-radius: 9px; display: grid; place-items: center; background: #19171d; color: #fff; }
+.vb-wallet-note > div { display: grid; gap: 2px; }
+.vb-wallet-note b { font-size: 9px; }
+.vb-wallet-note small { color: var(--vb-muted); font-size: 7px; line-height: 1.35; }
+
+.vb-empty-page { min-height: 520px; border: 1px solid var(--vb-line); border-radius: 22px; background: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 40px; }
+.vb-empty-icon { width: 58px; height: 58px; border-radius: 18px; background: #ede8ff; color: #5d3ce3; display: grid; place-items: center; font-size: 26px; margin-bottom: 18px; }
+.vb-empty-page h2 { font-size: 28px; letter-spacing: -.04em; margin: 8px 0; }
+.vb-empty-page p { max-width: 500px; color: var(--vb-muted); line-height: 1.6; font-size: 11px; margin: 0 0 20px; }
+
+.vb-modal-backdrop { position: fixed; inset: 0; z-index: 100; background: rgba(17, 13, 27, .46); backdrop-filter: blur(8px); display: grid; place-items: center; padding: 18px; }
+.vb-modal { width: min(100%, 420px); background: #fff; border: 1px solid rgba(255,255,255,.6); border-radius: 22px; padding: 24px; box-shadow: 0 28px 80px rgba(21, 15, 41, .26); display: grid; gap: 16px; }
+.vb-modal-head { display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; }
+.vb-modal-head h2 { margin: 4px 0 0; font-size: 22px; letter-spacing: -.04em; }
+.vb-modal-head > button { border: 0; width: 31px; height: 31px; border-radius: 9px; background: #f1eff4; cursor: pointer; font-size: 18px; }
+.vb-modal label { display: grid; gap: 7px; color: #6f6a78; font-size: 9px; font-weight: 800; }
+.vb-modal input { width: 100%; min-height: 44px; border: 1px solid #dfdce3; border-radius: 11px; background: #fbfafc; padding: 0 12px; outline: none; color: var(--vb-ink); }
+.vb-modal input:focus { border-color: #9d88ff; box-shadow: 0 0 0 3px rgba(101,69,245,.1); }
+.vb-money-input { position: relative; }
+.vb-money-input > span { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: #77717f; font-weight: 900; }
+.vb-money-input input { padding-left: 27px; }
+.vb-modal-balance { padding: 11px 12px; border-radius: 11px; background: #f6f4f8; display: flex; justify-content: space-between; gap: 12px; font-size: 9px; }
+.vb-modal-balance span { color: var(--vb-muted); }
+.vb-primary-button.vb-full { width: 100%; min-height: 46px; }
+.vb-modal-disclaimer { text-align: center; color: var(--vb-muted); font-size: 8px; line-height: 1.45; margin: -5px 0 0; }
+.vb-mini-card-preview { min-height: 82px; border-radius: 15px; padding: 14px; color: #fff; background: linear-gradient(135deg, #25164f, #6846dc 60%, #9a7aff); display: grid; grid-template-columns: 34px 1fr auto; gap: 10px; align-items: center; }
+.vb-mini-card-preview .vb-logo-mark { width: 31px; height: 31px; background: rgba(255,255,255,.14); box-shadow: none; border: 1px solid rgba(255,255,255,.2); }
+.vb-mini-card-preview div { display: grid; gap: 3px; }
+.vb-mini-card-preview small { font-size: 6px; letter-spacing: .12em; opacity: .68; }
+.vb-mini-card-preview b { font-size: 10px; }
+.vb-mini-card-preview strong { font-size: 13px; font-style: italic; }
+
+.vb-toast { position: fixed; right: 24px; bottom: 24px; z-index: 120; background: #18151f; color: #fff; padding: 12px 15px; border-radius: 12px; font-size: 10px; font-weight: 800; box-shadow: 0 14px 42px rgba(20,15,31,.28); animation: vbToastIn .2s ease-out; }
+@keyframes vbToastIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+.vb-shell button:focus-visible, .vb-shell input:focus-visible, .vb-shell a:focus-visible { outline: 3px solid rgba(101,69,245,.25); outline-offset: 2px; }
+
+@media (max-width: 1080px) {
+  .vb-shell { grid-template-columns: 210px minmax(0, 1fr); }
+  .vb-overview-grid, .vb-content-grid { grid-template-columns: 1fr; }
+  .vb-quick-grid { grid-template-columns: repeat(4, 1fr); }
+  .vb-quick-grid button { grid-template-columns: 1fr; grid-template-rows: auto auto auto; }
+  .vb-quick-grid button > span { grid-row: auto; }
+  .vb-card-gallery { grid-template-columns: repeat(2, 1fr); }
+  .vb-card-detail-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 760px) {
+  .vb-shell { display: block; min-height: 100svh; }
+  .vb-sidebar { display: none; }
+  .vb-main { padding: 19px 14px calc(28px + env(safe-area-inset-bottom)); }
+  .vb-topbar { align-items: center; margin-bottom: 15px; }
+  .vb-mobile-logo { display: flex; align-items: center; gap: 8px; margin-bottom: 15px; font-size: 13px; }
+  .vb-mobile-logo .vb-logo-mark { width: 28px; height: 28px; border-radius: 9px; }
+  .vb-topbar h1 { font-size: 25px; }
+  .vb-topbar p { font-size: 11px; }
+  .vb-icon-button { display: none; }
+  .vb-primary-button { min-height: 39px; padding-inline: 12px; font-size: 10px; }
+  .vb-safety-note { align-items: flex-start; }
+  .vb-safety-note p { font-size: 9px; }
+  .vb-overview-grid, .vb-content-grid { gap: 11px; }
+  .vb-balance-card, .vb-quick-card, .vb-panel { border-radius: 17px; }
+  .vb-balance-card { padding: 20px 18px 0; }
+  .vb-account-strip { margin: 0 -18px; padding-inline: 18px; }
+  .vb-account-strip > div { display: grid; }
+  .vb-account-strip > div + div { padding-left: 14px; margin-left: 14px; }
+  .vb-quick-card, .vb-panel { padding: 18px; }
+  .vb-quick-grid { grid-template-columns: 1fr 1fr; }
+  .vb-quick-grid button { grid-template-columns: 28px 1fr; grid-template-rows: auto auto; }
+  .vb-quick-grid button > span { grid-row: 1 / span 2; }
+  .vb-card { margin-inline: auto; min-height: 190px; }
+  .vb-card-actions button { min-height: 42px; }
+  .vb-card-gallery { display: flex; overflow-x: auto; scroll-snap-type: x mandatory; padding-bottom: 5px; }
+  .vb-card-choice, .vb-add-card-tile { flex: 0 0 82%; scroll-snap-align: start; }
+  .vb-card-detail-grid { gap: 11px; }
+  .vb-details-box { grid-template-columns: 1fr 1fr; }
+  .vb-details-box > div:first-child { grid-column: 1 / -1; }
+  .vb-details-box button { grid-column: 1 / -1; }
+  .vb-limit-presets { grid-template-columns: 1fr 1fr; }
+  .vb-transaction { min-height: 60px; }
+  .vb-empty-page { min-height: 480px; padding: 28px 20px; }
+  .vb-empty-page h2 { font-size: 23px; }
+  .vb-modal-backdrop { align-items: end; padding: 0; }
+  .vb-modal { width: 100%; border-radius: 22px 22px 0 0; padding: 23px 18px calc(20px + env(safe-area-inset-bottom)); }
+  .vb-toast { right: 14px; left: 14px; bottom: calc(14px + env(safe-area-inset-bottom)); text-align: center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vb-shell *, .vb-shell *::before, .vb-shell *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; transition-duration: .01ms !important; }
+}

--- a/app/bank/page.js
+++ b/app/bank/page.js
@@ -1,0 +1,11 @@
+import BankClient from './BankClient';
+import './bank.css';
+
+export const metadata = {
+  title: 'Vault Bank — Digital cards',
+  description: 'Demo banking dashboard with balances, transfers, transaction history, and controllable digital cards.',
+};
+
+export default function BankPage() {
+  return <BankClient />;
+}


### PR DESCRIPTION
## What this adds
- New `/bank` banking-style dashboard
- Demo checking + savings balances and activity
- Digital card gallery with freeze/unfreeze and reveal/hide controls
- Adjustable monthly spending limits
- Create additional virtual cards in-browser
- Demo money transfer and demo top-up interactions
- Responsive mobile layout and accessible focus/reduced-motion behavior

## Safety boundary
This is intentionally a clearly labeled prototype. It does not represent a licensed bank, move real funds, or issue real payment cards. Production card/deposit rails should only be enabled after an approved regulated provider integration.

## Scope
Additive route only; existing VoxelPop/product routes are not changed.