### PR TITLE
Rebuild Voxel Vault as guided property voxel studio

### DIFF
--- a/app/components/FinancialOSNav.js
+++ b/app/components/FinancialOSNav.js
@@ -17,12 +17,20 @@ function activeDockItem(pathname) {
   return 'home';
 }
 
+function usesPropertyStudioNavigation(pathname) {
+  return pathname === '/'
+    || pathname === '/property'
+    || pathname.startsWith('/property/')
+    || pathname === '/vault/property-drafts'
+    || pathname.startsWith('/vault/property-drafts/');
+}
+
 export default function FinancialOSNav() {
   const pathname = usePathname() || '/';
   if (!isOrganizedUserRoute(pathname)) return null;
 
-  // Home and the paid creator already use the focused top navigation.
-  if (pathname === '/' || pathname === '/property') return null;
+  // The focused property studio, mint and inventory pages provide their own consistent navigation.
+  if (usesPropertyStudioNavigation(pathname)) return null;
 
   const active = activeDockItem(pathname);
 

--- a/app/home.module.css
+++ b/app/home.module.css
@@ -1,1 +1,135 @@
-.page{min-height:100vh;padding-bottom:calc(96px + env(safe-area-inset-bottom));background:radial-gradient(circle at 50% 0,rgba(111,61,244,.14),transparent 28%),radial-gradient(circle at 10% 12%,rgba(201,255,84,.15),transparent 24%),linear-gradient(180deg,#fffdf8 0%,#fffaf3 62%,#f5f1eb 100%);color:var(--vv-ink);font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.page *{box-sizing:border-box}.shell{width:min(920px,100%);margin:0 auto;padding:0 22px}.hero{padding:54px 0 28px;text-align:center}.kicker{width:max-content;max-width:100%;margin:0 auto;padding:7px 11px;border:1px solid #e0d6ee;border-radius:999px;background:rgba(255,255,255,.84);color:var(--vv-purple);font-size:9px;font-weight:1000;letter-spacing:.14em}.hero h1{margin:16px 0 10px;font-size:clamp(68px,13vw,132px);line-height:.82;letter-spacing:-.075em}.hero h1 em{font-style:normal;color:var(--vv-purple);text-shadow:0 8px 0 rgba(92,46,210,.08)}.heroLine{max-width:620px;margin:0 auto;color:#625866;font-size:18px;line-height:1.55}.centerMachine{width:min(700px,100%);margin:30px auto 0;padding:12px;border:1px solid rgba(220,210,227,.95);border-radius:32px;background:rgba(255,255,255,.76);box-shadow:0 30px 80px rgba(62,39,78,.14);backdrop-filter:blur(18px);-webkit-backdrop-filter:blur(18px)}.primaryAction{min-height:58px;margin-top:10px;padding:0 22px;border-radius:18px;display:flex;align-items:center;justify-content:center;background:linear-gradient(180deg,#7d43ff,#6932ed);color:#fff;text-decoration:none;font-size:14px;font-weight:1000;box-shadow:0 6px 0 #5120d0,0 15px 34px rgba(102,55,219,.20);transition:transform .16s ease}.primaryAction:hover{transform:translateY(-2px)}.microCopy{margin:13px 4px 3px;color:#746b78;font-size:10.5px;font-weight:800;line-height:1.45}.simpleSteps{width:min(700px,100%);margin:20px auto 0;display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.simpleSteps>div{min-height:82px;padding:12px;border:1px solid #e4dce7;border-radius:18px;background:rgba(255,255,255,.8);display:flex;align-items:center;gap:10px;text-align:left;box-shadow:0 9px 24px rgba(67,49,77,.04)}.simpleSteps i{width:34px;height:34px;flex:0 0 34px;border-radius:11px;background:var(--vv-lime);color:#334710;display:grid;place-items:center;font-style:normal;font-size:10px;font-weight:1000}.simpleSteps span{display:grid;gap:3px}.simpleSteps b{font-size:13px;letter-spacing:-.02em}.simpleSteps small{color:#786d7b;font-size:9.5px;line-height:1.35}.truthCard{margin-top:8px;padding:18px 20px;border:1px solid #dfe9cb;border-radius:22px;background:linear-gradient(145deg,#fbfff3,#f4ffe2);display:grid;grid-template-columns:auto 1fr;gap:20px;align-items:center}.truthCard>div{display:grid;gap:4px}.truthCard b{color:#3e541c;font-size:13px}.truthCard span{color:#64774a;font-size:10px;font-weight:850}.truthCard p{margin:0;color:#69765c;font-size:9.5px;line-height:1.55;text-align:right}.footer{margin-top:28px;padding:20px 2px 4px;border-top:1px solid #e2dbd5;display:flex;justify-content:space-between;gap:18px;color:#776e79;font-size:10px;line-height:1.55}.footer a{color:var(--vv-purple);font-weight:900;text-decoration:none}.page a:focus-visible{outline:3px solid rgba(111,61,244,.28);outline-offset:3px}@media(max-width:700px){.shell{padding:0 11px}.hero{padding:30px 0 22px}.hero h1{font-size:clamp(55px,20vw,82px);margin:12px 0 9px}.heroLine{font-size:14px;padding:0 8px}.centerMachine{margin-top:22px;padding:9px;border-radius:26px}.primaryAction{min-height:54px;border-radius:16px;font-size:13px}.simpleSteps{grid-template-columns:1fr;gap:6px;margin-top:14px}.simpleSteps>div{min-height:64px;padding:10px 12px}.truthCard{grid-template-columns:1fr;padding:15px;border-radius:19px;gap:8px;text-align:left}.truthCard p{text-align:left}.footer{display:grid;gap:8px;margin-top:20px;padding-bottom:5px;font-size:9.5px}}
+.page {
+  --ink: #17131f;
+  --muted: #716a7a;
+  --purple: #6f42f5;
+  --purpleDark: #4e25c4;
+  --lime: #c9ff55;
+  --blue: #76d7ff;
+  --coral: #ff8d77;
+  --yellow: #ffd45e;
+  min-height: 100vh;
+  padding: 18px clamp(12px, 3vw, 34px) calc(76px + env(safe-area-inset-bottom));
+  background:
+    radial-gradient(circle at 0 0, rgba(118, 215, 255, .48), transparent 27rem),
+    radial-gradient(circle at 100% 2%, rgba(201, 255, 85, .38), transparent 31rem),
+    radial-gradient(circle at 50% 100%, rgba(255, 141, 119, .18), transparent 34rem),
+    linear-gradient(180deg, #faf8ff 0%, #f8f5ff 54%, #fff9f4 100%);
+  color: var(--ink);
+  font-family: Inter, ui-rounded, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+.page * { box-sizing: border-box; }
+.topbar,
+.hero,
+.flowSection,
+.featureGrid,
+.finalCta,
+.footer { width: min(1160px, 100%); margin-left: auto; margin-right: auto; }
+.topbar { min-height: 62px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.brand { display: inline-flex; align-items: center; gap: 11px; color: var(--ink); text-decoration: none; font-size: 12px; font-weight: 1000; }
+.brandMark { width: 40px; height: 40px; display: grid; place-items: center; border-radius: 13px; background: linear-gradient(145deg, #7e54ff, #6334e8); color: #fff; box-shadow: 0 5px 0 var(--purpleDark), 0 11px 24px rgba(84, 45, 184, .2); font-size: 18px; }
+.nav { display: flex; gap: 7px; }
+.nav a { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; padding: 0 13px; border: 1px solid rgba(40,29,61,.11); border-radius: 999px; background: rgba(255,255,255,.78); color: #51495c; text-decoration: none; font-size: 10px; font-weight: 900; backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); }
+.hero { min-height: 690px; display: grid; grid-template-columns: minmax(0,.95fr) minmax(420px,1.05fr); gap: clamp(30px,6vw,80px); align-items: center; padding: 60px 0 56px; }
+.eyebrow { margin: 0; color: #7251c6; font-size: 9px; font-weight: 1000; letter-spacing: .16em; text-transform: uppercase; }
+.heroCopy h1 { max-width: 690px; margin: 12px 0 18px; font-size: clamp(62px,8.3vw,108px); line-height: .83; letter-spacing: -.078em; }
+.heroCopy h1 em { color: var(--purple); font-style: normal; }
+.lead { max-width: 640px; margin: 0; color: var(--muted); font-size: 16px; line-height: 1.62; }
+.heroActions { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 26px; }
+.primary,
+.secondary { min-height: 58px; padding: 0 22px; border-radius: 18px; display: inline-flex; align-items: center; justify-content: center; text-decoration: none; font-size: 13px; font-weight: 1000; }
+.primary { background: linear-gradient(180deg,#7b50ff,#6737ed); color: #fff; box-shadow: 0 6px 0 var(--purpleDark),0 16px 28px rgba(91,48,205,.2); }
+.secondary { border: 1px solid rgba(40,29,61,.11); background: #fff; color: #5d4b87; box-shadow: 0 5px 0 rgba(60,38,82,.07); }
+.trustRow { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-top: 20px; color: #81798a; font-size: 9px; font-weight: 850; }
+.heroVisual { min-height: 560px; position: relative; overflow: hidden; border: 1px solid rgba(255,255,255,.55); border-radius: 44px; background: linear-gradient(145deg,#7750f9 0%,#9072ff 36%,#76d7ff 100%); box-shadow: 0 34px 80px rgba(65,44,116,.2); }
+.skyOrb { position: absolute; width: 240px; height: 240px; border-radius: 50%; right: -60px; top: -70px; background: rgba(201,255,85,.84); filter: blur(.1px); }
+.voxelScene { position: absolute; inset: 0; }
+.plot { position: absolute; left: 13%; right: 13%; bottom: 11%; height: 33%; border-radius: 30px; background: #c9ff55; transform: perspective(520px) rotateX(62deg); box-shadow: 0 35px 45px rgba(36,24,69,.22); }
+.house { position: absolute; left: 26%; right: 26%; bottom: 25%; height: 37%; border-radius: 22px 22px 11px 11px; background: #fff5dc; box-shadow: 0 28px 50px rgba(45,27,81,.32); }
+.roof { position: absolute; left: -12%; right: -12%; top: -25%; height: 31%; clip-path: polygon(50% 0,100% 100%,0 100%); background: var(--coral); }
+.door { position: absolute; width: 24%; height: 45%; left: 38%; bottom: 0; border-radius: 9px 9px 0 0; background: var(--purple); }
+.window { position: absolute; width: 19%; height: 21%; top: 27%; border-radius: 7px; background: var(--blue); box-shadow: inset 0 0 0 4px rgba(255,255,255,.52); }
+.windowOne { left: 16%; }
+.windowTwo { right: 16%; }
+.floatingVoxel { position: absolute; width: 66px; height: 66px; display: grid; place-items: center; border-radius: 19px; color: #2d2340; font-size: 17px; font-weight: 1000; box-shadow: 0 14px 30px rgba(37,24,67,.2); }
+.voxelOne { left: 8%; top: 15%; background: var(--yellow); transform: rotate(-10deg); }
+.voxelTwo { right: 9%; top: 28%; background: #fff; transform: rotate(9deg); }
+.voxelThree { right: 14%; bottom: 13%; background: var(--lime); transform: rotate(-8deg); }
+.visualLabel { position: absolute; left: 22px; bottom: 20px; padding: 11px 13px; border: 1px solid rgba(255,255,255,.48); border-radius: 15px; background: rgba(28,20,37,.68); color: #fff; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
+.visualLabel b,
+.visualLabel span { display: block; }
+.visualLabel b { font-size: 8px; letter-spacing: .08em; }
+.visualLabel span { margin-top: 3px; color: rgba(255,255,255,.72); font-size: 8px; }
+.flowSection { padding: 62px 0 30px; }
+.sectionHeading { max-width: 720px; margin-bottom: 22px; }
+.sectionHeading h2,
+.finalCta h2 { margin: 8px 0 8px; font-size: clamp(40px,6vw,68px); line-height: .94; letter-spacing: -.06em; }
+.sectionHeading > p:last-child { margin: 0; color: var(--muted); font-size: 14px; }
+.steps { display: grid; grid-template-columns: repeat(5,minmax(0,1fr)); gap: 9px; }
+.stepCard { min-height: 220px; padding: 18px; border: 1px solid rgba(40,29,61,.1); border-radius: 25px; background: rgba(255,255,255,.84); box-shadow: 0 15px 40px rgba(64,43,88,.07); }
+.stepTop { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.stepTop span { width: 38px; height: 38px; display: grid; place-items: center; border-radius: 12px; background: #eee8ff; color: #6545b4; font-size: 10px; font-weight: 1000; }
+.stepTop b { color: #a99fb0; font-size: 14px; }
+.stepCard h3 { margin: 28px 0 7px; font-size: 20px; letter-spacing: -.035em; }
+.stepCard p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.55; }
+.featureGrid { padding: 50px 0 34px; display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; }
+.featureCard { min-height: 350px; padding: 28px; border-radius: 32px; overflow: hidden; box-shadow: 0 20px 50px rgba(65,43,88,.1); }
+.featureCard small { font-size: 8px; font-weight: 1000; letter-spacing: .12em; }
+.featureCard h2 { margin: 72px 0 12px; max-width: 350px; font-size: 34px; line-height: .98; letter-spacing: -.055em; }
+.featureCard p { margin: 0; max-width: 370px; font-size: 11px; line-height: 1.6; }
+.featurePurple { background: linear-gradient(145deg,#764cf8,#9a78ff); color: #fff; }
+.featurePurple p { color: rgba(255,255,255,.74); }
+.featureLime { background: var(--lime); color: #293d08; }
+.featureLime p { color: #536a2e; }
+.featureDark { background: #201629; color: #fff; }
+.featureDark p { color: #bdb5c3; }
+.finalCta { margin-top: 34px; padding: 34px; border: 1px solid rgba(40,29,61,.1); border-radius: 32px; display: flex; align-items: center; justify-content: space-between; gap: 30px; background: rgba(255,255,255,.84); box-shadow: 0 18px 50px rgba(65,43,88,.08); }
+.finalCta h2 { max-width: 760px; font-size: clamp(36px,5vw,58px); }
+.finalCta .primary { flex: 0 0 auto; }
+.footer { margin-top: 34px; padding: 22px 2px 0; border-top: 1px solid rgba(40,29,61,.1); display: flex; align-items: center; justify-content: space-between; gap: 20px; color: #8b8491; font-size: 9px; }
+.footer a { color: #684bb2; text-decoration: none; font-weight: 900; }
+.page a:focus-visible { outline: 3px solid rgba(111,66,245,.25); outline-offset: 3px; }
+@media(max-width:900px) {
+  .hero { grid-template-columns: 1fr; min-height: 0; padding-top: 42px; }
+  .heroCopy { text-align: center; }
+  .heroCopy h1,
+  .lead { margin-left: auto; margin-right: auto; }
+  .heroActions,
+  .trustRow { justify-content: center; }
+  .heroVisual { min-height: 520px; }
+  .steps { grid-template-columns: repeat(2,1fr); }
+  .stepCard:last-child { grid-column: 1/-1; }
+  .featureGrid { grid-template-columns: 1fr; }
+  .featureCard { min-height: 300px; }
+  .featureCard h2 { margin-top: 50px; }
+  .finalCta { align-items: flex-start; flex-direction: column; }
+}
+@media(max-width:620px) {
+  .page { padding: 10px 9px calc(70px + env(safe-area-inset-bottom)); }
+  .topbar { min-height: 54px; }
+  .brand { font-size: 10px; }
+  .brandMark { width: 37px; height: 37px; border-radius: 12px; }
+  .nav a { min-height: 37px; padding: 0 10px; font-size: 8px; }
+  .hero { padding: 36px 0 38px; gap: 34px; }
+  .heroCopy h1 { font-size: clamp(56px,18vw,78px); }
+  .lead { font-size: 13px; }
+  .heroActions { display: grid; }
+  .primary,
+  .secondary { width: 100%; min-height: 55px; }
+  .heroVisual { min-height: 430px; border-radius: 30px; }
+  .floatingVoxel { width: 54px; height: 54px; border-radius: 16px; font-size: 14px; }
+  .visualLabel { left: 14px; bottom: 14px; }
+  .flowSection { padding-top: 44px; }
+  .sectionHeading { text-align: center; }
+  .sectionHeading h2 { font-size: 44px; }
+  .steps { grid-template-columns: 1fr; }
+  .stepCard,
+  .stepCard:last-child { grid-column: auto; min-height: 180px; }
+  .stepCard h3 { margin-top: 22px; }
+  .featureGrid { padding-top: 38px; }
+  .featureCard { min-height: 280px; padding: 23px; border-radius: 26px; }
+  .featureCard h2 { font-size: 30px; }
+  .finalCta { padding: 25px 20px; border-radius: 26px; text-align: center; }
+  .finalCta .primary { width: 100%; }
+  .footer { display: grid; gap: 8px; text-align: center; }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -8,14 +8,14 @@ import './spatial-os-interactions.css';
 
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL || 'https://www.voxelvault.io').replace(/\/$/, '');
 
-const TITLE = 'VoxelPop | Turn a House Photo into a 3D Voxel Photo';
-const DESCRIPTION = 'Turn a House Photo into a 3D Voxel Photo for $4.99. Approve the voxel photo, then get a movable 3D voxel. Source photo stays on your device; minting is optional. Saved to Vault.';
+const TITLE = 'Voxel Vault | Turn Property Photos into 3D Voxel Collectibles';
+const DESCRIPTION = 'Take a property photo, confirm the address, build a 3D voxel collectible, save it to your Voxel Vault Inventory, and mint it when you want.';
 
 export const metadata = {
   metadataBase: new URL(SITE_URL),
-  title: { default: TITLE, template: '%s | VoxelPop' },
+  title: { default: TITLE, template: '%s | Voxel Vault' },
   description: DESCRIPTION,
-  keywords: ['VoxelPop', 'house photo to voxel', '3D voxel photo', 'voxel house creator', 'Voxel Vault'],
+  keywords: ['Voxel Vault', 'property voxel', 'house photo to voxel', '3D voxel collectible', 'property NFT'],
   robots: { index: true, follow: true },
   icons: { icon: '/voxelpop/voxelpop-logo.png', apple: '/voxelpop/voxelpop-logo.png' },
   openGraph: {
@@ -23,8 +23,8 @@ export const metadata = {
     description: DESCRIPTION,
     type: 'website',
     url: SITE_URL,
-    siteName: 'VoxelPop',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'VoxelPop photo to 3D voxel' }],
+    siteName: 'Voxel Vault',
+    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: 'Voxel Vault property photo to 3D voxel' }],
   },
   twitter: { card: 'summary_large_image', title: TITLE, description: DESCRIPTION, images: ['/opengraph-image'] },
 };
@@ -32,8 +32,8 @@ export const metadata = {
 export const viewport = {
   width: 'device-width', initialScale: 1, viewportFit: 'cover',
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#fffaf0' },
-    { media: '(prefers-color-scheme: dark)', color: '#fffaf0' },
+    { media: '(prefers-color-scheme: light)', color: '#f8f5ff' },
+    { media: '(prefers-color-scheme: dark)', color: '#f8f5ff' },
   ],
 };
 

--- a/app/page.js
+++ b/app/page.js
@@ -96,7 +96,7 @@ export default function Home() {
       <Link className={styles.primary} href="/property">Start with a photo</Link>
     </section>
 
-    <p className={styles.truth}>This collectible is digital only. Saving or minting it does not create or transfer deed, title, equity, occupancy, rent, or other physical-property rights.</p>
+    <p style={{ width: 'min(1000px, 100%)', margin: '36px auto 0', color: '#8b8491', fontSize: '10px', lineHeight: 1.6, textAlign: 'center' }}>This collectible is digital only. Saving or minting it does not create or transfer deed, title, equity, occupancy, rent, or other physical-property rights.</p>
 
     <footer className={styles.footer}>
       <span>Voxel Vault · digital property collectibles</span>

--- a/app/page.js
+++ b/app/page.js
@@ -1,43 +1,104 @@
 import Link from 'next/link';
-import ProductTopNav from './components/ProductTopNav';
-import HomeProductPreview from './components/HomeProductPreview';
 import styles from './home.module.css';
 
 export const metadata = { alternates: { canonical: '/' } };
 
+const steps = [
+  ['01', 'Take a photo', 'Use a clear front or angled exterior photo.'],
+  ['02', 'Confirm address', 'Give the building a unique property identity.'],
+  ['03', 'Build the voxel', 'Preview the voxel look, then create the movable 3D collectible.'],
+  ['04', 'Mint if you want', 'Make the one-of-one collectible on-chain when you are ready.'],
+  ['05', 'Keep it in Vault', 'Every finished property stays in your personal Inventory.'],
+];
+
 export default function Home() {
   return <main className={styles.page}>
-    <ProductTopNav/>
-    <div className={styles.shell}>
-      <section className={styles.hero}>
-        <p className={styles.kicker}>HOUSE PHOTO → VOXEL → MINT</p>
-        <h1><em>VOXEL VAULT</em></h1>
-        <p className={styles.heroLine}>Take a house photo, confirm the address, and Voxel Vault turns it into a collectible 3D voxel.</p>
+    <header className={styles.topbar}>
+      <Link className={styles.brand} href="/">
+        <span className={styles.brandMark}>V</span>
+        <span>VOXEL VAULT</span>
+      </Link>
+      <nav className={styles.nav} aria-label="Voxel Vault navigation">
+        <Link href="/property">Create</Link>
+        <Link href="/vault/property-drafts">Inventory</Link>
+      </nav>
+    </header>
 
-        <div className={styles.centerMachine}>
-          <HomeProductPreview/>
-          <Link className={styles.primaryAction} href="/property">Create house voxel</Link>
-          <p className={styles.microCopy}>Saved to Inventory · mint when ready</p>
+    <section className={styles.hero}>
+      <div className={styles.heroCopy}>
+        <p className={styles.eyebrow}>PROPERTY → COLLECTIBLE</p>
+        <h1>Turn a real place into a <em>3D voxel.</em></h1>
+        <p className={styles.lead}>Take one property photo, confirm the address, watch it become a block-built 3D collectible, then mint it or keep it private in your Voxel Vault.</p>
+        <div className={styles.heroActions}>
+          <Link className={styles.primary} href="/property">Create a property voxel</Link>
+          <Link className={styles.secondary} href="/vault/property-drafts">Open Inventory</Link>
         </div>
-
-        <div className={styles.simpleSteps} aria-label="House voxel steps">
-          <div><i>1</i><span><b>Photo</b><small>Take or upload one house shot.</small></span></div>
-          <div><i>2</i><span><b>Address</b><small>Confirm the real building.</small></span></div>
-          <div><i>3</i><span><b>Voxel image</b><small>Your photo becomes voxel blocks.</small></span></div>
-          <div><i>4</i><span><b>3D voxel</b><small>Built and saved to Inventory.</small></span></div>
-          <div><i>5</i><span><b>Mint</b><small>Mint the one-of-one only if you want.</small></span></div>
+        <div className={styles.trustRow}>
+          <span>✓ Mobile photo upload</span>
+          <span>✓ Unique property lock</span>
+          <span>✓ Minting optional</span>
         </div>
-      </section>
+      </div>
 
-      <section className={styles.truthCard}>
-        <div><b>This collectible is digital only.</b><span>One confirmed property can have one Voxel Vault collectible.</span></div>
-        <p>It does not create or transfer deed, title, or physical-property rights.</p>
-      </section>
+      <div className={styles.heroVisual} aria-label="Voxel house illustration">
+        <div className={styles.skyOrb}/>
+        <div className={styles.voxelScene}>
+          <div className={styles.plot}/>
+          <div className={styles.house}>
+            <div className={styles.roof}/>
+            <div className={styles.door}/>
+            <div className={`${styles.window} ${styles.windowOne}`}/>
+            <div className={`${styles.window} ${styles.windowTwo}`}/>
+          </div>
+          <div className={`${styles.floatingVoxel} ${styles.voxelOne}`}>1</div>
+          <div className={`${styles.floatingVoxel} ${styles.voxelTwo}`}>3D</div>
+          <div className={`${styles.floatingVoxel} ${styles.voxelThree}`}>✓</div>
+        </div>
+        <div className={styles.visualLabel}><b>YOUR PROPERTY</b><span>photo → voxel → vault</span></div>
+      </div>
+    </section>
 
-      <footer className={styles.footer}>
-        <span>Voxel Vault</span>
-        <span><Link href="/demo">Demo</Link> · <Link href="/about">About</Link> · <Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link></span>
-      </footer>
-    </div>
+    <section className={styles.flowSection}>
+      <div className={styles.sectionHeading}>
+        <p className={styles.eyebrow}>ONE SIMPLE FLOW</p>
+        <h2>Five pages. One design. No maze.</h2>
+        <p>Each screen asks for one thing and moves you cleanly to the next step.</p>
+      </div>
+      <div className={styles.steps}>
+        {steps.map(([number, title, description], index) => <article className={styles.stepCard} key={title}>
+          <div className={styles.stepTop}><span>{number}</span><b>{index < steps.length - 1 ? '→' : '✓'}</b></div>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </article>)}
+      </div>
+    </section>
+
+    <section className={styles.featureGrid}>
+      <article className={`${styles.featureCard} ${styles.featurePurple}`}>
+        <small>PHOTO FIRST</small>
+        <h2>Your camera roll is the starting point.</h2>
+        <p>iPhone HEIC, JPG, PNG and WebP photos are supported. The original source photo stays on your device.</p>
+      </article>
+      <article className={`${styles.featureCard} ${styles.featureLime}`}>
+        <small>ONE PROPERTY · ONE MINT</small>
+        <h2>Every building gets a unique collectible identity.</h2>
+        <p>Address confirmation helps prevent duplicate property mints inside Voxel Vault.</p>
+      </article>
+      <article className={`${styles.featureCard} ${styles.featureDark}`}>
+        <small>YOUR INVENTORY</small>
+        <h2>Mint now or just keep the voxel.</h2>
+        <p>The finished 3D collectible is saved first. Minting is a choice, not a requirement.</p>
+      </article>
+    </section>
+
+    <section className={styles.finalCta}>
+      <div><p className={styles.eyebrow}>READY WHEN YOU ARE</p><h2>Your next property can become a voxel.</h2></div>
+      <Link className={styles.primary} href="/property">Start with a photo</Link>
+    </section>
+
+    <footer className={styles.footer}>
+      <span>Voxel Vault · digital property collectibles</span>
+      <span><Link href="/about">About</Link> · <Link href="/privacy">Privacy</Link> · <Link href="/terms">Terms</Link></span>
+    </footer>
   </main>;
 }

--- a/app/page.js
+++ b/app/page.js
@@ -6,9 +6,9 @@ export const metadata = { alternates: { canonical: '/' } };
 const steps = [
   ['01', 'Take a photo', 'Use a clear front or angled exterior photo.'],
   ['02', 'Confirm address', 'Give the building a unique property identity.'],
-  ['03', 'Build the voxel', 'Preview the voxel look, then create the movable 3D collectible.'],
+  ['03', 'Build the voxel', 'Preview the voxel image, then create the movable 3D collectible.'],
   ['04', 'Mint if you want', 'Make the one-of-one collectible on-chain when you are ready.'],
-  ['05', 'Keep it in Vault', 'Every finished property stays in your personal Inventory.'],
+  ['05', 'Keep it in Vault', 'The finished voxel is saved to Inventory first.'],
 ];
 
 export default function Home() {
@@ -95,6 +95,8 @@ export default function Home() {
       <div><p className={styles.eyebrow}>READY WHEN YOU ARE</p><h2>Your next property can become a voxel.</h2></div>
       <Link className={styles.primary} href="/property">Start with a photo</Link>
     </section>
+
+    <p className={styles.truth}>This collectible is digital only. Saving or minting it does not create or transfer deed, title, equity, occupancy, rent, or other physical-property rights.</p>
 
     <footer className={styles.footer}>
       <span>Voxel Vault · digital property collectibles</span>

--- a/app/property/PropertyStudio.module.css
+++ b/app/property/PropertyStudio.module.css
@@ -1,0 +1,357 @@
+:global(body) {
+  margin: 0;
+  background: #f6f3ff;
+  color: #17131f;
+  font-family: Inter, ui-rounded, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.page,
+.pricingPage,
+.inventoryPage {
+  --ink: #17131f;
+  --muted: #736d7e;
+  --line: rgba(40, 29, 61, 0.11);
+  --purple: #6f42f5;
+  --purple-dark: #4e25c4;
+  --lime: #c9ff55;
+  --blue: #76d7ff;
+  --coral: #ff8d77;
+  --yellow: #ffd45e;
+  min-height: 100vh;
+  box-sizing: border-box;
+  background:
+    radial-gradient(circle at 0 0, rgba(118, 215, 255, 0.46), transparent 25rem),
+    radial-gradient(circle at 100% 3%, rgba(201, 255, 85, 0.36), transparent 28rem),
+    radial-gradient(circle at 55% 100%, rgba(255, 141, 119, 0.2), transparent 32rem),
+    linear-gradient(180deg, #faf8ff 0%, #f7f4ff 55%, #fff9f4 100%);
+  padding: 18px clamp(12px, 3vw, 34px) calc(92px + env(safe-area-inset-bottom));
+}
+
+.page *,
+.pricingPage *,
+.inventoryPage * { box-sizing: border-box; }
+
+.shell,
+.inventoryShell,
+.pricingShell { width: min(1080px, 100%); margin: 0 auto; }
+
+.topbar { min-height: 62px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.brand { display: inline-flex; align-items: center; gap: 11px; color: var(--ink); text-decoration: none; font-size: 12px; font-weight: 1000; letter-spacing: -0.02em; }
+.brandMark { width: 40px; height: 40px; display: grid; place-items: center; border-radius: 13px; background: linear-gradient(145deg, #7e54ff, #6334e8); color: #fff; box-shadow: 0 5px 0 var(--purple-dark), 0 11px 24px rgba(84, 45, 184, 0.2); font-size: 18px; font-weight: 1000; }
+.nav { display: flex; align-items: center; gap: 7px; }
+.nav a,
+.nav button,
+.topPill { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; padding: 0 13px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255, 255, 255, 0.78); color: #51495c; text-decoration: none; font: 900 10px/1 Inter, ui-rounded, sans-serif; cursor: pointer; backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); }
+.nav a:hover,
+.nav button:hover,
+.topPill:hover { transform: translateY(-1px); }
+
+.progressWrap { margin: 24px 0 18px; padding: 10px; border: 1px solid var(--line); border-radius: 22px; background: rgba(255, 255, 255, 0.72); box-shadow: 0 14px 40px rgba(68, 47, 93, 0.08); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); }
+.progress { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 7px; }
+.progressItem { min-width: 0; min-height: 58px; display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 15px; color: #9b95a4; }
+.progressItem span { width: 30px; height: 30px; flex: 0 0 30px; display: grid; place-items: center; border-radius: 10px; background: #eeeaf3; font-size: 10px; font-weight: 1000; }
+.progressItem div { min-width: 0; }
+.progressItem b,
+.progressItem small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.progressItem b { font-size: 9px; letter-spacing: 0.02em; }
+.progressItem small { margin-top: 3px; font-size: 7px; font-weight: 800; }
+.progressDone,
+.progressCurrent { color: #392a56; }
+.progressDone span { background: var(--lime); color: #354a0d; }
+.progressCurrent { background: #f0eaff; }
+.progressCurrent span { background: var(--purple); color: #fff; box-shadow: 0 4px 0 var(--purple-dark); }
+
+.stageHeader { margin: 30px auto 18px; text-align: center; }
+.eyebrow { margin: 0; color: #7453c8; font-size: 9px; font-weight: 1000; letter-spacing: 0.16em; text-transform: uppercase; }
+.stageHeader h1,
+.signInCard h1,
+.completeCopy h1,
+.mintHeader h1,
+.inventoryHero h1,
+.pricingHero h1 { margin: 10px 0 10px; color: var(--ink); font-size: clamp(42px, 7.6vw, 74px); line-height: 0.92; letter-spacing: -0.065em; }
+.stageHeader p,
+.signInCard > p,
+.completeCopy > p,
+.mintHeader > p,
+.inventoryHero > p,
+.pricingHero > p { max-width: 620px; margin: 0 auto; color: var(--muted); font-size: 14px; line-height: 1.6; }
+
+.stageCard,
+.signInCard,
+.mintCard,
+.emptyCard { border: 1px solid var(--line); border-radius: 34px; background: rgba(255, 255, 255, 0.88); box-shadow: 0 24px 70px rgba(66, 43, 94, 0.12); overflow: hidden; }
+.signInCard,
+.emptyCard { min-height: 560px; display: grid; place-items: center; align-content: center; gap: 12px; padding: 42px 24px; text-align: center; }
+.signInVoxel { width: 104px; height: 104px; position: relative; margin-bottom: 8px; border-radius: 30px; background: linear-gradient(145deg, var(--yellow), #ffb34e); box-shadow: 0 10px 0 #e59b35, 0 22px 45px rgba(235, 164, 58, 0.22); }
+.signInVoxel::before,
+.signInVoxel::after { content: ""; position: absolute; border-radius: 12px; background: var(--purple); }
+.signInVoxel::before { width: 28px; height: 28px; left: 19px; top: 23px; }
+.signInVoxel::after { width: 34px; height: 38px; right: 16px; bottom: 16px; background: var(--blue); }
+
+.primary,
+.secondary,
+.softButton,
+.textButton,
+.mintLink,
+.createButton { min-height: 58px; border-radius: 18px; padding: 0 22px; display: inline-flex; align-items: center; justify-content: center; text-align: center; text-decoration: none; font: 1000 14px/1 Inter, ui-rounded, sans-serif; transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease; cursor: pointer; }
+.primary,
+.mintLink,
+.createButton { border: 0; background: linear-gradient(180deg, #7b50ff, #6737ed); color: #fff; box-shadow: 0 6px 0 var(--purple-dark), 0 16px 28px rgba(91, 48, 205, 0.2); }
+.primary:hover,
+.mintLink:hover,
+.createButton:hover,
+.secondary:hover,
+.softButton:hover { transform: translateY(-2px); }
+.primary:disabled,
+.softButton:disabled { opacity: 0.48; box-shadow: none; transform: none; cursor: default; }
+.secondary,
+.softButton { border: 1px solid var(--line); background: #fff; color: #5e4a8e; box-shadow: 0 5px 0 rgba(60, 38, 82, 0.08); }
+.textButton { min-height: 42px; border: 0; background: transparent; color: #6e51b4; font-size: 10px; box-shadow: none; text-decoration: underline; text-underline-offset: 3px; }
+
+.uploadZone { min-height: 540px; padding: clamp(24px, 6vw, 58px); display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 0.8fr); align-items: center; gap: clamp(24px, 5vw, 70px); }
+.uploadArt { min-height: 360px; position: relative; border-radius: 28px; overflow: hidden; background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 55%), linear-gradient(145deg, #6f42f5 0%, #916eff 38%, #77d9ff 100%); box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3); }
+.uploadArtHouse { position: absolute; left: 18%; right: 18%; bottom: 18%; height: 44%; border-radius: 18px 18px 12px 12px; background: #fff6df; box-shadow: 0 20px 50px rgba(40, 21, 75, 0.28); }
+.uploadArtHouse::before { content: ""; position: absolute; left: -10%; right: -10%; top: -27%; height: 34%; clip-path: polygon(50% 0, 100% 100%, 0 100%); background: var(--coral); }
+.uploadArtHouse::after { content: ""; position: absolute; width: 27%; height: 47%; left: 37%; bottom: 0; border-radius: 8px 8px 0 0; background: var(--purple); }
+.sparkOne,
+.sparkTwo,
+.sparkThree { position: absolute; width: 52px; height: 52px; display: grid; place-items: center; border-radius: 16px; font-size: 22px; font-weight: 1000; box-shadow: 0 12px 30px rgba(40, 21, 75, 0.18); }
+.sparkOne { left: 9%; top: 10%; background: var(--lime); transform: rotate(-8deg); }
+.sparkTwo { right: 9%; top: 16%; background: var(--yellow); transform: rotate(11deg); }
+.sparkThree { right: 12%; bottom: 10%; background: #fff; transform: rotate(-6deg); }
+.uploadCopy h2,
+.addressCopy h2,
+.previewCopy h2,
+.buildCopy h2,
+.planHeading h2 { margin: 8px 0 10px; color: var(--ink); font-size: clamp(32px, 5vw, 50px); line-height: 0.96; letter-spacing: -0.055em; }
+.uploadCopy > p,
+.addressCopy > p,
+.previewCopy > p,
+.buildCopy > p,
+.planHeading > p { margin: 0 0 20px; color: var(--muted); font-size: 13px; line-height: 1.6; }
+.helper { display: block; margin-top: 12px; color: #9991a2; font-size: 9px; line-height: 1.5; }
+.hiddenInput { display: none; }
+
+.splitCard { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr); min-height: 560px; }
+.photoPanel { position: relative; min-height: 520px; overflow: hidden; background: #20172a; }
+.photoPanel img { width: 100%; height: 100%; min-height: 520px; display: block; object-fit: cover; }
+.photoBadge,
+.viewerBadge,
+.statusBadge,
+.cardBadge { position: absolute; z-index: 7; top: 15px; left: 15px; display: inline-flex; align-items: center; gap: 6px; padding: 8px 10px; border: 1px solid rgba(255, 255, 255, 0.48); border-radius: 999px; background: rgba(29, 20, 38, 0.72); color: #fff; font-size: 7px; font-weight: 1000; letter-spacing: 0.08em; backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); }
+.addressCopy { align-self: center; padding: clamp(26px, 5vw, 50px); }
+.addressForm { display: grid; gap: 10px; margin-top: 22px; }
+.addressInput { width: 100%; min-height: 60px; padding: 0 16px; border: 1px solid rgba(73, 53, 101, 0.16); border-radius: 18px; outline: none; background: #fff; color: var(--ink); font: 850 16px/1.2 Inter, ui-rounded, sans-serif; }
+.addressInput:focus { border-color: rgba(111, 66, 245, 0.65); box-shadow: 0 0 0 5px rgba(111, 66, 245, 0.09); }
+.addressInput::placeholder { color: #afa8b8; }
+
+.viewerStage { padding: 14px; }
+.viewerShell { position: relative; height: min(64vh, 620px); min-height: 430px; overflow: hidden; border-radius: 25px; background: radial-gradient(circle at 50% 34%, rgba(118, 215, 255, 0.16), transparent 25%), #1d1526; }
+.viewerShell > div { height: 100% !important; min-height: 100% !important; }
+.viewerShell :global(.viewerShell) { position: absolute !important; inset: 0 !important; min-height: 100% !important; border-radius: 0 !important; }
+.viewerCaption { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 16px 6px 4px; }
+.viewerCaption > div { min-width: 0; }
+.viewerCaption b { display: block; color: var(--ink); font-size: 14px; }
+.viewerCaption span { display: block; margin-top: 3px; overflow: hidden; color: var(--muted); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.viewerCaption .primary,
+.viewerCaption .softButton { min-height: 48px; flex: 0 0 auto; padding: 0 16px; font-size: 11px; }
+
+.buildLayout { display: grid; grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.28fr); min-height: 580px; }
+.buildCopy { align-self: center; padding: clamp(28px, 5vw, 52px); }
+.buildSteps { display: grid; gap: 8px; margin-top: 22px; }
+.buildStep { display: flex; align-items: center; gap: 10px; padding: 10px 12px; border-radius: 15px; background: #f4f0fb; color: #696171; font-size: 10px; font-weight: 850; }
+.buildStep span { width: 25px; height: 25px; display: grid; place-items: center; flex: 0 0 25px; border-radius: 8px; background: #fff; color: var(--purple); font-size: 9px; font-weight: 1000; }
+.buildViewer { min-height: 580px; padding: 14px; }
+.buildViewer .viewerShell { height: 100%; min-height: 552px; }
+
+.completeGrid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr); min-height: 590px; }
+.completeViewer { padding: 14px; }
+.completeViewer .viewerShell { height: 100%; min-height: 560px; }
+.completeCopy { align-self: center; padding: clamp(30px, 5vw, 54px); }
+.completeMark,
+.successMark { width: 68px; height: 68px; display: grid; place-items: center; border-radius: 22px; background: var(--lime); color: #3b5313; box-shadow: 0 7px 0 #a5db36, 0 16px 28px rgba(135, 191, 51, 0.17); font-size: 28px; font-weight: 1000; }
+.completeActions { display: grid; gap: 9px; margin-top: 22px; }
+.completeAddress { margin-top: 14px !important; color: #4d4256 !important; font-weight: 900; }
+.truth,
+.status,
+.finePrint { max-width: 760px; margin: 13px auto 0; color: #948d9c; font-size: 9px; line-height: 1.6; text-align: center; }
+.status { min-height: 20px; color: #686071; font-weight: 800; }
+.inlineWarning { margin-top: 10px; padding: 11px 12px; border: 1px solid #ffd5ca; border-radius: 14px; background: #fff4f0; color: #8b4c3f; font-size: 9px; line-height: 1.45; }
+
+.planBar { width: min(1080px, calc(100% - 24px)); min-height: 48px; margin: 10px auto -4px; padding: 8px 11px; border: 1px solid rgba(65, 43, 88, 0.1); border-radius: 15px; display: flex; align-items: center; justify-content: space-between; gap: 12px; background: rgba(255, 255, 255, 0.78); box-shadow: 0 10px 30px rgba(65, 43, 88, 0.07); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px); }
+.planIdentity,
+.planActions { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.planDot { width: 8px; height: 8px; flex: 0 0 8px; border-radius: 50%; background: #7bcc31; box-shadow: 0 0 0 4px rgba(123, 204, 49, 0.13); }
+.planIdentity strong,
+.planActions span { font-size: 9px; }
+.planIdentity small { color: #8f8797; font-size: 8px; }
+.planActions button { border: 0; border-radius: 999px; background: #eee8f8; color: #654d96; padding: 7px 9px; font: 900 8px/1 Inter, sans-serif; }
+
+.pricingHero { padding: 52px 0 30px; text-align: center; }
+.pricingHero h1 em { color: var(--purple); font-style: normal; }
+.flowRibbon { width: max-content; max-width: 100%; margin: 22px auto 0; display: flex; align-items: center; flex-wrap: wrap; justify-content: center; gap: 6px; }
+.flowRibbon span { padding: 8px 10px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,.8); color: #5f5669; font-size: 8px; font-weight: 1000; }
+.flowRibbon b { color: #a89dad; font-size: 10px; }
+.planHeading { margin: 18px 0 14px; text-align: center; }
+.planGrid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.planCard { position: relative; min-height: 380px; padding: 20px; border: 1px solid var(--line); border-radius: 28px; display: flex; flex-direction: column; overflow: hidden; background: rgba(255, 255, 255, 0.9); box-shadow: 0 18px 50px rgba(65, 43, 88, 0.08); }
+.planCard::before { content: ""; position: absolute; left: 0; right: 0; top: 0; height: 7px; background: var(--blue); }
+.planCard:nth-child(2)::before { background: var(--purple); }
+.planCard:nth-child(3)::before { background: var(--lime); }
+.planCard:nth-child(4)::before { background: linear-gradient(90deg, var(--yellow), var(--coral), var(--purple)); }
+.planCardTop { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-top: 5px; }
+.planCardTop p { margin: 0; font-size: 13px; font-weight: 1000; }
+.planCardTop strong { font-size: 25px; letter-spacing: -0.05em; }
+.planCardTop strong small { font-size: 8px; letter-spacing: 0; color: #93899a; }
+.planBadge { display: inline-block; margin-top: 6px; padding: 5px 7px; border-radius: 999px; background: #ede7ff; color: #6848bd; font-size: 6px; font-weight: 1000; letter-spacing: .06em; }
+.planCard h3 { margin: 28px 0 5px; font-size: 24px; letter-spacing: -0.045em; }
+.planBlurb { min-height: 38px; margin: 0; color: #817786; font-size: 10px; line-height: 1.5; }
+.planFeatures { list-style: none; margin: 19px 0 22px; padding: 0; display: grid; gap: 9px; }
+.planFeatures li { display: flex; align-items: center; gap: 8px; color: #5d5564; font-size: 9px; font-weight: 800; }
+.planFeatures span { width: 20px; height: 20px; display: grid; place-items: center; border-radius: 7px; background: #f0ebf6; color: #6948bd; font-size: 8px; font-weight: 1000; }
+.planCard button { width: 100%; min-height: 50px; margin-top: auto; border: 0; border-radius: 15px; background: var(--ink); color: #fff; font: 950 11px/1 Inter, sans-serif; cursor: pointer; }
+.planCard:nth-child(2) button { background: var(--purple); box-shadow: 0 5px 0 var(--purple-dark); }
+.planCard:nth-child(3) button { background: var(--lime); color: #354a0d; box-shadow: 0 5px 0 #a5da37; }
+.planCard button:disabled { opacity: .5; box-shadow: none; }
+
+.mintHeader { padding: 40px 0 18px; text-align: center; }
+.mintLayout { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(300px, .85fr); min-height: 600px; }
+.mintViewer { padding: 14px; }
+.mintViewer .viewerShell { height: 100%; min-height: 570px; }
+.mintPanel { align-self: center; padding: clamp(28px, 5vw, 48px); }
+.mintPanel h2 { margin: 10px 0 8px; font-size: 34px; letter-spacing: -0.05em; }
+.mintPanel > p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
+.mintActions { display: grid; gap: 9px; margin-top: 22px; }
+.walletLine { margin: 12px 0 0; color: #8b8292; font-size: 8px; }
+.successBox { display: grid; gap: 8px; justify-items: start; margin-top: 22px; padding: 18px; border: 1px solid #d8ecad; border-radius: 20px; background: #f7ffe9; }
+.successBox b { font-size: 19px; }
+.successBox span { color: #697653; font-size: 9px; }
+.successLinks { width: 100%; display: grid; grid-template-columns: 1fr 1fr; gap: 7px; margin-top: 5px; }
+.successLinks a { min-height: 42px; display: grid; place-items: center; border: 1px solid #dce7c7; border-radius: 12px; background: #fff; color: #5e4b8b; text-decoration: none; font-size: 8px; font-weight: 950; }
+
+.inventoryHero { padding: 50px 0 28px; text-align: center; }
+.heroActions { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 9px; margin-top: 20px; }
+.heroActions .createButton,
+.heroActions .secondary { min-width: 180px; }
+.inventoryGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(285px, 1fr)); gap: 13px; }
+.inventoryCard { overflow: hidden; border: 1px solid var(--line); border-radius: 28px; background: rgba(255,255,255,.9); box-shadow: 0 18px 48px rgba(64, 43, 88, .08); }
+.inventoryVisual { height: 225px; position: relative; overflow: hidden; background: radial-gradient(circle at 50% 34%, rgba(118, 215, 255, .22), transparent 30%), linear-gradient(145deg, #21172d, #322140); }
+.inventoryVisual img { width: 100%; height: 100%; display: block; object-fit: cover; }
+.inventoryVoxel { position: absolute; left: 28%; right: 28%; bottom: 26%; height: 37%; border-radius: 9px 9px 4px 4px; background: #fff6df; box-shadow: 0 16px 35px rgba(0,0,0,.25); }
+.inventoryVoxel::before { content: ""; position: absolute; left: -9%; right: -9%; top: -26%; height: 33%; clip-path: polygon(50% 0,100% 100%,0 100%); background: var(--coral); }
+.inventoryVoxel::after { content: ""; position: absolute; width: 27%; height: 45%; left: 37%; bottom: 0; background: var(--purple); }
+.cardBadge { position: absolute; background: var(--lime); color: #354a0d; border: 0; }
+.inventoryBody { padding: 18px; }
+.inventoryBody > small { color: #7555c7; font-size: 7px; font-weight: 1000; letter-spacing: .1em; }
+.inventoryBody h2 { margin: 7px 0 5px; font-size: 23px; letter-spacing: -.04em; }
+.inventoryMeta { margin: 0 0 13px; color: #847c8c; font-size: 9px; line-height: 1.45; }
+.cardActions { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
+.cardActions a,
+.cardActions button { min-height: 44px; border: 1px solid var(--line); border-radius: 13px; background: #fff; color: #5e5666; display: grid; place-items: center; text-decoration: none; text-align: center; font: 950 8px/1 Inter, sans-serif; cursor: pointer; }
+.cardActions a:first-child { background: var(--purple); border: 0; color: #fff; }
+.cardActions .mintCardAction { background: var(--ink); border: 0; color: #fff; }
+.cardActions .publicAction { background: var(--lime); border: 0; color: #33480e; }
+.cardMore { display: flex; gap: 14px; margin-top: 11px; }
+.cardMore button { border: 0; background: transparent; color: #9a929f; padding: 0; font: 850 8px/1 Inter, sans-serif; cursor: pointer; }
+.emptyCard { min-height: 430px; }
+.emptyCard h2 { margin: 4px 0 0; font-size: 32px; letter-spacing: -.045em; }
+.emptyCard > p { max-width: 520px; margin: 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.paidRow { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin: 0 0 12px; padding: 10px 11px; border-radius: 13px; background: #f4ffe5; color: #53682e; font-size: 9px; }
+.paidRow strong { font-size: 14px; }
+
+.page a:focus-visible,
+.page button:focus-visible,
+.pricingPage a:focus-visible,
+.pricingPage button:focus-visible,
+.inventoryPage a:focus-visible,
+.inventoryPage button:focus-visible,
+.addressInput:focus-visible { outline: 3px solid rgba(111, 66, 245, .25); outline-offset: 3px; }
+
+@media (max-width: 860px) {
+  .planGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .uploadZone,
+  .splitCard,
+  .buildLayout,
+  .completeGrid,
+  .mintLayout { grid-template-columns: 1fr; }
+  .uploadArt { min-height: 320px; }
+  .photoPanel,
+  .photoPanel img { min-height: 420px; }
+  .buildViewer { min-height: 500px; }
+  .buildViewer .viewerShell { min-height: 470px; }
+  .completeViewer .viewerShell,
+  .mintViewer .viewerShell { min-height: 500px; }
+}
+
+@media (max-width: 640px) {
+  .page,
+  .pricingPage,
+  .inventoryPage { padding: 10px 9px calc(82px + env(safe-area-inset-bottom)); }
+  .topbar { min-height: 54px; }
+  .brand { font-size: 10px; }
+  .brandMark { width: 37px; height: 37px; border-radius: 12px; }
+  .nav { gap: 5px; }
+  .nav a,
+  .nav button { min-height: 37px; padding: 0 10px; font-size: 8px; }
+  .progressWrap { margin-top: 16px; padding: 7px; border-radius: 18px; }
+  .progress { gap: 4px; }
+  .progressItem { min-height: 46px; padding: 5px; display: grid; place-items: center; text-align: center; }
+  .progressItem span { width: 27px; height: 27px; flex-basis: 27px; border-radius: 9px; }
+  .progressItem b { display: none; }
+  .progressItem small { margin: 3px 0 0; font-size: 6px; }
+  .stageHeader { margin: 24px auto 14px; }
+  .stageHeader h1,
+  .signInCard h1,
+  .completeCopy h1,
+  .mintHeader h1,
+  .inventoryHero h1,
+  .pricingHero h1 { font-size: clamp(40px, 13vw, 58px); }
+  .stageHeader p,
+  .signInCard > p,
+  .completeCopy > p,
+  .mintHeader > p,
+  .inventoryHero > p,
+  .pricingHero > p { font-size: 12px; }
+  .stageCard,
+  .signInCard,
+  .mintCard,
+  .emptyCard { border-radius: 25px; }
+  .signInCard { min-height: 520px; }
+  .uploadZone { min-height: 0; padding: 12px; gap: 22px; }
+  .uploadArt { min-height: 300px; border-radius: 21px; }
+  .uploadCopy { padding: 0 9px 18px; text-align: center; }
+  .uploadCopy h2,
+  .addressCopy h2,
+  .previewCopy h2,
+  .buildCopy h2 { font-size: 36px; }
+  .splitCard { min-height: 0; }
+  .photoPanel,
+  .photoPanel img { min-height: 340px; }
+  .addressCopy { padding: 26px 16px 22px; }
+  .viewerStage { padding: 9px; }
+  .viewerShell { min-height: 380px; border-radius: 19px; }
+  .viewerCaption { align-items: flex-start; padding: 13px 3px 3px; }
+  .viewerCaption .primary,
+  .viewerCaption .softButton { min-height: 44px; max-width: 155px; }
+  .buildCopy { padding: 28px 18px 14px; text-align: center; }
+  .buildSteps { max-width: 420px; margin-left: auto; margin-right: auto; text-align: left; }
+  .buildViewer { min-height: 420px; padding: 9px; }
+  .buildViewer .viewerShell { min-height: 400px; }
+  .completeViewer,
+  .mintViewer { padding: 9px; }
+  .completeViewer .viewerShell,
+  .mintViewer .viewerShell { min-height: 420px; }
+  .completeCopy,
+  .mintPanel { padding: 28px 18px; text-align: center; }
+  .completeMark,
+  .successMark { margin-left: auto; margin-right: auto; }
+  .planBar { width: calc(100% - 18px); }
+  .planIdentity small,
+  .planActions span { display: none; }
+  .planGrid { grid-template-columns: 1fr; }
+  .pricingHero { padding-top: 36px; }
+  .inventoryHero { padding-top: 36px; }
+  .inventoryGrid { grid-template-columns: 1fr; }
+  .successLinks { grid-template-columns: 1fr; }
+}

--- a/app/property/PropertyStudioFlow.js
+++ b/app/property/PropertyStudioFlow.js
@@ -1,0 +1,409 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
+import { savePropertyDraft } from '../../lib/property-drafts';
+import { savePropertyDraftToAccount } from '../../lib/property-drafts-account';
+import LocalVoxelModelViewer from './LocalVoxelModelViewer';
+import PhotoReliefModelViewer from './PhotoReliefModelViewer';
+import styles from './PropertyStudio.module.css';
+
+function clean(value) { return String(value || '').trim(); }
+function newDraftId() {
+  const random = globalThis.crypto?.randomUUID?.().replace(/-/g, '') || `${Date.now()}${Math.random().toString(16).slice(2)}`;
+  return `vp-${random.slice(0, 28)}`;
+}
+function isHeic(file) {
+  return /image\/(heic|heif)/i.test(String(file?.type || '')) || /\.(heic|heif)$/i.test(String(file?.name || ''));
+}
+function isSupportedPhoto(file) {
+  return ['image/jpeg', 'image/png', 'image/webp'].includes(String(file?.type || '').toLowerCase()) || isHeic(file);
+}
+async function normalizeIphonePhoto(file) {
+  if (!isHeic(file)) return file;
+  const url = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = url;
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = () => reject(new Error('This HEIC photo could not be opened. Try a screenshot instead.'));
+    });
+    const maxEdge = 2400;
+    const scale = Math.min(1, maxEdge / Math.max(image.naturalWidth || 1, image.naturalHeight || 1));
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round((image.naturalWidth || 1) * scale));
+    canvas.height = Math.max(1, Math.round((image.naturalHeight || 1) * scale));
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Photo conversion is unavailable on this device.');
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/jpeg', 0.93));
+    if (!blob) throw new Error('Photo conversion failed.');
+    return new File([blob], String(file.name || 'house.heic').replace(/\.(heic|heif)$/i, '.jpg'), { type: 'image/jpeg', lastModified: Date.now() });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+const STAGES = ['photo', 'address', 'preview', 'build', 'complete'];
+const PROGRESS = [
+  { label: 'PHOTO', detail: 'Choose' },
+  { label: 'ADDRESS', detail: 'Confirm' },
+  { label: 'VOXEL', detail: 'Preview' },
+  { label: 'BUILD', detail: 'Create 3D' },
+  { label: 'VAULT', detail: 'Save + mint' },
+];
+
+function StudioTopbar() {
+  return <header className={styles.topbar}>
+    <Link className={styles.brand} href="/">
+      <span className={styles.brandMark}>V</span>
+      <span>VOXEL VAULT</span>
+    </Link>
+    <nav className={styles.nav} aria-label="Voxel Vault navigation">
+      <Link href="/property">Create</Link>
+      <Link href="/vault/property-drafts">Inventory</Link>
+    </nav>
+  </header>;
+}
+
+function Progress({ stage }) {
+  const stageIndex = Math.max(0, STAGES.indexOf(stage));
+  return <div className={styles.progressWrap} aria-label={`Step ${stageIndex + 1} of ${PROGRESS.length}`}>
+    <div className={styles.progress}>
+      {PROGRESS.map((item, index) => {
+        const className = index < stageIndex
+          ? `${styles.progressItem} ${styles.progressDone}`
+          : index === stageIndex
+            ? `${styles.progressItem} ${styles.progressCurrent}`
+            : styles.progressItem;
+        return <div key={item.label} className={className}>
+          <span>{index < stageIndex ? '✓' : index + 1}</span>
+          <div><b>{item.label}</b><small>{item.detail}</small></div>
+        </div>;
+      })}
+    </div>
+  </div>;
+}
+
+export default function PropertyStudioFlow() {
+  const [authReady, setAuthReady] = useState(false);
+  const [session, setSession] = useState(null);
+  const [draftId, setDraftId] = useState('');
+  const [stage, setStage] = useState('photo');
+  const [photo, setPhoto] = useState(null);
+  const [photoUrl, setPhotoUrl] = useState('');
+  const [address, setAddress] = useState('');
+  const [property, setProperty] = useState(null);
+  const [voxelImageReady, setVoxelImageReady] = useState(false);
+  const [final3d, setFinal3d] = useState(null);
+  const [savedDraft, setSavedDraft] = useState(null);
+  const [busy, setBusy] = useState('');
+  const [message, setMessage] = useState('Choose a property photo to begin.');
+  const [claimedByYou, setClaimedByYou] = useState(false);
+  const inputRef = useRef(null);
+  const clientRef = useRef(null);
+  const registeringRef = useRef(false);
+
+  useEffect(() => {
+    let active = true;
+    let subscription = null;
+    getSupabaseBrowserAsync().then(async (client) => {
+      if (!active) return;
+      clientRef.current = client;
+      const { data } = await client.auth.getSession();
+      if (!active) return;
+      setSession(data.session || null);
+      setAuthReady(true);
+      if (data.session?.user) setDraftId(newDraftId());
+      const auth = client.auth.onAuthStateChange((_event, next) => {
+        if (!active) return;
+        setSession(next || null);
+        setAuthReady(true);
+        if (next?.user) setDraftId((current) => current || newDraftId());
+      });
+      subscription = auth.data.subscription;
+    }).catch(() => {
+      if (active) {
+        setAuthReady(true);
+        setMessage('Sign-in is unavailable on this deployment.');
+      }
+    });
+    return () => { active = false; subscription?.unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => () => {
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+  }, [photoUrl]);
+
+  function authHeaders(extra = {}) {
+    return { Authorization: `Bearer ${session?.access_token || ''}`, ...extra };
+  }
+
+  async function signIn() {
+    setBusy('signin');
+    setMessage('Opening secure sign-in…');
+    try {
+      const client = clientRef.current || await getSupabaseBrowserAsync();
+      clientRef.current = client;
+      const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: window.location.href } });
+      if (error) throw error;
+    } catch (error) {
+      setBusy('');
+      setMessage(String(error?.message || error || 'Could not sign in.'));
+    }
+  }
+
+  function choosePhoto() {
+    if (!session?.access_token) return;
+    inputRef.current?.click();
+  }
+
+  async function selectPhoto(event) {
+    const selected = event.target.files?.[0];
+    event.target.value = '';
+    if (!selected) return;
+    if (!isSupportedPhoto(selected)) {
+      setMessage('Choose a JPG, PNG, WebP, HEIC, or HEIF photo.');
+      return;
+    }
+    if (selected.size > 12 * 1024 * 1024) {
+      setMessage('Choose a photo smaller than 12 MB.');
+      return;
+    }
+
+    setBusy('photo');
+    setMessage('Preparing your photo…');
+    try {
+      const normalized = await normalizeIphonePhoto(selected);
+      if (normalized.size > 8 * 1024 * 1024) throw new Error('This photo is still too large. Try a screenshot or smaller version.');
+      setPhoto(normalized);
+      setPhotoUrl((current) => {
+        if (current) URL.revokeObjectURL(current);
+        return URL.createObjectURL(normalized);
+      });
+      setAddress('');
+      setProperty(null);
+      setVoxelImageReady(false);
+      setFinal3d(null);
+      setSavedDraft(null);
+      setClaimedByYou(false);
+      setStage('address');
+      setMessage('Photo ready. Confirm the property address.');
+    } catch (error) {
+      setMessage(String(error?.message || error || 'The photo could not be prepared.'));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  async function confirmAddress(event) {
+    event.preventDefault();
+    if (!photo || !draftId || !session?.access_token || !clean(address)) return;
+    setBusy('address');
+    setClaimedByYou(false);
+    setMessage('Confirming this property…');
+    try {
+      const response = await fetch('/api/property-generation/confirm', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ draftId, address: clean(address) }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.confirmed) {
+        if (data?.ownedByYou) setClaimedByYou(true);
+        throw new Error(data?.error || 'This address could not be confirmed.');
+      }
+      setAddress(data.address || clean(address));
+      setProperty({ identityKey: data.identityKey, atlasId: data.atlasId, address: data.address || clean(address) });
+      setVoxelImageReady(false);
+      setStage('preview');
+      setMessage('Address confirmed. Building your voxel preview…');
+    } catch (error) {
+      setMessage(String(error?.message || error || 'This address could not be confirmed.'));
+    } finally {
+      setBusy('');
+    }
+  }
+
+  const saveFinishedVoxel = useCallback(async (recipe) => {
+    if (!recipe || !session?.access_token || !session?.user || !draftId || !property?.identityKey || registeringRef.current) return;
+    registeringRef.current = true;
+    setBusy('model');
+    setMessage('Saving your finished 3D voxel to inventory…');
+    try {
+      const response = await fetch('/api/property-local-voxel', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ draftId, recipe }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.ok || !data?.taskId || !data?.modelUrl) throw new Error(data?.error || 'The 3D voxel could not be saved.');
+
+      const finalize = await fetch('/api/property-generation/finalize', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ draftId, identityKey: property.identityKey, taskId: data.taskId }),
+      });
+      const lock = await finalize.json().catch(() => ({}));
+      if (!finalize.ok || !lock?.finalized) throw new Error(lock?.error || 'The one-property collectible lock could not be finalized.');
+
+      const now = new Date().toISOString();
+      const finishedDraft = {
+        schemaVersion: 1,
+        type: 'voxel-vault-property-3d-draft',
+        id: `voxelpop:${draftId}`,
+        label: property.address || 'My Voxel Property',
+        createdAt: now,
+        updatedAt: now,
+        state: 'saved',
+        fidelity: 'photo-approved-local-voxel',
+        geometryKind: 'digital-only',
+        coordinates: { latitude: null, longitude: null },
+        geometry: null,
+        propertyIdentity: { atlasId: property.atlasId || null, parcelId: null, pin: null, sbl: null },
+        evidence: {},
+        visual: { modelUrl: data.modelUrl, modelTaskId: data.taskId, renderMode: 'voxelpop-local-3d' },
+        voxelpop: {
+          engine: 'voxelpop-local-webgl-v2',
+          sourcePhotoStoredByVoxelVault: false,
+          previewApproved: true,
+          creationDraftId: draftId,
+          modelTaskId: data.taskId,
+          modelUrl: data.modelUrl,
+          identityKey: property.identityKey,
+          atlasId: property.atlasId || null,
+          propertyAddress: property.address || address,
+          onePropertyOneMint: true,
+          onePropertyOnePurchase: true,
+        },
+        blockchain: { minted: false, optional: true, optionalAfterCreation: true, onePropertyOneMint: true, tokenId: null, network: null },
+        world: { public: false, publishedAt: null, publicLabel: 'Voxel Property' },
+        legal: {
+          titleVerified: false,
+          ownershipRightsCreatedByDraft: false,
+          ownershipRightsCreatedByMint: false,
+          note: 'This is a digital voxel collectible only. Saving or minting it does not create rights in the physical property.',
+        },
+      };
+
+      const localSaved = savePropertyDraft(finishedDraft);
+      try {
+        const client = clientRef.current || await getSupabaseBrowserAsync();
+        clientRef.current = client;
+        await savePropertyDraftToAccount(client, session.user, localSaved);
+      } catch {}
+
+      setFinal3d({ taskId: data.taskId, modelUrl: data.modelUrl });
+      setSavedDraft(localSaved);
+      setStage('complete');
+      setMessage('Done. Your voxel is saved in Inventory and ready to mint.');
+    } catch (error) {
+      setMessage(`${String(error?.message || error || 'The voxel could not be saved.')} Tap retry.`);
+    } finally {
+      registeringRef.current = false;
+      setBusy('');
+    }
+  }, [address, draftId, property, session?.access_token, session?.user]);
+
+  async function reset() {
+    if (property?.identityKey && stage !== 'complete') {
+      fetch('/api/property-generation/confirm', {
+        method: 'DELETE',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ identityKey: property.identityKey }),
+      }).catch(() => {});
+    }
+    setDraftId(newDraftId());
+    setStage('photo');
+    setPhoto(null);
+    setPhotoUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return '';
+    });
+    setAddress('');
+    setProperty(null);
+    setVoxelImageReady(false);
+    setFinal3d(null);
+    setSavedDraft(null);
+    setClaimedByYou(false);
+    setBusy('');
+    setMessage('Choose a property photo to begin.');
+  }
+
+  if (!authReady) return <main className={styles.page}><section className={styles.shell}><StudioTopbar/><div className={styles.signInCard}><div className={styles.signInVoxel} aria-hidden="true"/><p className={styles.eyebrow}>PROPERTY STUDIO</p><h1>Opening your studio…</h1></div></section></main>;
+
+  if (!session?.user) return <main className={styles.page}><section className={styles.shell}>
+    <StudioTopbar/>
+    <div className={styles.signInCard}>
+      <div className={styles.signInVoxel} aria-hidden="true"/>
+      <p className={styles.eyebrow}>PROPERTY STUDIO</p>
+      <h1>Make a property collectible.</h1>
+      <p>Sign in once so the finished voxel can be saved to your private Inventory and minted later if you choose.</p>
+      <button className={styles.primary} type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Continue with Google'}</button>
+      <p className={styles.status} role="status">{message}</p>
+    </div>
+  </section></main>;
+
+  const mintHref = final3d?.taskId && final3d?.modelUrl
+    ? `/property/mint?draftId=${encodeURIComponent(draftId)}&taskId=${encodeURIComponent(final3d.taskId)}&name=${encodeURIComponent(savedDraft?.label || 'Voxel Property')}&modelUrl=${encodeURIComponent(final3d.modelUrl)}`
+    : '#';
+
+  return <main className={styles.page}><section className={styles.shell}>
+    <StudioTopbar/>
+    <Progress stage={stage}/>
+    <input ref={inputRef} className={styles.hiddenInput} type="file" accept="image/*,.heic,.heif" onChange={selectPhoto}/>
+
+    {stage === 'photo' ? <>
+      <header className={styles.stageHeader}><p className={styles.eyebrow}>STEP 1 · PHOTO</p><h1>Start with one great photo.</h1><p>Front or angled exterior shots work best. We use the image to build the collectible; your original photo stays on your device.</p></header>
+      <section className={styles.stageCard}><div className={styles.uploadZone}>
+        <div className={styles.uploadArt} aria-hidden="true"><div className={styles.uploadArtHouse}/><span className={styles.sparkOne}>✦</span><span className={styles.sparkTwo}>⌂</span><span className={styles.sparkThree}>3D</span></div>
+        <div className={styles.uploadCopy}><p className={styles.eyebrow}>CAMERA ROLL → VOXEL</p><h2>Choose a property photo.</h2><p>Use a photo you own or have permission to use. JPG, PNG, WebP and iPhone HEIC photos are supported.</p><button className={styles.primary} type="button" onClick={choosePhoto} disabled={busy === 'photo'}>{busy === 'photo' ? 'Preparing photo…' : 'Choose photo'}</button><span className={styles.helper}>Up to 12 MB · mobile camera photos supported</span></div>
+      </div></section>
+    </> : null}
+
+    {stage === 'address' ? <>
+      <header className={styles.stageHeader}><p className={styles.eyebrow}>STEP 2 · ADDRESS</p><h1>Which property is this?</h1><p>Confirming the address gives the collectible a real property identity and prevents duplicate Voxel Vault mints.</p></header>
+      <section className={`${styles.stageCard} ${styles.splitCard}`}>
+        <div className={styles.photoPanel}><img src={photoUrl} alt="Selected property"/><span className={styles.photoBadge}>YOUR PHOTO</span></div>
+        <div className={styles.addressCopy}><p className={styles.eyebrow}>PROPERTY IDENTITY</p><h2>Confirm the address.</h2><p>We only use it to identify the building and enforce the one-property collectible rule.</p>
+          <form className={styles.addressForm} onSubmit={confirmAddress}>
+            <input className={styles.addressInput} value={address} onChange={(event) => setAddress(event.target.value)} placeholder="123 Main St, City, State" autoComplete="street-address" autoCapitalize="words" aria-label="Property address"/>
+            <button className={styles.primary} type="submit" disabled={!clean(address) || busy === 'address'}>{busy === 'address' ? 'Confirming property…' : 'Confirm address'}</button>
+            <button className={styles.textButton} type="button" onClick={choosePhoto}>Use a different photo</button>
+          </form>
+          {claimedByYou ? <div className={styles.inlineWarning}>This property is already in your account. <Link href="/vault/property-drafts">Open Inventory</Link> to view it.</div> : null}
+        </div>
+      </section>
+    </> : null}
+
+    {stage === 'preview' ? <>
+      <header className={styles.stageHeader}><p className={styles.eyebrow}>STEP 3 · VOXEL PREVIEW</p><h1>See the voxel look first.</h1><p>We turn the property photo into a block-built preview before creating the movable 3D collectible.</p></header>
+      <section className={`${styles.stageCard} ${styles.viewerStage}`}>
+        <div className={styles.viewerShell}><PhotoReliefModelViewer imageUrl={photoUrl} onReady={() => setVoxelImageReady(true)}/><span className={styles.viewerBadge}>{voxelImageReady ? 'PREVIEW READY' : 'BUILDING PREVIEW'}</span></div>
+        <div className={styles.viewerCaption}><div><b>{voxelImageReady ? 'Your voxel preview is ready.' : 'Voxelizing your photo…'}</b><span>{property?.address}</span></div><button className={styles.primary} type="button" disabled={!voxelImageReady} onClick={() => { setStage('build'); setMessage('Preview approved. Building your movable 3D voxel…'); }}>Build the 3D voxel</button></div>
+      </section>
+    </> : null}
+
+    {stage === 'build' ? <>
+      <header className={styles.stageHeader}><p className={styles.eyebrow}>STEP 4 · BUILD</p><h1>Your property becomes 3D.</h1><p>The finished movable voxel is saved to your Inventory automatically. You can mint it after it finishes.</p></header>
+      <section className={`${styles.stageCard} ${styles.buildLayout}`}>
+        <div className={styles.buildCopy}><p className={styles.eyebrow}>3D BUILD</p><h2>Building the collectible.</h2><p>{property?.address}</p><div className={styles.buildSteps}><div className={styles.buildStep}><span>✓</span>Photo prepared</div><div className={styles.buildStep}><span>✓</span>Address locked</div><div className={styles.buildStep}><span>3</span>Constructing voxel geometry</div><div className={styles.buildStep}><span>4</span>Saving to Inventory</div></div></div>
+        <div className={styles.buildViewer}><div className={styles.viewerShell}><LocalVoxelModelViewer imageUrl={photoUrl} sourceImageUrl={photoUrl} onReady={saveFinishedVoxel}/><span className={styles.viewerBadge}>{busy === 'model' ? 'SAVING TO VAULT' : 'BUILDING 3D VOXEL'}</span></div></div>
+      </section>
+    </> : null}
+
+    {stage === 'complete' ? <>
+      <header className={styles.stageHeader}><p className={styles.eyebrow}>STEP 5 · VAULT</p><h1>Your voxel is yours.</h1><p>It is already saved in your Inventory. Mint the one-of-one collectible now, or keep it private and come back later.</p></header>
+      <section className={`${styles.stageCard} ${styles.completeGrid}`}>
+        <div className={styles.completeViewer}><div className={styles.viewerShell}><LocalVoxelModelViewer imageUrl={photoUrl} sourceImageUrl={photoUrl}/><span className={styles.viewerBadge}>SAVED 3D VOXEL</span></div></div>
+        <div className={styles.completeCopy}><div className={styles.completeMark}>✓</div><p className={styles.eyebrow}>SAVED TO INVENTORY</p><h1>Ready to keep or mint.</h1><p className={styles.completeAddress}>{property?.address}</p><div className={styles.completeActions}><Link className={styles.mintLink} href={mintHref}>Mint this voxel</Link><Link className={styles.secondary} href="/vault/property-drafts">Keep in Inventory</Link><button className={styles.textButton} type="button" onClick={reset}>Create another property</button></div></div>
+      </section>
+    </> : null}
+
+    {stage !== 'photo' && stage !== 'complete' ? <button className={styles.textButton} type="button" onClick={reset}>Start over</button> : null}
+    <p className={styles.status} role="status">{message}</p>
+    <p className={styles.truth}>A Voxel Vault mint represents the digital voxel collectible only. It does not create or transfer deed, title, equity, rent, occupancy, or other rights in the physical property.</p>
+  </section></main>;
+}

--- a/app/property/VoxelMakerSubscriptionGate.js
+++ b/app/property/VoxelMakerSubscriptionGate.js
@@ -1,10 +1,25 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
 import { VOXEL_MAKER_PLANS, formatVoxelMakerPrice } from '../../lib/voxel-maker-plans';
+import styles from './PropertyStudio.module.css';
 
 function clean(value) { return String(value || '').trim(); }
+
+function Topbar() {
+  return <header className={styles.topbar}>
+    <Link className={styles.brand} href="/">
+      <span className={styles.brandMark}>V</span>
+      <span>VOXEL VAULT</span>
+    </Link>
+    <nav className={styles.nav} aria-label="Voxel Vault navigation">
+      <Link href="/property">Create</Link>
+      <Link href="/vault/property-drafts">Inventory</Link>
+    </nav>
+  </header>;
+}
 
 export default function VoxelMakerSubscriptionGate({ children }) {
   const [ready, setReady] = useState(false);
@@ -155,51 +170,43 @@ export default function VoxelMakerSubscriptionGate({ children }) {
     }
   }
 
-  if (!ready) return <main className="vmPage"><div className="vmLoading"><div className="vmCube">V</div><strong>Opening Voxel Maker…</strong></div><style jsx>{styles}</style></main>;
+  if (!ready) return <main className={styles.pricingPage}><section className={styles.pricingShell}><Topbar/><div className={styles.signInCard}><div className={styles.signInVoxel} aria-hidden="true"/><p className={styles.eyebrow}>VOXEL MAKER</p><h1>Opening the studio…</h1></div></section></main>;
 
   if (subscription?.active) {
     const used = Number(subscription?.usage?.used || 0);
     const limit = Number(subscription?.usage?.limit || subscription?.plan?.monthlyVoxels || 0);
     return <>
-      <div className="vmPlanBar">
-        <div className="vmPlanIdentity"><span className="vmDot"/><strong>Voxel Maker {subscription.plan?.name}</strong><small>{used}/{limit} creations this month</small></div>
-        <div className="vmPlanActions"><span>{formatVoxelMakerPrice(subscription.plan?.priceCents || 0)}/mo</span>{subscription.canManageBilling ? <button type="button" onClick={manageBilling}>Manage</button> : null}</div>
+      <div className={styles.planBar}>
+        <div className={styles.planIdentity}><span className={styles.planDot}/><strong>{subscription.plan?.name} plan</strong><small>{used}/{limit} creations this month</small></div>
+        <div className={styles.planActions}><span>{formatVoxelMakerPrice(subscription.plan?.priceCents || 0)}/mo</span>{subscription.canManageBilling ? <button type="button" onClick={manageBilling}>Manage plan</button> : null}</div>
       </div>
       {children}
-      <style jsx>{styles}</style>
     </>;
   }
 
-  return <main className="vmPage">
-    <section className="vmShell">
-      <header className="vmHero">
-        <div className="vmBrand"><div className="vmCube">V</div><span>VOXEL VAULT</span></div>
-        <p className="vmEyebrow">VOXEL MAKER</p>
-        <h1>Turn houses into<br/><em>collectible voxels.</em></h1>
-        <p className="vmLead">Upload a house photo, confirm its address, build the voxel, save it to your inventory, and mint it when you want.</p>
-        <div className="vmFlow"><span>PHOTO</span><b>→</b><span>ADDRESS</span><b>→</b><span>VOXEL</span><b>→</b><span>INVENTORY</span></div>
-      </header>
+  return <main className={styles.pricingPage}><section className={styles.pricingShell}>
+    <Topbar/>
+    <header className={styles.pricingHero}>
+      <p className={styles.eyebrow}>PROPERTY STUDIO</p>
+      <h1>Photos become <em>collectible places.</em></h1>
+      <p>Choose a plan, then use the same simple studio every time: photo, address, voxel preview, 3D build, Inventory.</p>
+      <div className={styles.flowRibbon} aria-label="Property creation flow"><span>PHOTO</span><b>→</b><span>ADDRESS</span><b>→</b><span>VOXEL</span><b>→</b><span>3D</span><b>→</b><span>VAULT</span></div>
+    </header>
 
-      <div className="vmPricingHeading"><div><p className="vmEyebrow">MONTHLY PLANS</p><h2>Pick how much you create.</h2></div><p>Cancel anytime. Minting stays optional.</p></div>
+    <div className={styles.planHeading}><p className={styles.eyebrow}>MONTHLY PLANS</p><h2>Pick how much you create.</h2><p>Cancel anytime. Minting is always optional.</p></div>
 
-      <div className="vmPlans">
-        {VOXEL_MAKER_PLANS.map((plan) => <article key={plan.id} className={`vmPlan vmPlan-${plan.id}`}>
-          <div className="vmPlanTop"><div><p>{plan.name}</p>{plan.badge ? <span>{plan.badge}</span> : null}</div><strong>{formatVoxelMakerPrice(plan.priceCents)}<small>/mo</small></strong></div>
-          <h3>{plan.monthlyVoxels} voxels <small>each month</small></h3>
-          <p className="vmBlurb">{plan.blurb}</p>
-          <ul>{plan.features.map((feature) => <li key={feature}><span>✓</span>{feature}</li>)}</ul>
-          <button type="button" onClick={() => checkout(plan.id)} disabled={Boolean(busyPlan)}>{busyPlan === plan.id ? 'Opening…' : session?.user ? `Choose ${plan.name}` : `Start ${plan.name}`}</button>
-        </article>)}
-      </div>
+    <div className={styles.planGrid}>
+      {VOXEL_MAKER_PLANS.map((plan) => <article key={plan.id} className={styles.planCard}>
+        <div className={styles.planCardTop}><div><p>{plan.name}</p>{plan.badge ? <span className={styles.planBadge}>{plan.badge}</span> : null}</div><strong>{formatVoxelMakerPrice(plan.priceCents)}<small>/mo</small></strong></div>
+        <h3>{plan.monthlyVoxels} voxels / month</h3>
+        <p className={styles.planBlurb}>{plan.blurb}</p>
+        <ul className={styles.planFeatures}>{plan.features.map((feature) => <li key={feature}><span>✓</span>{feature}</li>)}</ul>
+        <button type="button" onClick={() => checkout(plan.id)} disabled={Boolean(busyPlan)}>{busyPlan === plan.id ? 'Opening…' : session?.user ? `Choose ${plan.name}` : `Start ${plan.name}`}</button>
+      </article>)}
+    </div>
 
-      {!session?.user ? <p className="vmSigninNote">Choosing a plan starts with Google sign-in so your voxels stay attached to your inventory.</p> : null}
-      {loadingStatus ? <p className="vmMessage">Checking your subscription…</p> : message ? <p className="vmMessage" role="status">{message}</p> : null}
-      <p className="vmFine">Each plan covers the Voxel Maker creation allowance shown above. A Voxel Vault mint represents the digital collectible only and does not create ownership rights in the physical property.</p>
-    </section>
-    <style jsx>{styles}</style>
-  </main>;
+    {!session?.user ? <p className={styles.status}>Choosing a plan starts with Google sign-in so your voxels stay attached to your Inventory.</p> : null}
+    {loadingStatus ? <p className={styles.status}>Checking your subscription…</p> : message ? <p className={styles.status} role="status">{message}</p> : null}
+    <p className={styles.finePrint}>Plans cover the creation allowance shown above. Minting a digital voxel does not create ownership rights in the physical property.</p>
+  </section></main>;
 }
-
-const styles = `
-:global(body){margin:0;background:#fff9f1;color:#251a2c;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.vmPage{min-height:100vh;padding:18px 14px calc(80px + env(safe-area-inset-bottom));background:radial-gradient(circle at 12% 2%,rgba(255,194,72,.38),transparent 27%),radial-gradient(circle at 92% 8%,rgba(111,54,245,.18),transparent 28%),radial-gradient(circle at 46% 100%,rgba(190,255,74,.24),transparent 30%),#fff9f1}.vmShell{width:min(1080px,100%);margin:0 auto}.vmLoading{min-height:70vh;display:grid;place-items:center;align-content:center;gap:16px;color:#6845b8}.vmCube{width:58px;height:58px;display:grid;place-items:center;border-radius:18px;background:linear-gradient(145deg,#8c59ff,#642eed);box-shadow:0 7px 0 #4f1bc9,0 16px 34px rgba(92,42,220,.23);color:#fff;font-size:28px;font-weight:1000}.vmBrand{display:flex;align-items:center;gap:13px}.vmBrand span,.vmEyebrow{font-size:9px;font-weight:1000;letter-spacing:.14em;color:#7653b7}.vmHero{padding:18px 4px 32px}.vmHero .vmEyebrow{margin:35px 0 9px}.vmHero h1{margin:0;max-width:820px;font-size:clamp(48px,8vw,86px);line-height:.88;letter-spacing:-.075em}.vmHero h1 em{font-style:normal;color:#7540f3}.vmLead{max-width:620px;margin:21px 0 18px;color:#756b75;font-size:14px;line-height:1.65}.vmFlow{display:flex;align-items:center;flex-wrap:wrap;gap:7px}.vmFlow span{padding:8px 10px;border:1px solid #ded2e5;border-radius:999px;background:rgba(255,255,255,.8);font-size:8px;font-weight:1000;letter-spacing:.06em}.vmFlow b{color:#9f8aaa}.vmPricingHeading{display:flex;align-items:end;justify-content:space-between;gap:18px;margin:8px 4px 15px}.vmPricingHeading h2{margin:5px 0 0;font-size:clamp(28px,4vw,42px);letter-spacing:-.055em}.vmPricingHeading>p{max-width:260px;margin:0;color:#887d87;font-size:11px;text-align:right}.vmPlans{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}.vmPlan{position:relative;overflow:hidden;min-height:390px;padding:18px;border:1px solid #e2d7e6;border-radius:27px;background:rgba(255,255,255,.92);box-shadow:0 18px 45px rgba(62,40,76,.08);display:flex;flex-direction:column}.vmPlan:before{content:"";position:absolute;inset:0 0 auto;height:7px;background:#ddd}.vmPlan-starter:before{background:#ffc44d}.vmPlan-creator:before{background:#8b53ff}.vmPlan-pro:before{background:#c8ff50}.vmPlan-studio{background:linear-gradient(160deg,#2a1c33,#17111f);border-color:#3b2b49;color:#fff;box-shadow:0 22px 55px rgba(39,20,54,.2)}.vmPlan-studio:before{background:linear-gradient(90deg,#c6ff4d,#8a50ff,#ffbf43)}.vmPlanTop{display:flex;align-items:start;justify-content:space-between;gap:8px;margin-top:4px}.vmPlanTop p{margin:0;font-size:13px;font-weight:1000}.vmPlanTop div span{display:inline-block;margin-top:6px;padding:5px 7px;border-radius:999px;background:#ede5ff;color:#7043d1;font-size:6px;font-weight:1000;letter-spacing:.08em}.vmPlan-studio .vmPlanTop div span{background:#c9ff52;color:#293a0c}.vmPlanTop>strong{font-size:26px;letter-spacing:-.055em}.vmPlanTop>strong small{font-size:9px;font-weight:800;letter-spacing:0;color:#8e828f}.vmPlan h3{margin:26px 0 6px;font-size:25px;letter-spacing:-.05em}.vmPlan h3 small{display:block;margin-top:2px;color:#8f8490;font-size:10px;letter-spacing:0}.vmBlurb{min-height:41px;margin:0;color:#837884;font-size:10px;line-height:1.5}.vmPlan-studio .vmBlurb,.vmPlan-studio h3 small{color:#b8aebb}.vmPlan ul{list-style:none;padding:0;margin:21px 0 24px;display:grid;gap:10px}.vmPlan li{display:flex;gap:8px;align-items:center;font-size:9px;font-weight:800;color:#5e545f}.vmPlan-studio li{color:#e2dbe5}.vmPlan li span{width:20px;height:20px;display:grid;place-items:center;border-radius:7px;background:#f0e9f3;color:#7446d5;font-size:9px}.vmPlan-studio li span{background:#392b45;color:#ccff5d}.vmPlan button{margin-top:auto;min-height:52px;border:0;border-radius:16px;background:#251a2c;color:#fff;font:950 12px inherit;cursor:pointer}.vmPlan-creator button{background:#7440f2;box-shadow:0 5px 0 #5523cb}.vmPlan-pro button{background:#c6ff4d;color:#344313;box-shadow:0 5px 0 #9fd42d}.vmPlan-studio button{background:#fff;color:#251a2c;box-shadow:0 5px 0 #cfc5d2}.vmPlan button:disabled{opacity:.55;box-shadow:none}.vmSigninNote,.vmMessage,.vmFine{max-width:700px;margin:18px auto 0;text-align:center;color:#776d77;font-size:10px;line-height:1.55}.vmMessage{color:#6942bc;font-weight:850}.vmFine{color:#9a9099;font-size:8px}.vmPlanBar{position:sticky;top:0;z-index:90;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:9px max(12px,calc((100vw - 720px)/2));border-bottom:1px solid #e2d8e5;background:rgba(255,250,243,.92);backdrop-filter:blur(18px);color:#332739}.vmPlanIdentity{display:flex;align-items:center;gap:8px;min-width:0}.vmDot{width:9px;height:9px;border-radius:50%;background:#aee63d;box-shadow:0 0 0 4px rgba(174,230,61,.18)}.vmPlanIdentity strong{font-size:10px;white-space:nowrap}.vmPlanIdentity small{color:#887d88;font-size:8px;white-space:nowrap}.vmPlanActions{display:flex;align-items:center;gap:8px}.vmPlanActions span{font-size:9px;font-weight:900;color:#7551b6}.vmPlanActions button{min-height:31px;padding:0 10px;border:1px solid #dbd1e1;border-radius:10px;background:#fff;color:#6442ae;font:900 8px inherit;cursor:pointer}@media(max-width:850px){.vmPlans{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:580px){.vmPage{padding-left:10px;padding-right:10px}.vmHero{padding-top:10px}.vmHero h1{font-size:49px}.vmPricingHeading{align-items:start;flex-direction:column}.vmPricingHeading>p{text-align:left}.vmPlans{grid-template-columns:1fr}.vmPlan{min-height:350px}.vmPlanIdentity small{display:none}.vmPlanActions span{display:none}}
-`;

--- a/app/property/mint/page.js
+++ b/app/property/mint/page.js
@@ -1,20 +1,64 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import MeshyModelViewer from '../../vault/earth/MeshyModelViewer';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import { readPropertyDrafts } from '../../../lib/property-drafts';
 import { connectVoxelFlipWallet, mintVoxelFlip } from '../../../lib/voxelflip';
+import styles from '../PropertyStudio.module.css';
 
 function clean(value) { return String(value || '').trim(); }
-function short(value) { const text = clean(value); return text ? `${text.slice(0, 7)}…${text.slice(-5)}` : ''; }
-function errorText(error) { return String(error?.reason || error?.shortMessage || error?.message || error || 'Minting failed.'); }
+function short(value) {
+  const text = clean(value);
+  return text ? `${text.slice(0, 7)}…${text.slice(-5)}` : '';
+}
+function errorText(error) {
+  return String(error?.reason || error?.shortMessage || error?.message || error || 'Minting failed.');
+}
 function storageKey(draftId, taskId) { return `voxelpop:property-mint:${draftId}:${taskId}`; }
+
+function Topbar() {
+  return <header className={styles.topbar}>
+    <Link className={styles.brand} href="/">
+      <span className={styles.brandMark}>V</span>
+      <span>VOXEL VAULT</span>
+    </Link>
+    <nav className={styles.nav} aria-label="Voxel Vault navigation">
+      <Link href="/property">Create</Link>
+      <Link href="/vault/property-drafts">Inventory</Link>
+    </nav>
+  </header>;
+}
+
+function Progress({ complete = false }) {
+  const items = [
+    ['✓', 'PHOTO', 'Done'],
+    ['✓', 'ADDRESS', 'Confirmed'],
+    ['✓', 'VOXEL', 'Built'],
+    [complete ? '✓' : '4', 'MINT', complete ? 'Complete' : 'Optional'],
+    ['5', 'VAULT', 'Inventory'],
+  ];
+  return <div className={styles.progressWrap}><div className={styles.progress}>
+    {items.map(([number, label, detail], index) => {
+      const isDone = index < 3 || (complete && index === 3);
+      const isCurrent = !complete && index === 3;
+      const className = isDone
+        ? `${styles.progressItem} ${styles.progressDone}`
+        : isCurrent
+          ? `${styles.progressItem} ${styles.progressCurrent}`
+          : styles.progressItem;
+      return <div className={className} key={label}>
+        <span>{number}</span><div><b>{label}</b><small>{detail}</small></div>
+      </div>;
+    })}
+  </div></div>;
+}
 
 export default function PropertyVoxelMintPage() {
   const [authReady, setAuthReady] = useState(false);
   const [session, setSession] = useState(null);
-  const [params, setParams] = useState({ draftId: '', taskId: '', name: 'VoxelPop Property', modelUrl: '' });
+  const [params, setParams] = useState({ draftId: '', taskId: '', name: 'Voxel Property', modelUrl: '' });
   const [wallet, setWallet] = useState('');
   const [busy, setBusy] = useState('');
   const [message, setMessage] = useState('Opening your finished voxel…');
@@ -25,21 +69,39 @@ export default function PropertyVoxelMintPage() {
 
   useEffect(() => {
     const query = new URLSearchParams(window.location.search);
-    const next = {
-      draftId: clean(query.get('draftId')),
-      taskId: clean(query.get('taskId')),
-      name: clean(query.get('name')) || 'VoxelPop Property',
-      modelUrl: clean(query.get('modelUrl')),
-    };
+    const draftId = clean(query.get('draftId'));
+    const taskId = clean(query.get('taskId'));
+    let resolvedModelUrl = clean(query.get('modelUrl'));
+    let resolvedName = clean(query.get('name')) || 'Voxel Property';
+
+    if ((!resolvedModelUrl || resolvedName === 'Voxel Property') && draftId && taskId) {
+      try {
+        const found = readPropertyDrafts().find((draft) => {
+          const savedDraftId = clean(draft?.voxelpop?.creationDraftId);
+          const savedTaskId = clean(draft?.visual?.modelTaskId || draft?.voxelpop?.modelTaskId);
+          return savedDraftId === draftId && savedTaskId === taskId;
+        });
+        if (found) {
+          resolvedModelUrl = resolvedModelUrl || clean(found?.visual?.modelUrl || found?.voxelpop?.modelUrl);
+          resolvedName = clean(found?.label) || resolvedName;
+        }
+      } catch {}
+    }
+
+    const next = { draftId, taskId, name: resolvedName, modelUrl: resolvedModelUrl };
     setParams(next);
     try {
       const saved = JSON.parse(localStorage.getItem(storageKey(next.draftId, next.taskId)) || 'null');
       if (saved?.verified && saved?.tokenId) {
         setMinted(saved);
         setWallet(saved.owner || '');
-        setMessage(`VoxelFlip #${saved.tokenId} is already verified for this voxel.`);
+        setMessage(`Voxel #${saved.tokenId} is already verified for this collectible.`);
+      } else {
+        setMessage('Your finished voxel is ready. Minting is optional.');
       }
-    } catch {}
+    } catch {
+      setMessage('Your finished voxel is ready. Minting is optional.');
+    }
   }, []);
 
   useEffect(() => {
@@ -89,7 +151,7 @@ export default function PropertyVoxelMintPage() {
       connected = await connectVoxelFlipWallet();
       setWallet(connected.address);
       setBusy('prepare');
-      setMessage('Checking this finished voxel and its one-time Base mint voucher…');
+      setMessage('Preparing the one-time mint for this finished voxel…');
       const response = await fetch('/api/property-voxel-nft/prepare', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
@@ -104,7 +166,7 @@ export default function PropertyVoxelMintPage() {
       if (!result?.tokenId || !result?.hash) throw new Error('The wallet transaction completed, but the token ID could not be read.');
 
       setBusy('verify');
-      setMessage(`VoxelFlip #${result.tokenId} was submitted. Verifying it on Base…`);
+      setMessage(`Voxel #${result.tokenId} was submitted. Verifying it…`);
       const confirm = await fetch('/api/property-voxel-nft/confirm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
@@ -118,12 +180,12 @@ export default function PropertyVoxelMintPage() {
         }),
       });
       const verified = await confirm.json().catch(() => ({}));
-      if (!confirm.ok || !verified?.verified) throw new Error(verified?.error || `VoxelFlip #${result.tokenId} was submitted, but verification is not complete. Do not mint it again.`);
+      if (!confirm.ok || !verified?.verified) throw new Error(verified?.error || `Voxel #${result.tokenId} was submitted, but verification is not complete. Do not mint it again.`);
       const finalResult = { ...result, ...verified, verified: true };
       setMinted(finalResult);
       setWallet(finalResult.owner || connected.address);
       try { localStorage.setItem(storageKey(params.draftId, params.taskId), JSON.stringify(finalResult)); } catch {}
-      setMessage(`Done. VoxelFlip #${finalResult.tokenId} is verified and owned by ${short(finalResult.owner)}.`);
+      setMessage(`Done. Voxel #${finalResult.tokenId} is verified and owned by ${short(finalResult.owner)}.`);
     } catch (error) {
       if (error?.code === 'NO_WALLET_PROVIDER' && error?.deepLink) {
         window.location.href = error.deepLink;
@@ -136,39 +198,52 @@ export default function PropertyVoxelMintPage() {
   }
 
   const invalid = !params.draftId || !params.taskId || !modelUrl;
-  if (!authReady) return <main className="page"><section className="shell"><div className="mark">V</div><h1>Opening mint…</h1><p className="status">{message}</p><style jsx>{styles}</style></section></main>;
 
-  return <main className="page"><section className="shell">
-    <nav><Link href="/property">← CREATE</Link><span>VOXELPOP · MINT</span><Link href="/vault/property-drafts">INVENTORY</Link></nav>
+  if (!authReady) return <main className={styles.page}><section className={styles.shell}><Topbar/><div className={styles.signInCard}><div className={styles.signInVoxel} aria-hidden="true"/><p className={styles.eyebrow}>MINT STUDIO</p><h1>Opening your voxel…</h1></div></section></main>;
 
-    {invalid ? <section className="notice"><b>Open Mint from a finished VoxelPop 3D voxel.</b><Link href="/property">Create a voxel</Link></section> : <>
-      <header>
-        <div className="ready">✓ 3D VOXEL SAVED · ONE MINT MAX</div>
-        <h1>{minted ? 'Mint complete.' : 'Mint your voxel.'}</h1>
-        <p>{minted ? 'Your digital voxel is verified on Base.' : 'It is already safe in your Voxel Vault inventory. Minting is optional.'}</p>
+  return <main className={styles.page}><section className={styles.shell}>
+    <Topbar/>
+    <Progress complete={Boolean(minted)}/>
+
+    {invalid ? <div className={styles.emptyCard}>
+      <div className={styles.signInVoxel} aria-hidden="true"/>
+      <p className={styles.eyebrow}>MINT STUDIO</p>
+      <h2>Open Mint from a saved voxel.</h2>
+      <p>The model link is missing from this mint request. Open the collectible from Inventory and choose Mint again.</p>
+      <Link className={styles.primary} href="/vault/property-drafts">Open Inventory</Link>
+    </div> : <>
+      <header className={styles.mintHeader}>
+        <p className={styles.eyebrow}>{minted ? 'MINT COMPLETE' : 'OPTIONAL MINT'}</p>
+        <h1>{minted ? 'Your voxel is on-chain.' : 'Mint the one-of-one.'}</h1>
+        <p>{minted ? 'The digital collectible is verified and remains visible in your Voxel Vault Inventory.' : 'Your voxel is already safe in Inventory. Minting simply gives this digital collectible an on-chain owner.'}</p>
       </header>
 
-      <div className="viewer"><MeshyModelViewer modelUrl={modelUrl}/><span>{minted ? `VOXELFLIP #${minted.tokenId}` : 'YOUR GENERATED 3D VOXEL'}</span></div>
-
-      {minted ? <section className="done">
-        <div className="doneMark">✓</div>
-        <b>VoxelFlip #{minted.tokenId}</b>
-        <span>Verified owner · {short(minted.owner)}</span>
-        <div className="links">{minted.openSeaUrl ? <a href={minted.openSeaUrl} target="_blank" rel="noreferrer">OpenSea ↗</a> : null}{minted.explorerUrl ? <a href={minted.explorerUrl} target="_blank" rel="noreferrer">Transaction ↗</a> : null}<Link href="/vault/property-drafts">Open inventory</Link></div>
-      </section> : <section className="actions">
-        {!session?.user ? <button className="primary" type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Sign in to mint'}</button> : <button className="primary" type="button" onClick={mint} disabled={Boolean(busy)}>{busy === 'wallet' ? 'Connecting wallet…' : busy === 'prepare' ? 'Checking voxel…' : busy === 'mint' ? 'Confirm in wallet…' : busy === 'verify' ? 'Verifying…' : 'Mint this voxel'}</button>}
-        <Link className="later" href="/vault/property-drafts">Keep in inventory</Link>
-        <small>One property can mint only one VoxelPop NFT.</small>
-      </section>}
-
-      {wallet && !minted ? <p className="wallet">Wallet · {short(wallet)}</p> : null}
-      <p className="status" role="status">{message}</p>
-      <p className="truth">The NFT represents the finished digital VoxelPop voxel only. It is not the deed, title, equity, rent, occupancy, investment rights, or ownership of the physical property.</p>
+      <section className={`${styles.mintCard} ${styles.mintLayout}`}>
+        <div className={styles.mintViewer}><div className={styles.viewerShell}><MeshyModelViewer modelUrl={modelUrl}/><span className={styles.viewerBadge}>{minted ? `MINTED #${minted.tokenId}` : 'YOUR 3D VOXEL'}</span></div></div>
+        <div className={styles.mintPanel}>
+          {minted ? <>
+            <div className={styles.successMark}>✓</div>
+            <p className={styles.eyebrow}>VERIFIED COLLECTIBLE</p>
+            <h2>Voxel #{minted.tokenId}</h2>
+            <p>Owned by {short(minted.owner)}. You can keep it in Inventory or open the public transaction details.</p>
+            <div className={styles.successBox}><b>Mint complete</b><span>{params.name}</span><div className={styles.successLinks}>{minted.openSeaUrl ? <a href={minted.openSeaUrl} target="_blank" rel="noreferrer">OpenSea ↗</a> : null}{minted.explorerUrl ? <a href={minted.explorerUrl} target="_blank" rel="noreferrer">Transaction ↗</a> : null}</div></div>
+            <div className={styles.mintActions}><Link className={styles.primary} href="/vault/property-drafts">Back to Inventory</Link><Link className={styles.secondary} href="/property">Create another property</Link></div>
+          </> : <>
+            <p className={styles.eyebrow}>READY TO MINT</p>
+            <h2>{params.name}</h2>
+            <p>One property can have one Voxel Vault mint. You will connect a wallet only after you choose to mint.</p>
+            <div className={styles.mintActions}>
+              {!session?.user
+                ? <button className={styles.primary} type="button" onClick={signIn} disabled={busy === 'signin'}>{busy === 'signin' ? 'Opening Google…' : 'Sign in to mint'}</button>
+                : <button className={styles.primary} type="button" onClick={mint} disabled={Boolean(busy)}>{busy === 'wallet' ? 'Connecting…' : busy === 'prepare' ? 'Preparing mint…' : busy === 'mint' ? 'Confirm in wallet…' : busy === 'verify' ? 'Verifying…' : 'Mint this voxel'}</button>}
+              <Link className={styles.secondary} href="/vault/property-drafts">Keep in Inventory</Link>
+            </div>
+            {wallet ? <p className={styles.walletLine}>Connected wallet · {short(wallet)}</p> : null}
+          </>}
+        </div>
+      </section>
+      <p className={styles.status} role="status">{message}</p>
+      <p className={styles.truth}>The NFT represents the digital voxel only. It is not the deed, title, equity, rent, occupancy, investment rights, or ownership of the physical property.</p>
     </>}
-    <style jsx>{styles}</style>
   </section></main>;
 }
-
-const styles = `
-:global(body){margin:0;background:#fffaf2;color:#281b12;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}.page{min-height:100vh;padding:10px 12px calc(92px + env(safe-area-inset-bottom));background:radial-gradient(circle at 90% 8%,rgba(113,56,245,.12),transparent 30%),radial-gradient(circle at 10% 88%,rgba(201,255,84,.18),transparent 28%),#fffaf2}.shell{width:min(680px,100%);margin:auto;text-align:center}nav{height:48px;display:flex;align-items:center;justify-content:space-between;gap:10px;font-size:8px;font-weight:1000;letter-spacing:.1em;color:#8c8179}nav a{color:#6b4db2;text-decoration:none;padding:8px}header{margin:26px auto 14px}.ready{display:inline-flex;padding:7px 10px;border:1px solid #cce99b;border-radius:999px;background:#f5ffe4;color:#527025;font-size:8px;font-weight:1000;letter-spacing:.08em}header h1{font-size:clamp(39px,8vw,56px);line-height:.94;letter-spacing:-.055em;margin:14px 0 8px}header p{max-width:520px;margin:0 auto;color:#786e67;font-size:12px;line-height:1.5}.viewer{position:relative;width:100%;height:min(58vh,520px);min-height:350px;overflow:hidden;border:1px solid #e4dacf;border-radius:26px;background:#21172c;box-shadow:0 20px 48px rgba(70,47,87,.13)}.viewer>div{height:100%!important;min-height:100%!important}.viewer :global(.viewerShell){position:absolute!important;inset:0!important;min-height:100%!important;border-radius:0!important}.viewer>span{position:absolute;z-index:7;left:12px;top:12px;padding:8px 10px;border:1px solid rgba(255,255,255,.5);border-radius:999px;background:rgba(32,23,39,.76);color:#fff;font-size:7px;font-weight:1000;letter-spacing:.08em;backdrop-filter:blur(10px)}.actions{display:grid;gap:9px;margin-top:12px;padding:14px;border:1px solid #e7ded4;border-radius:21px;background:#fff}.primary,.later{width:100%;min-height:57px;border-radius:17px;display:flex;align-items:center;justify-content:center;font:950 16px inherit;text-decoration:none}.primary{border:0;background:#7138f5;color:#fff;box-shadow:0 6px 0 #5120d0;cursor:pointer}.primary:disabled{opacity:.5;box-shadow:none}.later{border:1px solid #ddd2eb;background:#fff;color:#6846b7}.actions small{color:#938a83;font-size:9px}.status{min-height:18px;margin:12px auto 0;max-width:590px;color:#6f655e;font-size:10px;font-weight:700;line-height:1.5}.wallet{margin:10px 0 0;font-size:8px;color:#8c8179}.truth{max-width:610px;margin:11px auto;color:#9c938c;font-size:8px;line-height:1.55}.done{display:grid;gap:9px;margin-top:12px;padding:19px;border:1px solid #d8edac;border-radius:21px;background:#f7ffe8}.doneMark,.mark{width:54px;height:54px;margin:auto;border-radius:17px;background:#c9ff54;color:#456318;display:grid;place-items:center;font-size:25px;font-weight:1000;box-shadow:0 6px 0 #aada35}.done>b{font-size:20px}.done>span{font-size:10px;color:#6f7b59}.links{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:3px}.links a{min-height:47px;display:grid;place-items:center;border:1px solid #dfd7e4;border-radius:13px;background:#fff;color:#614fa2;text-decoration:none;font-size:9px;font-weight:950}.links a:last-child{grid-column:1/-1;background:#21172c;color:#fff;border:0}.notice{margin-top:70px;display:grid;gap:14px;padding:28px;border:1px solid #e6ddd5;border-radius:22px;background:#fff}.notice b{font-size:20px}.notice a{color:#7138f5;font-weight:900}.mark{margin-top:70px}.shell>.mark+h1{font-size:36px;letter-spacing:-.04em}.page button:focus-visible,.page a:focus-visible{outline:3px solid rgba(113,56,245,.24);outline-offset:3px}@media(max-width:520px){.page{padding:8px 8px calc(78px + env(safe-area-inset-bottom))}.viewer{min-height:330px;border-radius:21px}.links{grid-template-columns:1fr}.links a:last-child{grid-column:auto}}
-`;

--- a/app/property/page.js
+++ b/app/property/page.js
@@ -1,9 +1,8 @@
 'use client';
 
 import { useEffect } from 'react';
-import ProductTopNav from '../components/ProductTopNav';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
-import HouseVoxelMintFlow from './HouseVoxelMintFlow';
+import PropertyStudioFlow from './PropertyStudioFlow';
 import VoxelMakerSubscriptionGate from './VoxelMakerSubscriptionGate';
 
 function cleanOAuthParams() {
@@ -46,9 +45,8 @@ function OAuthRecovery() {
 export default function PropertyJourneyPage() {
   return <>
     <OAuthRecovery/>
-    <ProductTopNav/>
     <VoxelMakerSubscriptionGate>
-      <HouseVoxelMintFlow/>
+      <PropertyStudioFlow/>
     </VoxelMakerSubscriptionGate>
   </>;
 }

--- a/app/vault/property-drafts/page.js
+++ b/app/vault/property-drafts/page.js
@@ -3,26 +3,50 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
-import { deletePropertyDraft, exportPropertyDraft, readPropertyDrafts, setPropertyDraftWorldVisibility } from '../../../lib/property-drafts';
-import { deletePropertyDraftFromAccount, savePropertyDraftToAccount, syncLocalPropertyDraftsToAccount } from '../../../lib/property-drafts-account';
+import {
+  deletePropertyDraft,
+  exportPropertyDraft,
+  readPropertyDrafts,
+  setPropertyDraftWorldVisibility,
+} from '../../../lib/property-drafts';
+import {
+  deletePropertyDraftFromAccount,
+  savePropertyDraftToAccount,
+  syncLocalPropertyDraftsToAccount,
+} from '../../../lib/property-drafts-account';
+import styles from '../../property/PropertyStudio.module.css';
 
+function clean(value) { return String(value || '').trim(); }
 function dollars(cents) {
   if (!Number(cents)) return '';
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(cents) / 100);
 }
-
 function directMintHref(draft) {
-  const draftId = String(draft?.voxelpop?.creationDraftId || '').trim();
-  const taskId = String(draft?.visual?.modelTaskId || draft?.voxelpop?.modelTaskId || '').trim();
-  if (!draftId || !taskId.startsWith('local-v1:')) return '';
-  const name = String(draft?.label || 'VoxelPop Property').trim();
-  return `/property/mint?draftId=${encodeURIComponent(draftId)}&taskId=${encodeURIComponent(taskId)}&name=${encodeURIComponent(name)}`;
+  const draftId = clean(draft?.voxelpop?.creationDraftId);
+  const taskId = clean(draft?.visual?.modelTaskId || draft?.voxelpop?.modelTaskId);
+  const modelUrl = clean(draft?.visual?.modelUrl || draft?.voxelpop?.modelUrl);
+  if (!draftId || !taskId || !modelUrl) return '';
+  const name = clean(draft?.label) || 'Voxel Property';
+  return `/property/mint?draftId=${encodeURIComponent(draftId)}&taskId=${encodeURIComponent(taskId)}&name=${encodeURIComponent(name)}&modelUrl=${encodeURIComponent(modelUrl)}`;
+}
+
+function Topbar() {
+  return <header className={styles.topbar}>
+    <Link className={styles.brand} href="/">
+      <span className={styles.brandMark}>V</span>
+      <span>VOXEL VAULT</span>
+    </Link>
+    <nav className={styles.nav} aria-label="Voxel Vault navigation">
+      <Link href="/property">Create</Link>
+      <Link href="/world">World</Link>
+    </nav>
+  </header>;
 }
 
 export default function PropertyDraftsPage() {
   const [drafts, setDrafts] = useState([]);
   const [session, setSession] = useState(null);
-  const [note, setNote] = useState('Your saved and collected digital property voxels. Minting stays optional.');
+  const [note, setNote] = useState('Every finished property voxel lives here. Minting stays optional.');
   const [busy, setBusy] = useState('');
   const clientRef = useRef(null);
 
@@ -40,7 +64,7 @@ export default function PropertyDraftsPage() {
         const merged = await syncLocalPropertyDraftsToAccount(client, nextSession.user);
         if (active) setDrafts(merged);
       } catch (error) {
-        if (active) setNote(String(error?.message || error || 'Account sync is unavailable. Local Vault still works.'));
+        if (active) setNote(String(error?.message || error || 'Account sync is unavailable. Local Inventory still works.'));
       }
     }
     getSupabaseBrowserAsync().then(async (client) => {
@@ -59,7 +83,9 @@ export default function PropertyDraftsPage() {
       clientRef.current = client;
       const { error } = await client.auth.signInWithOAuth({ provider: 'google', options: { redirectTo: new URL('/vault/property-drafts', window.location.origin).toString() } });
       if (error) throw error;
-    } catch (error) { setNote(String(error?.message || error || 'Could not sign in.')); }
+    } catch (error) {
+      setNote(String(error?.message || error || 'Could not sign in.'));
+    }
   }
 
   async function toggleWorld(draft) {
@@ -75,9 +101,12 @@ export default function PropertyDraftsPage() {
       clientRef.current = client;
       await savePropertyDraftToAccount(client, session.user, next);
       refresh();
-      setNote(next.world?.public ? 'This voxel is now visible on Public World.' : 'This voxel is private in My World.');
-    } catch (error) { setNote(String(error?.message || error)); }
-    finally { setBusy(''); }
+      setNote(next.world?.public ? 'This voxel is now visible on Public World.' : 'This voxel is private in your Inventory.');
+    } catch (error) {
+      setNote(String(error?.message || error));
+    } finally {
+      setBusy('');
+    }
   }
 
   async function remove(id) {
@@ -87,30 +116,56 @@ export default function PropertyDraftsPage() {
     try {
       const client = clientRef.current || await getSupabaseBrowserAsync();
       await deletePropertyDraftFromAccount(client, session.user, id);
-    } catch (error) { setNote(`Removed here. Account cleanup needs attention: ${String(error?.message || error)}`); }
+    } catch (error) {
+      setNote(`Removed here. Account cleanup needs attention: ${String(error?.message || error)}`);
+    }
   }
 
-  return <main className="page">
-    <header><Link href="/">V</Link><nav><Link href="/property">Create</Link><Link href="/world">World</Link></nav></header>
-    <section className="hero"><small>✦ YOUR VOXEL VAULT ✦</small><h1>Your collection.</h1><p>{note}</p>{!session?.user ? <button onClick={signIn}>SYNC WITH GOOGLE</button> : null}<div className="hub"><Link className="create" href="/property">+ Create Another</Link><Link className="world" href="/world">View My World</Link></div></section>
+  return <main className={styles.inventoryPage}><section className={styles.inventoryShell}>
+    <Topbar/>
 
-    {drafts.length ? <section className="grid">{drafts.map((draft) => {
+    <header className={styles.inventoryHero}>
+      <p className={styles.eyebrow}>YOUR INVENTORY</p>
+      <h1>Your property collection.</h1>
+      <p>{note}</p>
+      <div className={styles.heroActions}>
+        <Link className={styles.createButton} href="/property">+ Create a voxel</Link>
+        {!session?.user ? <button className={styles.secondary} type="button" onClick={signIn}>Sync with Google</button> : <Link className={styles.secondary} href="/world">View Public World</Link>}
+      </div>
+    </header>
+
+    {drafts.length ? <section className={styles.inventoryGrid}>{drafts.map((draft) => {
       const collected = draft?.commerce?.kind === 'property_voxel_collectible' && draft?.commerce?.status === 'paid';
-      const preview = draft?.visual?.thumbnailUrl || null;
+      const preview = clean(draft?.visual?.thumbnailUrl);
       const mintHref = directMintHref(draft);
-      const directMintReady = Boolean(mintHref);
-      return <article key={draft.id}>
-        <div className="visual">{preview ? <img src={preview} alt={draft.label || 'Voxel property preview'}/> : <><div className="ground"/><div className={String(draft.geometryKind || '').includes('building') ? 'house' : 'land'}>{String(draft.geometryKind || '').includes('building') ? <><i/><i/></> : null}</div></>}<span>{collected ? 'COLLECTED' : draft.world?.public ? 'WORLD' : draft.blockchain?.minted ? 'MINTED' : '3D'}</span></div>
-        <div className="body"><small>{collected ? 'COLLECTED DIGITAL VOXEL' : draft.blockchain?.minted ? 'MINTED DIGITAL MODEL' : directMintReady ? 'SAVED VOXEL · MINT OPTIONAL' : 'SAVED 3D MODEL'}</small><h2>{draft.label || 'Saved VoxelPop creation'}</h2>{collected ? <div className="paid"><b>{draft.commerce?.priceLabel || 'VoxelPop Digital Voxel'}</b><strong>{dollars(draft.commerce?.priceCents)}</strong></div> : null}
-          <div className="actions"><Link href={`/vault/property-drafts/${encodeURIComponent(draft.id)}`}>OPEN 3D</Link><button className={draft.world?.public ? 'active' : ''} onClick={() => toggleWorld(draft)} disabled={busy === draft.id}>{draft.world?.public ? 'PUBLIC WORLD' : 'SHARE TO WORLD'}</button><Link href={directMintReady ? mintHref : '/vault/properties/claim'}>{directMintReady ? 'MINT · OPTIONAL' : collected ? 'VERIFY + MINT · OPTIONAL' : 'VERIFY + MINT'}</Link></div>
-          <div className="more"><button onClick={() => exportPropertyDraft(draft)}>EXPORT</button><button onClick={() => remove(draft.id)}>REMOVE</button></div>
+      const minted = draft?.blockchain?.minted === true;
+      const status = collected ? 'COLLECTED' : minted ? 'MINTED' : draft?.world?.public ? 'PUBLIC' : 'IN VAULT';
+      return <article className={styles.inventoryCard} key={draft.id}>
+        <div className={styles.inventoryVisual}>
+          {preview ? <img src={preview} alt={draft.label || 'Voxel property preview'}/> : <div className={styles.inventoryVoxel} aria-hidden="true"/>}
+          <span className={styles.cardBadge}>{status}</span>
+        </div>
+        <div className={styles.inventoryBody}>
+          <small>{minted ? 'MINTED PROPERTY VOXEL' : 'SAVED PROPERTY VOXEL'}</small>
+          <h2>{draft.label || 'Saved Voxel Property'}</h2>
+          <p className={styles.inventoryMeta}>{minted ? 'On-chain collectible · saved in your Voxel Vault' : mintHref ? 'Finished 3D collectible · mint whenever you want' : 'Saved digital property collectible'}</p>
+          {collected ? <div className={styles.paidRow}><b>{draft.commerce?.priceLabel || 'Digital voxel'}</b><strong>{dollars(draft.commerce?.priceCents)}</strong></div> : null}
+          <div className={styles.cardActions}>
+            <Link href={`/vault/property-drafts/${encodeURIComponent(draft.id)}`}>OPEN 3D</Link>
+            <button className={draft.world?.public ? styles.publicAction : ''} type="button" onClick={() => toggleWorld(draft)} disabled={busy === draft.id}>{draft.world?.public ? 'PUBLIC' : 'SHARE'}</button>
+            {mintHref ? <Link className={styles.mintCardAction} href={mintHref}>{minted ? 'VIEW MINT' : 'MINT · OPTIONAL'}</Link> : <Link className={styles.mintCardAction} href="/vault/properties/claim">VERIFY + MINT</Link>}
+          </div>
+          <div className={styles.cardMore}><button type="button" onClick={() => exportPropertyDraft(draft)}>Export</button><button type="button" onClick={() => remove(draft.id)}>Remove</button></div>
         </div>
       </article>;
-    })}</section> : <section className="empty"><div className="cube"><i/><i/><i/></div><b>No property voxels yet.</b><span>Choose one photo: 3D picture → approve → 3D voxel → mint now or save here for later.</span><Link href="/property">+ CREATE FIRST VOXEL</Link></section>}
+    })}</section> : <section className={styles.emptyCard}>
+      <div className={styles.signInVoxel} aria-hidden="true"/>
+      <p className={styles.eyebrow}>EMPTY VAULT</p>
+      <h2>Your first property can start now.</h2>
+      <p>Choose a photo, confirm its address, build the 3D voxel, then keep it here or mint it.</p>
+      <Link className={styles.primary} href="/property">Create first voxel</Link>
+    </section>}
 
-    <p className="truth">Vault stores your saved and collected digital property voxels. Saving, sharing, or minting a voxel does not itself transfer deed/title, rent, fractional investment, occupancy, or other rights in the physical property.</p>
-    <style jsx>{`
-      :global(body){margin:0;background:#fffaf0;color:#171221;font-family:Inter,ui-rounded,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.page{min-height:100vh;padding:14px clamp(12px,3vw,30px) calc(90px + env(safe-area-inset-bottom));background:radial-gradient(circle at 4% 22%,#efffb6 0,transparent 25%),radial-gradient(circle at 95% 8%,#eee5ff 0,transparent 26%),#fffaf0}header{max-width:920px;height:52px;margin:auto;display:flex;align-items:center;justify-content:space-between}header>a{width:40px;height:40px;border-radius:13px;background:#7138f5;color:#fff;text-decoration:none;display:grid;place-items:center;font-weight:1000;box-shadow:0 6px 0 #4d1bc5}nav{display:flex;gap:7px}nav a{padding:10px 13px;color:#51495a;text-decoration:none;font-size:11px;font-weight:900;border:1px solid #e1dbe7;border-radius:999px;background:#ffffffc9}.hero{max-width:920px;margin:48px auto 24px;text-align:center}.hero small{color:#7041ed;font-size:12px;font-weight:950;letter-spacing:.14em}.hero h1{font-size:clamp(52px,9vw,82px);line-height:.9;letter-spacing:-.06em;margin:14px 0 8px}.hero p{color:#7a7280;font-size:14px;margin:0}.hero>button{margin-top:14px;border:1px solid #ddd6e5;border-radius:999px;background:#fff;color:#5d5565;padding:11px 15px;font-size:10px;font-weight:950}.hub{max-width:540px;margin:20px auto 0;display:grid;grid-template-columns:1fr 1fr;gap:10px}.hub a{min-height:54px;border-radius:18px;display:grid;place-items:center;text-decoration:none;font-size:12px;font-weight:1000}.hub .create{background:#7138f5;color:#fff;box-shadow:0 7px 0 #4d1bc5}.hub .world{background:#c9ff54;color:#263d00;box-shadow:0 7px 0 #aee43c}.grid{max-width:920px;margin:0 auto;display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:14px}.grid article{overflow:hidden;border:1px solid #e4dfea;border-radius:26px;background:#ffffffdb;box-shadow:0 16px 45px #6f51a10e}.visual{height:210px;position:relative;overflow:hidden;background:radial-gradient(circle at 50% 35%,#c9ff5424,transparent 30%),#21162c}.visual>img{width:100%;height:100%;object-fit:cover;display:block}.ground{position:absolute;left:11%;right:11%;bottom:17%;height:32%;border:1px solid #8c79a0;transform:perspective(340px) rotateX(62deg);border-radius:14px}.house{position:absolute;left:30%;right:30%;bottom:30%;height:38%;background:#fff}.house:before{content:'';position:absolute;left:-10%;right:-10%;top:-13%;height:18%;background:#7138f5}.house i{position:absolute;bottom:18%;width:20%;height:34%;background:#c9ff54}.house i:first-child{left:18%}.house i:last-child{right:18%}.land{position:absolute;left:24%;right:24%;bottom:25%;height:28%;border:2px solid #c9ff54;transform:perspective(320px) rotateX(62deg);border-radius:12px;background:#c9ff5412}.visual span{position:absolute;top:13px;left:13px;padding:7px 10px;border-radius:999px;background:#c9ff54;color:#263d00;font-size:8px;font-weight:950;letter-spacing:.08em}.body{padding:18px}.body small{color:#7041ed;font-size:8px;font-weight:950;letter-spacing:.1em}.body h2{font-size:23px;letter-spacing:-.04em;margin:6px 0 12px}.paid{display:flex;align-items:center;justify-content:space-between;gap:10px;margin:0 0 13px;padding:10px 11px;border-radius:13px;background:#f3ffe1;color:#50672d}.paid b{font-size:9px}.paid strong{font-size:15px}.actions{display:grid;grid-template-columns:1fr 1fr;gap:7px}.actions a,.actions button{min-height:44px;border:1px solid #ddd6e5;border-radius:14px;background:#fff;color:#5e5666;text-decoration:none;display:grid;place-items:center;font:inherit;font-size:8px;font-weight:950;cursor:pointer;text-align:center;padding:5px}.actions a:first-child{background:#7138f5;color:#fff;border:0}.actions a:last-child{grid-column:1/-1;background:#171221;color:#fff;border:0}.actions .active{background:#c9ff54;color:#171221;border:0}.more{margin-top:9px;display:flex;gap:12px}.more button{border:0;background:none;color:#a098a3;font-size:8px;font-weight:900;padding:4px 0}.empty{max-width:700px;margin:30px auto;padding:42px 24px;border:1px solid #e4dfea;border-radius:30px;background:#ffffffd7;display:grid;justify-items:center;gap:10px;text-align:center}.empty b{font-size:24px}.empty span{color:#7a7280;font-size:14px}.empty a{margin-top:8px;background:#7138f5;color:#fff;text-decoration:none;border-radius:18px;padding:15px 18px;font-size:12px;font-weight:950;box-shadow:0 7px 0 #4d1bc5}.cube{position:relative;width:66px;height:66px;transform:rotate(30deg) skewY(-8deg);background:#c9ff54;border-radius:10px;box-shadow:0 8px 0 #aee43c}.cube i{position:absolute;background:#7138f5}.cube i:nth-child(1){width:15px;height:15px;left:9px;top:11px}.cube i:nth-child(2){width:15px;height:15px;right:9px;top:11px}.cube i:nth-child(3){width:15px;height:15px;left:25px;bottom:9px}.truth{max-width:920px;margin:16px auto;color:#99909d;font-size:9px;line-height:1.5}@media(max-width:620px){.page{padding:10px 10px calc(82px + env(safe-area-inset-bottom))}.hero{margin-top:34px}.hero h1{font-size:55px}.hub{grid-template-columns:1fr}.grid{grid-template-columns:1fr}.visual{height:210px}.actions a,.actions button{min-height:47px}}
-    `}</style>
-  </main>;
+    <p className={styles.truth}>Inventory stores your saved digital property voxels. Saving, sharing, or minting a voxel does not transfer deed, title, rent, equity, occupancy, or other rights in the physical property.</p>
+  </section></main>;
 }

--- a/scripts/audit-ui-system.mjs
+++ b/scripts/audit-ui-system.mjs
@@ -20,17 +20,20 @@ const uiFiles = tracked.filter(uiFile);
 const required = [
   'app/components/ProductTopNav.js',
   'app/components/ProductTopNav.module.css',
-  'app/components/HomeProductPreview.js',
   'app/components/ConsumerFooter.js',
   'app/components/FinancialOSNav.js',
   'app/components/FinancialOSNav.module.css',
   'app/ui-system.css',
   'app/page.js',
+  'app/home.module.css',
   'app/demo/page.js',
   'app/property/page.js',
-  'app/property/HouseVoxelMintFlow.js',
+  'app/property/PropertyStudioFlow.js',
+  'app/property/PropertyStudio.module.css',
   'app/property/PhotoReliefModelViewer.js',
   'app/property/LocalVoxelModelViewer.js',
+  'app/property/mint/page.js',
+  'app/vault/property-drafts/page.js',
   'app/world/page.js',
   'app/vault/page.js',
   'app/privacy/page.js',
@@ -40,7 +43,7 @@ const required = [
 for (const file of required) must(fs.existsSync(path.join(root, file)), `${file}: required consumer UI file is missing`);
 
 const home = read('app/page.js');
-const preview = read('app/components/HomeProductPreview.js');
+const homeCss = read('app/home.module.css');
 const topNav = read('app/components/ProductTopNav.js');
 const topCss = read('app/components/ProductTopNav.module.css');
 const dock = read('app/components/FinancialOSNav.js');
@@ -49,31 +52,33 @@ const footer = read('app/components/ConsumerFooter.js');
 const system = read('app/ui-system.css');
 const demo = read('app/demo/page.js');
 const propertyRoute = read('app/property/page.js');
-const property = read('app/property/HouseVoxelMintFlow.js');
+const property = read('app/property/PropertyStudioFlow.js');
+const propertyCss = read('app/property/PropertyStudio.module.css');
 const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const localViewer = read('app/property/LocalVoxelModelViewer.js');
+const mintPage = read('app/property/mint/page.js');
+const inventory = read('app/vault/property-drafts/page.js');
 
-must(/HomeProductPreview/.test(home), 'Homepage must use real production 3D proof.');
-must(!/voxelHouse/.test(home), 'Homepage must not regress to a decorative CSS house.');
-must(/className=\{styles\.primaryAction\} href="\/property"/.test(home), 'Create must be the single visual primary hero action.');
-must(!/secondaryAction/.test(home), 'Homepage must not present a competing secondary hero button.');
-must(/HOUSE PHOTO → VOXEL → MINT/.test(home) && /confirm the address/i.test(home) && /Saved to Inventory/i.test(home), 'Homepage must explain the condensed house creation path.');
-must(!/\$4\.99/.test(home), 'Homepage must not place checkout pricing in the core house flow.');
-must(/collectible is digital/i.test(home) && /deed, title, or physical-property rights/i.test(home), 'Homepage must keep the digital-only physical-property boundary visible.');
-must(/LocalVoxelModelViewer/.test(preview), 'Home product proof must use the actual movable-voxel viewer.');
-must(/>Address</.test(preview) && />Inventory</.test(preview), 'Home proof must show address confirmation and Inventory.');
-must(!/\$4\.99/.test(preview), 'Home proof must not reintroduce a price badge.');
+must(/PROPERTY → COLLECTIBLE/.test(home), 'Homepage must state the focused property collectible product.');
+must(/Create a property voxel/.test(home) && /href="\/property"/.test(home), 'Homepage must have a clear property-creation CTA.');
+must(/Open Inventory/.test(home), 'Homepage must keep Inventory reachable without entering creation.');
+must(/confirm the address/i.test(home) && /voxel image/i.test(home) && /saved to Inventory first/i.test(home), 'Homepage must explain the guided photo-to-Inventory path.');
+must(/Mint if you want|Minting optional/i.test(home), 'Homepage must keep minting explicitly optional.');
+must(/This collectible is digital only\./.test(home) && /does not create or transfer deed, title/i.test(home), 'Homepage must keep the digital-only property-rights boundary visible.');
+must(!/\$4\.99/.test(home), 'Homepage must not place legacy per-property checkout pricing in the core flow.');
+must(!/BUY PIECE|BUY WHOLE|guaranteed returns|guaranteed yield|risk[- ]free/i.test(home), 'Homepage must not make physical-property purchase or return claims.');
+must(/#6f42f5/i.test(homeCss) && /#c9ff55/i.test(homeCss), 'Homepage must use the new playful Voxel Vault color system.');
+must(/@media\(max-width:620px\)/.test(homeCss), 'Homepage must retain a dedicated mobile layout.');
 
-must(/label: 'Create'/.test(topNav) && /label: 'Inventory'/.test(topNav), 'Primary product nav must stay focused on Create + Inventory.');
-must(!/\$4\.99/.test(topNav), 'Primary product nav must not insert a checkout price.');
-must(!/label: 'World'/.test(topNav) && !/className=\{styles\.demo\}/.test(topNav), 'World and Demo must not compete in the primary header.');
-must(/focusedFunnel/.test(topNav) && /mobileDocked/.test(topNav) && /isOrganizedUserRoute/.test(topNav), 'Shared top nav must distinguish focused Home/Create from organized secondary routes.');
+must(/label: 'Create'/.test(topNav) && /label: 'Inventory'/.test(topNav), 'Legacy shared product nav must remain focused where it is still used.');
+must(!/\$4\.99/.test(topNav), 'Shared product nav must not insert checkout pricing.');
+must(!/label: 'World'/.test(topNav) && !/className=\{styles\.demo\}/.test(topNav), 'World and Demo must not compete in the shared product header.');
+must(/focusedFunnel/.test(topNav) && /mobileDocked/.test(topNav) && /isOrganizedUserRoute/.test(topNav), 'Shared top nav must distinguish focused and organized routes.');
 must(/\.mobileDocked \.links\{display:none\}/.test(topCss), 'Organized mobile routes must let the bottom dock own navigation.');
-must(/\.focusedFunnel \.links a:nth-child\(2\)\{display:inline-flex\}/.test(topCss), 'Focused Home/Create mobile header must keep Inventory reachable.');
-must(/pathname === '\/' \|\| pathname === '\/property'/.test(dock), 'Home and creator must suppress the duplicate bottom dock.');
-must(/const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/.test(dock), 'Mobile dock must remain Home, Create, and Vault.');
-must(!/id: 'world'/.test(dock) && !/id: 'more'/.test(dock), 'World and More must not compete in the primary mobile dock.');
-must(/@media\(max-width:720px\)/.test(dockCss) && /\.nav\{display:none\}/.test(dockCss), 'Bottom dock must be mobile-only.');
+must(/usesPropertyStudioNavigation/.test(dock), 'The old mobile dock must stay out of the redesigned Home/Create/Mint/Inventory experience.');
+must(/const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/.test(dock), 'Mobile dock must remain Home, Create, and Vault on legacy organized routes.');
+must(!/id: 'world'/.test(dock) && !/id: 'more'/.test(dock), 'World and More must not compete in the legacy mobile dock.');
+must(/@media\(max-width:720px\)/.test(dockCss) && /\.nav\{display:none\}/.test(dockCss), 'Bottom dock must stay mobile-only.');
 
 must(!/fontSize:\s*7\.8/.test(footer), 'Shared footer must not use unreadable 7.8px legal text.');
 must(/\/demo/.test(footer) && /\/privacy/.test(footer) && /\/about/.test(footer), 'Shared footer must cover demo and trust surfaces.');
@@ -81,7 +86,7 @@ must(/\.vvConsumerFooterTruth\{[^}]*font-size:10\.5px/.test(system), 'Shared leg
 must(/\[role="button"\]:focus-visible/.test(system), 'Custom interactive controls must receive visible keyboard focus.');
 must(/prefers-reduced-motion:reduce/.test(system), 'UI system must respect reduced motion.');
 
-must(/ProductTopNav/.test(demo), 'Public demo must use shared product chrome.');
+must(/ProductTopNav/.test(demo), 'Public demo must keep its shared product chrome.');
 must(/role="tablist"/.test(demo) && /aria-selected/.test(demo), 'Public demo stage switcher must expose tab semantics.');
 for (const file of ['app/privacy/page.js','app/terms/page.js','app/about/page.js']) {
   const source = read(file);
@@ -90,25 +95,31 @@ for (const file of ['app/privacy/page.js','app/terms/page.js','app/about/page.js
   must(!/styles\.footer/.test(source), `${file}: trust surface must not own a duplicate footer`);
 }
 
-must(/HouseVoxelMintFlow/.test(propertyRoute), 'Live /property route must use the house voxel flow.');
-must(/const LABELS = \['PHOTO', 'ADDRESS', 'VOXEL IMAGE', '3D VOXEL', 'DONE'\]/.test(property), 'Creator must show the requested five-stage journey.');
-must(/Upload one house photo\./.test(property), 'Creator must start with one obvious photo action.');
-must(/Confirm the address\./.test(property), 'Address confirmation must be the second step.');
+must(/PropertyStudioFlow/.test(propertyRoute), 'Live /property route must use the redesigned guided property studio.');
+must(/const PROGRESS = \[[\s\S]*PHOTO[\s\S]*ADDRESS[\s\S]*VOXEL[\s\S]*BUILD[\s\S]*VAULT/.test(property), 'Creator must expose the requested five-stage property journey.');
+must(/Start with one great photo\./.test(property), 'Creator must start with one obvious photo page.');
+must(/Confirm the address\./.test(property), 'Address confirmation must be the second page.');
 must(/\/api\/property-generation\/confirm/.test(property), 'Creator must use the duplicate-safe address confirmation endpoint.');
-must(!/\/api\/property-generation\/checkout|Pay \$|Stripe/i.test(property), 'Creator must not contain a checkout step.');
-must(/PhotoReliefModelViewer/.test(property) && /setStage\('model'\)/.test(property), 'Voxel image must automatically advance into 3D generation.');
-must(!/Looks good · continue|approveVoxelImage|approvePreviewAndBuildVoxel/.test(property), 'Creator must not add an unnecessary voxel-image approval click.');
+must(!/\/api\/property-generation\/checkout|Pay \$|Stripe/i.test(property), 'Live creator must not contain a per-property checkout step.');
+must(/PhotoReliefModelViewer/.test(property), 'Creator must include a real voxel preview page.');
+must(/Build the 3D voxel/.test(property) && /setStage\('build'\)/.test(property), 'Voxel preview must require the requested explicit page-by-page continue action.');
 must(/LocalVoxelModelViewer/.test(property) && /\/api\/property-local-voxel/.test(property), 'Creator must build and persist a real movable voxel.');
 must(/\/api\/property-generation\/finalize/.test(property), 'Creator must finalize the one-property lock after the 3D voxel exists.');
-must(/savePropertyDraft\(finishedDraft\)/.test(property) && /savePropertyDraftToAccount/.test(property), 'Completion must save the result locally and to the signed-in Inventory.');
-must(/Mint voxel/.test(property) && /Keep in inventory/.test(property), 'Completion must offer both mint and keep-in-inventory outcomes.');
+must(/savePropertyDraft\(finishedDraft\)/.test(property) && /savePropertyDraftToAccount/.test(property), 'Completion must save locally and to signed-in Inventory.');
+must(/Mint this voxel/.test(property) && /Keep in Inventory/.test(property), 'Completion must offer both mint and keep-in-inventory outcomes.');
+must(/modelUrl=\$\{encodeURIComponent\(final3d\.modelUrl\)\}/.test(property), 'Completion must carry the saved 3D model into Mint.');
 must(/does not create rights in the physical property/i.test(property), 'Completion must preserve the physical-property rights boundary.');
 must(!/PropertyWorldMap|Add to My World/.test(property), 'World/map controls must stay out of the core creation funnel.');
-must(/aria-label="House address"/.test(property), 'Address field must have an accessible label.');
+must(/aria-label="Property address"/.test(property), 'Address field must have an accessible label.');
 must(/role="status"/.test(property), 'Dynamic creation status must be announced.');
 must(/normalizeIphonePhoto/.test(property) && /\.heic,\.heif/.test(property), 'Creator must remain iPhone-photo friendly.');
-must(/new THREE\.InstancedMesh/.test(photoPreview), 'Voxel image stage must use real voxel instances.');
+must(/#6f42f5/i.test(propertyCss) && /#c9ff55/i.test(propertyCss), 'Creator, Mint and Inventory must share the new color system.');
+must(/safe-area-inset-bottom/.test(propertyCss), 'Shared property studio styles must respect iPhone safe areas.');
+must(/new THREE\.InstancedMesh/.test(photoPreview), 'Voxel preview stage must use real voxel instances.');
 must(/InstancedMesh/.test(localViewer), 'Movable 3D result must use real voxel geometry.');
+must(/readPropertyDrafts/.test(mintPage), 'Mint must recover model continuity from saved Inventory when needed.');
+must(/Keep in Inventory/i.test(mintPage), 'Mint must preserve the no-mint Inventory choice.');
+must(/directMintHref/.test(inventory) && /encodeURIComponent\(modelUrl\)/.test(inventory), 'Inventory must send the exact saved model into Mint.');
 
 let tinyDeclarations = 0;
 const tinyByFile = [];
@@ -143,5 +154,5 @@ if (failures.length) {
   for (const failure of failures) console.error(`  ERROR ${failure}`);
   process.exitCode = 1;
 } else {
-  console.log('\nUI system invariants passed: photo -> address -> voxel image -> automatic 3D voxel -> Inventory -> optional one-property mint, with focused navigation, trust boundaries, accessibility, and responsive behavior.');
+  console.log('\nUI system invariants passed: photo -> address -> voxel preview -> explicit 3D build -> Inventory -> optional one-property mint, with consistent navigation, trust boundaries, accessibility, and responsive behavior.');
 }

--- a/scripts/test-financial-os-coherence.mjs
+++ b/scripts/test-financial-os-coherence.mjs
@@ -9,9 +9,9 @@ const capabilitiesApi = fs.readFileSync(new URL('../app/api/world-atlas/capabili
 const productMap = fs.readFileSync(new URL('../lib/product-map.js', import.meta.url), 'utf8');
 const interactions = fs.readFileSync(new URL('../app/spatial-os-interactions.css', import.meta.url), 'utf8');
 const rootHome = fs.readFileSync(new URL('../app/page.js', import.meta.url), 'utf8');
-const homePreview = fs.readFileSync(new URL('../app/components/HomeProductPreview.js', import.meta.url), 'utf8');
 const propertyRoute = fs.readFileSync(new URL('../app/property/page.js', import.meta.url), 'utf8');
-const property = fs.readFileSync(new URL('../app/property/HouseVoxelMintFlow.js', import.meta.url), 'utf8');
+const property = fs.readFileSync(new URL('../app/property/PropertyStudioFlow.js', import.meta.url), 'utf8');
+const propertyCss = fs.readFileSync(new URL('../app/property/PropertyStudio.module.css', import.meta.url), 'utf8');
 const more = fs.readFileSync(new URL('../app/more/page.js', import.meta.url), 'utf8');
 const slice = fs.readFileSync(new URL('../app/geo/slice/page.js', import.meta.url), 'utf8');
 const integrationsPage = fs.readFileSync(new URL('../app/admin/integrations/page.js', import.meta.url), 'utf8');
@@ -21,7 +21,7 @@ const vaultLayout = fs.readFileSync(new URL('../app/vault/layout.js', import.met
 const home = fs.readFileSync(new URL('../app/real-estate/page.js', import.meta.url), 'utf8');
 
 // The wider app keeps its canonical directory for advanced surfaces, while the
-// shipping Voxel Vault shell deliberately exposes only the few actions needed now.
+// shipping Voxel Vault property studio deliberately exposes only the few actions needed now.
 for (const label of ['Home', 'Create', 'World', 'Vault', 'More']) {
   assert.match(productMap, new RegExp(`label: '${label}'`), `canonical product directory should include ${label}`);
 }
@@ -33,7 +33,7 @@ for (const route of ['/property', '/vault/earth', '/geo', '/studio', '/capture',
 }
 assert.match(productMap, /\$1\.99 Property Sandbox/, 'the tiny property comparison must remain explicitly sandboxed under More');
 assert.match(productMap, /No real funds or property rights move/, 'sandbox description must preserve the no-rights boundary');
-assert.match(productMap, /Authorized house photo → \$4\.99 → 3D voxel photo → approval → movable 3D voxel → save or optional mint/, 'legacy product directory copy remains available for compatibility while the live creator is simplified');
+assert.match(productMap, /Authorized house photo → \$4\.99 → 3D voxel photo → approval → movable 3D voxel → save or optional mint/, 'legacy product directory copy remains available for compatibility while the live creator is redesigned');
 assert.match(productMap, /badge: 'PROVIDER-GATED'/, 'regulated investment tools must be visibly provider-gated');
 assert.match(productMap, /A token or VoxelPop item is never the deed/, 'direct ownership path must keep title separate from the token');
 assert.match(productMap, /APP_USER_PREFIXES[\s\S]*'\/admin'/, 'owner routes should keep the global app shell');
@@ -41,11 +41,13 @@ assert.match(productMap, /isOrganizedUserRoute/);
 assert.match(productMap, /isSimplePropertyRoute/);
 assert.match(productMap, /dockItemForPath/);
 
-assert.match(nav, /const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/, 'mobile primary navigation must be Home, VoxelPop, and Vault only');
+assert.match(nav, /const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/, 'mobile primary navigation must be Home, Create, and Vault only');
 assert.doesNotMatch(nav, /id: 'world'|id: 'more'/, 'World and More must not compete in the primary mobile dock');
 assert.match(nav, /VoxelPop primary navigation/);
 assert.match(nav, /isOrganizedUserRoute/);
-assert.match(nav, /pathname === '\/' \|\| pathname === '\/property'/, 'Home and the live creator must not stack the bottom dock under their focused header');
+assert.match(nav, /usesPropertyStudioNavigation/, 'the legacy dock must not stack under the redesigned property studio, mint, or Inventory pages');
+assert.match(nav, /pathname\.startsWith\('\/property\/'\)/, 'all property studio subpages must use their own consistent navigation');
+assert.match(nav, /pathname\.startsWith\('\/vault\/property-drafts\/'\)/, 'Inventory detail pages must use the property studio navigation system');
 assert.match(nav, /FinancialOSNav\.module\.css/, 'consumer dock should use its responsive stylesheet');
 assert.match(navCss, /safe-area-inset-bottom/, 'consumer dock must respect the iPhone safe area');
 assert.match(navCss, /@media\(max-width:720px\)/, 'consumer dock must stay mobile-only when desktop top navigation is present');
@@ -53,8 +55,8 @@ assert.doesNotMatch(nav, /FINANCIAL_PREFIXES|financialRoute/, 'global app shell 
 assert.match(layout, /FinancialOSNav/);
 assert.match(layout, /AppCommandCenter/);
 assert.match(layout, /spatial-os-interactions\.css/);
-assert.match(layout, /Turn a House Photo into a 3D Voxel Photo/, 'public metadata must describe the focused shipping VoxelPop product');
-assert.match(layout, /Source photo stays on your device; minting is optional/, 'public metadata must preserve the device-local and optional-mint boundaries');
+assert.match(layout, /Turn Property Photos into 3D Voxel Collectibles/, 'public metadata must describe the redesigned focused product');
+assert.match(layout, /save it to your Voxel Vault Inventory, and mint it when you want/i, 'public metadata must describe Inventory persistence and optional downstream minting');
 assert.doesNotMatch(layout, /Real Property, Made Spatial|Your 3D Asset Vault|digital-twin pilot/i, 'public metadata must not revive older broad property/vault positioning');
 assert.doesNotMatch(vaultLayout, /VaultPortalNav/);
 
@@ -73,38 +75,36 @@ assert.match(commandCenter, /!isSimplePropertyRoute\(pathname\)/, 'advanced tool
 assert.match(commandCenter, /never automatically spends money, mints an NFT, or starts a paid 3D generation/, 'tool finder must disclose its non-execution boundary');
 assert.doesNotMatch(commandCenter, /fetch\(|method:\s*['"]POST['"]|wallet\.send|eth_sendTransaction|checkout\.sessions\.create/, 'tool finder must remain pure navigation and never execute side effects');
 
-// Consumer Home is intentionally tiny: one proof object, one create CTA, five
-// short steps, and the digital-only rights boundary. The live creator performs
-// photo -> address -> voxel image -> automatic 3D voxel -> Inventory -> optional mint.
-assert.match(rootHome, /HOUSE PHOTO → VOXEL → MINT/, 'root Home must state the live product in one short line');
-assert.match(rootHome, /Create house voxel/, 'root Home must have one clear creation CTA');
-assert.match(rootHome, /href="\/property"/, 'root Home must route creation into the maker');
+// The redesigned consumer Home is a focused entry into the property studio.
+assert.match(rootHome, /PROPERTY → COLLECTIBLE/, 'root Home must state the focused product');
+assert.match(rootHome, /Create a property voxel/, 'root Home must have a clear creation CTA');
+assert.match(rootHome, /href="\/property"/, 'root Home must route creation into the studio');
 assert.match(rootHome, /confirm the address/i, 'root Home must name address confirmation');
-assert.match(rootHome, /Voxel image/, 'root Home must name the voxel-image stage');
-assert.match(rootHome, /Saved to Inventory/, 'root Home must make automatic Inventory saving explicit');
-assert.match(rootHome, /mint when ready|Mint the one-of-one only if you want/i, 'minting must remain explicitly downstream and optional');
+assert.match(rootHome, /voxel image/i, 'root Home must name the voxel-preview stage');
+assert.match(rootHome, /saved to Inventory first/i, 'root Home must make automatic Inventory saving explicit');
+assert.match(rootHome, /Mint if you want|Minting optional/i, 'minting must remain explicitly downstream and optional');
 assert.match(rootHome, /This collectible is digital only\./, 'root Home must identify the product as digital');
-assert.match(rootHome, /does not create or transfer deed, title, or physical-property rights/i, 'root Home must keep the digital-only physical-property boundary visible');
-assert.match(rootHome, /HomeProductPreview/, 'root Home should prove the product with the production viewer rather than a decorative CSS house');
-assert.doesNotMatch(rootHome, /Create mine · \$4\.99|Create · \$4\.99|secondaryAction|Try voxel sample · no login|VOXELPOP OUTPUT|START → SIGN IN \+ UPLOAD PHOTO|TRY THE \$1\.99 SLICE|YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT/i, 'checkout CTAs, duplicate CTAs, output grids, stale funnel, banking, and sandbox-heavy language must stay off the front door');
+assert.match(rootHome, /does not create or transfer deed, title/i, 'root Home must keep the physical-property boundary visible');
+assert.doesNotMatch(rootHome, /Create mine · \$4\.99|Create · \$4\.99|Try voxel sample · no login|VOXELPOP OUTPUT|START → SIGN IN \+ UPLOAD PHOTO|TRY THE \$1\.99 SLICE|YOUR 3D MONEY \+ ASSET WORLD|PROPERTY · CASH · CRYPTO · NFT/i, 'checkout CTAs, stale funnel, banking, and sandbox-heavy language must stay off the front door');
 assert.doesNotMatch(rootHome, /BUY PIECE|BUY WHOLE|BUY A PIECE|BUY THE WHOLE THING|guaranteed returns|guaranteed yield|risk[- ]free/i, 'unverified physical-property purchase or return claims must stay out of the consumer front door');
 assert.doesNotMatch(rootHome, /RealEstatePlatformPage/, 'root home must not alias an older real-estate subsystem');
-assert.match(homePreview, /LocalVoxelModelViewer/, 'homepage proof must show the real movable voxel viewer');
-assert.match(homePreview, />Address</, 'homepage proof must disclose address confirmation');
-assert.match(homePreview, />Inventory</, 'homepage proof must disclose where the finished voxel is kept');
-assert.doesNotMatch(homePreview, /\$4\.99/, 'homepage proof must not reintroduce a checkout price');
 
-assert.match(propertyRoute, /HouseVoxelMintFlow/, 'the active /property route must use the live house voxel creator');
-assert.match(property, /const LABELS = \['PHOTO', 'ADDRESS', 'VOXEL IMAGE', '3D VOXEL', 'DONE'\]/, 'creator must expose the exact five-stage house journey');
-assert.match(property, /Upload one house photo\./, 'creator must begin with one obvious photo action');
+assert.match(propertyRoute, /PropertyStudioFlow/, 'the active /property route must use the new guided studio');
+assert.match(property, /const PROGRESS = \[[\s\S]*PHOTO[\s\S]*ADDRESS[\s\S]*VOXEL[\s\S]*BUILD[\s\S]*VAULT/, 'creator must expose the five-stage property journey');
+assert.match(property, /Start with one great photo\./, 'creator must begin with one obvious photo action');
 assert.match(property, /Confirm the address\./, 'creator must confirm the real property before generation');
-assert.match(property, /PhotoReliefModelViewer/, 'creator must build the voxel-image stage with real voxel geometry');
-assert.match(property, /setStage\('model'\)/, 'voxel-image readiness must automatically advance into 3D generation');
-assert.doesNotMatch(property, /Looks good · continue|approveVoxelImage|\/api\/property-generation\/checkout/, 'live creator must not add approval or checkout detours');
+assert.match(property, /PhotoReliefModelViewer/, 'creator must build the voxel preview with real voxel geometry');
+assert.match(property, /Build the 3D voxel/, 'the page-by-page experience must stop on preview until the user continues');
+assert.match(property, /setStage\('build'\)/, 'the preview continue action must enter the dedicated 3D build page');
+assert.doesNotMatch(property, /\/api\/property-generation\/checkout|Pay \$|Stripe/i, 'live creator must not add a per-property checkout detour');
 assert.match(property, /savePropertyDraft\(finishedDraft\)/, 'finished creation must save to Inventory automatically');
-assert.match(property, /Keep in inventory/, 'finished creation must expose the saved result');
-assert.match(property, /Mint voxel/, 'minting must remain optional after the saved result');
+assert.match(property, /Keep in Inventory/, 'finished creation must expose the saved result');
+assert.match(property, /Mint this voxel/, 'minting must remain optional after the saved result');
+assert.match(property, /modelUrl=\$\{encodeURIComponent\(final3d\.modelUrl\)\}/, 'the actual saved model must be handed into Mint');
 assert.doesNotMatch(property, /PropertyWorldMap|Add to My World/, 'World/map controls must stay outside the core creator');
+assert.match(propertyCss, /#6f42f5/i, 'the property journey must use the new purple design system');
+assert.match(propertyCss, /#c9ff55/i, 'the property journey must use the new playful lime accent');
+assert.match(propertyCss, /safe-area-inset-bottom/, 'the shared studio UI must respect iPhone safe areas');
 
 // The $1.99 comparison remains a pure sandbox, not a faux bank/wallet surface.
 assert.match(slice, /PROPERTY SLICE · SANDBOX/, 'slice page must identify itself as a sandbox before the demo interaction');
@@ -124,20 +124,15 @@ assert.doesNotMatch(homeCapabilities, /process\.env|MESHY_API_KEY|BRIDGE_ACCESS_
 assert.match(capabilitiesApi, /automaticGeneration:\s*false/, 'server capability contract must keep Meshy automatic generation disabled');
 assert.match(capabilitiesApi, /Boolean\(process\.env\.MESHY_API_KEY\?\.trim\(\)\)/, 'Meshy readiness may expose only a boolean');
 
-// Extras keeps advanced and optional tools available without making them part of
-// the normal live house creation funnel. Legacy paid copy remains isolated here
-// until those compatibility surfaces are revised separately.
+// Extras keeps advanced and optional tools available without making them part of the live studio.
 assert.match(more, /Keep VoxelPop simple\.[\s\S]*Open extras only when needed\./i, 'Extras must explain its deliberately secondary role');
 assert.match(more, /main product is Create → 3D voxel photo → movable voxel → Vault/i, 'Extras must retain its compatibility description');
 assert.match(more, /Making a house voxel\?/, 'Extras must lead users back to the core creation task');
-assert.match(more, /3D voxel photo[\s\S]*separate movable model/i, 'Extras must preserve its legacy voxel-photo description');
 assert.match(more, /Create VoxelPop · \$4\.99 →/, 'legacy Extras paid path remains available separately from live /property');
 assert.match(more, /See free sample →/, 'Extras must keep the public sample reachable');
 assert.match(more, /Open Vault →/, 'Extras must keep saved creations reachable');
 assert.match(more, /World, minting, and the tools below are optional/, 'Extras must keep World and minting outside the core funnel');
-assert.match(more, /OTHER DIGITAL TOOLS/, 'secondary digital products must remain collapsed away from the core flow');
 assert.match(more, /OWNER \/ PROVIDER TOOLS/, 'provider and owner rails must stay visibly advanced');
-assert.match(more, /not part of the \$4\.99 VoxelPop product/i, 'advanced provider tooling must stay explicitly separate from the legacy paid VoxelPop product');
 assert.match(more, /A VoxelPop model or NFT is a digital creation/, 'Extras must preserve the digital-not-deed boundary');
 
 assert.match(integrationsApi, /requireVoxelVaultAdmin/, 'integration status must be owner-authenticated');
@@ -172,4 +167,4 @@ assert.match(home, /Voxel Vault is not itself a bank, broker, exchange, custodia
 assert.doesNotMatch(home, /guaranteed returns|risk[- ]free|guaranteed profit|guaranteed yield/i);
 assert.doesNotMatch(home, /token is (?:the )?deed|blockchain deed/i);
 
-console.log('Voxel Vault checks passed: one-action Home, five-stage house creation, confirmed address, automatic voxel-image → movable 3D build + Inventory save, three-action mobile navigation, optional minting, sandbox boundaries, and fail-closed advanced rails stay distinct.');
+console.log('Voxel Vault checks passed: focused Home, guided five-stage property studio, confirmed address, explicit voxel preview approval, automatic Inventory save, optional minting, sandbox boundaries, and fail-closed advanced rails stay distinct.');

--- a/scripts/test-paid-property-generation.mjs
+++ b/scripts/test-paid-property-generation.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
 const route = read('app/property/page.js');
+const liveProperty = read('app/property/PropertyStudioFlow.js');
 const property = read('app/property/PropertyJourneySimple.js');
 const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const checkout = read('app/api/property-generation/checkout/route.ts');
@@ -19,8 +20,10 @@ const mintMetadata = read('app/api/property-voxel-nft/metadata/route.ts');
 const mintPage = read('app/property/mint/page.js');
 const vault = read('app/vault/property-drafts/page.js');
 
-assert.match(route, /HouseVoxelMintFlow/, 'the live /property route must use the condensed no-checkout house creator');
+assert.match(route, /PropertyStudioFlow/, 'the live /property route must use the guided no-checkout property studio');
 assert.doesNotMatch(route, /from '\.\/PropertyJourneySimple'/, 'the legacy paid creator must not be wired into the live /property route');
+assert.match(liveProperty, /Build the 3D voxel/, 'the live creator keeps the requested page-by-page preview approval');
+assert.match(liveProperty, /Mint this voxel/, 'the live creator finishes with optional minting after Inventory save');
 assert.match(property, /const PRICE = '\$4\.99'/, 'legacy paid creator keeps its historical $4.99 contract while it remains available for compatibility');
 assert.match(property, /const labels = \['PHOTO', 'REVIEW', 'BUILD', 'DONE'\]/, 'legacy paid creator remains condensed to four user-facing stages');
 assert.match(property, /Sign in once\./, 'legacy creator keeps one account gate');
@@ -100,6 +103,6 @@ assert.match(mintConfirm, /markPropertyCollectibleMinted/, 'verified mint uses t
 assert.match(mintState, /state: 'minted'/, 'verified mint permanently records the minted property state');
 assert.match(mintConfirm, /onePropertyOneMint: true/, 'mint confirmation records the one-property-one-mint result');
 assert.match(mintMetadata, /animation_url/, 'NFT metadata points to the finished 3D model');
-assert.match(mintPage, /Keep in inventory/, 'mint page still lets the user leave without minting');
+assert.match(mintPage, /Keep in Inventory/i, 'mint page still lets the user leave without minting');
 
-console.log('Legacy paid VoxelPop compatibility passed alongside the live no-checkout house flow: the old paid component remains internally coherent, while /property uses photo -> address -> voxel image -> automatic 3D voxel -> Inventory -> optional one-time mint.');
+console.log('Legacy paid VoxelPop compatibility passed alongside the live guided property studio: the old paid component remains internally coherent, while /property uses photo -> address -> voxel preview -> explicit 3D build -> Inventory -> optional one-time mint.');

--- a/scripts/test-photo-to-voxel-autostart.mjs
+++ b/scripts/test-photo-to-voxel-autostart.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 const propertyRoute = read('app/property/page.js');
-const property = read('app/property/HouseVoxelMintFlow.js');
+const property = read('app/property/PropertyStudioFlow.js');
 const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
 const viewer = read('app/property/LocalVoxelModelViewer.js');
@@ -13,28 +13,30 @@ const mintPrepare = read('app/api/property-voxel-nft/prepare/route.ts');
 const mintPage = read('app/property/mint/page.js');
 const vault = read('app/vault/property-drafts/page.js');
 
-assert.match(propertyRoute, /HouseVoxelMintFlow/, 'the live property route uses the house voxel mint flow');
-assert.match(property, /Upload one house photo\./, 'the flow starts with one obvious photo action');
+assert.match(propertyRoute, /PropertyStudioFlow/, 'the live property route uses the guided property studio');
+assert.match(property, /Start with one great photo\./, 'the flow starts with one obvious photo action');
 assert.match(property, /Confirm the address\./, 'address confirmation follows photo selection');
 assert.match(property, /\/api\/property-generation\/confirm/, 'address confirmation uses the dedicated one-property lock endpoint');
-assert.doesNotMatch(property, /\/api\/property-generation\/checkout|generation_session|Pay \$|Stripe/i, 'the live house flow contains no checkout or payment resume path');
+assert.doesNotMatch(property, /\/api\/property-generation\/checkout|generation_session|Pay \$|Stripe/i, 'the live studio contains no per-property checkout or payment resume path');
 
-assert.match(property, /PhotoReliefModelViewer/, 'the photo is rebuilt as a voxel image stage');
+assert.match(property, /PhotoReliefModelViewer/, 'the photo is rebuilt as a voxel preview stage');
 assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'the source image supplies voxel color data');
-assert.match(photoPreview, /new THREE\.InstancedMesh/, 'the voxel image uses real voxel instances');
-assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'the voxel image is physical cube geometry');
-assert.match(property, /setVoxelImageReady\(true\)/, 'the flow detects when the voxel image is ready');
-assert.match(property, /setStage\('model'\)/, 'voxel image readiness automatically advances to 3D generation');
-assert.doesNotMatch(property, /Looks good · continue|approvePreviewAndBuildVoxel|approveVoxelImage/, 'no extra approval click interrupts the automatic conversion');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, 'the voxel preview uses real voxel instances');
+assert.match(photoPreview, /new THREE\.BoxGeometry\(1, 1, 1\)/, 'the voxel preview is physical cube geometry');
+assert.match(property, /setVoxelImageReady\(true\)/, 'the flow detects when the voxel preview is ready');
+assert.match(property, /Build the 3D voxel/, 'the page-by-page flow asks for an explicit continue action after preview');
+assert.match(property, /setStage\('build'\)/, 'preview approval advances into the dedicated 3D build page');
 
-assert.match(property, /LocalVoxelModelViewer imageUrl=\{photoUrl\} sourceImageUrl=\{photoUrl\} onReady=\{saveFinishedVoxel\}/, 'movable voxel builds directly from the selected house photo');
+assert.match(property, /LocalVoxelModelViewer imageUrl=\{photoUrl\} sourceImageUrl=\{photoUrl\} onReady=\{saveFinishedVoxel\}/, 'movable voxel builds directly from the selected property photo');
 assert.match(property, /\/api\/property-local-voxel/, 'the finished local voxel is registered for continuity and minting');
 assert.match(property, /\/api\/property-generation\/finalize/, 'the property lock is finalized only after the 3D voxel exists');
 assert.match(property, /const localSaved = savePropertyDraft\(finishedDraft\)/, 'the finished voxel is saved to Inventory automatically');
 assert.match(property, /savePropertyDraftToAccount/, 'the saved voxel is associated with the signed-in account');
-assert.match(property, /Mint voxel/, 'completion exposes the mint action');
-assert.match(property, /Keep in inventory/, 'completion also preserves the inventory-only choice');
+assert.match(property, /Mint this voxel/, 'completion exposes the mint action');
+assert.match(property, /Keep in Inventory/, 'completion also preserves the inventory-only choice');
+assert.match(property, /modelUrl=\$\{encodeURIComponent\(final3d\.modelUrl\)\}/, 'the finished model URL is handed to Mint');
 assert.match(vault, /directMintHref/, 'saved local voxels can recover their mint route from Inventory');
+assert.match(vault, /modelUrl=\$\{encodeURIComponent\(modelUrl\)\}/, 'Inventory includes the saved model URL when opening Mint');
 
 assert.match(viewer, /sampleRecipe/, 'the interactive local voxel derives from the property photo');
 assert.match(viewer, /rawMask/, 'the viewer separates the building from background');
@@ -48,7 +50,8 @@ assert.match(confirm, /acquirePropertyCollectibleReservation/, 'a confirmed prop
 assert.match(finalize, /updatePropertyCollectibleReservation/, 'a completed voxel gets a permanent property lock');
 assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint checks the exact account-owned finished voxel');
 assert.match(mintPrepare, /already been minted|duplicate mint/i, 'mint blocks a second NFT for the same property');
-assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint does not reintroduce Meshy');
-assert.match(mintPage, /Keep in inventory/, 'the mint page keeps inventory ownership useful without immediate minting');
+assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'mint does not reintroduce provider generation');
+assert.match(mintPage, /Keep in Inventory/i, 'the mint page keeps inventory ownership useful without immediate minting');
+assert.match(mintPage, /readPropertyDrafts/, 'Mint can recover model continuity from older saved Inventory links');
 
-console.log('House voxel regression passed: photo -> address -> voxel image -> automatic movable 3D voxel -> automatic Inventory save -> optional one-of-one mint.');
+console.log('Property studio regression passed: photo -> address -> voxel preview -> explicit 3D build -> automatic Inventory save -> optional one-of-one mint.');

--- a/scripts/test-property-draft-funnel.mjs
+++ b/scripts/test-property-draft-funnel.mjs
@@ -40,20 +40,23 @@ assert.match(truth, />MINT</, 'minting may remain available as a later step');
 assert.match(truth, /MINTING IS A LATER CHOICE, NOT THE CREATION STEP/, 'minting must never be the event that creates the property draft');
 assert.doesNotMatch(truth, /mintVoxelFlip|eth_requestAccounts|MetaMask/, 'the 3D draft maker must not require wallet code');
 
-assert.match(vaultPage, /YOUR VOXEL VAULT/, 'the consumer Vault must present the VoxelPop inventory clearly');
-assert.match(vaultPage, /Your collection\./, 'Vault should read as a collection hub rather than a technical draft list');
-assert.match(vaultPage, /saved and collected digital property voxels/i, 'Vault should describe its contents as digital voxels rather than physical property ownership');
-assert.match(vaultPage, /syncLocalPropertyDraftsToAccount/, 'the simplified Vault must retain cross-device account sync');
-assert.match(vaultPage, /SYNC WITH GOOGLE/, 'account sync must remain available without dominating the page');
-assert.match(vaultPage, /Create Another/, 'Vault must provide the repeat creation loop');
-assert.match(vaultPage, /View My World/, 'Vault must provide the World loop');
+assert.match(vaultPage, /YOUR INVENTORY/, 'the consumer Vault must present the saved property inventory clearly');
+assert.match(vaultPage, /Your property collection\./, 'Inventory should read as a collection hub rather than a technical draft list');
+assert.match(vaultPage, /Every finished property voxel lives here\. Minting stays optional\./, 'Inventory must explain that finished voxels are saved before optional minting');
+assert.match(vaultPage, /syncLocalPropertyDraftsToAccount/, 'the simplified Inventory must retain cross-device account sync');
+assert.match(vaultPage, /Sync with Google/, 'account sync must remain available without dominating the page');
+assert.match(vaultPage, /\+ Create a voxel/, 'Inventory must provide the repeat creation loop');
+assert.match(vaultPage, /View Public World/, 'Inventory must provide the optional World loop');
 assert.match(vaultPage, /OPEN 3D/, 'saved property cards must reopen their exact 3D model');
 assert.match(vaultPage, /\/vault\/property-drafts\/\$\{encodeURIComponent\(draft\.id\)\}/, 'saved cards must deep-link by stable draft id');
-assert.match(vaultPage, /setPropertyDraftWorldVisibility/, 'public World publication must remain explicit from the Vault');
+assert.match(vaultPage, /setPropertyDraftWorldVisibility/, 'public World publication must remain explicit from Inventory');
 assert.match(vaultPage, /deletePropertyDraftFromAccount/, 'synced deletions must not reappear from cloud storage');
-assert.match(vaultPage, /VERIFY \+ MINT · OPTIONAL/, 'paid digital collectibles must keep verification and mint optional');
-assert.match(vaultPage, /does not itself transfer deed\/title, rent, fractional investment, occupancy, or other rights/, 'Vault must preserve digital-versus-real-property truth');
-assert.doesNotMatch(vaultPage, /MetaMask|eth_requestAccounts/, 'the basic property Vault must not require a wallet');
+assert.match(vaultPage, /directMintHref/, 'finished local voxels must recover a direct mint route from Inventory');
+assert.match(vaultPage, /modelUrl=\$\{encodeURIComponent\(modelUrl\)\}/, 'Inventory must carry the exact saved 3D model into Mint');
+assert.match(vaultPage, /MINT · OPTIONAL/, 'finished digital collectibles must keep direct minting optional');
+assert.match(vaultPage, /VERIFY \+ MINT/, 'older drafts without direct mint metadata must retain the verification fallback');
+assert.match(vaultPage, /Saving, sharing, or minting a voxel does not transfer deed, title, rent, equity, occupancy, or other rights in the physical property\./, 'Inventory must preserve digital-versus-real-property truth');
+assert.doesNotMatch(vaultPage, /MetaMask|eth_requestAccounts/, 'the basic property Inventory must not require a wallet');
 
 assert.match(draftViewer, /readPropertyDraft\(draftId\)/, 'exact viewer must first load the saved local snapshot');
 assert.match(draftViewer, /loadAccountPropertyDrafts/, 'exact viewer must restore a missing local snapshot from the signed-in account');
@@ -71,4 +74,4 @@ assert.match(draftViewer, /single source photo cannot verify unseen sides/i, 'si
 assert.match(earthPage, /PropertyTruthStack/, 'the advanced Earth property experience must remain available behind the simple product');
 assert.match(earthPage, /automatic|MESHY|Meshy/i, 'Earth must keep its controlled high-fidelity reconstruction layer');
 
-console.log('Property draft guards passed: VoxelPop collection UX, wallet-free drafts, opt-in public World sharing, account sync, actual generated-model reopen, land truth, separate rights verification, and optional minting remain enforced.');
+console.log('Property draft guards passed: redesigned Inventory, wallet-free drafts, opt-in public World sharing, account sync, exact-model reopen, land truth, separate rights verification, and optional minting remain enforced.');

--- a/scripts/test-property-one-of-one.mjs
+++ b/scripts/test-property-one-of-one.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
-const property = read('app/property/HouseVoxelMintFlow.js');
+const property = read('app/property/PropertyStudioFlow.js');
 const confirmAddress = read('app/api/property-generation/confirm/route.ts');
 const finalize = read('app/api/property-generation/finalize/route.ts');
 const mint = read('lib/property-voxel-mint.ts');
@@ -11,6 +11,7 @@ const confirmMint = read('app/api/property-voxel-nft/confirm/route.ts');
 const mintState = read('lib/property-collectible-mint-state.ts');
 
 assert.match(property, /Confirm the address\./, 'live creator confirms the property identity before generation');
+assert.match(property, /onePropertyOneMint:\s*true/, 'saved studio collectible records the one-property-one-mint invariant');
 assert.match(confirmAddress, /propertyCollectibleIdentity\(atlasId\)/, 'address confirmation derives a canonical source-backed identity');
 assert.match(confirmAddress, /acquirePropertyCollectibleReservation/, 'address confirmation atomically reserves the property before voxel generation');
 assert.match(confirmAddress, /hold\.sold/, 'already completed or minted properties are rejected before creation');

--- a/scripts/test-property-platform-safety.mjs
+++ b/scripts/test-property-platform-safety.mjs
@@ -111,20 +111,20 @@ requireMarkers(distribution, 'distribution vault', [
   'InvalidStatementHash',
 ]);
 
-// The public root is intentionally focused on the shipping house-voxel product.
+// The public root is intentionally focused on the shipping property-voxel product.
 // Regulated property/investment disclosures belong on their advanced surfaces,
 // while the front door must still preserve optional minting and the digital-only
 // physical-property rights boundary.
 requireMarkers(root, 'simple root homepage', [
-  'HOUSE PHOTO → VOXEL → MINT',
-  'Create house voxel',
+  'PROPERTY → COLLECTIBLE',
+  'Create a property voxel',
   'confirm the address',
-  'Saved to Inventory',
-  'Mint',
+  'saved to Inventory first',
+  'Mint if you want',
   'This collectible is digital only.',
-  'does not create or transfer deed, title, or physical-property rights',
+  'does not create or transfer deed, title',
 ]);
-assert.doesNotMatch(root, /Create mine · \$4\.99|Create · \$4\.99/, 'the live house creator must not reintroduce the legacy checkout CTA');
+assert.doesNotMatch(root, /Create mine · \$4\.99|Create · \$4\.99/, 'the live property creator must not reintroduce the legacy checkout CTA');
 requireMarkers(productMap, 'advanced product directory', [
   "href: '/real-estate/reits'",
   'Provider-backed securities may appear only when an approved provider, offering and eligibility path are actually active.',

--- a/scripts/test-public-demo-positioning.mjs
+++ b/scripts/test-public-demo-positioning.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
 const home = read('app/page.js');
+const homeCss = read('app/home.module.css');
 const homePreview = read('app/components/HomeProductPreview.js');
 const photoViewer = read('app/property/PhotoReliefModelViewer.js');
 const photoViewerStyles = read('app/property/PhotoReliefModelViewer.module.css');
@@ -17,22 +18,32 @@ const legacyTerms = read('terms.html');
 const readme = read('README.md');
 const og = read('app/opengraph-image.js');
 
-assert.match(home, /HOUSE PHOTO → VOXEL → MINT/, 'home must communicate the complete house flow immediately');
-assert.match(home, /Create house voxel/, 'home must keep one clear creation CTA');
+assert.match(home, /PROPERTY → COLLECTIBLE/, 'home must communicate the focused property collectible product immediately');
+assert.match(home, /Create a property voxel/, 'home must keep a clear creation CTA');
+assert.match(home, /Open Inventory/, 'home must keep the saved collection reachable from the front door');
 assert.match(home, /confirm the address/i, 'home must include the property confirmation step');
-assert.match(home, /Saved to Inventory/i, 'home must make the automatic saved result clear');
-assert.doesNotMatch(home, /Create mine · \$4\.99|Create · \$4\.99/, 'home must not insert checkout copy into the condensed creator');
-assert.match(home, /HomeProductPreview/, 'home hero must show the real interactive product result instead of decorative art');
-assert.doesNotMatch(home, /secondaryAction|Try voxel sample · no login/, 'home must not add a competing hero action');
-assert.match(homePreview, /LocalVoxelModelViewer/, 'home product proof must use the production movable-voxel viewer');
-assert.doesNotMatch(homePreview, /PhotoReliefModelViewer/, 'home proof must not force users through a stage switcher before creating');
-assert.match(homePreview, />Address</, 'home proof must disclose address confirmation');
-assert.match(homePreview, />Inventory</, 'home proof must disclose where the finished voxel is saved');
-assert.match(homePreview, /MOVABLE 3D VOXEL/, 'home proof must identify the interactive final result');
-assert.doesNotMatch(homePreview, /\$4\.99/, 'home proof must not show stale checkout pricing');
+assert.match(home, /voxel image/i, 'home must explain the voxel-preview stage');
+assert.match(home, /saved to Inventory first/i, 'home must make the automatic saved result clear');
+assert.match(home, /Mint if you want|Minting optional/i, 'home must keep minting explicitly optional');
+assert.doesNotMatch(home, /Create mine · \$4\.99|Create · \$4\.99/, 'home must not insert legacy per-property checkout copy into the guided studio');
+assert.match(home, /heroVisual/, 'home hero must use the new branded voxel-house visual system');
+assert.match(homeCss, /#6f42f5/i, 'home must use the new Voxel Vault purple');
+assert.match(homeCss, /#c9ff55/i, 'home must use the playful lime accent');
+assert.match(homeCss, /@media\(max-width:620px\)/, 'home must include a dedicated phone layout');
+assert.match(home, /This collectible is digital only\./, 'home must identify the collectible as digital');
+assert.match(home, /does not create or transfer deed, title/i, 'home must preserve the physical-property rights boundary');
 assert.match(home, /Privacy/, 'home footer must expose Privacy');
 assert.match(home, /Terms/, 'home footer must expose Terms');
 assert.match(home, /About/, 'home footer must expose About/contact information');
+
+// Keep the production viewer proof component healthy for demo/secondary surfaces even though
+// the redesigned homepage intentionally uses a playful branded illustration instead.
+assert.match(homePreview, /LocalVoxelModelViewer/, 'production proof component must keep the real movable-voxel viewer');
+assert.doesNotMatch(homePreview, /PhotoReliefModelViewer/, 'production proof component must not force users through a stage switcher');
+assert.match(homePreview, />Address</, 'production proof component must disclose address confirmation');
+assert.match(homePreview, />Inventory</, 'production proof component must disclose where the finished voxel is saved');
+assert.match(homePreview, /MOVABLE 3D VOXEL/, 'production proof component must identify the interactive final result');
+assert.doesNotMatch(homePreview, /\$4\.99/, 'production proof component must not show stale checkout pricing');
 
 assert.match(photoViewer, /getImageData\(0, 0, columns, rows\)/, 'voxel-photo stage must sample visible source-image colors');
 assert.match(photoViewer, /new THREE\.InstancedMesh/, 'voxel-photo stage must render actual voxel instances');
@@ -56,10 +67,11 @@ assert.match(demo, /not a fake reconstruction of unseen walls/i, 'demo must expl
 assert.match(demo, /cannot prove hidden sides/i, 'demo must state what a single photo cannot establish');
 assert.doesNotMatch(demo, /getSupabaseBrowserAsync|signInWithOAuth|checkout\.sessions|\/api\/property-generation\/checkout/, 'public demo must not hide an auth or payment gate');
 
-assert.match(layout, /Turn a House Photo into a 3D Voxel/, 'site metadata must use the focused current promise');
-assert.match(layout, /3D voxel photo/, 'metadata must describe the voxel-photo product');
+assert.match(layout, /Turn Property Photos into 3D Voxel Collectibles/, 'site metadata must use the redesigned current promise');
+assert.match(layout, /confirm the address, build a 3D voxel collectible/i, 'metadata must describe the property-photo creation journey');
+assert.match(layout, /mint it when you want/i, 'metadata must keep minting optional and downstream');
 assert.doesNotMatch(layout, /real estate digital twin|NFT vault/i, 'metadata must not revive broad legacy positioning');
-assert.match(og, /house photo into a movable 3D voxel/i, 'social preview must show the current product story');
+assert.match(og, /house photo into a movable 3D voxel/i, 'social preview may retain the detailed product story');
 assert.match(og, /3D VOXEL PHOTO/, 'social preview steps must name the voxel-photo stage');
 assert.match(og, /MOVABLE VOXEL/, 'social preview steps must name the movable-voxel stage');
 
@@ -79,5 +91,5 @@ assert.match(readme, /Repo scope/, 'README must separate experimental systems fr
 assert.match(readme, /CONTRIBUTING\.md/, 'README must expose contribution guidance');
 assert.doesNotMatch(readme.split('## What this repo currently ships')[0], /bank|REIT|Algorand|liquidity engine/i, 'README front door must not lead with experimental finance systems');
 
-console.log('Public Voxel Vault positioning checks passed: one-action house creator, real final voxel proof, address confirmation, high-fidelity voxel geometry, Inventory persistence, optional minting, and current trust surfaces remain aligned.');
+console.log('Public Voxel Vault positioning checks passed: branded property-collectible home, guided creation, high-fidelity voxel geometry, Inventory persistence, optional minting, and current trust surfaces remain aligned.');
 await import('./test-public-surface-coherence.mjs');

--- a/scripts/test-simple-property-world.mjs
+++ b/scripts/test-simple-property-world.mjs
@@ -5,10 +5,9 @@ const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), '
 
 const home = read('app/page.js');
 const homeCss = read('app/home.module.css');
-const homePreview = read('app/components/HomeProductPreview.js');
-const topNav = read('app/components/ProductTopNav.js');
 const propertyRoute = read('app/property/page.js');
-const property = read('app/property/HouseVoxelMintFlow.js');
+const property = read('app/property/PropertyStudioFlow.js');
+const propertyCss = read('app/property/PropertyStudio.module.css');
 const photoPreview = read('app/property/PhotoReliefModelViewer.js');
 const localViewer = read('app/property/LocalVoxelModelViewer.js');
 const localVoxel = read('app/api/property-local-voxel/route.ts');
@@ -24,41 +23,39 @@ const drafts = read('lib/property-drafts.js');
 const dock = read('app/components/FinancialOSNav.js');
 const command = read('app/components/AppCommandCenter.js');
 
-assert.match(propertyRoute, /HouseVoxelMintFlow/, '/property must use the house photo -> voxel -> mint flow');
-assert.match(home, /HOUSE PHOTO → VOXEL → MINT/, 'home communicates the new product in one short line');
+assert.match(home, /PROPERTY → COLLECTIBLE/, 'home communicates the focused property collectible product');
 assert.match(home, /confirm the address/i, 'home includes address confirmation');
-assert.match(home, /Saved to Inventory/i, 'home makes inventory persistence clear');
-assert.doesNotMatch(home, /\$4\.99|Create mine/i, 'home no longer inserts a checkout into the core flow');
-assert.match(homePreview, /LocalVoxelModelViewer/, 'home shows the actual interactive finished voxel viewer');
-assert.match(homePreview, />Address</, 'home proof includes address confirmation');
-assert.doesNotMatch(homePreview, /\$4\.99/, 'home preview has no price badge');
-assert.match(topNav, /label: 'Create'/, 'primary nav has one create destination');
-assert.match(topNav, /label: 'Inventory'/, 'primary nav exposes the saved inventory');
-assert.doesNotMatch(topNav, /\$4\.99/, 'primary nav does not advertise a checkout');
+assert.match(home, /saved to Inventory first/i, 'home makes Inventory persistence clear');
+assert.match(home, /Mint if you want|Minting optional/i, 'home keeps minting optional');
+assert.match(home, /This collectible is digital only\./, 'home identifies the product as a digital collectible');
+assert.match(home, /does not create or transfer deed, title/i, 'home keeps the physical-property rights boundary visible');
 assert.doesNotMatch(home, /BUY A PIECE|BUY THE WHOLE THING|blockchain deed|guaranteed returns|guaranteed yield/i, 'unsafe property-purchase or return language stays out of home');
+assert.match(homeCss, /#6f42f5/i, 'home uses the new Voxel Vault purple');
+assert.match(homeCss, /#c9ff55/i, 'home uses the playful lime accent');
+assert.match(homeCss, /@media\(max-width:620px\)/, 'home includes a dedicated mobile layout');
 
-assert.match(homeCss, /#fffaf3|#fffaf2|#fff9f1/i, 'home keeps the warm VoxelPop canvas');
-assert.match(property, /#fff9f1/i, 'creator keeps the warm VoxelPop canvas');
-assert.match(property, /#824dff|#7a44ff/i, 'VoxelPop purple remains');
-assert.match(property, /#caff56/i, 'VoxelPop lime remains');
-assert.match(property, /safe-area-inset-bottom/, 'property flow respects iPhone safe areas');
+assert.match(propertyRoute, /PropertyStudioFlow/, '/property must use the guided property studio');
+assert.match(propertyCss, /#6f42f5/i, 'creator shares the new purple design system');
+assert.match(propertyCss, /#c9ff55/i, 'creator shares the new lime design system');
+assert.match(propertyCss, /safe-area-inset-bottom/, 'property flow respects iPhone safe areas');
+assert.match(propertyCss, /@media \(max-width: 640px\)/, 'creator has a focused phone layout');
 
 assert.match(property, /Continue with Google/, 'account gate has one clear action');
-assert.match(property, /const LABELS = \['PHOTO', 'ADDRESS', 'VOXEL IMAGE', '3D VOXEL', 'DONE'\]/, 'the creator shows the exact five-stage house journey');
-assert.match(property, /Upload one house photo\./, 'first signed-in screen is photo-first');
+assert.match(property, /const PROGRESS = \[[\s\S]*PHOTO[\s\S]*ADDRESS[\s\S]*VOXEL[\s\S]*BUILD[\s\S]*VAULT/, 'the creator exposes the five-stage property journey');
+assert.match(property, /Start with one great photo\./, 'first signed-in screen is photo-first');
 assert.match(property, /accept="image\/\*,\.heic,\.heif"/, 'iPhone HEIC/HEIF selection remains supported');
 assert.match(property, /normalizeIphonePhoto/, 'iPhone photo preparation remains automatic');
-assert.match(property, /Confirm the address\./, 'address confirmation is the only user gate after photo selection');
+assert.match(property, /Confirm the address\./, 'address confirmation is the second page');
 assert.match(property, /\/api\/property-generation\/confirm/, 'the creator uses the one-property confirmation API');
-assert.doesNotMatch(property, /\/api\/property-generation\/checkout|Pay \$|Stripe/i, 'the new core creator has no checkout');
+assert.doesNotMatch(property, /\/api\/property-generation\/checkout|Pay \$|Stripe/i, 'the live creator has no per-property checkout');
 
-assert.match(property, /PhotoReliefModelViewer/, 'voxel image remains a real generated stage');
-assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'voxel image samples the uploaded image');
-assert.match(photoPreview, /new THREE\.InstancedMesh/, 'voxel image uses real voxel geometry');
-assert.match(property, /setStage\('model'\)/, 'voxel image automatically advances to 3D generation');
-assert.doesNotMatch(property, /Looks good · continue|approveVoxelImage|approvePreviewAndBuildVoxel/, 'there is no extra approval step after the address');
+assert.match(property, /PhotoReliefModelViewer/, 'voxel preview remains a real generated stage');
+assert.match(photoPreview, /getImageData\(0, 0, columns, rows\)/, 'voxel preview samples the uploaded image');
+assert.match(photoPreview, /new THREE\.InstancedMesh/, 'voxel preview uses real voxel geometry');
+assert.match(property, /Build the 3D voxel/, 'preview gets a clear page-by-page continue action');
+assert.match(property, /setStage\('build'\)/, 'preview approval advances to the 3D build page');
 
-assert.match(property, /LocalVoxelModelViewer imageUrl=\{photoUrl\} sourceImageUrl=\{photoUrl\} onReady=\{saveFinishedVoxel\}/, '3D voxel builds directly from the uploaded house photo');
+assert.match(property, /LocalVoxelModelViewer imageUrl=\{photoUrl\} sourceImageUrl=\{photoUrl\} onReady=\{saveFinishedVoxel\}/, '3D voxel builds directly from the uploaded property photo');
 assert.match(localViewer, /const GRID = 32/, 'building voxel keeps the higher-detail local grid');
 assert.match(localViewer, /InstancedMesh/, 'local viewer builds real Three.js voxel geometry');
 assert.match(localVoxel, /const MAX_SIDE = 32/, 'server accepts the higher-detail local recipe');
@@ -66,20 +63,22 @@ assert.match(property, /\/api\/property-local-voxel/, 'finished 3D voxel is regi
 assert.match(property, /\/api\/property-generation\/finalize/, 'one-property lock becomes permanent only after a finished voxel exists');
 assert.match(property, /const localSaved = savePropertyDraft\(finishedDraft\)/, 'finished voxel auto-saves to Inventory');
 assert.match(property, /savePropertyDraftToAccount/, 'finished voxel also saves to the signed-in account');
-assert.match(property, /Mint voxel/, 'completion exposes minting');
-assert.match(property, /Keep in inventory/, 'completion also exposes the no-mint inventory path');
-assert.match(property, /\/property\/mint\?draftId=/, 'finished voxel retains its dedicated mint route');
+assert.match(property, /Mint this voxel/, 'completion exposes minting');
+assert.match(property, /Keep in Inventory/, 'completion also exposes the no-mint Inventory path');
+assert.match(property, /modelUrl=\$\{encodeURIComponent\(final3d\.modelUrl\)\}/, 'finished voxel sends the saved 3D model to Mint');
 
 assert.match(confirm, /inspectWorldAtlas/, 'address confirmation resolves a source-backed building');
 assert.match(confirm, /propertyCollectibleIdentity/, 'address confirmation derives a stable property identity');
 assert.match(confirm, /acquirePropertyCollectibleReservation/, 'address confirmation blocks concurrent duplicate creation');
 assert.match(finalize, /updatePropertyCollectibleReservation/, 'finished voxel finalizes the property lock');
-assert.match(finalize, /state: 'paid'/, 'finished lock is promoted to the existing permanent reservation state');
+assert.match(finalize, /state: 'paid'/, 'finished lock is promoted to the permanent pre-mint reservation state');
 assert.match(mintPrepare, /verifyOwnedFinalVoxelModel/, 'mint preparation verifies ownership of the exact finished local voxel');
 assert.match(mintPrepare, /already been minted|duplicate mint/i, 'mint preparation blocks duplicate minting');
 assert.doesNotMatch(mintPrepare, /MESHY_API_KEY|api\.meshy|image-to-3d/i, 'property mint does not require Meshy');
-assert.match(mintPage, /Keep in inventory/, 'mint page still allows keeping the voxel without minting immediately');
+assert.match(mintPage, /Keep in Inventory/i, 'mint page still allows keeping the voxel without minting immediately');
+assert.match(mintPage, /readPropertyDrafts/, 'mint page can recover a model from an older Inventory link');
 assert.match(vault, /directMintHref/, 'Inventory can recover the direct mint route');
+assert.match(vault, /modelUrl=\$\{encodeURIComponent\(modelUrl\)\}/, 'Inventory carries the actual saved model into Mint');
 
 assert.doesNotMatch(property, /PropertyWorldMap|mapBuilding|saveToMyWorld|Add to My World/, 'World/map controls stay out of the core creation funnel');
 assert.match(world, /MY WORLD \+ PUBLIC WORLD/, 'World remains available as its own organized destination');
@@ -90,6 +89,7 @@ assert.match(property, /does not create rights in the physical property/i, 'crea
 
 assert.match(dock, /const DOCK = \[[\s\S]*id: 'home'[\s\S]*id: 'create'[\s\S]*id: 'vault'/, 'mobile navigation stays condensed to Home, Create, and Vault');
 assert.doesNotMatch(dock, /id: 'world'|id: 'more'/, 'World and More stay out of the primary mobile dock');
+assert.match(dock, /usesPropertyStudioNavigation/, 'the old dock stays out of the redesigned studio, mint, and Inventory pages');
 assert.match(command, /!isSimplePropertyRoute\(pathname\)/, 'advanced command search stays hidden on simple routes');
 
-console.log('House voxel flow checks passed: photo -> address confirmation -> voxel image -> automatic 3D voxel -> Inventory -> optional mint, with one-property/one-mint protection.');
+console.log('Property studio checks passed: photo -> address -> voxel preview -> explicit 3D build -> Inventory -> optional mint, with one-property/one-mint protection and a consistent mobile design.');


### PR DESCRIPTION
## What changed
- Rebuilt the Voxel Vault landing page around one focused property-to-voxel product.
- Added a consistent, playful/professional visual system across Home, plan selection, creation, Mint, and Inventory.
- Replaced the live `/property` experience with a guided five-stage studio: Photo → Address → Voxel Preview → 3D Build → Vault.
- Kept the existing authentication, subscription, duplicate-property reservation, local voxel generation, Supabase Inventory, and Base minting plumbing underneath the new UI.
- Made voxel-preview approval explicit so the user moves page-by-page instead of auto-advancing.
- Fixed the finished-model handoff into Mint by carrying `modelUrl` from creation and Inventory; Mint also recovers older saved links from local Inventory.
- Kept minting optional and preserved one-property/one-mint and physical-property-rights boundaries.
- Hid the legacy bottom dock on the new property studio/mint/inventory routes so the redesign stays visually consistent.
- Updated regression/UI audits to validate the new guided flow without weakening backend uniqueness, provider, or safety checks.

## Verification
- `Voxel Vault web build` has already passed on the redesign branch.
- Opening this PR runs the repository's full Quality Gate matrix.