### PR TITLE
Galactic Trust: add Increase sandbox hosted onboarding

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -67,6 +67,8 @@ jobs:
         run: node scripts/test-galactic-trust-provider-boundary.mjs
       - name: Galactic Trust truthful UI states
         run: node scripts/test-galactic-trust-ui-truth.mjs
+      - name: Galactic Trust Increase onboarding
+        run: node scripts/test-galactic-trust-increase-onboarding.mjs
       - name: Galactic Trust Increase webhooks
         run: node scripts/test-galactic-trust-increase-webhooks.mjs
       - name: Hyperreal voxel building

--- a/app/api/admin/bank/increase/onboarding/route.ts
+++ b/app/api/admin/bank/increase/onboarding/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server';
+import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
+import {
+  bootstrapIncreaseSandboxAccount,
+  completeIncreaseSandboxSetup,
+  createIncreaseSandboxOnboardingSession,
+  getIncreaseSandboxEntityReadiness,
+  inspectIncreaseSandboxOnboarding,
+  simulateIncreaseSandboxEntityValid,
+  submitIncreaseSandboxOnboardingSession,
+} from '../../../../../../lib/banking/increase-onboarding-sandbox.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}
+
+function providerError(error: any) {
+  return response({
+    ok: false,
+    authorized: true,
+    provider: 'Increase',
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    providerStatus: Number.isFinite(error?.status) ? error.status : null,
+    error: error instanceof Error ? error.message : 'Increase sandbox onboarding action failed.',
+  }, Number.isFinite(error?.status) ? 502 : 400);
+}
+
+export async function GET(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if (auth.ok === false) {
+    return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
+  }
+
+  try {
+    const url = new URL(request.url);
+    const entityId = String(url.searchParams.get('entity_id') || '').trim();
+    const onboarding = await inspectIncreaseSandboxOnboarding(process.env);
+    const entity = entityId ? await getIncreaseSandboxEntityReadiness(entityId, process.env) : null;
+    return response({
+      ok: true,
+      authorized: true,
+      ...onboarding,
+      entity,
+      note: 'Owner-only Increase sandbox onboarding status. No customer identity fields or account-number details are returned.',
+    });
+  } catch (error: any) {
+    return providerError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  const auth = await requireVoxelVaultAdmin(request);
+  if (auth.ok === false) {
+    return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const action = String(body?.action || '').trim().toLowerCase();
+
+  try {
+    if (action === 'create_session') {
+      const redirectUrl = new URL('/bank', request.url);
+      redirectUrl.searchParams.set('increase_onboarding', 'complete');
+      const result = await createIncreaseSandboxOnboardingSession({
+        programId: String(body?.programId || ''),
+        entityId: String(body?.entityId || ''),
+        redirectUrl: redirectUrl.toString(),
+      }, process.env);
+      return response({ ok: true, authorized: true, action, ...result });
+    }
+
+    if (action === 'simulate_submit') {
+      const result = await submitIncreaseSandboxOnboardingSession(String(body?.sessionId || ''), process.env);
+      return response({
+        ok: true,
+        authorized: true,
+        action,
+        ...result,
+        note: 'Sandbox-only simulated form submission. This creates test data and is not customer KYC approval.',
+      });
+    }
+
+    if (action === 'simulate_valid') {
+      const entity = await simulateIncreaseSandboxEntityValid(String(body?.entityId || ''), process.env);
+      return response({
+        ok: true,
+        authorized: true,
+        action,
+        entity,
+        canMoveRealMoney: false,
+        note: 'Sandbox-only validation simulation. This is not a real KYC/CIP/AML decision.',
+      });
+    }
+
+    if (action === 'bootstrap') {
+      const result = await bootstrapIncreaseSandboxAccount({
+        entityId: String(body?.entityId || ''),
+        programId: String(body?.programId || ''),
+        accountName: String(body?.accountName || ''),
+      }, process.env);
+      return response({ ok: true, authorized: true, action, ...result });
+    }
+
+    if (action === 'complete_setup') {
+      const result = await completeIncreaseSandboxSetup({
+        entityId: String(body?.entityId || ''),
+        programId: String(body?.programId || ''),
+        accountName: String(body?.accountName || ''),
+      }, process.env);
+      return response({
+        ok: true,
+        authorized: true,
+        action,
+        ...result,
+        note: 'Sandbox-only setup: validation was simulated before creating/reusing a test Account and Account Number. No real money can move.',
+      });
+    }
+
+    return response({
+      ok: false,
+      authorized: true,
+      canMoveRealMoney: false,
+      error: 'Unsupported Increase sandbox onboarding action.',
+    }, 400);
+  } catch (error: any) {
+    return providerError(error);
+  }
+}

--- a/app/api/admin/bank/increase/onboarding/route.ts
+++ b/app/api/admin/bank/increase/onboarding/route.ts
@@ -66,10 +66,12 @@ export async function POST(request: Request) {
 
   try {
     if (action === 'create_session') {
+      const requestedProgramId = String(body?.programId || '').trim();
       const redirectUrl = new URL('/bank', request.url);
       redirectUrl.searchParams.set('increase_onboarding', 'complete');
+      if (requestedProgramId) redirectUrl.searchParams.set('increase_program_id', requestedProgramId);
       const result = await createIncreaseSandboxOnboardingSession({
-        programId: String(body?.programId || ''),
+        programId: requestedProgramId,
         entityId: String(body?.entityId || ''),
         redirectUrl: redirectUrl.toString(),
       }, process.env);

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -164,7 +164,7 @@ export default function GalacticBankGate() {
 
   return (
     <>
-      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={accessToken} />
+      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={session?.access_token || ''} />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
       {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}
     </>

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
 import BankClient from './BankClient';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
+import GalacticSandboxSetup from './GalacticSandboxSetup';
 
 function userLabel(user) {
   return String(user?.user_metadata?.full_name || user?.user_metadata?.name || user?.email || 'Galactic member');
@@ -159,11 +160,13 @@ export default function GalacticBankGate() {
 
   const activeSignOut = session?.user ? signOut : () => setDemoAccess(false);
   const label = session?.user ? userLabel(session.user) : 'Demo Explorer';
+  const accessToken = session?.access_token || '';
 
   return (
     <>
-      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={session?.access_token || ''} />
+      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={accessToken} />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
+      {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}
     </>
   );
 }

--- a/app/bank/GalacticSandboxSetup.js
+++ b/app/bank/GalacticSandboxSetup.js
@@ -35,6 +35,14 @@ function authHeaders(accessToken, json = false) {
   return headers;
 }
 
+function safeHostedSessionUrl(value) {
+  const url = new URL(String(value || ''));
+  if (url.protocol !== 'https:' || !(url.hostname === 'increase.com' || url.hostname.endsWith('.increase.com'))) {
+    throw new Error('Increase did not return a safe hosted onboarding URL.');
+  }
+  return url.toString();
+}
+
 export default function GalacticSandboxSetup({ accessToken = '' }) {
   const [authorized, setAuthorized] = useState(null);
   const [status, setStatus] = useState(null);
@@ -55,7 +63,9 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
 
     const query = new URLSearchParams(window.location.search);
     const returnedEntity = String(query.get('entity_id') || '').trim();
+    const returnedProgram = String(query.get('increase_program_id') || '').trim();
     if (/^(sandbox_)?entity_[a-zA-Z0-9_-]+$/.test(returnedEntity)) setEntityId(returnedEntity);
+    if (/^(sandbox_)?program_[a-zA-Z0-9_-]+$/.test(returnedProgram)) setProgramId(returnedProgram);
 
     Promise.all([
       fetch('/api/admin/bank/increase/status', {
@@ -116,9 +126,7 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
     setMessage('');
     try {
       const payload = await post('create_session');
-      const sessionUrl = String(payload?.session?.sessionUrl || '');
-      if (!/^https:\/\/[a-z0-9.-]*increase\.com\//i.test(sessionUrl)) throw new Error('Increase did not return a safe hosted onboarding URL.');
-      window.location.assign(sessionUrl);
+      window.location.assign(safeHostedSessionUrl(payload?.session?.sessionUrl));
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'Could not start Increase sandbox onboarding.');
       setBusy(false);

--- a/app/bank/GalacticSandboxSetup.js
+++ b/app/bank/GalacticSandboxSetup.js
@@ -1,0 +1,208 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+const panelStyle = {
+  position: 'fixed',
+  left: '18px',
+  bottom: '18px',
+  zIndex: 80,
+  width: 'min(390px, calc(100vw - 36px))',
+  padding: '16px',
+  borderRadius: '18px',
+  border: '1px solid rgba(113, 86, 255, 0.22)',
+  background: 'rgba(255, 255, 255, 0.97)',
+  boxShadow: '0 18px 50px rgba(44, 34, 96, 0.18)',
+  color: '#26213d',
+  fontFamily: 'inherit',
+};
+
+const buttonStyle = {
+  width: '100%',
+  marginTop: '10px',
+  padding: '11px 14px',
+  border: 0,
+  borderRadius: '12px',
+  background: '#6f55f5',
+  color: '#fff',
+  fontWeight: 800,
+  cursor: 'pointer',
+};
+
+function authHeaders(accessToken, json = false) {
+  const headers = { Authorization: `Bearer ${accessToken}` };
+  if (json) headers['Content-Type'] = 'application/json';
+  return headers;
+}
+
+export default function GalacticSandboxSetup({ accessToken = '' }) {
+  const [authorized, setAuthorized] = useState(null);
+  const [status, setStatus] = useState(null);
+  const [programs, setPrograms] = useState([]);
+  const [programId, setProgramId] = useState('');
+  const [entityId, setEntityId] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const accountCount = Number(status?.counts?.accounts || 0);
+  const connected = Boolean(status?.connected);
+  const needsAccount = connected && accountCount === 0;
+  const returnedFromOnboarding = Boolean(entityId);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    let active = true;
+
+    const query = new URLSearchParams(window.location.search);
+    const returnedEntity = String(query.get('entity_id') || '').trim();
+    if (/^(sandbox_)?entity_[a-zA-Z0-9_-]+$/.test(returnedEntity)) setEntityId(returnedEntity);
+
+    Promise.all([
+      fetch('/api/admin/bank/increase/status', {
+        cache: 'no-store',
+        headers: authHeaders(accessToken),
+      }),
+      fetch('/api/admin/bank/increase/onboarding', {
+        cache: 'no-store',
+        headers: authHeaders(accessToken),
+      }),
+    ]).then(async ([statusResponse, onboardingResponse]) => {
+      if (!active) return;
+      if (statusResponse.status === 403 || onboardingResponse.status === 403) {
+        setAuthorized(false);
+        return;
+      }
+      const [statusPayload, onboardingPayload] = await Promise.all([
+        statusResponse.json().catch(() => ({})),
+        onboardingResponse.json().catch(() => ({})),
+      ]);
+      if (!active) return;
+      setAuthorized(Boolean(statusPayload?.authorized && onboardingPayload?.authorized));
+      setStatus(statusPayload);
+      const nextPrograms = Array.isArray(onboardingPayload?.programs) ? onboardingPayload.programs : [];
+      setPrograms(nextPrograms);
+      if (nextPrograms.length === 1) setProgramId(nextPrograms[0].id);
+    }).catch(() => {
+      if (active) setAuthorized(false);
+    });
+
+    return () => { active = false; };
+  }, [accessToken]);
+
+  const heading = useMemo(() => {
+    if (returnedFromOnboarding) return 'Finish Increase sandbox setup';
+    if (!connected) return 'Increase sandbox setup';
+    return 'Create your sandbox account';
+  }, [connected, returnedFromOnboarding]);
+
+  async function post(action, extra = {}) {
+    const response = await fetch('/api/admin/bank/increase/onboarding', {
+      method: 'POST',
+      cache: 'no-store',
+      headers: authHeaders(accessToken, true),
+      body: JSON.stringify({ action, programId, ...extra }),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(payload?.error || 'Increase sandbox setup failed.');
+    return payload;
+  }
+
+  async function startOnboarding() {
+    if (programs.length > 1 && !programId) {
+      setMessage('Choose the Increase sandbox Program for this test Entity.');
+      return;
+    }
+    setBusy(true);
+    setMessage('');
+    try {
+      const payload = await post('create_session');
+      const sessionUrl = String(payload?.session?.sessionUrl || '');
+      if (!/^https:\/\/[a-z0-9.-]*increase\.com\//i.test(sessionUrl)) throw new Error('Increase did not return a safe hosted onboarding URL.');
+      window.location.assign(sessionUrl);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not start Increase sandbox onboarding.');
+      setBusy(false);
+    }
+  }
+
+  async function completeSetup() {
+    if (!entityId) return;
+    setBusy(true);
+    setMessage('');
+    try {
+      await post('complete_setup', { entityId });
+      const cleanUrl = new URL('/bank', window.location.origin);
+      window.location.replace(cleanUrl.toString());
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not complete Increase sandbox setup.');
+      setBusy(false);
+    }
+  }
+
+  if (!accessToken || authorized !== true) return null;
+  if (!returnedFromOnboarding && connected && accountCount > 0) return null;
+
+  return (
+    <aside style={panelStyle} aria-label="Owner Increase sandbox setup">
+      <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+        <span aria-hidden="true" style={{ fontSize: '24px' }}>🪐</span>
+        <div>
+          <strong style={{ display: 'block', fontSize: '15px' }}>{heading}</strong>
+          <small style={{ display: 'block', marginTop: '2px', color: '#6a6482' }}>Owner-only · pretend money · production remains locked</small>
+        </div>
+      </div>
+
+      {!connected && (
+        <p style={{ margin: '12px 0 0', fontSize: '13px', lineHeight: 1.45, color: '#5f5875' }}>
+          Add the server-only Increase sandbox key and enable switch in Vercel, then redeploy. Never put the key in client code or chat.
+        </p>
+      )}
+
+      {needsAccount && !returnedFromOnboarding && (
+        <>
+          <p style={{ margin: '12px 0 0', fontSize: '13px', lineHeight: 1.45, color: '#5f5875' }}>
+            Identity details are entered on Increase&apos;s hosted sandbox form, not inside Galactic Trust.
+          </p>
+          {programs.length > 1 && (
+            <select
+              value={programId}
+              onChange={(event) => setProgramId(event.target.value)}
+              aria-label="Increase sandbox Program"
+              style={{ width: '100%', marginTop: '10px', padding: '10px', borderRadius: '10px', border: '1px solid #ded9f5', background: '#fff' }}
+            >
+              <option value="">Choose a sandbox Program</option>
+              {programs.map((program) => <option key={program.id} value={program.id}>{program.name}</option>)}
+            </select>
+          )}
+          <button type="button" onClick={startOnboarding} disabled={busy} style={{ ...buttonStyle, opacity: busy ? 0.65 : 1 }}>
+            {busy ? 'Opening Increase…' : 'Start hosted sandbox onboarding'}
+          </button>
+        </>
+      )}
+
+      {returnedFromOnboarding && (
+        <>
+          <p style={{ margin: '12px 0 0', fontSize: '13px', lineHeight: 1.45, color: '#5f5875' }}>
+            Increase returned a test Entity. Completing setup will simulate a successful sandbox validation, then create or reuse a sandbox Account and Account Number. This is not real KYC approval.
+          </p>
+          {programs.length > 1 && (
+            <select
+              value={programId}
+              onChange={(event) => setProgramId(event.target.value)}
+              aria-label="Increase sandbox Program"
+              style={{ width: '100%', marginTop: '10px', padding: '10px', borderRadius: '10px', border: '1px solid #ded9f5', background: '#fff' }}
+            >
+              <option value="">Choose a sandbox Program</option>
+              {programs.map((program) => <option key={program.id} value={program.id}>{program.name}</option>)}
+            </select>
+          )}
+          <button type="button" onClick={completeSetup} disabled={busy || (programs.length > 1 && !programId)} style={{ ...buttonStyle, opacity: busy ? 0.65 : 1 }}>
+            {busy ? 'Creating sandbox account…' : 'Complete sandbox setup'}
+          </button>
+        </>
+      )}
+
+      {message && <p role="status" style={{ margin: '10px 0 0', fontSize: '12px', lineHeight: 1.4, color: '#9d2d55' }}>{message}</p>}
+    </aside>
+  );
+}

--- a/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
+++ b/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
@@ -9,6 +9,7 @@ Official references:
 - https://increase.com/documentation/sandbox
 - https://increase.com/documentation/api
 - https://increase.com/documentation/entities
+- https://increase.com/documentation/hosted-onboarding
 - https://increase.com/terms
 
 ## What is wired in this repository
@@ -17,7 +18,13 @@ Official references:
 
 `GET /api/admin/bank/increase/status` is owner-only. It verifies the Voxel Vault admin session, then performs read-only sandbox requests for programs, accounts and entities. The response exposes counts and connectivity state only. It never returns the API key or provider records containing customer identity data.
 
-The owner Integrations Center also tracks whether the sandbox key and explicit enable switch are configured.
+`lib/banking/increase-onboarding-sandbox.js` adds the sandbox onboarding boundary. It can create an Increase-hosted Entity Onboarding Session, read only sanitized Entity validation state, simulate validation in sandbox, and create or reuse a sandbox Account plus Account Number after validation is explicitly `valid`. The setup response withholds raw account-number and routing-number details.
+
+`GET/POST /api/admin/bank/increase/onboarding` is owner-only and no-store. Supported actions are sandbox-specific: create a hosted session, simulate a sandbox session submission, simulate a valid Entity, bootstrap a validated Entity into an Account and Account Number, or explicitly complete the sandbox setup by simulating validation before bootstrap. Every response reports `canMoveRealMoney: false`.
+
+The `/bank` owner experience includes a temporary sandbox setup control. It first checks the owner-only status/onboarding APIs. Unauthorized signed-in users do not see the control. When no sandbox Account exists, the owner can launch Increase-hosted onboarding. After Increase redirects back with the test `entity_id`, the owner can explicitly complete sandbox setup. Identity form fields stay on Increase's hosted page rather than being collected by Galactic Trust.
+
+The existing dashboard reads provider-authoritative sandbox balances and transactions, ACH simulations use the sandbox Account Number, signed webhooks are processed idempotently, and reconciliation provides a polling backstop.
 
 ## Founder setup — the only external step required now
 
@@ -25,27 +32,25 @@ The owner Integrations Center also tracks whether the sandbox key and explicit e
 2. In Vercel, add the key as a server-only environment variable named `INCREASE_SANDBOX_API_KEY`.
 3. Set `GALACTIC_INCREASE_SANDBOX_ENABLED=true` for the environment you want to test.
 4. Redeploy.
-5. Sign in to the owner Integrations Center and call the owner-only Increase status endpoint to verify the connection.
+5. Sign in to `/bank`. The owner-only setup control will verify the sandbox connection and, when no sandbox Account exists, offer the hosted onboarding flow.
 
 Do **not** paste the sandbox key into ChatGPT, GitHub issues, commits, screenshots, client-side code or a `NEXT_PUBLIC_` variable.
 
+## Sandbox onboarding sequence now implemented
+
+1. Create an Increase-hosted Entity Onboarding Session for the selected sandbox Program.
+2. Redirect the owner to Increase's hosted form; Galactic Trust does not receive the identity form fields.
+3. Increase redirects back to `/bank` with the test Entity and session identifiers.
+4. The owner explicitly completes sandbox setup. Because sandbox validations do not run automatically, Galactic Trust calls Increase's sandbox validation simulation with no issues and clearly labels that action as simulated, not real KYC approval.
+5. Only after the provider reports the test Entity as active and `valid`, create or reuse a USD sandbox Account tied to the Entity and Program.
+6. Create or reuse an active Account Number, while withholding raw account/routing details from the setup response.
+7. Reload the sandbox dashboard from Increase-authoritative balances and transactions.
+8. Use existing inbound/outbound ACH simulations, webhook processing and reconciliation against the provider state.
+
 ## What remains before customer banking
 
-A successful sandbox connection is engineering evidence only. It does not make Galactic Trust a bank, open customer accounts, make deposits FDIC-insured through Galactic Trust, or authorize real money movement.
+A successful sandbox connection or simulated validation is engineering evidence only. It does not make Galactic Trust a bank, open production customer accounts, make deposits FDIC-insured through Galactic Trust, or authorize real money movement.
 
 Before any customer-facing account opening or live transfer flow, the selected provider/bank must approve the program, customer eligibility and onboarding, KYC/CIP/AML and sanctions controls, account terms and disclosures, Regulation E/error-resolution handling, ACH/payment use cases and limits, card program, ledger/reconciliation process, deposit-insurance wording, privacy/security, complaints/disputes, incident response and production launch.
 
-The hard locks in `lib/banking/regulated-launch.js` remain false until that production integration and evidence are reviewed in code.
-
-## Next implementation after the sandbox key is connected
-
-Once the read-only probe succeeds, build the sandbox customer journey in this order:
-
-1. Provider-hosted or tokenized onboarding session for a test Entity.
-2. Provider-confirmed Entity validation state.
-3. Sandbox Account creation tied to that Entity and Program.
-4. Provider-authoritative balance and transaction reads.
-5. Sandbox account-number and ACH simulations.
-6. Webhook signature verification and idempotent event processing.
-7. Reconciliation records that compare provider account/transaction state to the Galactic Trust application ledger.
-8. Only after formal production approval: a separate reviewed production adapter. Never convert the sandbox adapter into production by changing a URL or environment flag.
+The hard locks in `lib/banking/regulated-launch.js` remain false until that production integration and evidence are reviewed in code. The reviewed production adapter remains a separate implementation and must never be enabled by changing the sandbox URL, reusing the sandbox key, or flipping an environment flag alone.

--- a/lib/banking/increase-onboarding-sandbox.js
+++ b/lib/banking/increase-onboarding-sandbox.js
@@ -116,7 +116,7 @@ export async function inspectIncreaseSandboxOnboarding(env = process.env) {
   };
 }
 
-export async function createIncreaseSandboxOnboardingSession({ programId = '', redirectUrl, entityId = '' } = {}, env = process.env) {
+export async function createIncreaseSandboxOnboardingSession({ programId = '', redirectUrl = '', entityId = '' } = {}, env = process.env) {
   const program = await resolveProgram(programId, env);
   const body = {
     program_id: program.id,
@@ -210,7 +210,7 @@ async function findOrCreateAccountNumber(accountId, env = process.env) {
   return { accountNumber, created: true };
 }
 
-export async function bootstrapIncreaseSandboxAccount({ entityId, programId = '', accountName = '' } = {}, env = process.env) {
+export async function bootstrapIncreaseSandboxAccount({ entityId = '', programId = '', accountName = '' } = {}, env = process.env) {
   const readiness = await getIncreaseSandboxEntityReadiness(entityId, env);
   if (!readiness.readyForSandboxAccount) {
     throw new Error(`Increase sandbox Entity is not ready for account creation. Validation status: ${readiness.validationStatus}.`);
@@ -244,7 +244,7 @@ export async function bootstrapIncreaseSandboxAccount({ entityId, programId = ''
   };
 }
 
-export async function completeIncreaseSandboxSetup({ entityId, programId = '', accountName = '' } = {}, env = process.env) {
+export async function completeIncreaseSandboxSetup({ entityId = '', programId = '', accountName = '' } = {}, env = process.env) {
   const validation = await simulateIncreaseSandboxEntityValid(entityId, env);
   const bootstrap = await bootstrapIncreaseSandboxAccount({ entityId: validation.entityId, programId, accountName }, env);
   const dashboard = await getIncreaseSandboxDashboard(env);

--- a/lib/banking/increase-onboarding-sandbox.js
+++ b/lib/banking/increase-onboarding-sandbox.js
@@ -1,0 +1,252 @@
+import {
+  getIncreaseSandboxConfig,
+  getIncreaseSandboxDashboard,
+  increaseSandboxRequest,
+} from './increase-sandbox.js';
+
+function listData(payload) {
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+function providerId(value, prefix, label) {
+  const id = String(value || '').trim();
+  const allowedPrefix = prefix ? id.startsWith(prefix) || id.startsWith(`sandbox_${prefix}`) : true;
+  if (!id || id.length > 160 || !/^[a-zA-Z0-9_-]+$/.test(id) || !allowedPrefix) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return id;
+}
+
+function safeText(value, fallback, max = 100) {
+  const text = String(value || '').replace(/[^a-zA-Z0-9 .,'&()/_-]/g, '').trim().slice(0, max);
+  return text || fallback;
+}
+
+function safeRedirectUrl(value) {
+  const url = new URL(String(value || ''));
+  const localHttp = url.protocol === 'http:' && ['localhost', '127.0.0.1'].includes(url.hostname);
+  if (url.username || url.password || (url.protocol !== 'https:' && !localHttp)) {
+    throw new Error('Increase sandbox onboarding redirect URL must use HTTPS, except for localhost development.');
+  }
+  return url.toString();
+}
+
+function safeSessionUrl(value) {
+  const url = new URL(String(value || ''));
+  if (url.protocol !== 'https:' || !(url.hostname === 'increase.com' || url.hostname.endsWith('.increase.com'))) {
+    throw new Error('Increase returned an unexpected onboarding session URL.');
+  }
+  return url.toString();
+}
+
+function sanitizeProgram(program) {
+  return {
+    id: String(program?.id || ''),
+    name: safeText(program?.name, 'Increase sandbox program', 100),
+    bank: safeText(program?.bank, 'Increase sandbox', 60),
+  };
+}
+
+async function listPrograms(env = process.env) {
+  const payload = await increaseSandboxRequest('/programs?limit=100', {}, env);
+  return listData(payload).filter((program) => program?.id).map(sanitizeProgram);
+}
+
+async function resolveProgram(requestedProgramId = '', env = process.env) {
+  const programs = await listPrograms(env);
+  if (!programs.length) throw new Error('Increase sandbox has no Program available for onboarding.');
+
+  if (requestedProgramId) {
+    const programId = providerId(requestedProgramId, 'program_', 'Increase sandbox Program ID');
+    const selected = programs.find((program) => program.id === programId);
+    if (!selected) throw new Error('Requested Increase sandbox Program was not found.');
+    return selected;
+  }
+
+  if (programs.length > 1) {
+    throw new Error('Multiple Increase sandbox Programs are available. Select a Program explicitly before onboarding.');
+  }
+  return programs[0];
+}
+
+function sanitizeSession(session) {
+  return {
+    id: providerId(session?.id, 'entity_onboarding_session_', 'Increase sandbox onboarding session ID'),
+    status: String(session?.status || 'unknown'),
+    programId: String(session?.program_id || ''),
+    entityId: session?.entity_id ? providerId(session.entity_id, 'entity_', 'Increase sandbox Entity ID') : null,
+    sessionUrl: session?.session_url ? safeSessionUrl(session.session_url) : null,
+    expiresAt: session?.expires_at ? String(session.expires_at) : null,
+  };
+}
+
+function sanitizeEntityReadiness(entity) {
+  const issues = Array.isArray(entity?.validation?.issues) ? entity.validation.issues : [];
+  return {
+    entityId: providerId(entity?.id, 'entity_', 'Increase sandbox Entity ID'),
+    entityStatus: String(entity?.status || 'unknown'),
+    structure: String(entity?.structure || 'unknown'),
+    validationStatus: String(entity?.validation?.status || 'not_simulated'),
+    issueCategories: issues.map((issue) => safeText(issue?.category, 'unknown', 80)).slice(0, 20),
+    readyForSandboxAccount: entity?.status === 'active' && entity?.validation?.status === 'valid',
+    canMoveRealMoney: false,
+  };
+}
+
+export async function inspectIncreaseSandboxOnboarding(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured) {
+    return {
+      provider: config.provider,
+      environment: 'sandbox',
+      connected: false,
+      programs: [],
+      canMoveRealMoney: false,
+      setupRequired: true,
+    };
+  }
+  const programs = await listPrograms(env);
+  return {
+    provider: config.provider,
+    environment: 'sandbox',
+    connected: true,
+    programs,
+    canMoveRealMoney: false,
+    setupRequired: programs.length === 0,
+  };
+}
+
+export async function createIncreaseSandboxOnboardingSession({ programId = '', redirectUrl, entityId = '' } = {}, env = process.env) {
+  const program = await resolveProgram(programId, env);
+  const body = {
+    program_id: program.id,
+    redirect_url: safeRedirectUrl(redirectUrl),
+  };
+  if (entityId) body.entity_id = providerId(entityId, 'entity_', 'Increase sandbox Entity ID');
+
+  const session = await increaseSandboxRequest('/entity_onboarding_sessions', {
+    method: 'POST',
+    idempotencyKey: `galactic-sandbox-onboarding-${crypto.randomUUID()}`,
+    body,
+  }, env);
+
+  return {
+    provider: 'Increase',
+    environment: 'sandbox',
+    program,
+    session: sanitizeSession(session),
+    canMoveRealMoney: false,
+    note: 'Hosted Increase sandbox onboarding only. Galactic Trust does not collect the identity form data.',
+  };
+}
+
+export async function submitIncreaseSandboxOnboardingSession(sessionId, env = process.env) {
+  const id = providerId(sessionId, 'entity_onboarding_session_', 'Increase sandbox onboarding session ID');
+  const session = await increaseSandboxRequest(`/simulations/entity_onboarding_sessions/${encodeURIComponent(id)}/submit`, {
+    method: 'POST',
+  }, env);
+  return {
+    provider: 'Increase',
+    environment: 'sandbox',
+    session: sanitizeSession(session),
+    canMoveRealMoney: false,
+    simulated: true,
+  };
+}
+
+export async function getIncreaseSandboxEntityReadiness(entityId, env = process.env) {
+  const id = providerId(entityId, 'entity_', 'Increase sandbox Entity ID');
+  const entity = await increaseSandboxRequest(`/entities/${encodeURIComponent(id)}`, {}, env);
+  return sanitizeEntityReadiness(entity);
+}
+
+export async function simulateIncreaseSandboxEntityValid(entityId, env = process.env) {
+  const id = providerId(entityId, 'entity_', 'Increase sandbox Entity ID');
+  const entity = await increaseSandboxRequest(`/simulations/entities/${encodeURIComponent(id)}/update_validation`, {
+    method: 'POST',
+    idempotencyKey: `galactic-sandbox-validation-${crypto.randomUUID()}`,
+    body: { issues: [] },
+  }, env);
+  return {
+    ...sanitizeEntityReadiness(entity),
+    validationSimulation: true,
+  };
+}
+
+async function findOrCreateAccount(entityId, program, accountName, env = process.env) {
+  const accountPayload = await increaseSandboxRequest(`/accounts?entity_id=${encodeURIComponent(entityId)}&limit=100`, {}, env);
+  const existing = listData(accountPayload).find((account) => account?.status === 'open' && account?.currency === 'USD');
+  if (existing?.id) return { account: existing, created: false };
+
+  const account = await increaseSandboxRequest('/accounts', {
+    method: 'POST',
+    idempotencyKey: `galactic-sandbox-account-${crypto.randomUUID()}`,
+    body: {
+      entity_id: entityId,
+      name: safeText(accountName, 'Galactic Trust Sandbox Checking', 120),
+      program_id: program.id,
+    },
+  }, env);
+  return { account, created: true };
+}
+
+async function findOrCreateAccountNumber(accountId, env = process.env) {
+  const payload = await increaseSandboxRequest(`/account_numbers?account_id=${encodeURIComponent(accountId)}&limit=100`, {}, env);
+  const existing = listData(payload).find((item) => item?.status === 'active') || listData(payload)[0];
+  if (existing?.id) return { accountNumber: existing, created: false };
+
+  const accountNumber = await increaseSandboxRequest('/account_numbers', {
+    method: 'POST',
+    idempotencyKey: `galactic-sandbox-account-number-${crypto.randomUUID()}`,
+    body: {
+      account_id: accountId,
+      name: 'Galactic Trust Sandbox ACH',
+    },
+  }, env);
+  return { accountNumber, created: true };
+}
+
+export async function bootstrapIncreaseSandboxAccount({ entityId, programId = '', accountName = '' } = {}, env = process.env) {
+  const readiness = await getIncreaseSandboxEntityReadiness(entityId, env);
+  if (!readiness.readyForSandboxAccount) {
+    throw new Error(`Increase sandbox Entity is not ready for account creation. Validation status: ${readiness.validationStatus}.`);
+  }
+
+  const program = await resolveProgram(programId, env);
+  const { account, created: accountCreated } = await findOrCreateAccount(readiness.entityId, program, accountName, env);
+  const accountId = providerId(account?.id, 'account_', 'Increase sandbox Account ID');
+  const { accountNumber, created: accountNumberCreated } = await findOrCreateAccountNumber(accountId, env);
+  const accountNumberId = providerId(accountNumber?.id, 'account_number_', 'Increase sandbox Account Number ID');
+
+  return {
+    provider: 'Increase',
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    entity: readiness,
+    program,
+    account: {
+      id: accountId,
+      name: safeText(account?.name, 'Galactic Trust Sandbox Checking', 120),
+      status: String(account?.status || 'unknown'),
+      created: accountCreated,
+    },
+    accountNumber: {
+      id: accountNumberId,
+      status: String(accountNumber?.status || 'unknown'),
+      created: accountNumberCreated,
+      detailsWithheld: true,
+    },
+    note: 'Sandbox account number details are intentionally withheld from this setup response.',
+  };
+}
+
+export async function completeIncreaseSandboxSetup({ entityId, programId = '', accountName = '' } = {}, env = process.env) {
+  const validation = await simulateIncreaseSandboxEntityValid(entityId, env);
+  const bootstrap = await bootstrapIncreaseSandboxAccount({ entityId: validation.entityId, programId, accountName }, env);
+  const dashboard = await getIncreaseSandboxDashboard(env);
+  return {
+    ...bootstrap,
+    validationSimulation: true,
+    dashboard,
+  };
+}

--- a/lib/banking/increase-onboarding-sandbox.js
+++ b/lib/banking/increase-onboarding-sandbox.js
@@ -175,7 +175,11 @@ export async function simulateIncreaseSandboxEntityValid(entityId, env = process
 
 async function findOrCreateAccount(entityId, program, accountName, env = process.env) {
   const accountPayload = await increaseSandboxRequest(`/accounts?entity_id=${encodeURIComponent(entityId)}&limit=100`, {}, env);
-  const existing = listData(accountPayload).find((account) => account?.status === 'open' && account?.currency === 'USD');
+  const existing = listData(accountPayload).find((account) => (
+    account?.status === 'open'
+    && account?.currency === 'USD'
+    && account?.program_id === program.id
+  ));
   if (existing?.id) return { account: existing, created: false };
 
   const account = await increaseSandboxRequest('/accounts', {

--- a/scripts/test-galactic-trust-increase-onboarding.mjs
+++ b/scripts/test-galactic-trust-increase-onboarding.mjs
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  bootstrapIncreaseSandboxAccount,
+  createIncreaseSandboxOnboardingSession,
+  getIncreaseSandboxEntityReadiness,
+  inspectIncreaseSandboxOnboarding,
+  simulateIncreaseSandboxEntityValid,
+  submitIncreaseSandboxOnboardingSession,
+} from '../lib/banking/increase-onboarding-sandbox.js';
+
+const env = {
+  GALACTIC_INCREASE_SANDBOX_ENABLED: 'true',
+  INCREASE_SANDBOX_API_KEY: 'sandbox-test-key',
+};
+
+const program = {
+  id: 'sandbox_program_test',
+  name: 'Commercial Banking',
+  bank: 'increase_bank',
+};
+const entity = {
+  id: 'sandbox_entity_test',
+  status: 'active',
+  structure: 'natural_person',
+  validation: null,
+};
+let session = {
+  id: 'sandbox_entity_onboarding_session_test',
+  status: 'active',
+  program_id: program.id,
+  entity_id: null,
+  session_url: 'https://onboarding.increase.com/onboarding/sessions?id=sandbox-test',
+  expires_at: '2026-08-31T00:00:00Z',
+};
+let account = null;
+let accountNumber = null;
+const calls = [];
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+globalThis.fetch = async (input, options = {}) => {
+  const url = input instanceof URL ? input : new URL(String(input));
+  const method = String(options.method || 'GET').toUpperCase();
+  const body = options.body ? JSON.parse(String(options.body)) : null;
+  calls.push({ url: url.toString(), method, headers: options.headers || {}, body });
+
+  assert.equal(url.origin, 'https://sandbox.increase.com', 'onboarding must never leave the Increase sandbox API origin');
+  assert.equal(options.headers?.Authorization, 'Bearer sandbox-test-key', 'sandbox credential must be used server-side');
+
+  if (method === 'GET' && url.pathname === '/programs') return jsonResponse({ data: [program] });
+
+  if (method === 'POST' && url.pathname === '/entity_onboarding_sessions') {
+    assert.deepEqual(body, {
+      program_id: program.id,
+      redirect_url: 'https://www.voxelvault.io/bank?increase_onboarding=complete',
+    });
+    return jsonResponse(session);
+  }
+
+  if (method === 'POST' && url.pathname === `/simulations/entity_onboarding_sessions/${session.id}/submit`) {
+    session = { ...session, status: 'expired', entity_id: entity.id, session_url: null };
+    return jsonResponse(session);
+  }
+
+  if (method === 'GET' && url.pathname === `/entities/${entity.id}`) return jsonResponse(entity);
+
+  if (method === 'POST' && url.pathname === `/simulations/entities/${entity.id}/update_validation`) {
+    assert.deepEqual(body, { issues: [] });
+    entity.validation = { status: 'valid', issues: [] };
+    return jsonResponse(entity);
+  }
+
+  if (method === 'GET' && url.pathname === '/accounts' && url.searchParams.get('entity_id') === entity.id) {
+    return jsonResponse({ data: account ? [account] : [] });
+  }
+
+  if (method === 'POST' && url.pathname === '/accounts') {
+    assert.equal(body.entity_id, entity.id);
+    assert.equal(body.program_id, program.id);
+    assert.equal(body.name, 'Galactic Trust Sandbox Checking');
+    account = {
+      id: 'sandbox_account_test',
+      entity_id: entity.id,
+      program_id: program.id,
+      name: body.name,
+      status: 'open',
+      currency: 'USD',
+    };
+    return jsonResponse(account);
+  }
+
+  if (method === 'GET' && url.pathname === '/account_numbers' && url.searchParams.get('account_id') === account?.id) {
+    return jsonResponse({ data: accountNumber ? [accountNumber] : [] });
+  }
+
+  if (method === 'POST' && url.pathname === '/account_numbers') {
+    assert.equal(body.account_id, account?.id);
+    accountNumber = {
+      id: 'sandbox_account_number_test',
+      account_id: account.id,
+      name: body.name,
+      status: 'active',
+      account_number: '123456789',
+      routing_number: '101050001',
+    };
+    return jsonResponse(accountNumber);
+  }
+
+  throw new Error(`Unexpected mocked Increase request: ${method} ${url}`);
+};
+
+const inspection = await inspectIncreaseSandboxOnboarding(env);
+assert.equal(inspection.connected, true);
+assert.equal(inspection.canMoveRealMoney, false);
+assert.deepEqual(inspection.programs, [{ id: program.id, name: program.name, bank: program.bank }]);
+
+const created = await createIncreaseSandboxOnboardingSession({
+  redirectUrl: 'https://www.voxelvault.io/bank?increase_onboarding=complete',
+}, env);
+assert.equal(created.canMoveRealMoney, false);
+assert.equal(created.session.id, session.id);
+assert.match(created.session.sessionUrl, /^https:\/\/onboarding\.increase\.com\//);
+assert.equal(JSON.stringify(created).includes('sandbox-test-key'), false, 'API key must never be returned');
+
+const submitted = await submitIncreaseSandboxOnboardingSession(session.id, env);
+assert.equal(submitted.simulated, true);
+assert.equal(submitted.session.entityId, entity.id);
+assert.equal(submitted.session.status, 'expired');
+
+const beforeValidation = await getIncreaseSandboxEntityReadiness(entity.id, env);
+assert.equal(beforeValidation.validationStatus, 'not_simulated');
+assert.equal(beforeValidation.readyForSandboxAccount, false);
+
+await assert.rejects(
+  () => bootstrapIncreaseSandboxAccount({ entityId: entity.id }, env),
+  /not ready for account creation/i,
+  'account creation must fail closed until the sandbox Entity validation is explicitly valid',
+);
+
+const validation = await simulateIncreaseSandboxEntityValid(entity.id, env);
+assert.equal(validation.validationSimulation, true);
+assert.equal(validation.validationStatus, 'valid');
+assert.equal(validation.readyForSandboxAccount, true);
+
+const bootstrapped = await bootstrapIncreaseSandboxAccount({ entityId: entity.id }, env);
+assert.equal(bootstrapped.canMoveRealMoney, false);
+assert.equal(bootstrapped.account.id, 'sandbox_account_test');
+assert.equal(bootstrapped.account.created, true);
+assert.equal(bootstrapped.accountNumber.id, 'sandbox_account_number_test');
+assert.equal(bootstrapped.accountNumber.created, true);
+assert.equal(bootstrapped.accountNumber.detailsWithheld, true);
+assert.equal('account_number' in bootstrapped.accountNumber, false, 'raw account number must not leave bootstrap helper');
+assert.equal('routing_number' in bootstrapped.accountNumber, false, 'raw routing number must not leave bootstrap helper');
+
+const requestBodies = JSON.stringify(calls.map((call) => call.body));
+for (const sensitiveField of ['social_security_number', 'tax_identifier', 'date_of_birth', 'identification', 'address']) {
+  assert.equal(requestBodies.includes(sensitiveField), false, `Galactic Trust must not collect hosted-onboarding PII field: ${sensitiveField}`);
+}
+
+await assert.rejects(
+  () => createIncreaseSandboxOnboardingSession({ redirectUrl: 'http://attacker.example/callback' }, env),
+  /must use HTTPS/i,
+  'non-local onboarding redirects must be HTTPS',
+);
+
+const routeSource = await readFile(new URL('../app/api/admin/bank/increase/onboarding/route.ts', import.meta.url), 'utf8');
+assert.match(routeSource, /requireVoxelVaultAdmin/, 'onboarding API must remain owner-only');
+assert.match(routeSource, /private, no-store/, 'onboarding API must prohibit caching');
+assert.match(routeSource, /complete_setup/, 'route should expose an explicit sandbox-completion action');
+assert.match(routeSource, /not a real KYC\/CIP\/AML decision/, 'sandbox validation simulation must be clearly disclosed');
+assert.equal(routeSource.includes('NEXT_PUBLIC_'), false, 'onboarding API must not use client-side provider credentials');
+
+console.log('Galactic Trust Increase sandbox onboarding checks passed.');

--- a/scripts/test-galactic-trust-increase-onboarding.mjs
+++ b/scripts/test-galactic-trust-increase-onboarding.mjs
@@ -176,4 +176,16 @@ assert.match(routeSource, /complete_setup/, 'route should expose an explicit san
 assert.match(routeSource, /not a real KYC\/CIP\/AML decision/, 'sandbox validation simulation must be clearly disclosed');
 assert.equal(routeSource.includes('NEXT_PUBLIC_'), false, 'onboarding API must not use client-side provider credentials');
 
+const setupSource = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
+assert.match(setupSource, /\/api\/admin\/bank\/increase\/onboarding/, 'owner UI must use the owner-only onboarding endpoint');
+assert.match(setupSource, /Start hosted sandbox onboarding/, 'owner UI should launch Increase-hosted onboarding');
+assert.match(setupSource, /This is not real KYC approval/, 'owner UI must label sandbox validation simulation honestly');
+assert.equal(setupSource.includes('INCREASE_SANDBOX_API_KEY'), false, 'client UI must never read the Increase API key');
+assert.equal(setupSource.includes('account_number'), false, 'client setup UI must not handle raw account-number data');
+assert.equal(setupSource.includes('routing_number'), false, 'client setup UI must not handle raw routing-number data');
+
+const gateSource = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
+assert.match(gateSource, /GalacticSandboxSetup/, 'bank gate should mount the sandbox setup control');
+assert.match(gateSource, /session\?\.user && <GalacticSandboxSetup/, 'sandbox setup control should only mount for signed-in sessions before server authorization');
+
 console.log('Galactic Trust Increase sandbox onboarding checks passed.');


### PR DESCRIPTION
## What changed
- adds an Increase-sandbox onboarding boundary for hosted Entity Onboarding Sessions
- keeps identity-form fields on Increase's hosted flow instead of collecting KYC PII in Galactic Trust
- adds owner-only, no-store `/api/admin/bank/increase/onboarding` actions for hosted session creation, sandbox submission/validation simulation, validated account bootstrap, and explicit sandbox completion
- requires the test Entity to be active and validation `valid` before Account creation
- creates or reuses a sandbox USD Account and active Account Number; raw account/routing details are withheld from setup responses
- adds an owner-only `/bank` setup control that is hidden from unauthorized signed-in users
- documents the implemented sandbox sequence and keeps the external sandbox-key setup as the only founder-side blocker
- adds a mocked provider regression test and runs it in the main Quality Gate

## Safety / compliance boundary
- Increase API traffic remains pinned to `https://sandbox.increase.com`
- sandbox validation is explicitly labeled as simulation, not KYC/CIP/AML approval
- `canMoveRealMoney` remains false throughout
- no production banking switch or production credential path changed
- no unrelated Voxel Vault product files were removed or moved
