### PR TITLE
Galactic Trust: isolate banking providers and harden fail-closed path

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -63,6 +63,8 @@ jobs:
         run: node scripts/test-financial-os-coherence.mjs
       - name: Galactic Trust regulated launch
         run: node scripts/test-galactic-trust-regulated-launch.mjs
+      - name: Galactic Trust provider boundary
+        run: node scripts/test-galactic-trust-provider-boundary.mjs
       - name: Galactic Trust Increase webhooks
         run: node scripts/test-galactic-trust-increase-webhooks.mjs
       - name: Hyperreal voxel building

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -10,10 +10,8 @@ function userLabel(user) {
 }
 
 function returnUrl() {
-  if (typeof window === 'undefined') return '/';
-  const url = new URL('/', window.location.origin);
-  url.searchParams.set('auth', 'galactic');
-  return url.toString();
+  if (typeof window === 'undefined') return '/bank';
+  return new URL('/bank', window.location.origin).toString();
 }
 
 export default function GalacticBankGate() {

--- a/lib/banking/providers/demo-null.js
+++ b/lib/banking/providers/demo-null.js
@@ -1,0 +1,44 @@
+function locked(action) {
+  throw new Error(`${action} is unavailable because Galactic Trust is not connected to an approved banking provider.`);
+}
+
+export function createDemoNullProvider() {
+  return Object.freeze({
+    id: 'galactic-demo',
+    provider: 'Galactic Trust Demo',
+    environment: 'demo',
+    connected: false,
+    canMoveRealMoney: false,
+    productionSupported: false,
+
+    async inspect() {
+      return {
+        provider: 'Galactic Trust Demo',
+        environment: 'demo',
+        connected: false,
+        canMoveRealMoney: false,
+        productionSupported: false,
+      };
+    },
+
+    async getDashboard() {
+      return {
+        provider: 'Galactic Trust Demo',
+        environment: 'demo',
+        connected: false,
+        canMoveRealMoney: false,
+        accounts: [],
+        transactions: [],
+        setupRequired: false,
+      };
+    },
+
+    async simulateDeposit() {
+      return locked('Provider funding');
+    },
+
+    async initiateTransfer() {
+      return locked('Provider transfers');
+    },
+  });
+}

--- a/lib/banking/providers/increase/production.js
+++ b/lib/banking/providers/increase/production.js
@@ -1,0 +1,97 @@
+import {
+  bankingLaunchSnapshot,
+  LIVE_BANKING_IMPLEMENTATION_READY,
+} from '../../regulated-launch.js';
+
+// Production has its own adapter and origin. Never import or reuse the sandbox
+// request helper here. This module intentionally contains no live request code
+// until sponsor-bank/provider production acceptance is complete.
+export const INCREASE_PRODUCTION_BASE_URL = 'https://api.increase.com';
+
+function productionConfig(env = process.env) {
+  const snapshot = bankingLaunchSnapshot(env);
+  const apiKey = String(env.INCREASE_PRODUCTION_API_KEY || '').trim();
+  const configuredPlatform = String(env.GALACTIC_BANKING_PLATFORM || '').trim().toLowerCase();
+
+  return {
+    provider: 'Increase',
+    environment: 'production',
+    baseUrl: INCREASE_PRODUCTION_BASE_URL,
+    platformSelected: configuredPlatform === 'increase',
+    credentialsConfigured: Boolean(apiKey),
+    implementationReady: LIVE_BANKING_IMPLEMENTATION_READY,
+    launchApproved: snapshot.liveBankingEnabled,
+    apiKey,
+  };
+}
+
+function assertProductionUnlocked(env = process.env) {
+  const config = productionConfig(env);
+
+  if (!config.implementationReady) {
+    throw new Error('Production banking is locked. LIVE_BANKING_IMPLEMENTATION_READY is false.');
+  }
+  if (!config.launchApproved) {
+    throw new Error('Production banking is locked. Required launch evidence or the live switch is incomplete.');
+  }
+  if (!config.platformSelected) {
+    throw new Error('Production banking is locked. Increase is not the selected approved banking platform.');
+  }
+  if (!config.credentialsConfigured) {
+    throw new Error('Production banking is locked. Dedicated Increase production credentials are not configured.');
+  }
+
+  return config;
+}
+
+function notImplemented(action, env) {
+  assertProductionUnlocked(env);
+  throw new Error(`${action} is not implemented in the Galactic Trust production adapter. Production remains fail-closed.`);
+}
+
+export function inspectIncreaseProduction(env = process.env) {
+  const config = productionConfig(env);
+  return {
+    provider: config.provider,
+    environment: config.environment,
+    baseUrl: config.baseUrl,
+    platformSelected: config.platformSelected,
+    credentialsConfigured: config.credentialsConfigured,
+    implementationReady: config.implementationReady,
+    launchApproved: config.launchApproved,
+    connected: false,
+    canMoveRealMoney: false,
+    productionSupported: false,
+  };
+}
+
+export function createIncreaseProductionProvider(env = process.env) {
+  return Object.freeze({
+    id: 'increase-production-locked',
+    provider: 'Increase',
+    environment: 'production',
+    connected: false,
+    canMoveRealMoney: false,
+    productionSupported: false,
+
+    async inspect() {
+      return inspectIncreaseProduction(env);
+    },
+
+    async getDashboard() {
+      return notImplemented('Production dashboard access', env);
+    },
+
+    async createApplicant() {
+      return notImplemented('Production applicant onboarding', env);
+    },
+
+    async createAccount() {
+      return notImplemented('Production account creation', env);
+    },
+
+    async initiateTransfer() {
+      return notImplemented('Production money movement', env);
+    },
+  });
+}

--- a/lib/banking/providers/increase/sandbox.js
+++ b/lib/banking/providers/increase/sandbox.js
@@ -1,0 +1,36 @@
+import {
+  getIncreaseSandboxConfig,
+  getIncreaseSandboxDashboard,
+  inspectIncreaseSandbox,
+  simulateIncreaseSandboxDeposit,
+  simulateIncreaseSandboxSend,
+} from '../../increase-sandbox.js';
+
+export function createIncreaseSandboxProvider(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+
+  return Object.freeze({
+    id: 'increase-sandbox',
+    provider: config.provider,
+    environment: 'sandbox',
+    connected: Boolean(config.enabled && config.credentialsConfigured),
+    canMoveRealMoney: false,
+    productionSupported: false,
+
+    inspect() {
+      return inspectIncreaseSandbox(env);
+    },
+
+    getDashboard() {
+      return getIncreaseSandboxDashboard(env);
+    },
+
+    simulateDeposit({ amountCents }) {
+      return simulateIncreaseSandboxDeposit(amountCents, env);
+    },
+
+    initiateTransfer({ amountCents, recipient }) {
+      return simulateIncreaseSandboxSend(amountCents, recipient, env);
+    },
+  });
+}

--- a/lib/banking/providers/index.js
+++ b/lib/banking/providers/index.js
@@ -1,0 +1,24 @@
+import { getIncreaseSandboxConfig } from '../increase-sandbox.js';
+import { bankingLaunchSnapshot } from '../regulated-launch.js';
+import { createDemoNullProvider } from './demo-null.js';
+import { createIncreaseSandboxProvider } from './increase/sandbox.js';
+import { createIncreaseProductionProvider } from './increase/production.js';
+
+export function resolveBankingProvider(env = process.env) {
+  const launch = bankingLaunchSnapshot(env);
+  const platform = String(env.GALACTIC_BANKING_PLATFORM || '').trim().toLowerCase();
+
+  // A live provider is selected only after the regulated launch snapshot says
+  // live banking is actually enabled. The production adapter remains a locked
+  // stub until its real implementation is reviewed and accepted.
+  if (launch.liveBankingEnabled && platform === 'increase') {
+    return createIncreaseProductionProvider(env);
+  }
+
+  const sandbox = getIncreaseSandboxConfig(env);
+  if (sandbox.enabled && sandbox.credentialsConfigured) {
+    return createIncreaseSandboxProvider(env);
+  }
+
+  return createDemoNullProvider();
+}

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import {
+  bankingEvidenceRequirements,
+  LIVE_BANKING_IMPLEMENTATION_READY,
+} from '../lib/banking/regulated-launch.js';
+import { INCREASE_SANDBOX_BASE_URL } from '../lib/banking/increase-sandbox.js';
+import { resolveBankingProvider } from '../lib/banking/providers/index.js';
+import {
+  INCREASE_PRODUCTION_BASE_URL,
+  inspectIncreaseProduction,
+} from '../lib/banking/providers/increase/production.js';
+
+const read = (path) => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+assert.equal(LIVE_BANKING_IMPLEMENTATION_READY, false, 'production banking must remain hard-locked');
+assert.notEqual(INCREASE_SANDBOX_BASE_URL, INCREASE_PRODUCTION_BASE_URL, 'sandbox and production Increase origins must be separate');
+assert.equal(new URL(INCREASE_SANDBOX_BASE_URL).hostname, 'sandbox.increase.com', 'sandbox must stay pinned to sandbox.increase.com');
+assert.equal(new URL(INCREASE_PRODUCTION_BASE_URL).hostname, 'api.increase.com', 'production origin belongs only to the locked production adapter');
+
+const demo = resolveBankingProvider({});
+assert.equal(demo.environment, 'demo', 'missing provider configuration must resolve to demo');
+assert.equal(demo.canMoveRealMoney, false, 'demo provider must never move real money');
+
+const sandbox = resolveBankingProvider({
+  GALACTIC_INCREASE_SANDBOX_ENABLED: 'true',
+  INCREASE_SANDBOX_API_KEY: 'test-only-placeholder',
+});
+assert.equal(sandbox.environment, 'sandbox', 'configured sandbox must resolve to the Increase sandbox provider');
+assert.equal(sandbox.canMoveRealMoney, false, 'Increase sandbox provider must never move real money');
+assert.equal(sandbox.productionSupported, false, 'sandbox provider must never advertise production support');
+
+const allEvidence = Object.fromEntries(
+  bankingEvidenceRequirements.map((requirement) => [requirement.assertionEnvKey, 'true'])
+);
+const attemptedProduction = resolveBankingProvider({
+  ...allEvidence,
+  GALACTIC_LIVE_BANKING_ENABLED: 'true',
+  GALACTIC_BANKING_PLATFORM: 'increase',
+  INCREASE_PRODUCTION_API_KEY: 'production-placeholder',
+});
+assert.equal(attemptedProduction.environment, 'demo', 'environment assertions must not bypass the implementation lock');
+assert.equal(attemptedProduction.canMoveRealMoney, false, 'attempted production enablement must fail closed');
+
+const productionStatus = inspectIncreaseProduction({
+  ...allEvidence,
+  GALACTIC_LIVE_BANKING_ENABLED: 'true',
+  GALACTIC_BANKING_PLATFORM: 'increase',
+  INCREASE_PRODUCTION_API_KEY: 'production-placeholder',
+});
+assert.equal(productionStatus.implementationReady, false, 'production adapter inspection must expose the hard implementation lock');
+assert.equal(productionStatus.launchApproved, false, 'launch approval cannot become true while implementation is locked');
+assert.equal(productionStatus.connected, false, 'production stub must not claim connectivity');
+assert.equal(productionStatus.canMoveRealMoney, false, 'production stub must not claim money movement capability');
+
+const sandboxSource = read('lib/banking/providers/increase/sandbox.js');
+const productionSource = read('lib/banking/providers/increase/production.js');
+const resolverSource = read('lib/banking/providers/index.js');
+const gateSource = read('app/bank/GalacticBankGate.js');
+
+assert.doesNotMatch(productionSource, /increase-sandbox/i, 'production adapter must not import or reuse sandbox request code');
+assert.doesNotMatch(productionSource, /INCREASE_SANDBOX_API_KEY/, 'production adapter must not accept sandbox credentials');
+assert.match(productionSource, /INCREASE_PRODUCTION_API_KEY/, 'production adapter must require a dedicated production credential');
+assert.match(productionSource, /Production remains fail-closed/, 'production stub must fail explicitly until implementation exists');
+assert.match(sandboxSource, /\.\.\/\.\.\/increase-sandbox\.js/, 'sandbox provider wrapper must delegate only to the pinned sandbox adapter');
+assert.match(resolverSource, /launch\.liveBankingEnabled && platform === 'increase'/, 'resolver must require the regulated launch snapshot before production selection');
+assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Google and OTP auth must return directly to the Galactic Trust dashboard');
+
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated and auth returns to /bank.');


### PR DESCRIPTION
## What this changes

- keeps the rest of Voxel Vault intact; no unrelated files are removed or moved
- returns Google/OTP sign-in directly to `/bank`
- adds an explicit banking provider boundary:
  - demo/null provider
  - Increase sandbox wrapper (still pinned to sandbox and pretend money only)
  - separate Increase production adapter skeleton that is intentionally nonfunctional and fail-closed
  - resolver that cannot select production unless the regulated launch snapshot is truly live
- adds a dedicated CI test proving demo/sandbox/production separation
- adds that test to the existing Quality Gate

## Safety properties preserved

- `LIVE_BANKING_IMPLEMENTATION_READY` remains `false`
- sandbox still cannot move real money
- production does not import or reuse the sandbox request helper
- production requires a dedicated `INCREASE_PRODUCTION_API_KEY` if it is ever implemented later
- env assertions still cannot bypass the hard implementation lock
- no FDIC/bank/deposit claims are enabled

## Why this direction

Galactic Trust is already a bounded `/app/bank` product surface, but provider concerns were not yet formalized behind an environment-specific interface. This PR isolates that foundation without deleting or destabilizing the broader repo. A later PR can split the large `BankClient.js` UI and deepen sandbox onboarding after this boundary is green.