### PR TITLE
Upgrade Orbit chatbot responses

### DIFF
--- a/app/bank/BankClient.js
+++ b/app/bank/BankClient.js
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
+import { buildOrbitResponse } from '../../lib/banking/orbit-chat.js';
 
 const navItems = [
   ['dashboard', '⌂', 'Dashboard'],
@@ -76,38 +77,35 @@ function GalacticCard({ pink = false, frozen = false, onFreeze }) {
   );
 }
 
-function OrbitChat() {
+function OrbitChat({ sandboxConnected, checking, savings, transactions, accountLabel, blueFrozen, pinkFrozen }) {
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState([
-    { role: 'assistant', text: 'Hi! I’m Orbit 👋 Ask me about transfers, cards, crypto, security, privacy, rewards, or Galactic Trust.' },
+    { role: 'assistant', text: 'Hi! I’m Orbit ✨ Ask me what your balance means, how to test a transfer, whether this is real money, how cards work, or anything about Galactic Trust.' },
   ]);
 
+  const suggestions = sandboxConnected
+    ? ['What’s my sandbox balance?', 'How do I test an ACH transfer?', 'Is this real money?']
+    : ['What’s my balance?', 'How do transfers work?', 'Is Galactic Trust a bank?'];
+
   function replyTo(raw) {
-    const message = raw.trim().slice(0, 500);
+    const message = String(raw || '').trim().slice(0, 500);
     if (!message) return;
-    const q = message.toLowerCase();
-    let answer = 'I can help with Galactic Trust accounts, transfers, cards, crypto, rewards, security, privacy, and demo/live status.';
+    const response = buildOrbitResponse(message, {
+      sandboxConnected,
+      checking,
+      savings,
+      transactions,
+      accountLabel,
+      blueFrozen,
+      pinkFrozen,
+    });
 
-    if (/password|pin|cvv|one.?time|otp|recovery|seed phrase|private key/.test(q)) {
-      answer = 'For your security, never share passwords, PINs, CVVs, one-time codes, recovery phrases, or private keys in chat. I do not need them to help you.';
-    } else if (/transfer|send money/.test(q)) {
-      answer = 'Use Transfer from the sidebar or Quick Actions. Owner testing can use Increase sandbox ACH simulations, while real money movement remains blocked.';
-    } else if (/crypto|bitcoin|btc|ethereum|eth|usdc|buy|sell/.test(q)) {
-      answer = 'The Crypto panel lets you practice BTC, ETH, and USDC buys and sells. Orders are simulated right now; no real crypto is purchased or sold until an approved trading/custody provider is connected.';
-    } else if (/private|privacy|data/.test(q)) {
-      answer = 'Galactic Trust is designed to minimize sensitive data exposure. Card numbers stay masked, the assistant does not request account credentials, and provider secrets belong server-side only.';
-    } else if (/safe|security|secure|protect/.test(q)) {
-      answer = 'Security protections include masked card data, same-origin financial actions, restrictive browser headers, fail-closed live-money switches, and short-lived signed authentication for banking integrations.';
-    } else if (/fee|cost|price/.test(q)) {
-      answer = 'This prototype does not charge real banking or crypto fees. Any future fees must match the approved live partner program and be disclosed before a user confirms an action.';
-    } else if (/reward|star/.test(q)) {
-      answer = 'The reference experience includes Galactic Stars and merchant rewards. The displayed 2,450 stars are demo rewards in this build.';
-    } else if (/real|live|demo|sandbox/.test(q)) {
-      answer = 'The website is live, but real banking is not. Increase sandbox can supply pretend-money account and ACH test data for owner testing; production customer money stays hard-locked.';
-    }
-
-    setMessages((current) => [...current, { role: 'user', text: message }, { role: 'assistant', text: answer }]);
+    setMessages((current) => [
+      ...current.slice(-14),
+      { role: 'user', text: message },
+      { role: 'assistant', text: response.text },
+    ]);
     setInput('');
   }
 
@@ -120,12 +118,12 @@ function OrbitChat() {
             <div><strong>Orbit</strong><small><i /> Galactic Trust assistant</small></div>
             <button type="button" onClick={() => setOpen(false)} aria-label="Close Orbit">×</button>
           </header>
-          <div className="gt-chat-warning"><span>🔒</span><p>Never share passwords, PINs, CVVs, recovery codes, or one-time codes here.</p></div>
+          <div className="gt-chat-warning"><span>🔒</span><p>Never share passwords, PINs, CVVs, recovery codes, one-time codes, or API keys here.</p></div>
           <div className="gt-chat-messages" aria-live="polite">
             {messages.map((message, index) => <div key={`${message.role}-${index}`} className={`gt-chat-bubble ${message.role}`}>{message.text}</div>)}
           </div>
           <div className="gt-chat-suggestions">
-            {['How do transfers work?', 'How does crypto work?', 'Is my data private?'].map((text) => <button key={text} type="button" onClick={() => replyTo(text)}>{text}</button>)}
+            {suggestions.map((text) => <button key={text} type="button" onClick={() => replyTo(text)}>{text}</button>)}
           </div>
           <form className="gt-chat-form" onSubmit={(event) => { event.preventDefault(); replyTo(input); }}>
             <input value={input} maxLength={500} onChange={(event) => setInput(event.target.value)} placeholder="Ask Orbit anything…" aria-label="Message Orbit" autoComplete="off" />
@@ -445,7 +443,15 @@ export default function GalacticApp({ galacticUser = null, demoAccess = false, o
         </div>
       </section>
 
-      <OrbitChat />
+      <OrbitChat
+        sandboxConnected={sandboxConnected}
+        checking={checking}
+        savings={savings}
+        transactions={transactions}
+        accountLabel={memberName}
+        blueFrozen={blueFrozen}
+        pinkFrozen={pinkFrozen}
+      />
     </main>
   );
 }

--- a/lib/banking/orbit-chat.js
+++ b/lib/banking/orbit-chat.js
@@ -1,0 +1,186 @@
+export function normalizeOrbitQuestion(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim().slice(0, 500);
+}
+
+function money(value) {
+  const number = Number(value);
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number.isFinite(number) ? number : 0);
+}
+
+function recentSummary(transactions) {
+  const items = Array.isArray(transactions) ? transactions.slice(0, 3) : [];
+  if (!items.length) return 'There are no recent transactions to summarize yet.';
+  return items.map((item) => {
+    const amount = Number(item?.amount || 0);
+    const direction = amount >= 0 ? 'in' : 'out';
+    return `${String(item?.name || item?.category || 'Activity').slice(0, 48)}: ${money(Math.abs(amount))} ${direction}`;
+  }).join('; ');
+}
+
+export function buildOrbitResponse(rawMessage, context = {}) {
+  const message = normalizeOrbitQuestion(rawMessage);
+  const q = message.toLowerCase();
+  const sandboxConnected = Boolean(context.sandboxConnected);
+  const checking = Number(context.checking || 0);
+  const savings = Number(context.savings || 0);
+  const total = checking + savings;
+  const transactions = Array.isArray(context.transactions) ? context.transactions : [];
+  const spending = transactions.filter((item) => Number(item?.amount) < 0).reduce((sum, item) => sum + Math.abs(Number(item.amount || 0)), 0);
+  const blueFrozen = Boolean(context.blueFrozen);
+  const pinkFrozen = Boolean(context.pinkFrozen);
+  const accountLabel = String(context.accountLabel || '').trim();
+
+  if (!message) return { intent: 'empty', text: '' };
+
+  if (/(password|passcode|pin|cvv|cvc|one.?time|otp|verification code|recovery|seed phrase|private key|api key|secret key)/i.test(q)) {
+    return {
+      intent: 'sensitive-data',
+      text: 'Please do not share passwords, PINs, CVVs, one-time codes, recovery phrases, private keys, or API keys here. Orbit never needs those secrets. If you are trying to fix access, I can walk you through the safe account or sandbox steps instead.',
+    };
+  }
+
+  if (/^(hi|hello|hey|yo|good morning|good afternoon|good evening)\b/.test(q)) {
+    return {
+      intent: 'greeting',
+      text: `Hi${accountLabel ? ` ${accountLabel.split('@')[0]}` : ''} 👋 I’m Orbit. I can explain your balance, recent activity, transfers, cards, security, crypto, rewards, and whether you’re looking at demo data or Increase sandbox data.`,
+    };
+  }
+
+  if (/(thank you|thanks|thx|appreciate it)/.test(q)) {
+    return { intent: 'thanks', text: 'You got it ✨ If you want, ask me what to do next and I’ll point you to the right Galactic Trust control.' };
+  }
+
+  if (/(what can you do|what do you do|help me|help$|how can you help)/.test(q)) {
+    return {
+      intent: 'capabilities',
+      text: 'I can explain balances and recent activity, show you how to test transfers or add money, explain card controls, clarify demo vs. Increase sandbox vs. production, cover security/privacy, and answer questions about the demo crypto and rewards sections. I won’t ask for secret credentials or pretend a test transaction is real money.',
+    };
+  }
+
+  if (/(balance|how much money|how much do i have|money do i have|account total|available funds)/.test(q)) {
+    return {
+      intent: 'balance',
+      text: sandboxConnected
+        ? `Your connected Increase sandbox accounts currently show ${money(total)} total: ${money(checking)} in the primary sandbox account and ${money(savings)} in the second account if one is available. This is provider-backed test data using pretend money, not a real customer deposit.`
+        : `Your dashboard currently shows ${money(total)} in simulated balances: ${money(checking)} checking and ${money(savings)} savings. Those numbers are demo data and are not real deposits.`,
+    };
+  }
+
+  if (/(recent|transaction|activity|purchase|payment history|what did i spend)/.test(q)) {
+    return {
+      intent: 'activity',
+      text: `${sandboxConnected ? 'Your recent Increase sandbox activity' : 'Your recent demo activity'} includes: ${recentSummary(transactions)}. ${sandboxConnected ? 'These entries come from the sandbox provider and use pretend money.' : 'These entries are simulated.'}`,
+    };
+  }
+
+  if (/(spend|spending|spent|budget|expenses)/.test(q)) {
+    return {
+      intent: 'spending',
+      text: `Based on the activity currently loaded in the dashboard, outgoing activity totals about ${money(spending)}. ${sandboxConnected ? 'That is calculated from Increase sandbox transactions only.' : 'That is calculated from the current demo transaction list.'}`,
+    };
+  }
+
+  if (/(transfer|send money|send cash|ach|recipient|pay someone)/.test(q)) {
+    return {
+      intent: 'transfer',
+      text: sandboxConnected
+        ? 'Use Transfer in the sidebar or Quick Actions. Owner testing currently sends an Increase sandbox ACH using fixed test banking coordinates, so no real recipient bank account is used. Sandbox sends are capped at $1,000 and use pretend money only.'
+        : 'Use Transfer in the sidebar or Quick Actions, enter a recipient name and amount, then confirm the simulation. In demo mode the dashboard updates locally and no real money moves.',
+    };
+  }
+
+  if (/(add money|deposit|fund|funding|top up|put money|direct deposit)/.test(q)) {
+    return {
+      intent: 'funding',
+      text: sandboxConnected
+        ? 'Open Add Money and choose Increase sandbox ACH. The current test flow simulates a $500 inbound ACH into the sandbox account. Debit-card and direct-deposit funding are not wired to the sandbox yet, and no real money is involved.'
+        : 'Open Add Money to simulate funding the demo account. The current demo buttons can add test funds locally; they do not charge a card, debit a bank, or create a real deposit.',
+    };
+  }
+
+  if (/(card|freeze|unfreeze|locked|lock card|debit card)/.test(q)) {
+    return {
+      intent: 'cards',
+      text: `The displayed Galactic cards are still demo cards. Nebula Blue is ${blueFrozen ? 'currently frozen' : 'currently active in the demo UI'}, and Cosmic Pink is ${pinkFrozen ? 'currently frozen' : 'currently active in the demo UI'}. You can use Freeze Card or the card controls to change the demo state instantly. No production card is being issued or controlled yet.`,
+    };
+  }
+
+  if (/(crypto|bitcoin|btc|ethereum|eth|usdc|buy crypto|sell crypto)/.test(q)) {
+    return {
+      intent: 'crypto',
+      text: 'The Crypto section is a practice experience for BTC, ETH, and USDC. Buys and sells only change demo holdings in the interface; no real cryptocurrency is purchased, sold, custodied, or transferred. Crypto production access stays separately locked from banking.',
+    };
+  }
+
+  if (/(reward|rewards|star|stars|points|cash back|cashback)/.test(q)) {
+    return {
+      intent: 'rewards',
+      text: 'Galactic Stars are currently demo rewards. The interface shows 2,450 stars so you can preview the experience, but they do not have cash value and are not yet tied to a live rewards program.',
+    };
+  }
+
+  if (/(fee|fees|cost|price|charge|monthly fee|subscription)/.test(q)) {
+    return {
+      intent: 'fees',
+      text: 'Galactic Trust is not charging real banking or crypto fees in the current demo/sandbox build. If a live program launches later, any fees would need to come from the approved provider program and be clearly disclosed before a user confirms an action.',
+    };
+  }
+
+  if (/(fdic|insured|insurance|bank|real bank|sponsor bank|deposit insurance)/.test(q)) {
+    return {
+      intent: 'bank-status',
+      text: 'Galactic Trust is a financial technology product, not a bank, and Galactic Trust itself is not an FDIC-insured institution. The current experience is demo/sandbox only. A future live program would need an approved sponsor-bank relationship and bank-approved disclosures before any deposit-insurance language could apply.',
+    };
+  }
+
+  if (/(real money|real|live|production|demo|sandbox|increase)/.test(q)) {
+    return {
+      intent: 'environment',
+      text: sandboxConnected
+        ? 'You are looking at an Increase sandbox-connected experience. The balances and ACH events can come from the provider sandbox, but the money is pretend. Production customer deposits and real money movement remain hard-locked.'
+        : 'You are looking at Galactic Trust demo mode. The website is live, but the balances, cards, transfers, rewards, and crypto are simulated. Real banking stays locked until an approved sponsor-bank/provider program is actually live.',
+    };
+  }
+
+  if (/(privacy|private|data|track|tracking|information|personal info)/.test(q)) {
+    return {
+      intent: 'privacy',
+      text: 'The current design keeps provider secrets server-side, masks card information, and does not ask Orbit for passwords, PINs, CVVs, or one-time codes. Future identity/KYC data is intended to use provider-hosted or tokenized flows rather than exposing sensitive documents to the browser whenever possible.',
+    };
+  }
+
+  if (/(secure|security|safe|fraud|scam|hacked|hack|protect|protection)/.test(q)) {
+    return {
+      intent: 'security',
+      text: 'Key protections include authenticated sessions, masked card details, server-side provider credentials, no-store financial endpoints, sandbox-only provider routing for current tests, and fail-closed production money switches. If you suspect account compromise, sign out and do not share codes or credentials in Orbit.',
+    };
+  }
+
+  if (/(sign in|login|log in|sign out|logout|google|email link|magic link)/.test(q)) {
+    return {
+      intent: 'auth',
+      text: 'You can sign in with Google or a secure email sign-in link. Log Out in the sidebar ends the authenticated Galactic Trust session. Orbit will never ask you to send back a password or one-time sign-in code.',
+    };
+  }
+
+  if (/(not working|doesn't work|does not work|error|failed|failure|stuck|broken|problem)/.test(q)) {
+    return {
+      intent: 'troubleshooting',
+      text: sandboxConnected
+        ? 'If a sandbox action fails, first confirm you are signed in with the authorized account and that the Increase sandbox is connected. Then retry once. Do not paste the sandbox API key into Orbit, screenshots, or GitHub. If it still fails, the owner integration status is the right place to check provider connectivity.'
+        : 'If something is stuck, refresh once and confirm you are signed in. Demo actions should work without bank credentials. If you are trying to use Increase sandbox features, the sandbox must be enabled server-side and available to the authorized owner account.',
+    };
+  }
+
+  if (/(atm|withdraw|cash withdrawal|cash deposit|check deposit|mobile check|wire transfer|wire)/.test(q)) {
+    return {
+      intent: 'unsupported-banking',
+      text: 'That feature is not live in Galactic Trust yet. The current banking test surface focuses on balances, recent sandbox activity, simulated inbound ACH, and simulated outbound ACH. I won’t imply ATM, cash, checks, or production wire capabilities that are not actually connected.',
+    };
+  }
+
+  return {
+    intent: 'fallback',
+    text: `I’m not fully sure what you mean yet. Try asking something like “What’s my balance?”, “How do I test a transfer?”, “Is this real money?”, “Is Galactic Trust a bank?”, “Is my card frozen?”, or “Show me my recent activity.” I’ll answer using the current ${sandboxConnected ? 'Increase sandbox' : 'demo'} state without asking for sensitive credentials.`,
+  };
+}

--- a/scripts/test-galactic-trust-regulated-launch.mjs
+++ b/scripts/test-galactic-trust-regulated-launch.mjs
@@ -7,6 +7,7 @@ import {
   bankingEvidenceRequirements,
   bankingLaunchSnapshot,
 } from '../lib/banking/regulated-launch.js';
+import { buildOrbitResponse } from '../lib/banking/orbit-chat.js';
 
 const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
@@ -16,6 +17,7 @@ const enhancements = read('app/bank/GalacticDashboardEnhancements.js');
 const readinessPage = read('app/bank/readiness/page.js');
 const readinessApi = read('app/api/bank/readiness/route.ts');
 const increaseSandbox = read('lib/banking/increase-sandbox.js');
+const orbitChat = read('lib/banking/orbit-chat.js');
 const increaseStatusApi = read('app/api/admin/bank/increase/status/route.ts');
 const increaseDashboardApi = read('app/api/admin/bank/increase/dashboard/route.ts');
 const increaseFundApi = read('app/api/admin/bank/increase/fund/route.ts');
@@ -61,6 +63,47 @@ assert.match(bankClient, /\/api\/admin\/bank\/increase\/transfer/, 'owner dashbo
 assert.match(bankClient, /INCREASE SANDBOX/, 'dashboard must visibly label provider-backed test data as sandbox');
 assert.match(bankClient, /No real recipient or bank account is used/i, 'sandbox send flow must disclose that it never targets a real bank recipient');
 assert.match(bankClient, /typeof onSignOut === 'function' \? onSignOut\(\)/, 'visible sidebar sign-out must call the real sign-out handler');
+assert.match(bankClient, /buildOrbitResponse/, 'Orbit must use the richer contextual response engine');
+assert.match(bankClient, /sandboxConnected,\n\s+checking,\n\s+savings,\n\s+transactions,/s, 'Orbit must receive current dashboard financial context rather than static canned answers');
+
+assert.match(orbitChat, /sensitive-data/, 'Orbit must include a dedicated sensitive-data safety response');
+assert.match(orbitChat, /bank-status/, 'Orbit must distinguish nonbank and deposit-insurance questions');
+assert.match(orbitChat, /unsupported-banking/, 'Orbit must clearly say when a banking feature is not connected');
+
+const orbitContext = {
+  sandboxConnected: true,
+  checking: 100,
+  savings: 20,
+  accountLabel: 'Test User',
+  blueFrozen: true,
+  pinkFrozen: false,
+  transactions: [
+    { name: 'Sandbox ACH', amount: -12.5, category: 'Sandbox ACH' },
+    { name: 'Inbound test', amount: 50, category: 'Sandbox ACH' },
+  ],
+};
+const orbitBalance = buildOrbitResponse('what is my balance?', orbitContext);
+assert.equal(orbitBalance.intent, 'balance', 'Orbit must understand balance questions');
+assert.match(orbitBalance.text, /\$120\.00/, 'Orbit balance response must use current dashboard values');
+assert.match(orbitBalance.text, /pretend money/i, 'sandbox balance response must preserve pretend-money boundary');
+
+const orbitTransfer = buildOrbitResponse('how do I send an ACH?', orbitContext);
+assert.equal(orbitTransfer.intent, 'transfer', 'Orbit must understand transfer questions');
+assert.match(orbitTransfer.text, /fixed test banking coordinates/i, 'sandbox transfer response must explain the safe test destination');
+assert.match(orbitTransfer.text, /\$1,000/, 'sandbox transfer response must communicate the current test limit');
+
+const orbitCard = buildOrbitResponse('is my card frozen?', orbitContext);
+assert.equal(orbitCard.intent, 'cards', 'Orbit must understand card-status questions');
+assert.match(orbitCard.text, /Nebula Blue is currently frozen/i, 'Orbit card response must reflect live UI state');
+
+const orbitBankStatus = buildOrbitResponse('are you a real FDIC bank?', orbitContext);
+assert.equal(orbitBankStatus.intent, 'bank-status', 'Orbit must understand bank/FDIC questions');
+assert.match(orbitBankStatus.text, /not a bank/i, 'Orbit must not misrepresent Galactic Trust as a bank');
+assert.match(orbitBankStatus.text, /not an FDIC-insured institution/i, 'Orbit must keep FDIC attribution accurate');
+
+const orbitSecret = buildOrbitResponse('my API key is abc123', orbitContext);
+assert.equal(orbitSecret.intent, 'sensitive-data', 'Orbit must prioritize secret-handling safety');
+assert.match(orbitSecret.text, /do not share/i, 'Orbit must tell users not to share secrets');
 
 assert.match(enhancements, /financial technology product, not a bank/i, 'dashboard trust strip must preserve the nonbank boundary');
 assert.match(enhancements, /approved sponsor-bank program/i, 'dashboard must name the real launch authority instead of a founder toggle');
@@ -130,4 +173,4 @@ for (const key of [
 assert.match(envExample, /INCREASE_SANDBOX_API_KEY=\n/, 'Increase sandbox API key must be documented as an empty server-only secret');
 assert.doesNotMatch(envExample, /NEXT_PUBLIC_INCREASE/i, 'Increase credentials must never be exposed to browser code');
 
-console.log('Galactic Trust regulated launch checks passed: nonbank disclosure, sponsor-bank authority, consumer-protection gates, owner-only Increase sandbox dashboard/ACH simulations, real sign-out and hard-locked live money/crypto are enforced.');
+console.log('Galactic Trust regulated launch checks passed: nonbank disclosure, sponsor-bank authority, consumer-protection gates, contextual Orbit responses, owner-only Increase sandbox dashboard/ACH simulations, real sign-out and hard-locked live money/crypto are enforced.');


### PR DESCRIPTION
## What this improves

- replaces Orbit's small canned-response switch with a reusable contextual response engine
- answers balance, spending, recent activity, transfer, funding, card-status, crypto, rewards, fees, auth, privacy, security, troubleshooting, sandbox, production, and unsupported-feature questions
- uses the current dashboard state so answers can reflect the displayed balance, recent transactions, card freeze state, and whether Increase sandbox is connected
- adds clearer suggested questions depending on demo vs. Increase sandbox mode
- preserves strict secret-handling guidance for passwords, PINs, CVVs, OTPs, recovery phrases, private keys, and API keys
- keeps Galactic Trust's nonbank / non-FDIC / pretend-money boundaries accurate
- adds regression coverage for contextual balance, ACH, card, FDIC/nonbank, and secret-handling responses

No real banking capability is enabled by this change. Orbit remains a support assistant and never executes financial actions or asks for sensitive credentials.