### PR TITLE
Connect Galactic Trust to an Increase banking sandbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ GALACTIC_PROVIDER_PRODUCTION_ACCEPTED=false
 GALACTIC_LIVE_BANKING_ENABLED=false
 GALACTIC_LIVE_CRYPTO_ENABLED=false
 
+# First banking infrastructure sandbox candidate: Increase.
+# This is sandbox-only and is not evidence of a contracted banking relationship.
+# Use only the sandbox key from the Increase dashboard. Never commit the key.
+GALACTIC_INCREASE_SANDBOX_ENABLED=false
+INCREASE_SANDBOX_API_KEY=
+
 # Stripe server configuration. Server-only; never use NEXT_PUBLIC_ prefixes.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/app/api/admin/bank/increase/status/route.ts
+++ b/app/api/admin/bank/increase/status/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
+import {
+  getIncreaseSandboxConfig,
+  inspectIncreaseSandbox,
+} from '../../../../../../lib/banking/increase-sandbox.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if (auth.ok === false) {
+    return response({
+      ok: false,
+      error: auth.error,
+      setupRequired: auth.setupRequired || false,
+    }, auth.status);
+  }
+
+  const config = getIncreaseSandboxConfig(process.env);
+  if (!config.enabled || !config.credentialsConfigured) {
+    return response({
+      ok: true,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      enabled: config.enabled,
+      credentialsConfigured: config.credentialsConfigured,
+      connected: false,
+      canMoveRealMoney: false,
+      setupRequired: true,
+      nextStep: config.credentialsConfigured
+        ? 'Set GALACTIC_INCREASE_SANDBOX_ENABLED=true in the server environment and redeploy.'
+        : 'Create an Increase sandbox account, then add INCREASE_SANDBOX_API_KEY to the server environment. Do not paste the key into chat or commit it to GitHub.',
+    });
+  }
+
+  try {
+    const snapshot = await inspectIncreaseSandbox(process.env);
+    return response({
+      ok: true,
+      authorized: true,
+      ...snapshot,
+      note: 'This route performs read-only sandbox inspection. It cannot move real money and never returns the API key.',
+    });
+  } catch (error: any) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      connected: false,
+      canMoveRealMoney: false,
+      providerStatus: Number.isFinite(error?.status) ? error.status : null,
+      error: 'Increase sandbox connection check failed. Verify the sandbox key and provider account status.',
+    }, 502);
+  }
+}

