### PR TITLE
Add Increase webhooks and automatic reconciliation

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -63,6 +63,8 @@ jobs:
         run: node scripts/test-financial-os-coherence.mjs
       - name: Galactic Trust regulated launch
         run: node scripts/test-galactic-trust-regulated-launch.mjs
+      - name: Galactic Trust Increase webhooks
+        run: node scripts/test-galactic-trust-increase-webhooks.mjs
       - name: Hyperreal voxel building
         run: node scripts/test-hyperreal-voxel-building.mjs
       - name: Property draft funnel

--- a/app/api/admin/bank/increase/dashboard/route.ts
+++ b/app/api/admin/bank/increase/dashboard/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
 import { getIncreaseSandboxDashboard } from '../../../../../../lib/banking/increase-sandbox.js';
+import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../../lib/banking/increase-webhook-subscription.js';
+import { pollIncreaseSandboxEvents } from '../../../../../../lib/banking/increase-reconciliation';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -18,12 +20,31 @@ export async function GET(request: Request) {
     return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
   }
 
+  let webhookAutomation: any = null;
+  let reconciliationBackstop: any = null;
+  let automationIssue: string | null = null;
+
+  try {
+    webhookAutomation = await ensureIncreaseSandboxWebhookSubscription(process.env);
+  } catch {
+    automationIssue = 'Increase sandbox webhook subscription needs attention.';
+  }
+
+  try {
+    reconciliationBackstop = await pollIncreaseSandboxEvents({ maxPages: 2 });
+  } catch {
+    automationIssue = automationIssue || 'Increase sandbox reconciliation backstop needs attention.';
+  }
+
   try {
     const snapshot = await getIncreaseSandboxDashboard(process.env);
     return response({
       ok: true,
       authorized: true,
       ...snapshot,
+      webhookAutomation,
+      reconciliationBackstop,
+      automationIssue,
       note: 'Increase sandbox data only. Values are pretend money and cannot represent live customer funds.',
     });
   } catch (error: any) {
@@ -34,6 +55,9 @@ export async function GET(request: Request) {
       environment: 'sandbox',
       connected: false,
       canMoveRealMoney: false,
+      webhookAutomation,
+      reconciliationBackstop,
+      automationIssue,
       providerStatus: Number.isFinite(error?.status) ? error.status : null,
       error: error instanceof Error ? error.message : 'Increase sandbox dashboard sync failed.',
     }, 502);

--- a/app/api/admin/bank/increase/reconciliation/route.ts
+++ b/app/api/admin/bank/increase/reconciliation/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
+import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../../lib/banking/increase-webhook-subscription.js';
+import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents } from '../../../../../../lib/banking/increase-reconciliation';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}
+
+async function authorize(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if (auth.ok === false) {
+    return { ok: false as const, response: response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status) };
+  }
+  return { ok: true as const };
+}
+
+export async function GET(request: Request) {
+  const auth = await authorize(request);
+  if (!auth.ok) return auth.response;
+
+  try {
+    const [subscription, reconciliation] = await Promise.all([
+      ensureIncreaseSandboxWebhookSubscription(process.env),
+      getIncreaseReconciliationStatus(),
+    ]);
+    return response({
+      ok: true,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      subscription,
+      reconciliation,
+    });
+  } catch (error: any) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      providerStatus: Number.isFinite(error?.status) ? error.status : null,
+      error: 'Increase sandbox reconciliation status is unavailable.',
+    }, 502);
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await authorize(request);
+  if (!auth.ok) return auth.response;
+
+  try {
+    const subscription = await ensureIncreaseSandboxWebhookSubscription(process.env);
+    const backstop = await pollIncreaseSandboxEvents({ maxPages: 5, forceReconcile: true });
+    const reconciliation = await getIncreaseReconciliationStatus();
+    return response({
+      ok: true,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      subscription,
+      backstop,
+      reconciliation,
+      note: 'Provider Events were polled oldest-first and the sandbox snapshot was reconciled. No real money moved.',
+    });
+  } catch (error: any) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      providerStatus: Number.isFinite(error?.status) ? error.status : null,
+      error: 'Increase sandbox reconciliation failed.',
+    }, 502);
+  }
+}