--- a/app/api/admin/integrations/status/route.ts
+++ b/app/api/admin/integrations/status/route.ts
@@ -37,6 +37,9 @@ export async function GET(request: Request) {
   const x402 = nonzero('X402_PAY_TO');
   const liquidity = has('BASE_LIQUIDITY_MANAGER_ADDRESS') && nonzero('LIQUIDITY_OWNER_ADDRESS');
   const partnerFeeds = has('EARTH_PARTNER_FEEDS_JSON');
+  const increaseSandboxKey = has('INCREASE_SANDBOX_API_KEY');
+  const increaseSandboxEnabled = truthy('GALACTIC_INCREASE_SANDBOX_ENABLED');
+  const increaseSandbox = increaseSandboxKey && increaseSandboxEnabled;
 
   const regulatedChecks = [
     'REAL_ESTATE_REGISTERED_INTERMEDIARY_ACTIVE',
@@ -64,6 +67,7 @@ export async function GET(request: Request) {
     item('supabase-server', 'Supabase server', 'Identity + storage', supabaseServer ? 'CONFIGURED' : 'NOT CONFIGURED', 'Owner auth, durable records and private storage depend on server credentials.', supabaseServer, 'server-only'),
     item('supabase-browser', 'Supabase browser auth', 'Identity + storage', supabaseBrowser ? 'CONFIGURED' : 'NOT CONFIGURED', 'User sign-in and browser sessions use publishable Supabase configuration.', supabaseBrowser, 'publishable'),
     item('stripe', 'Stripe', 'Payments', stripe ? 'CONFIGURED' : 'NOT CONFIGURED', 'Server-authoritative checkout can run only when the Stripe secret is present.', stripe, 'server-only'),
+    item('increase-sandbox', 'Increase sandbox', 'Banking infrastructure', increaseSandbox ? 'SANDBOX READY' : increaseSandboxKey ? 'KEY PRESENT · DISABLED' : 'NOT CONFIGURED', increaseSandbox ? 'Sandbox credentials and the explicit sandbox switch are present. Owner-only health checks can inspect programs, accounts and entities without moving real money.' : increaseSandboxKey ? 'Sandbox key is present, but GALACTIC_INCREASE_SANDBOX_ENABLED is still false.' : 'Create an Increase sandbox account and add only the sandbox API key to the server environment. This is not a production banking relationship.', increaseSandbox, 'sandbox · no real money'),
     item('bridge', 'Bridge / RESO MLS', 'Property market', bridge ? 'CONFIGURED' : 'AWAITING ACCESS', 'Authorized U.S. listing coverage requires both dataset ID and access token.', bridge, 'licensed feed'),
     item('domain', 'Domain Australia', 'Property market', domain ? 'CONFIGURED' : 'AWAITING ACCESS', 'Australian listing access requires provider OAuth credentials.', domain, 'licensed feed'),
     item('partner-feeds', 'Additional property feeds', 'Property market', partnerFeeds ? 'CONFIGURED' : 'OPTIONAL', 'Country/provider adapters can be added through the normalized partner-feed contract.', partnerFeeds, 'server-only'),

--- a/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
+++ b/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
@@ -1,0 +1,51 @@
+# Galactic Trust — Increase sandbox integration
+
+Status: **sandbox candidate only — no production banking relationship is implied**.
+
+Galactic Trust is evaluating Increase as the first banking-infrastructure sandbox because its public API exposes accounts, account numbers, transactions, ACH, real-time payments, cards, entities, onboarding sessions, programs and webhooks, and it provides a sandbox environment where no real money moves.
+
+Official references:
+
+- https://increase.com/documentation/sandbox
+- https://increase.com/documentation/api
+- https://increase.com/documentation/entities
+- https://increase.com/terms
+
+## What is wired in this repository
+
+`lib/banking/increase-sandbox.js` is deliberately pinned to `https://sandbox.increase.com` and accepts only the server-only `INCREASE_SANDBOX_API_KEY`. It never falls back to the generic production banking-provider key and explicitly reports `canMoveRealMoney: false` and `productionSupported: false`.
+
+`GET /api/admin/bank/increase/status` is owner-only. It verifies the Voxel Vault admin session, then performs read-only sandbox requests for programs, accounts and entities. The response exposes counts and connectivity state only. It never returns the API key or provider records containing customer identity data.
+
+The owner Integrations Center also tracks whether the sandbox key and explicit enable switch are configured.
+
+## Founder setup — the only external step required now
+
+1. Create an Increase account and obtain the **sandbox** API key from the Increase dashboard.
+2. In Vercel, add the key as a server-only environment variable named `INCREASE_SANDBOX_API_KEY`.
+3. Set `GALACTIC_INCREASE_SANDBOX_ENABLED=true` for the environment you want to test.
+4. Redeploy.
+5. Sign in to the owner Integrations Center and call the owner-only Increase status endpoint to verify the connection.
+
+Do **not** paste the sandbox key into ChatGPT, GitHub issues, commits, screenshots, client-side code or a `NEXT_PUBLIC_` variable.
+
+## What remains before customer banking
+
+A successful sandbox connection is engineering evidence only. It does not make Galactic Trust a bank, open customer accounts, make deposits FDIC-insured through Galactic Trust, or authorize real money movement.
+
+Before any customer-facing account opening or live transfer flow, the selected provider/bank must approve the program, customer eligibility and onboarding, KYC/CIP/AML and sanctions controls, account terms and disclosures, Regulation E/error-resolution handling, ACH/payment use cases and limits, card program, ledger/reconciliation process, deposit-insurance wording, privacy/security, complaints/disputes, incident response and production launch.
+
+The hard locks in `lib/banking/regulated-launch.js` remain false until that production integration and evidence are reviewed in code.
+
+## Next implementation after the sandbox key is connected
+
+Once the read-only probe succeeds, build the sandbox customer journey in this order:
+
+1. Provider-hosted or tokenized onboarding session for a test Entity.
+2. Provider-confirmed Entity validation state.
+3. Sandbox Account creation tied to that Entity and Program.
+4. Provider-authoritative balance and transaction reads.
+5. Sandbox account-number and ACH simulations.
+6. Webhook signature verification and idempotent event processing.
+7. Reconciliation records that compare provider account/transaction state to the Galactic Trust application ledger.
+8. Only after formal production approval: a separate reviewed production adapter. Never convert the sandbox adapter into production by changing a URL or environment flag.

--- a/lib/banking/increase-sandbox.js
+++ b/lib/banking/increase-sandbox.js
@@ -1,0 +1,111 @@
+export const INCREASE_SANDBOX_BASE_URL = 'https://sandbox.increase.com';
+export const INCREASE_SANDBOX_PROVIDER = 'Increase';
+
+function truthy(value) {
+  return String(value || '').trim().toLowerCase() === 'true';
+}
+
+export function getIncreaseSandboxConfig(env = process.env) {
+  const apiKey = String(env.INCREASE_SANDBOX_API_KEY || '').trim();
+  return {
+    provider: INCREASE_SANDBOX_PROVIDER,
+    environment: 'sandbox',
+    baseUrl: INCREASE_SANDBOX_BASE_URL,
+    enabled: truthy(env.GALACTIC_INCREASE_SANDBOX_ENABLED),
+    credentialsConfigured: Boolean(apiKey),
+    apiKey,
+    canMoveRealMoney: false,
+    productionSupported: false,
+  };
+}
+
+function safePath(path) {
+  const value = String(path || '').trim();
+  if (!value.startsWith('/') || value.includes('..')) {
+    throw new Error('Increase sandbox request path is invalid.');
+  }
+  const url = new URL(value, `${INCREASE_SANDBOX_BASE_URL}/`);
+  if (url.origin !== new URL(INCREASE_SANDBOX_BASE_URL).origin) {
+    throw new Error('Increase sandbox requests must stay on the sandbox origin.');
+  }
+  return url;
+}
+
+export async function increaseSandboxRequest(path, options = {}, env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled) throw new Error('Increase sandbox is disabled. Set GALACTIC_INCREASE_SANDBOX_ENABLED=true only after a sandbox key is configured.');
+  if (!config.credentialsConfigured) throw new Error('Increase sandbox credentials are not configured. Add INCREASE_SANDBOX_API_KEY to the server environment.');
+
+  const method = String(options.method || 'GET').toUpperCase();
+  if (!['GET', 'POST', 'PATCH'].includes(method)) throw new Error('Increase sandbox request method is not allowed.');
+
+  const headers = {
+    Authorization: `Bearer ${config.apiKey}`,
+    Accept: 'application/json',
+  };
+  if (options.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (options.idempotencyKey) headers['Idempotency-Key'] = String(options.idempotencyKey);
+
+  const response = await fetch(safePath(path), {
+    method,
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    cache: 'no-store',
+    signal: options.signal,
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(`Increase sandbox request failed with status ${response.status}.`);
+    error.status = response.status;
+    error.providerType = typeof payload?.type === 'string' ? payload.type : '';
+    throw error;
+  }
+  return payload;
+}
+
+function countPage(payload) {
+  return Array.isArray(payload?.data) ? payload.data.length : 0;
+}
+
+export async function inspectIncreaseSandbox(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured) {
+    return {
+      provider: config.provider,
+      environment: config.environment,
+      enabled: config.enabled,
+      credentialsConfigured: config.credentialsConfigured,
+      connected: false,
+      canMoveRealMoney: false,
+      productionSupported: false,
+      counts: { programs: 0, accounts: 0, entities: 0 },
+    };
+  }
+
+  const [programs, accounts, entities] = await Promise.all([
+    increaseSandboxRequest('/programs?limit=20', {}, env),
+    increaseSandboxRequest('/accounts?limit=20', {}, env),
+    increaseSandboxRequest('/entities?limit=20', {}, env),
+  ]);
+
+  return {
+    provider: config.provider,
+    environment: config.environment,
+    enabled: true,
+    credentialsConfigured: true,
+    connected: true,
+    canMoveRealMoney: false,
+    productionSupported: false,
+    counts: {
+      programs: countPage(programs),
+      accounts: countPage(accounts),
+      entities: countPage(entities),
+    },
+    moreAvailable: {
+      programs: Boolean(programs?.next_cursor),
+      accounts: Boolean(accounts?.next_cursor),
+      entities: Boolean(entities?.next_cursor),
+    },
+  };
+}

--- a/scripts/test-galactic-trust-regulated-launch.mjs
+++ b/scripts/test-galactic-trust-regulated-launch.mjs
@@ -14,6 +14,9 @@ const gate = read('app/bank/GalacticBankGate.js');
 const enhancements = read('app/bank/GalacticDashboardEnhancements.js');
 const readinessPage = read('app/bank/readiness/page.js');
 const readinessApi = read('app/api/bank/readiness/route.ts');
+const increaseSandbox = read('lib/banking/increase-sandbox.js');
+const increaseStatusApi = read('app/api/admin/bank/increase/status/route.ts');
+const integrationsApi = read('app/api/admin/integrations/status/route.ts');
 const terms = read('app/terms/page.js');
 const privacy = read('app/privacy/page.js');
 const layout = read('app/layout.js');
@@ -57,6 +60,22 @@ assert.match(readinessPage, /No fake trust signals/, 'readiness page must forbid
 assert.match(readinessApi, /Cache-Control.*no-store/s, 'readiness endpoint must not cache launch-state assertions');
 assert.doesNotMatch(readinessApi, /API_KEY|SECRET|TOKEN/, 'public readiness endpoint must not expose provider credentials');
 
+assert.match(increaseSandbox, /https:\/\/sandbox\.increase\.com/, 'Increase integration must be pinned to the sandbox origin');
+assert.doesNotMatch(increaseSandbox, /https:\/\/api\.increase\.com/, 'Increase sandbox adapter must not contain the production API origin');
+assert.match(increaseSandbox, /INCREASE_SANDBOX_API_KEY/, 'Increase sandbox adapter must use the sandbox-specific key');
+assert.doesNotMatch(increaseSandbox, /GALACTIC_BANKING_PROVIDER_API_KEY/, 'sandbox adapter must not fall back to a generic production provider key');
+assert.match(increaseSandbox, /canMoveRealMoney:\s*false/, 'sandbox adapter must explicitly declare that it cannot move real money');
+assert.match(increaseSandbox, /productionSupported:\s*false/, 'sandbox adapter must explicitly reject production support');
+assert.match(increaseSandbox, /origin !== new URL\(INCREASE_SANDBOX_BASE_URL\)\.origin/, 'provider requests must be origin-pinned');
+
+assert.match(increaseStatusApi, /requireVoxelVaultAdmin/, 'Increase sandbox status must be owner-authenticated');
+assert.match(increaseStatusApi, /Cache-Control': 'private, no-store, max-age=0'/, 'Increase sandbox status must never be publicly cached');
+assert.match(increaseStatusApi, /canMoveRealMoney:\s*false/, 'Increase status must preserve the sandbox-only boundary');
+assert.match(increaseStatusApi, /never returns the API key/, 'Increase status must disclose its credential boundary');
+assert.doesNotMatch(increaseStatusApi, /process\.env\.INCREASE_SANDBOX_API_KEY/, 'owner status route must not directly read or return the sandbox key');
+assert.match(integrationsApi, /Increase sandbox/, 'owner integrations center must track the banking sandbox');
+assert.match(integrationsApi, /sandbox · no real money/, 'owner integrations center must label the no-real-money mode');
+
 assert.match(terms, /Galactic Trust itself is not an FDIC-insured institution/i, 'terms must keep FDIC attribution accurate');
 assert.match(terms, /current crypto panel is simulated/i, 'terms must keep crypto separate from banking approval');
 assert.match(privacy, /does not currently collect bank-program KYC documents/i, 'privacy notice must accurately describe current identity-data handling');
@@ -81,8 +100,11 @@ for (const key of [
   'GALACTIC_PROVIDER_PRODUCTION_ACCEPTED',
   'GALACTIC_LIVE_BANKING_ENABLED',
   'GALACTIC_LIVE_CRYPTO_ENABLED',
+  'GALACTIC_INCREASE_SANDBOX_ENABLED',
 ]) {
   assert.match(envExample, new RegExp(`${key}=false`), `${key} must default to false in .env.example`);
 }
+assert.match(envExample, /INCREASE_SANDBOX_API_KEY=\n/, 'Increase sandbox API key must be documented as an empty server-only secret');
+assert.doesNotMatch(envExample, /NEXT_PUBLIC_INCREASE/i, 'Increase credentials must never be exposed to browser code');
 
-console.log('Galactic Trust regulated launch checks passed: nonbank disclosure, sponsor-bank authority, consumer-protection gates, credential-safe status, real sign-out and hard-locked live money/crypto are enforced.');
+console.log('Galactic Trust regulated launch checks passed: nonbank disclosure, sponsor-bank authority, consumer-protection gates, owner-only Increase sandbox inspection, real sign-out and hard-locked live money/crypto are enforced.');


### PR DESCRIPTION
## What this does

- selects Increase as the first **sandbox banking-infrastructure candidate** without implying a production banking relationship
- adds a server-only Increase adapter pinned to `https://sandbox.increase.com`
- accepts only `INCREASE_SANDBOX_API_KEY` and never falls back to generic production-provider credentials
- adds an owner-authenticated read-only sandbox health endpoint for programs, accounts, and entities
- tracks Increase sandbox configuration in the owner Integrations Center
- documents the exact Vercel setup and the follow-on entity/account/ACH/webhook/reconciliation sequence
- extends the Galactic Trust regulated-launch regression test so the sandbox can never be converted into live banking just by changing environment variables

## Safety boundary

This PR does not move real money, does not open customer bank accounts, and does not claim an approved sponsor-bank relationship. The live banking and crypto implementation locks remain false. A successful Increase sandbox connection is engineering evidence only; production still requires the approved bank/provider program and all regulated-launch gates.