--- a/app/api/bank/increase/webhook/route.ts
+++ b/app/api/bank/increase/webhook/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { hashIncreaseWebhookPayload, verifyIncreaseSandboxWebhookSignature } from '../../../../../lib/banking/increase-webhook-signature.js';
+import { reconcileIncreaseSandbox, recordIncreaseSandboxEvent } from '../../../../../lib/banking/increase-reconciliation';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'no-store, max-age=0' },
+  });
+}
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const webhookId = request.headers.get('webhook-id');
+  const webhookTimestamp = request.headers.get('webhook-timestamp');
+  const webhookSignature = request.headers.get('webhook-signature');
+
+  const verification = verifyIncreaseSandboxWebhookSignature({
+    rawBody,
+    webhookId,
+    webhookTimestamp,
+    webhookSignature,
+    env: process.env,
+  });
+  if (verification.ok === false) {
+    const status = verification.reason === 'not_configured' ? 503 : 401;
+    return response({ received: false, error: 'Invalid Increase webhook.' }, status);
+  }
+
+  let event: any;
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return response({ received: false, error: 'Invalid Increase event payload.' }, 400);
+  }
+
+  if (!event || event.type !== 'event' || typeof event.id !== 'string' || event.id !== verification.webhookId) {
+    return response({ received: false, error: 'Increase event identity mismatch.' }, 400);
+  }
+
+  let recorded;
+  try {
+    recorded = await recordIncreaseSandboxEvent(event, {
+      source: 'webhook',
+      webhookMessageId: verification.webhookId,
+      payloadSha256: hashIncreaseWebhookPayload(rawBody),
+    });
+  } catch (error) {
+    console.error('Galactic Trust Increase webhook persistence failed', {
+      eventId: event.id,
+      category: event.category,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return response({ received: false, error: 'Webhook persistence failed.' }, 503);
+  }
+
+  if (recorded.duplicate) {
+    return response({ received: true, duplicate: true, environment: 'sandbox', canMoveRealMoney: false });
+  }
+
+  try {
+    const reconciliation = await reconcileIncreaseSandbox({ eventIds: [recorded.eventId], trigger: 'webhook' });
+    return response({
+      received: true,
+      duplicate: false,
+      reconciled: true,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      reconciledAt: reconciliation.reconciledAt,
+    });
+  } catch (error) {
+    // Increase does not retry failed sandbox webhooks. The durable Event row stays
+    // marked failed and the owner reconciliation poll can backfill from /events.
+    console.error('Galactic Trust Increase webhook reconciliation deferred', {
+      eventId: event.id,
+      category: event.category,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return response({
+      received: true,
+      duplicate: false,
+      reconciled: false,
+      backstopRequired: true,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+    });
+  }
+}

--- a/docs/GALACTIC_TRUST_INCREASE_WEBHOOKS.md
+++ b/docs/GALACTIC_TRUST_INCREASE_WEBHOOKS.md
@@ -1,0 +1,53 @@
+# Galactic Trust · Increase sandbox webhooks + reconciliation
+
+This integration is sandbox-only. Increase sandbox uses pretend money; nothing in this flow enables production banking or changes Galactic Trust's nonbank status.
+
+## What happens automatically
+
+When the authorized owner dashboard loads and the existing Increase sandbox configuration is enabled, Galactic Trust ensures an Increase sandbox Event Subscription exists for:
+
+`https://www.voxelvault.io/api/bank/increase/webhook`
+
+The subscription secret is derived server-side from the existing sandbox API key with HMAC key separation. It is never returned to the browser, stored in GitHub, or sent to Orbit.
+
+Increase sends Event objects to the public webhook endpoint. The endpoint:
+
+1. reads the raw request body;
+2. verifies `webhook-id`, `webhook-timestamp`, and `webhook-signature` using HMAC-SHA256;
+3. rejects timestamps outside a five-minute replay window;
+4. requires the signed `webhook-id` to match the Event ID;
+5. stores only minimal Event metadata plus a SHA-256 payload hash in Supabase;
+6. uses the Increase Event ID as the idempotency key;
+7. refreshes the authoritative sandbox account/balance/transaction snapshot;
+8. marks the Event processed or failed without ever storing provider credentials or the raw webhook body.
+
+The signature implementation follows Increase's Standard Webhooks guidance:
+
+- https://www.increase.com/documentation/webhooks
+- https://www.increase.com/documentation/api/event-subscriptions
+
+## Missed-event backstop
+
+Increase recommends polling the Events API as a backstop for data synchronization. Galactic Trust stores the Increase Events cursor and polls oldest-first from `/events` when the authorized owner dashboard loads or when the owner reconciliation endpoint is called.
+
+Owner-only endpoint:
+
+- `GET /api/admin/bank/increase/reconciliation` — inspect the latest reconciliation checkpoint and recent Event statuses.
+- `POST /api/admin/bank/increase/reconciliation` — poll up to five Event pages and force a fresh sandbox reconciliation.
+
+Increase keeps Events available for a limited window, so this cursor is persisted in Supabase rather than browser storage.
+
+## Durable tables
+
+Migration `024_galactic_increase_webhooks_reconciliation.sql` adds two service-role-only tables:
+
+- `galactic_increase_webhook_events` — Event IDs/categories/statuses, provider timestamps, source, and payload hashes. No raw webhook payloads or API keys.
+- `galactic_increase_reconciliation_state` — cursor, latest reconciliation timestamps, aggregate account/transaction counts, and aggregate sandbox balances.
+
+RLS is enabled and `anon`/`authenticated` access is revoked. Server service credentials are required.
+
+## Failure behavior
+
+A verified Event is persisted before reconciliation. If the provider refresh fails, the Event remains durable and is marked failed. The webhook still acknowledges the signed sandbox Event so the owner backstop can recover it from the Events API. Increase documents that failed sandbox webhooks are not retried.
+
+Production handling will require a separate reviewed adapter, production Event Subscription, independent secret-rotation procedure, queue/stream processing, operational alerting, and the existing regulated-launch approval gates. The sandbox code must not be converted to production by changing an origin or environment flag.

--- a/lib/banking/increase-reconciliation.ts
+++ b/lib/banking/increase-reconciliation.ts
@@ -1,0 +1,238 @@
+import { getSupabaseAdmin } from '../supabase-admin';
+import { getIncreaseSandboxDashboard, increaseSandboxRequest } from './increase-sandbox.js';
+
+type IncreaseEvent = {
+  id?: string;
+  type?: string;
+  category?: string;
+  associated_object_type?: string | null;
+  associated_object_id?: string | null;
+  created_at?: string | null;
+};
+
+type EventSource = 'webhook' | 'poll';
+
+function listData(payload: any): IncreaseEvent[] {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+function safeText(value: unknown, max = 200) {
+  return String(value || '').replace(/[\u0000-\u001f\u007f]/g, '').trim().slice(0, max);
+}
+
+function safeError(error: unknown) {
+  if (error && typeof error === 'object' && 'status' in error && Number.isFinite(Number((error as any).status))) {
+    return `provider_status_${Number((error as any).status)}`;
+  }
+  return error instanceof Error ? safeText(error.message, 160) : 'reconciliation_failed';
+}
+
+function dollarsToCents(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.round(number * 100) : 0;
+}
+
+function validateEvent(event: IncreaseEvent) {
+  const eventId = safeText(event?.id, 200);
+  const category = safeText(event?.category, 160);
+  if (!eventId || !category || event?.type !== 'event') throw new Error('Increase webhook event is invalid.');
+  return {
+    eventId,
+    category,
+    associatedObjectType: safeText(event?.associated_object_type, 120) || null,
+    associatedObjectId: safeText(event?.associated_object_id, 200) || null,
+    providerCreatedAt: event?.created_at ? new Date(event.created_at).toISOString() : null,
+  };
+}
+
+async function updateReconciliationState(values: Record<string, unknown>) {
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('galactic_increase_reconciliation_state').upsert({
+    environment: 'sandbox',
+    ...values,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'environment' });
+  if (error) throw error;
+}
+
+export async function recordIncreaseSandboxEvent(event: IncreaseEvent, options: {
+  source: EventSource;
+  webhookMessageId?: string | null;
+  payloadSha256?: string | null;
+}): Promise<{ duplicate: boolean; eventId: string }> {
+  const normalized = validateEvent(event);
+  const supabase = getSupabaseAdmin();
+  const now = new Date().toISOString();
+  const { error } = await supabase.from('galactic_increase_webhook_events').insert({
+    event_id: normalized.eventId,
+    category: normalized.category,
+    associated_object_type: normalized.associatedObjectType,
+    associated_object_id: normalized.associatedObjectId,
+    source: options.source,
+    webhook_message_id: safeText(options.webhookMessageId, 200) || null,
+    payload_sha256: safeText(options.payloadSha256, 64) || null,
+    provider_created_at: normalized.providerCreatedAt,
+    received_at: now,
+    processing_status: 'received',
+  });
+
+  if (error?.code === '23505') return { duplicate: true, eventId: normalized.eventId };
+  if (error) throw error;
+
+  await updateReconciliationState({
+    last_event_id: normalized.eventId,
+    last_event_category: normalized.category,
+    ...(options.source === 'webhook' ? { last_webhook_at: now } : { last_poll_at: now }),
+  });
+  return { duplicate: false, eventId: normalized.eventId };
+}
+
+async function markEvents(eventIds: string[], status: 'processed' | 'failed', lastError: string | null = null) {
+  const ids = Array.from(new Set(eventIds.map((id) => safeText(id, 200)).filter(Boolean)));
+  if (!ids.length) return;
+  const supabase = getSupabaseAdmin();
+  const update: Record<string, unknown> = {
+    processing_status: status,
+    processed_at: new Date().toISOString(),
+    last_error: lastError,
+  };
+  const { error } = await supabase.from('galactic_increase_webhook_events').update(update).in('event_id', ids);
+  if (error) throw error;
+}
+
+export async function reconcileIncreaseSandbox(options: {
+  eventIds?: string[];
+  trigger?: 'webhook' | 'poll' | 'owner' | 'dashboard';
+} = {}) {
+  const eventIds = Array.isArray(options.eventIds) ? options.eventIds : [];
+  const trigger = options.trigger || 'owner';
+  const startedAt = new Date().toISOString();
+
+  try {
+    const snapshot = await getIncreaseSandboxDashboard(process.env);
+    const accounts = Array.isArray(snapshot?.accounts) ? snapshot.accounts : [];
+    const transactions = Array.isArray(snapshot?.transactions) ? snapshot.transactions : [];
+    const currentBalanceCents = accounts.reduce((sum: number, account: any) => sum + dollarsToCents(account?.currentBalance), 0);
+    const availableBalanceCents = accounts.reduce((sum: number, account: any) => sum + dollarsToCents(account?.availableBalance), 0);
+    const lastTransactionId = safeText(transactions[0]?.id, 200) || null;
+    const reconciledAt = new Date().toISOString();
+
+    await updateReconciliationState({
+      last_reconciled_at: reconciledAt,
+      last_reconciliation_status: 'ok',
+      last_reconciliation_trigger: trigger,
+      account_count: accounts.length,
+      transaction_count: transactions.length,
+      current_balance_cents: currentBalanceCents,
+      available_balance_cents: availableBalanceCents,
+      last_transaction_id: lastTransactionId,
+      last_error: null,
+    });
+    await markEvents(eventIds, 'processed');
+
+    return {
+      ok: true,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      trigger,
+      startedAt,
+      reconciledAt,
+      accountCount: accounts.length,
+      transactionCount: transactions.length,
+      currentBalanceCents,
+      availableBalanceCents,
+      lastTransactionId,
+    };
+  } catch (error) {
+    const code = safeError(error);
+    try {
+      await updateReconciliationState({
+        last_reconciled_at: new Date().toISOString(),
+        last_reconciliation_status: 'failed',
+        last_reconciliation_trigger: trigger,
+        last_error: code,
+      });
+      await markEvents(eventIds, 'failed', code);
+    } catch {
+      // Preserve the original provider/database error for the caller.
+    }
+    throw error;
+  }
+}
+
+export async function pollIncreaseSandboxEvents(options: { maxPages?: number; forceReconcile?: boolean } = {}) {
+  const maxPages = Math.max(1, Math.min(5, Number(options.maxPages || 2)));
+  const supabase = getSupabaseAdmin();
+  const { data: state, error: stateError } = await supabase
+    .from('galactic_increase_reconciliation_state')
+    .select('event_cursor,last_reconciled_at')
+    .eq('environment', 'sandbox')
+    .maybeSingle();
+  if (stateError) throw stateError;
+
+  let cursor = safeText(state?.event_cursor, 500);
+  const newEventIds: string[] = [];
+  let pages = 0;
+  let scanned = 0;
+
+  while (pages < maxPages) {
+    const params = new URLSearchParams();
+    params.set('order_by.field', 'created_at');
+    params.set('order_by.direction', 'ascending');
+    params.set('limit', '100');
+    if (cursor) params.set('cursor', cursor);
+
+    const payload = await increaseSandboxRequest(`/events?${params.toString()}`, {}, process.env);
+    const events = listData(payload);
+    pages += 1;
+    scanned += events.length;
+
+    for (const event of events) {
+      const recorded = await recordIncreaseSandboxEvent(event, { source: 'poll' });
+      if (!recorded.duplicate) newEventIds.push(recorded.eventId);
+    }
+
+    const nextCursor = safeText(payload?.next_cursor, 500);
+    if (nextCursor) cursor = nextCursor;
+    await updateReconciliationState({ event_cursor: cursor || null, last_poll_at: new Date().toISOString() });
+    if (!events.length) break;
+  }
+
+  const shouldReconcile = newEventIds.length > 0 || Boolean(options.forceReconcile) || !state?.last_reconciled_at;
+  const reconciliation = shouldReconcile
+    ? await reconcileIncreaseSandbox({ eventIds: newEventIds, trigger: 'poll' })
+    : null;
+
+  return {
+    ok: true,
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    pages,
+    scanned,
+    newEvents: newEventIds.length,
+    cursorStored: Boolean(cursor),
+    reconciled: Boolean(reconciliation),
+    reconciliation,
+  };
+}
+
+export async function getIncreaseReconciliationStatus() {
+  const supabase = getSupabaseAdmin();
+  const [{ data: state, error: stateError }, { data: events, error: eventsError }] = await Promise.all([
+    supabase.from('galactic_increase_reconciliation_state').select('*').eq('environment', 'sandbox').maybeSingle(),
+    supabase
+      .from('galactic_increase_webhook_events')
+      .select('event_id,category,associated_object_type,source,provider_created_at,received_at,processed_at,processing_status,last_error')
+      .order('received_at', { ascending: false })
+      .limit(12),
+  ]);
+  if (stateError) throw stateError;
+  if (eventsError) throw eventsError;
+
+  return {
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    state: state || null,
+    recentEvents: Array.isArray(events) ? events : [],
+  };
+}

--- a/lib/banking/increase-webhook-signature.js
+++ b/lib/banking/increase-webhook-signature.js
@@ -1,0 +1,65 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+export const INCREASE_WEBHOOK_MAX_AGE_SECONDS = 300;
+export const INCREASE_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
+const WEBHOOK_SECRET_CONTEXT = 'galactic-trust/increase-sandbox/webhook/v1';
+
+function sandboxApiKey(env = process.env) {
+  return String(env.INCREASE_SANDBOX_API_KEY || '').trim();
+}
+
+export function deriveIncreaseSandboxWebhookSecret(env = process.env) {
+  const apiKey = sandboxApiKey(env);
+  if (!apiKey) throw new Error('Increase sandbox webhook verification is not configured.');
+  return createHmac('sha256', apiKey).update(WEBHOOK_SECRET_CONTEXT).digest('base64url');
+}
+
+function constantTimeEqual(left, right) {
+  const a = Buffer.from(String(left || ''), 'utf8');
+  const b = Buffer.from(String(right || ''), 'utf8');
+  if (!a.length || a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function hashIncreaseWebhookPayload(rawBody) {
+  return createHash('sha256').update(String(rawBody || ''), 'utf8').digest('hex');
+}
+
+export function verifyIncreaseSandboxWebhookSignature({
+  rawBody,
+  webhookId,
+  webhookTimestamp,
+  webhookSignature,
+  env = process.env,
+  nowSeconds = Math.floor(Date.now() / 1000),
+} = {}) {
+  const body = String(rawBody || '');
+  if (!body || Buffer.byteLength(body, 'utf8') > INCREASE_WEBHOOK_MAX_BODY_BYTES) {
+    return { ok: false, reason: 'invalid_body' };
+  }
+
+  const id = String(webhookId || '').trim();
+  const timestampText = String(webhookTimestamp || '').trim();
+  const signatures = String(webhookSignature || '').trim();
+  if (!id || !timestampText || !signatures) return { ok: false, reason: 'missing_headers' };
+
+  const timestamp = Number(timestampText);
+  if (!Number.isInteger(timestamp)) return { ok: false, reason: 'invalid_timestamp' };
+  if (Math.abs(Number(nowSeconds) - timestamp) > INCREASE_WEBHOOK_MAX_AGE_SECONDS) {
+    return { ok: false, reason: 'stale_timestamp' };
+  }
+
+  let secret;
+  try {
+    secret = deriveIncreaseSandboxWebhookSecret(env);
+  } catch {
+    return { ok: false, reason: 'not_configured' };
+  }
+
+  const signedPayload = `${id}.${timestampText}.${body}`;
+  const expected = `v1,${createHmac('sha256', secret).update(signedPayload, 'utf8').digest('base64')}`;
+  const verified = signatures.split(/\s+/).filter(Boolean).some((candidate) => constantTimeEqual(candidate, expected));
+  if (!verified) return { ok: false, reason: 'invalid_signature' };
+
+  return { ok: true, webhookId: id, timestamp };
+}

--- a/lib/banking/increase-webhook-signature.js
+++ b/lib/banking/increase-webhook-signature.js
@@ -4,16 +4,26 @@ export const INCREASE_WEBHOOK_MAX_AGE_SECONDS = 300;
 export const INCREASE_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
 const WEBHOOK_SECRET_CONTEXT = 'galactic-trust/increase-sandbox/webhook/v1';
 
+/**
+ * @param {Record<string, string | undefined>} [env]
+ */
 function sandboxApiKey(env = process.env) {
   return String(env.INCREASE_SANDBOX_API_KEY || '').trim();
 }
 
+/**
+ * @param {Record<string, string | undefined>} [env]
+ */
 export function deriveIncreaseSandboxWebhookSecret(env = process.env) {
   const apiKey = sandboxApiKey(env);
   if (!apiKey) throw new Error('Increase sandbox webhook verification is not configured.');
   return createHmac('sha256', apiKey).update(WEBHOOK_SECRET_CONTEXT).digest('base64url');
 }
 
+/**
+ * @param {unknown} left
+ * @param {unknown} right
+ */
 function constantTimeEqual(left, right) {
   const a = Buffer.from(String(left || ''), 'utf8');
   const b = Buffer.from(String(right || ''), 'utf8');
@@ -21,18 +31,33 @@ function constantTimeEqual(left, right) {
   return timingSafeEqual(a, b);
 }
 
+/**
+ * @param {unknown} rawBody
+ */
 export function hashIncreaseWebhookPayload(rawBody) {
   return createHash('sha256').update(String(rawBody || ''), 'utf8').digest('hex');
 }
 
-export function verifyIncreaseSandboxWebhookSignature({
-  rawBody,
-  webhookId,
-  webhookTimestamp,
-  webhookSignature,
-  env = process.env,
-  nowSeconds = Math.floor(Date.now() / 1000),
-} = {}) {
+/**
+ * @param {{
+ *   rawBody?: string,
+ *   webhookId?: string | null,
+ *   webhookTimestamp?: string | null,
+ *   webhookSignature?: string | null,
+ *   env?: Record<string, string | undefined>,
+ *   nowSeconds?: number,
+ * }} [options]
+ */
+export function verifyIncreaseSandboxWebhookSignature(options = {}) {
+  const {
+    rawBody,
+    webhookId,
+    webhookTimestamp,
+    webhookSignature,
+    env = process.env,
+    nowSeconds = Math.floor(Date.now() / 1000),
+  } = options;
+
   const body = String(rawBody || '');
   if (!body || Buffer.byteLength(body, 'utf8') > INCREASE_WEBHOOK_MAX_BODY_BYTES) {
     return { ok: false, reason: 'invalid_body' };

--- a/lib/banking/increase-webhook-subscription.js
+++ b/lib/banking/increase-webhook-subscription.js
@@ -1,0 +1,74 @@
+import { createHash } from 'node:crypto';
+import { getIncreaseSandboxConfig, increaseSandboxRequest } from './increase-sandbox.js';
+import { deriveIncreaseSandboxWebhookSecret } from './increase-webhook-signature.js';
+
+function listData(payload) {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+export function getIncreaseSandboxWebhookUrl(env = process.env) {
+  const base = String(env.NEXT_PUBLIC_APP_URL || env.NEXT_PUBLIC_SITE_URL || 'https://www.voxelvault.io').trim();
+  let url;
+  try {
+    url = new URL('/api/bank/increase/webhook', base);
+  } catch {
+    throw new Error('Galactic Trust public URL is invalid for Increase sandbox webhooks.');
+  }
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    throw new Error('Increase sandbox webhook URL must use HTTPS.');
+  }
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+function subscriptionIdempotencyKey(webhookUrl, secret) {
+  const fingerprint = createHash('sha256').update(`${webhookUrl}\n${secret}`, 'utf8').digest('hex').slice(0, 16);
+  return `galactic-trust-increase-sandbox-webhook-v1-${fingerprint}`;
+}
+
+export async function ensureIncreaseSandboxWebhookSubscription(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured) {
+    return {
+      configured: false,
+      active: false,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      reason: 'sandbox_not_configured',
+    };
+  }
+
+  const webhookUrl = getIncreaseSandboxWebhookUrl(env);
+  const secret = deriveIncreaseSandboxWebhookSecret(env);
+  const idempotencyKey = subscriptionIdempotencyKey(webhookUrl, secret);
+  const existingPayload = await increaseSandboxRequest(`/event_subscriptions?idempotency_key=${encodeURIComponent(idempotencyKey)}&limit=10`, {}, env);
+  let subscription = listData(existingPayload)[0] || null;
+
+  if (!subscription) {
+    subscription = await increaseSandboxRequest('/event_subscriptions', {
+      method: 'POST',
+      idempotencyKey,
+      body: {
+        url: webhookUrl,
+        shared_secret: secret,
+        status: 'active',
+      },
+    }, env);
+  } else if (subscription.status !== 'active') {
+    subscription = await increaseSandboxRequest(`/event_subscriptions/${encodeURIComponent(subscription.id)}`, {
+      method: 'PATCH',
+      body: { status: 'active' },
+    }, env);
+  }
+
+  return {
+    configured: true,
+    active: subscription?.status === 'active',
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    id: String(subscription?.id || ''),
+    status: String(subscription?.status || 'unknown'),
+    url: webhookUrl,
+  };
+}

--- a/scripts/test-galactic-trust-increase-webhooks.mjs
+++ b/scripts/test-galactic-trust-increase-webhooks.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import fs from 'node:fs';
+import {
+  deriveIncreaseSandboxWebhookSecret,
+  verifyIncreaseSandboxWebhookSignature,
+} from '../lib/banking/increase-webhook-signature.js';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const webhookRoute = read('app/api/bank/increase/webhook/route.ts');
+const reconciliationRoute = read('app/api/admin/bank/increase/reconciliation/route.ts');
+const dashboardRoute = read('app/api/admin/bank/increase/dashboard/route.ts');
+const subscription = read('lib/banking/increase-webhook-subscription.js');
+const signature = read('lib/banking/increase-webhook-signature.js');
+const reconciliation = read('lib/banking/increase-reconciliation.ts');
+const migration = read('supabase/migrations/024_galactic_increase_webhooks_reconciliation.sql');
+const sandbox = read('lib/banking/increase-sandbox.js');
+
+const env = { INCREASE_SANDBOX_API_KEY: 'sandbox_key_test_only_123456789' };
+const event = {
+  id: 'event_test_123',
+  type: 'event',
+  category: 'transaction.created',
+  associated_object_type: 'transaction',
+  associated_object_id: 'transaction_test_123',
+  created_at: '2026-08-30T00:00:00Z',
+};
+const rawBody = JSON.stringify(event);
+const timestamp = 1_800_000_000;
+const secret = deriveIncreaseSandboxWebhookSecret(env);
+const signedPayload = `${event.id}.${timestamp}.${rawBody}`;
+const webhookSignature = `v1,${createHmac('sha256', secret).update(signedPayload, 'utf8').digest('base64')}`;
+
+const valid = verifyIncreaseSandboxWebhookSignature({
+  rawBody,
+  webhookId: event.id,
+  webhookTimestamp: String(timestamp),
+  webhookSignature,
+  env,
+  nowSeconds: timestamp + 30,
+});
+assert.equal(valid.ok, true, 'valid Increase Standard Webhooks signature must verify');
+
+const tampered = verifyIncreaseSandboxWebhookSignature({
+  rawBody: `${rawBody} `,
+  webhookId: event.id,
+  webhookTimestamp: String(timestamp),
+  webhookSignature,
+  env,
+  nowSeconds: timestamp + 30,
+});
+assert.equal(tampered.ok, false, 'raw-body tampering must invalidate the signature');
+
+const stale = verifyIncreaseSandboxWebhookSignature({
+  rawBody,
+  webhookId: event.id,
+  webhookTimestamp: String(timestamp),
+  webhookSignature,
+  env,
+  nowSeconds: timestamp + 301,
+});
+assert.equal(stale.ok, false, 'webhooks older than five minutes must be rejected');
+
+assert.match(signature, /webhook-id|webhookId/, 'signature verifier must bind the webhook ID');
+assert.match(signature, /webhook-timestamp|webhookTimestamp/, 'signature verifier must bind the webhook timestamp');
+assert.match(signature, /webhook-signature|webhookSignature/, 'signature verifier must bind the webhook signature');
+assert.match(signature, /createHmac\('sha256'/, 'Increase webhook verification must use HMAC-SHA256');
+assert.match(signature, /timingSafeEqual/, 'signature comparison must be constant-time');
+assert.match(signature, /INCREASE_WEBHOOK_MAX_AGE_SECONDS = 300/, 'replay window must be five minutes');
+assert.match(signature, /INCREASE_WEBHOOK_MAX_BODY_BYTES = 64 \* 1024/, 'webhook bodies must be size bounded');
+assert.doesNotMatch(signature, /NEXT_PUBLIC_INCREASE/i, 'webhook signing material must never come from browser variables');
+
+assert.match(webhookRoute, /const rawBody = await request\.text\(\)/, 'webhook route must verify the raw request body');
+assert.match(webhookRoute, /request\.headers\.get\('webhook-id'\)/, 'webhook route must read Standard Webhooks ID header');
+assert.match(webhookRoute, /request\.headers\.get\('webhook-timestamp'\)/, 'webhook route must read Standard Webhooks timestamp header');
+assert.match(webhookRoute, /request\.headers\.get\('webhook-signature'\)/, 'webhook route must read Standard Webhooks signature header');
+assert.match(webhookRoute, /event\.id !== verification\.webhookId/, 'signed webhook ID must equal the Event body ID');
+assert.match(webhookRoute, /hashIncreaseWebhookPayload\(rawBody\)/, 'durable Event ledger should store a payload hash rather than raw provider payload');
+assert.match(webhookRoute, /reconcileIncreaseSandbox/, 'verified webhooks must trigger automatic reconciliation');
+assert.match(webhookRoute, /canMoveRealMoney: false/, 'webhook flow must preserve sandbox no-real-money boundary');
+assert.doesNotMatch(webhookRoute, /INCREASE_SANDBOX_API_KEY/, 'public webhook route must not directly read or expose the provider key');
+
+assert.match(subscription, /\/event_subscriptions/, 'sandbox integration must create an Increase Event Subscription');
+assert.match(subscription, /shared_secret: secret/, 'Event Subscription must use the server-derived signing secret');
+assert.match(subscription, /idempotencyKey/, 'Event Subscription creation must be idempotent');
+assert.match(subscription, /status: 'active'/, 'Event Subscription must be explicitly active');
+assert.match(subscription, /https:/, 'webhook callback must require HTTPS');
+assert.doesNotMatch(subscription, /api\.increase\.com/, 'webhook subscription helper must not contain the production Increase origin');
+
+assert.match(reconciliation, /galactic_increase_webhook_events/, 'Event metadata must persist durably');
+assert.match(reconciliation, /galactic_increase_reconciliation_state/, 'reconciliation cursor/state must persist durably');
+assert.match(reconciliation, /order_by\.field.*created_at/s, 'Events backstop must poll chronologically');
+assert.match(reconciliation, /order_by\.direction.*ascending/s, 'Events backstop must poll oldest-first');
+assert.match(reconciliation, /event_cursor/, 'Events backstop must persist Increase cursor');
+assert.match(reconciliation, /getIncreaseSandboxDashboard/, 'reconciliation must refresh authoritative provider sandbox balances/transactions');
+assert.match(reconciliation, /maxPages.*Math\.min\(5/, 'backstop polling must be bounded per request');
+assert.doesNotMatch(reconciliation, /raw_body|raw_payload|payload_json/i, 'reconciliation store must not persist raw webhook payloads');
+
+assert.match(migration, /event_id text primary key/, 'provider Event ID must enforce idempotency at the database layer');
+assert.match(migration, /enable row level security/g, 'webhook/reconciliation tables must have RLS enabled');
+assert.match(migration, /revoke all on table public\.galactic_increase_webhook_events from anon, authenticated/, 'Event ledger must be service-role-only');
+assert.match(migration, /revoke all on table public\.galactic_increase_reconciliation_state from anon, authenticated/, 'reconciliation state must be service-role-only');
+assert.match(migration, /payload_sha256/, 'Event ledger must retain only a payload fingerprint for auditability');
+
+assert.match(reconciliationRoute, /requireVoxelVaultAdmin/, 'reconciliation controls must be owner-authenticated');
+assert.match(reconciliationRoute, /private, no-store, max-age=0/, 'owner reconciliation status must never be publicly cached');
+assert.match(reconciliationRoute, /pollIncreaseSandboxEvents/, 'owner route must expose the missed-Event backstop');
+assert.doesNotMatch(reconciliationRoute, /process\.env\.INCREASE_SANDBOX_API_KEY/, 'owner route must not directly read or return the sandbox key');
+
+assert.match(dashboardRoute, /ensureIncreaseSandboxWebhookSubscription/, 'authorized dashboard load must ensure the webhook subscription exists');
+assert.match(dashboardRoute, /pollIncreaseSandboxEvents/, 'authorized dashboard load must backstop missed Events');
+assert.match(sandbox, /https:\/\/sandbox\.increase\.com/, 'all provider calls remain pinned to Increase sandbox');
+assert.doesNotMatch(sandbox, /https:\/\/api\.increase\.com/, 'production Increase origin must remain absent');
+
+console.log('Galactic Trust Increase webhook checks passed: signed Standard Webhooks verification, idempotent Event persistence, owner-only backstop polling, durable reconciliation and sandbox-only provider routing are enforced.');

--- a/supabase/migrations/024_galactic_increase_webhooks_reconciliation.sql
+++ b/supabase/migrations/024_galactic_increase_webhooks_reconciliation.sql
@@ -1,0 +1,60 @@
+create table if not exists public.galactic_increase_webhook_events (
+  event_id text primary key,
+  category text not null,
+  associated_object_type text,
+  associated_object_id text,
+  source text not null check (source in ('webhook', 'poll')),
+  webhook_message_id text,
+  payload_sha256 text,
+  provider_created_at timestamptz,
+  received_at timestamptz not null default now(),
+  processed_at timestamptz,
+  processing_status text not null default 'received' check (processing_status in ('received', 'processed', 'failed')),
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (char_length(event_id) between 1 and 200),
+  check (char_length(category) between 1 and 160),
+  check (payload_sha256 is null or char_length(payload_sha256) = 64)
+);
+
+create table if not exists public.galactic_increase_reconciliation_state (
+  environment text primary key check (environment = 'sandbox'),
+  event_cursor text,
+  last_event_id text,
+  last_event_category text,
+  last_webhook_at timestamptz,
+  last_poll_at timestamptz,
+  last_reconciled_at timestamptz,
+  last_reconciliation_status text check (last_reconciliation_status is null or last_reconciliation_status in ('ok', 'failed')),
+  last_reconciliation_trigger text check (last_reconciliation_trigger is null or last_reconciliation_trigger in ('webhook', 'poll', 'owner', 'dashboard')),
+  account_count integer not null default 0 check (account_count >= 0),
+  transaction_count integer not null default 0 check (transaction_count >= 0),
+  current_balance_cents bigint not null default 0,
+  available_balance_cents bigint not null default 0,
+  last_transaction_id text,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.galactic_increase_webhook_events enable row level security;
+alter table public.galactic_increase_reconciliation_state enable row level security;
+
+revoke all on table public.galactic_increase_webhook_events from anon, authenticated;
+revoke all on table public.galactic_increase_reconciliation_state from anon, authenticated;
+
+create index if not exists galactic_increase_webhook_events_received_idx
+on public.galactic_increase_webhook_events(received_at desc);
+
+create index if not exists galactic_increase_webhook_events_status_idx
+on public.galactic_increase_webhook_events(processing_status, received_at desc);
+
+create index if not exists galactic_increase_webhook_events_category_idx
+on public.galactic_increase_webhook_events(category, provider_created_at desc);
+
+comment on table public.galactic_increase_webhook_events is
+  'Service-role-only Increase sandbox Event ledger. Stores event metadata and a payload hash, never API credentials or the raw webhook body.';
+
+comment on table public.galactic_increase_reconciliation_state is
+  'Service-role-only Increase sandbox reconciliation checkpoint and aggregate provider snapshot. No production-money authority.';


### PR DESCRIPTION
## What this adds

- automatically ensures an Increase **sandbox** Event Subscription exists when the authorized Galactic Trust owner dashboard loads
- verifies Standard Webhooks signatures from the raw body using `webhook-id`, `webhook-timestamp`, `webhook-signature`, HMAC-SHA256, constant-time comparison, and a 5-minute replay window
- derives a sandbox-only webhook signing secret server-side from the existing Increase sandbox API key so no additional browser secret is introduced
- persists provider Event IDs/categories/status plus a payload hash in service-role-only Supabase tables; raw webhook bodies and provider credentials are not stored
- reconciles provider sandbox account/balance/transaction aggregates after every verified webhook
- persists the Increase Events cursor and adds an oldest-first polling backstop for missed deliveries
- automatically runs a bounded polling backstop on owner dashboard load
- adds owner-only GET/POST reconciliation controls
- adds migration 024 plus targeted webhook/reconciliation regression tests in the Quality Gate

## Safety boundary

This remains pinned to `https://sandbox.increase.com` and pretend money only. No production Increase origin, live customer money, FDIC claim, production bank account, or crypto capability is enabled. Production webhook handling would require a separate reviewed adapter, operational queueing, independent secret rotation, provider approval, and all existing regulated-launch gates.