### PR TITLE
Galactic Trust: bind Increase sandbox accounts to signed-in users

### DIFF
--- a/app/api/admin/bank/increase/dashboard/route.ts
+++ b/app/api/admin/bank/increase/dashboard/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
-import { getIncreaseSandboxDashboard } from '../../../../../../lib/banking/increase-sandbox.js';
+import { getIncreaseSandboxDashboardForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
 import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../../lib/banking/increase-webhook-subscription.js';
 import { pollIncreaseSandboxEvents } from '../../../../../../lib/banking/increase-reconciliation';
+import {
+  getProviderAccountBinding,
+  publicBindingSummary,
+} from '../../../../../../lib/real-estate/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -18,6 +22,51 @@ export async function GET(request: Request) {
   const auth = await requireVoxelVaultAdmin(request);
   if (auth.ok === false) {
     return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
+  }
+
+  let bindingState: any;
+  try {
+    bindingState = await getProviderAccountBinding(auth.admin, auth.user.id, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
+  } catch (error: any) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      connected: false,
+      setupRequired: true,
+      canMoveRealMoney: false,
+      error: error instanceof Error ? error.message : 'Increase sandbox identity binding could not be read.',
+    }, 500);
+  }
+
+  if (bindingState.setupRequired) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      connected: false,
+      setupRequired: true,
+      canMoveRealMoney: false,
+      error: bindingState.error || 'Provider identity binding storage is not ready.',
+    }, 503);
+  }
+
+  if (!bindingState.binding) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      connected: true,
+      setupRequired: true,
+      canMoveRealMoney: false,
+      error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner yet. Complete owner-scoped sandbox onboarding before provider balances or transactions are shown.',
+    }, 409);
   }
 
   let webhookAutomation: any = null;
@@ -37,15 +86,16 @@ export async function GET(request: Request) {
   }
 
   try {
-    const snapshot = await getIncreaseSandboxDashboard(process.env);
+    const snapshot = await getIncreaseSandboxDashboardForAccount(bindingState.binding.accountId, process.env);
     return response({
       ok: true,
       authorized: true,
       ...snapshot,
+      binding: publicBindingSummary(bindingState.binding),
       webhookAutomation,
       reconciliationBackstop,
       automationIssue,
-      note: 'Increase sandbox data only. Values are pretend money and cannot represent live customer funds.',
+      note: 'Increase sandbox data is scoped to the Account bound server-side to this signed-in owner. Values are pretend money and cannot represent live customer funds.',
     });
   } catch (error: any) {
     return response({
@@ -55,6 +105,7 @@ export async function GET(request: Request) {
       environment: 'sandbox',
       connected: false,
       canMoveRealMoney: false,
+      binding: publicBindingSummary(bindingState.binding),
       webhookAutomation,
       reconciliationBackstop,
       automationIssue,

--- a/app/api/admin/bank/increase/fund/route.ts
+++ b/app/api/admin/bank/increase/fund/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
-import { simulateIncreaseSandboxDeposit } from '../../../../../../lib/banking/increase-sandbox.js';
+import { simulateIncreaseSandboxDepositForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
+import {
+  getProviderAccountBinding,
+  publicBindingSummary,
+} from '../../../../../../lib/real-estate/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -25,14 +29,42 @@ export async function POST(request: Request) {
   }
 
   try {
-    const snapshot = await simulateIncreaseSandboxDeposit(Math.round(amount * 100), process.env);
+    const bindingState = await getProviderAccountBinding(auth.admin, auth.user.id, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
+    if (bindingState.setupRequired) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        canMoveRealMoney: false,
+        error: bindingState.error || 'Provider identity binding storage is not ready.',
+      }, 503);
+    }
+    if (!bindingState.binding) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        canMoveRealMoney: false,
+        error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner. Complete owner-scoped sandbox onboarding before simulating funding.',
+      }, 409);
+    }
+
+    const snapshot = await simulateIncreaseSandboxDepositForAccount(
+      Math.round(amount * 100),
+      bindingState.binding.accountId,
+      process.env,
+    );
     return response({
       ok: true,
       authorized: true,
       ...snapshot,
+      binding: publicBindingSummary(bindingState.binding),
       action: 'sandbox-inbound-ach-simulation',
       canMoveRealMoney: false,
-      note: 'Pretend Increase sandbox funds only. No external bank account was debited.',
+      note: 'Pretend Increase sandbox funds only, scoped to the Account bound server-side to this signed-in owner. No external bank account was debited.',
     });
   } catch (error: any) {
     return response({

--- a/app/api/admin/bank/increase/onboarding/route.ts
+++ b/app/api/admin/bank/increase/onboarding/route.ts
@@ -9,6 +9,11 @@ import {
   simulateIncreaseSandboxEntityValid,
   submitIncreaseSandboxOnboardingSession,
 } from '../../../../../../lib/banking/increase-onboarding-sandbox.js';
+import {
+  bindIncreaseSandboxAccount,
+  getProviderAccountBinding,
+  publicBindingSummary,
+} from '../../../../../../lib/real-estate/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -32,6 +37,16 @@ function providerError(error: any) {
   }, Number.isFinite(error?.status) ? 502 : 400);
 }
 
+async function bindOwnerSandboxAccount(auth: any, result: any, source: string) {
+  const binding = await bindIncreaseSandboxAccount(auth.admin, auth.user.id, {
+    entityId: String(result?.entity?.entityId || ''),
+    accountId: String(result?.account?.id || ''),
+    validationStatus: String(result?.entity?.validationStatus || ''),
+    source,
+  }, process.env);
+  return publicBindingSummary(binding);
+}
+
 export async function GET(request: Request) {
   const auth = await requireVoxelVaultAdmin(request);
   if (auth.ok === false) {
@@ -43,12 +58,19 @@ export async function GET(request: Request) {
     const entityId = String(url.searchParams.get('entity_id') || '').trim();
     const onboarding = await inspectIncreaseSandboxOnboarding(process.env);
     const entity = entityId ? await getIncreaseSandboxEntityReadiness(entityId, process.env) : null;
+    const bindingState = await getProviderAccountBinding(auth.admin, auth.user.id, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
     return response({
       ok: true,
       authorized: true,
       ...onboarding,
       entity,
-      note: 'Owner-only Increase sandbox onboarding status. No customer identity fields or account-number details are returned.',
+      binding: publicBindingSummary(bindingState.binding),
+      bindingSetupRequired: bindingState.setupRequired,
+      bindingError: bindingState.error || '',
+      note: 'Owner-only Increase sandbox onboarding status. Provider identity is scoped to the signed-in owner through a server-written binding; no customer identity fields or account-number details are returned.',
     });
   } catch (error: any) {
     return providerError(error);
@@ -107,7 +129,15 @@ export async function POST(request: Request) {
         programId: String(body?.programId || ''),
         accountName: String(body?.accountName || ''),
       }, process.env);
-      return response({ ok: true, authorized: true, action, ...result });
+      const binding = await bindOwnerSandboxAccount(auth, result, 'increase-sandbox-bootstrap');
+      return response({
+        ok: true,
+        authorized: true,
+        action,
+        ...result,
+        binding,
+        note: 'Sandbox Account ownership is bound server-side to the signed-in owner. Provider validation is sandbox simulation only; no real money can move.',
+      });
     }
 
     if (action === 'complete_setup') {
@@ -116,12 +146,14 @@ export async function POST(request: Request) {
         programId: String(body?.programId || ''),
         accountName: String(body?.accountName || ''),
       }, process.env);
+      const binding = await bindOwnerSandboxAccount(auth, result, 'increase-hosted-sandbox-onboarding');
       return response({
         ok: true,
         authorized: true,
         action,
         ...result,
-        note: 'Sandbox-only setup: validation was simulated before creating/reusing a test Account and Account Number. No real money can move.',
+        binding,
+        note: 'Sandbox-only setup: validation was simulated before creating/reusing a test Account and Account Number, then the provider Account was bound server-side to the signed-in owner. This is not real KYC approval and no real money can move.',
       });
     }
 

--- a/app/api/admin/bank/increase/transfer/route.ts
+++ b/app/api/admin/bank/increase/transfer/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireVoxelVaultAdmin } from '../../../../../../lib/admin-auth';
-import { simulateIncreaseSandboxSend } from '../../../../../../lib/banking/increase-sandbox.js';
+import { simulateIncreaseSandboxSendForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
+import {
+  getProviderAccountBinding,
+  publicBindingSummary,
+} from '../../../../../../lib/real-estate/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -29,14 +33,43 @@ export async function POST(request: Request) {
   }
 
   try {
-    const snapshot = await simulateIncreaseSandboxSend(Math.round(amount * 100), recipient, process.env);
+    const bindingState = await getProviderAccountBinding(auth.admin, auth.user.id, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
+    if (bindingState.setupRequired) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        canMoveRealMoney: false,
+        error: bindingState.error || 'Provider identity binding storage is not ready.',
+      }, 503);
+    }
+    if (!bindingState.binding) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        canMoveRealMoney: false,
+        error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner. Complete owner-scoped sandbox onboarding before simulating transfers.',
+      }, 409);
+    }
+
+    const snapshot = await simulateIncreaseSandboxSendForAccount(
+      Math.round(amount * 100),
+      recipient,
+      bindingState.binding.accountId,
+      process.env,
+    );
     return response({
       ok: true,
       authorized: true,
       ...snapshot,
+      binding: publicBindingSummary(bindingState.binding),
       action: 'sandbox-ach-transfer-simulation',
       canMoveRealMoney: false,
-      note: 'This transfer is routed only to Increase sandbox test coordinates. No real recipient or bank account is used.',
+      note: 'This transfer is scoped to the Increase sandbox Account bound server-side to this signed-in owner and routes only to sandbox test coordinates. No real recipient or bank account is used.',
     });
   } catch (error: any) {
     return response({

--- a/app/bank/GalacticSandboxSetup.js
+++ b/app/bank/GalacticSandboxSetup.js
@@ -81,6 +81,9 @@ function SetupStep({ number, title, detail, state = 'pending' }) {
 export default function GalacticSandboxSetup({ accessToken = '' }) {
   const [authorized, setAuthorized] = useState(null);
   const [status, setStatus] = useState(null);
+  const [binding, setBinding] = useState(null);
+  const [bindingSetupRequired, setBindingSetupRequired] = useState(false);
+  const [bindingError, setBindingError] = useState('');
   const [programs, setPrograms] = useState([]);
   const [programId, setProgramId] = useState('');
   const [entityId, setEntityId] = useState('');
@@ -89,9 +92,12 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
 
   const accountCount = Number(status?.counts?.accounts || 0);
   const connected = Boolean(status?.connected);
+  const bindingReady = Boolean(binding?.provider === 'increase' && binding?.environment === 'sandbox' && binding?.status === 'verified');
   const needsAccount = connected && accountCount === 0;
+  const needsBindingStorage = connected && bindingSetupRequired;
+  const needsBinding = connected && accountCount > 0 && !bindingReady && !needsBindingStorage;
   const returnedFromOnboarding = Boolean(entityId);
-  const blockingSetup = returnedFromOnboarding || needsAccount;
+  const blockingSetup = returnedFromOnboarding || needsAccount || needsBinding || needsBindingStorage;
 
   useEffect(() => {
     if (!accessToken) return;
@@ -125,6 +131,9 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
       if (!active) return;
       setAuthorized(Boolean(statusPayload?.authorized && onboardingPayload?.authorized));
       setStatus(statusPayload);
+      setBinding(onboardingPayload?.binding || null);
+      setBindingSetupRequired(Boolean(onboardingPayload?.bindingSetupRequired));
+      setBindingError(String(onboardingPayload?.bindingError || ''));
       const nextPrograms = Array.isArray(onboardingPayload?.programs) ? onboardingPayload.programs : [];
       setPrograms(nextPrograms);
       if (nextPrograms.length === 1) setProgramId(nextPrograms[0].id);
@@ -138,8 +147,10 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
   const heading = useMemo(() => {
     if (returnedFromOnboarding) return 'Finish Increase sandbox setup';
     if (!connected) return 'Increase sandbox setup';
+    if (needsBindingStorage) return 'Provider binding storage required';
+    if (needsBinding) return 'Sandbox account ownership setup required';
     return 'Sandbox connected — account setup required';
-  }, [connected, returnedFromOnboarding]);
+  }, [connected, needsBinding, needsBindingStorage, returnedFromOnboarding]);
 
   async function post(action, extra = {}) {
     const response = await fetch('/api/admin/bank/increase/onboarding', {
@@ -184,7 +195,17 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
   }
 
   if (!accessToken || authorized !== true) return null;
-  if (!returnedFromOnboarding && connected && accountCount > 0) return null;
+  if (!returnedFromOnboarding && connected && accountCount > 0 && bindingReady) return null;
+
+  const canStartOwnerOnboarding = connected && !returnedFromOnboarding && !needsBindingStorage && (needsAccount || needsBinding);
+  const stepTwoTitle = needsBinding ? 'Owner binding required' : needsBindingStorage ? 'Binding storage required' : 'Account setup required';
+  const stepTwoDetail = returnedFromOnboarding
+    ? 'A test Entity was returned. Complete the sandbox-only validation, Account bootstrap, and server-side owner binding.'
+    : needsBinding
+      ? 'Existing sandbox Accounts are not treated as yours. Complete owner-scoped hosted onboarding so Galactic Trust can bind exactly one provider Account to your signed-in user.'
+      : needsBindingStorage
+        ? (bindingError || 'Trusted provider binding storage must be installed before any provider Account can be treated as user-owned.')
+        : 'Use Increase-hosted onboarding to create the test Entity before an Account is created.';
 
   const panel = (
     <aside style={{ ...panelStyle, ...(blockingSetup ? {} : floatingPanelStyle) }} aria-label="Owner Increase sandbox setup" aria-modal={blockingSetup ? 'true' : undefined} role={blockingSetup ? 'dialog' : undefined}>
@@ -199,8 +220,8 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
       {blockingSetup && (
         <div style={{ marginTop: '14px', padding: '12px 14px', borderRadius: '14px', background: '#fbfaff', border: '1px solid #ece8ff' }}>
           <SetupStep number="1" title="Increase sandbox connected" detail="The provider connection is active. No real money can move." state="complete" />
-          <SetupStep number="2" title="Account setup required" detail={returnedFromOnboarding ? 'A test Entity was returned. Complete the sandbox-only validation and account bootstrap.' : 'Use Increase-hosted onboarding to create the test Entity before an Account is created.'} state="active" />
-          <SetupStep number="3" title="Sandbox dashboard ready" detail="Demo balances and transfer controls stay blocked until a provider-backed test Account exists." state="pending" />
+          <SetupStep number="2" title={stepTwoTitle} detail={stepTwoDetail} state="active" />
+          <SetupStep number="3" title="Owner-scoped sandbox dashboard ready" detail="Provider balances and transfer controls stay blocked until a sandbox Account is bound server-side to your signed-in user." state="pending" />
         </div>
       )}
 
@@ -210,10 +231,10 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
         </p>
       )}
 
-      {needsAccount && !returnedFromOnboarding && (
+      {canStartOwnerOnboarding && (
         <>
           <p style={{ margin: '12px 0 0', fontSize: '13px', lineHeight: 1.45, color: '#5f5875' }}>
-            Identity details are entered on Increase&apos;s hosted sandbox form, not inside Galactic Trust. The dashboard behind this setup screen is intentionally blocked so illustrative demo balances cannot be confused with provider test data.
+            Identity details are entered on Increase&apos;s hosted sandbox form, not inside Galactic Trust. Existing unbound provider Accounts are deliberately ignored so one user can never inherit another sandbox Account by accident.
           </p>
           {programs.length > 1 && (
             <select
@@ -227,7 +248,7 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
             </select>
           )}
           <button type="button" onClick={startOnboarding} disabled={busy} style={{ ...buttonStyle, opacity: busy ? 0.65 : 1 }}>
-            {busy ? 'Opening Increase…' : 'Start hosted sandbox onboarding'}
+            {busy ? 'Opening Increase…' : needsBinding ? 'Start owner-scoped sandbox onboarding' : 'Start hosted sandbox onboarding'}
           </button>
         </>
       )}
@@ -235,7 +256,7 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
       {returnedFromOnboarding && (
         <>
           <p style={{ margin: '12px 0 0', fontSize: '13px', lineHeight: 1.45, color: '#5f5875' }}>
-            Increase returned a test Entity. Completing setup will simulate a successful sandbox validation, then create or reuse a sandbox Account and Account Number. This is not real KYC approval.
+            Increase returned a test Entity. Completing setup will simulate a successful sandbox validation, create or reuse a sandbox Account and Account Number, then bind that Account server-side to your signed-in user. This is not real KYC approval.
           </p>
           {programs.length > 1 && (
             <select
@@ -248,12 +269,13 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
               {programs.map((program) => <option key={program.id} value={program.id}>{program.name}</option>)}
             </select>
           )}
-          <button type="button" onClick={completeSetup} disabled={busy || (programs.length > 1 && !programId)} style={{ ...buttonStyle, opacity: busy ? 0.65 : 1 }}>
-            {busy ? 'Creating sandbox account…' : 'Complete sandbox setup'}
+          <button type="button" onClick={completeSetup} disabled={busy || needsBindingStorage || (programs.length > 1 && !programId)} style={{ ...buttonStyle, opacity: busy || needsBindingStorage ? 0.65 : 1 }}>
+            {busy ? 'Creating and binding sandbox account…' : 'Complete sandbox setup'}
           </button>
         </>
       )}
 
+      {needsBindingStorage && bindingError && <p role="status" style={{ margin: '10px 0 0', fontSize: '12px', lineHeight: 1.4, color: '#9d2d55' }}>{bindingError}</p>}
       {message && <p role="status" style={{ margin: '10px 0 0', fontSize: '12px', lineHeight: 1.4, color: '#9d2d55' }}>{message}</p>}
     </aside>
   );

--- a/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
+++ b/docs/GALACTIC_TRUST_INCREASE_SANDBOX.md
@@ -22,19 +22,26 @@ Official references:
 
 `GET/POST /api/admin/bank/increase/onboarding` is owner-only and no-store. Supported actions are sandbox-specific: create a hosted session, simulate a sandbox session submission, simulate a valid Entity, bootstrap a validated Entity into an Account and Account Number, or explicitly complete the sandbox setup by simulating validation before bootstrap. Every response reports `canMoveRealMoney: false`.
 
-The `/bank` owner experience includes a temporary sandbox setup control. It first checks the owner-only status/onboarding APIs. Unauthorized signed-in users do not see the control. When no sandbox Account exists, the owner can launch Increase-hosted onboarding. After Increase redirects back with the test `entity_id`, the owner can explicitly complete sandbox setup. Identity form fields stay on Increase's hosted page rather than being collected by Galactic Trust.
+Galactic Trust reuses `vault_provider_account_bindings`, the existing trusted server-written provider identity table, rather than inventing a second account-ownership system. Migration `025_galactic_increase_account_bindings.sql` extends the table's provider allowlist from Dinari-only to Dinari plus Increase while preserving the existing row-level-security posture: authenticated browser users can read only their own row and have no client insert/update/delete policy. A provider Account also remains globally unique per provider/environment so one Increase Account cannot be silently assigned to two users.
 
-The existing dashboard reads provider-authoritative sandbox balances and transactions, ACH simulations use the sandbox Account Number, signed webhooks are processed idempotently, and reconciliation provides a polling backstop.
+After successful sandbox Account creation, the owner-only onboarding API writes an `increase` / `sandbox` binding using the authenticated Supabase user ID returned by server-side session verification. The stored provider validation marker is `SANDBOX_VALID_SIMULATION`, not `PASS`, so the test state cannot be confused with a real KYC/CIP/AML approval.
 
-## Founder setup — the only external step required now
+The `/bank` owner setup control requires both provider connectivity and a verified owner binding before it uncovers provider data. A pre-existing unbound Increase sandbox Account is deliberately ignored. In that case the owner is sent through owner-scoped hosted onboarding rather than inheriting a global test Account.
+
+`GET /api/admin/bank/increase/dashboard`, `POST /api/admin/bank/increase/fund`, and `POST /api/admin/bank/increase/transfer` now fail closed when the signed-in owner has no verified Increase sandbox binding. When a binding exists, each route uses the exact stored Account ID. The dashboard returns only that Account; pretend-money funding resolves its Account Number from that Account; and pretend-money transfers use that Account as the source. The browser only receives a masked binding summary, never the full provider Entity or Account ID from binding storage.
+
+Signed webhooks are processed idempotently and reconciliation provides a polling backstop. These provider-wide automation mechanisms do not authorize user ownership; the signed-in user's dashboard and actions remain scoped by the trusted binding table.
+
+## External setup required for the live sandbox environment
 
 1. Create an Increase account and obtain the **sandbox** API key from the Increase dashboard.
 2. In Vercel, add the key as a server-only environment variable named `INCREASE_SANDBOX_API_KEY`.
 3. Set `GALACTIC_INCREASE_SANDBOX_ENABLED=true` for the environment you want to test.
-4. Redeploy.
-5. Sign in to `/bank`. The owner-only setup control will verify the sandbox connection and, when no sandbox Account exists, offer the hosted onboarding flow.
+4. Ensure the Supabase migration workflow has its required repository secrets and apply pending migrations, including `024_galactic_increase_webhooks_reconciliation.sql` and `025_galactic_increase_account_bindings.sql`.
+5. Redeploy after the Vercel environment variables are present.
+6. Sign in to `/bank`. The owner-only setup control will verify the sandbox connection and the signed-in user's binding state before offering or completing hosted onboarding.
 
-Do **not** paste the sandbox key into ChatGPT, GitHub issues, commits, screenshots, client-side code or a `NEXT_PUBLIC_` variable.
+Do **not** paste the sandbox key, Supabase access token, database password, or other secrets into ChatGPT, GitHub issues, commits, screenshots, client-side code, or any `NEXT_PUBLIC_` variable.
 
 ## Sandbox onboarding sequence now implemented
 
@@ -44,12 +51,15 @@ Do **not** paste the sandbox key into ChatGPT, GitHub issues, commits, screensho
 4. The owner explicitly completes sandbox setup. Because sandbox validations do not run automatically, Galactic Trust calls Increase's sandbox validation simulation with no issues and clearly labels that action as simulated, not real KYC approval.
 5. Only after the provider reports the test Entity as active and `valid`, create or reuse a USD sandbox Account tied to the Entity and Program.
 6. Create or reuse an active Account Number, while withholding raw account/routing details from the setup response.
-7. Reload the sandbox dashboard from Increase-authoritative balances and transactions.
-8. Use existing inbound/outbound ACH simulations, webhook processing and reconciliation against the provider state.
+7. Bind that test Entity/Account to the authenticated Supabase user through trusted server code. The binding is stored as provider `increase`, environment `sandbox`, with validation marker `SANDBOX_VALID_SIMULATION`.
+8. Reload the dashboard from the exact Account referenced by the authenticated user's binding. Never fall back to another open sandbox Account.
+9. Route inbound/outbound ACH simulations through that same bound Account while signed webhooks and reconciliation continue to track provider state.
 
 ## What remains before customer banking
 
-A successful sandbox connection or simulated validation is engineering evidence only. It does not make Galactic Trust a bank, open production customer accounts, make deposits FDIC-insured through Galactic Trust, or authorize real money movement.
+This owner-scoped sandbox binding is an engineering identity boundary for test data. It is not yet a customer onboarding system and must not be reused as proof of production KYC approval.
+
+A successful sandbox connection, simulated validation, or server-side test Account binding does not make Galactic Trust a bank, open production customer accounts, make deposits FDIC-insured through Galactic Trust, or authorize real money movement.
 
 Before any customer-facing account opening or live transfer flow, the selected provider/bank must approve the program, customer eligibility and onboarding, KYC/CIP/AML and sanctions controls, account terms and disclosures, Regulation E/error-resolution handling, ACH/payment use cases and limits, card program, ledger/reconciliation process, deposit-insurance wording, privacy/security, complaints/disputes, incident response and production launch.
 

--- a/lib/banking/increase-onboarding-sandbox.js
+++ b/lib/banking/increase-onboarding-sandbox.js
@@ -1,6 +1,6 @@
 import {
   getIncreaseSandboxConfig,
-  getIncreaseSandboxDashboard,
+  getIncreaseSandboxDashboardForAccount,
   increaseSandboxRequest,
 } from './increase-sandbox.js';
 
@@ -247,7 +247,7 @@ export async function bootstrapIncreaseSandboxAccount({ entityId = '', programId
 export async function completeIncreaseSandboxSetup({ entityId = '', programId = '', accountName = '' } = {}, env = process.env) {
   const validation = await simulateIncreaseSandboxEntityValid(entityId, env);
   const bootstrap = await bootstrapIncreaseSandboxAccount({ entityId: validation.entityId, programId, accountName }, env);
-  const dashboard = await getIncreaseSandboxDashboard(env);
+  const dashboard = await getIncreaseSandboxDashboardForAccount(bootstrap.account.id, env);
   return {
     ...bootstrap,
     validationSimulation: true,

--- a/lib/banking/increase-sandbox.js
+++ b/lib/banking/increase-sandbox.js
@@ -14,6 +14,14 @@ function centsToDollars(value) {
   return Number.isFinite(cents) ? cents / 100 : 0;
 }
 
+function safeResourceId(value, label) {
+  const id = String(value || '').trim();
+  if (!id || id.length > 160 || !/^[a-zA-Z0-9_-]+$/.test(id)) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return id;
+}
+
 export function getIncreaseSandboxConfig(env = process.env) {
   const apiKey = String(env.INCREASE_SANDBOX_API_KEY || '').trim();
   return {
@@ -100,6 +108,15 @@ async function resolvePrimaryAccount(env = process.env) {
   return accounts[0];
 }
 
+async function resolveBoundAccount(accountId, env = process.env) {
+  const id = safeResourceId(accountId, 'Bound Increase sandbox Account ID');
+  const account = await increaseSandboxRequest(`/accounts/${encodeURIComponent(id)}`, {}, env);
+  if (String(account?.id || '') !== id || account?.status !== 'open' || account?.currency !== 'USD') {
+    throw new Error('The bound Increase sandbox Account is unavailable or no longer an open USD account.');
+  }
+  return account;
+}
+
 function transactionTone(amount, routeType) {
   if (amount > 0) return 'blue';
   if (/card/i.test(routeType)) return 'dark';
@@ -125,35 +142,8 @@ function transactionCategory(transaction) {
   return 'Increase Sandbox';
 }
 
-export async function getIncreaseSandboxDashboard(env = process.env) {
+async function buildDashboard(accounts, env = process.env, { boundAccount = false } = {}) {
   const config = getIncreaseSandboxConfig(env);
-  if (!config.enabled || !config.credentialsConfigured) {
-    return {
-      provider: config.provider,
-      environment: config.environment,
-      connected: false,
-      canMoveRealMoney: false,
-      accounts: [],
-      transactions: [],
-      setupRequired: true,
-    };
-  }
-
-  const accountPayload = await increaseSandboxRequest('/accounts?limit=100', {}, env);
-  const accounts = chooseAccounts(listData(accountPayload), config.preferredAccountId).slice(0, 2);
-  if (!accounts.length) {
-    return {
-      provider: config.provider,
-      environment: config.environment,
-      connected: true,
-      canMoveRealMoney: false,
-      accounts: [],
-      transactions: [],
-      setupRequired: true,
-      nextStep: 'Create an open USD account in the Increase sandbox.',
-    };
-  }
-
   const balances = await Promise.all(accounts.map((account) => increaseSandboxRequest(`/accounts/${encodeURIComponent(account.id)}/balance`, {}, env)));
   const primaryAccount = accounts[0];
   const transactionsPayload = await increaseSandboxRequest(`/transactions?account_id=${encodeURIComponent(primaryAccount.id)}&limit=20`, {}, env);
@@ -191,8 +181,46 @@ export async function getIncreaseSandboxDashboard(env = process.env) {
     accounts: sanitizedAccounts,
     transactions: sanitizedTransactions,
     setupRequired: false,
+    boundAccount,
     syncedAt: new Date().toISOString(),
   };
+}
+
+export async function getIncreaseSandboxDashboard(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured) {
+    return {
+      provider: config.provider,
+      environment: config.environment,
+      connected: false,
+      canMoveRealMoney: false,
+      accounts: [],
+      transactions: [],
+      setupRequired: true,
+    };
+  }
+
+  const accountPayload = await increaseSandboxRequest('/accounts?limit=100', {}, env);
+  const accounts = chooseAccounts(listData(accountPayload), config.preferredAccountId).slice(0, 2);
+  if (!accounts.length) {
+    return {
+      provider: config.provider,
+      environment: config.environment,
+      connected: true,
+      canMoveRealMoney: false,
+      accounts: [],
+      transactions: [],
+      setupRequired: true,
+      nextStep: 'Create an open USD account in the Increase sandbox.',
+    };
+  }
+
+  return buildDashboard(accounts, env);
+}
+
+export async function getIncreaseSandboxDashboardForAccount(accountId, env = process.env) {
+  const account = await resolveBoundAccount(accountId, env);
+  return buildDashboard([account], env, { boundAccount: true });
 }
 
 async function primaryAccountNumberId(accountId, env = process.env) {
@@ -204,12 +232,7 @@ async function primaryAccountNumberId(accountId, env = process.env) {
   return accountNumber.id;
 }
 
-export async function simulateIncreaseSandboxDeposit(amountCents, env = process.env) {
-  const amount = Number(amountCents);
-  if (!Number.isInteger(amount) || amount < 100 || amount > 500000) {
-    throw new Error('Sandbox deposit must be between $1 and $5,000.');
-  }
-  const account = await resolvePrimaryAccount(env);
+async function simulateDepositForAccount(amount, account, env = process.env) {
   const accountNumberId = await primaryAccountNumberId(account.id, env);
   await increaseSandboxRequest('/simulations/inbound_ach_transfers', {
     method: 'POST',
@@ -222,16 +245,30 @@ export async function simulateIncreaseSandboxDeposit(amountCents, env = process.
       receiver_name: 'Sandbox User',
     },
   }, env);
+}
+
+export async function simulateIncreaseSandboxDeposit(amountCents, env = process.env) {
+  const amount = Number(amountCents);
+  if (!Number.isInteger(amount) || amount < 100 || amount > 500000) {
+    throw new Error('Sandbox deposit must be between $1 and $5,000.');
+  }
+  const account = await resolvePrimaryAccount(env);
+  await simulateDepositForAccount(amount, account, env);
   return getIncreaseSandboxDashboard(env);
 }
 
-export async function simulateIncreaseSandboxSend(amountCents, recipient, env = process.env) {
+export async function simulateIncreaseSandboxDepositForAccount(amountCents, accountId, env = process.env) {
   const amount = Number(amountCents);
-  const safeRecipient = cleanText(recipient, 22) || 'Sandbox Recipient';
-  if (!Number.isInteger(amount) || amount < 100 || amount > 100000) {
-    throw new Error('Sandbox transfer must be between $1 and $1,000.');
+  if (!Number.isInteger(amount) || amount < 100 || amount > 500000) {
+    throw new Error('Sandbox deposit must be between $1 and $5,000.');
   }
-  const account = await resolvePrimaryAccount(env);
+  const account = await resolveBoundAccount(accountId, env);
+  await simulateDepositForAccount(amount, account, env);
+  return getIncreaseSandboxDashboardForAccount(account.id, env);
+}
+
+async function simulateSendForAccount(amount, recipient, account, env = process.env) {
+  const safeRecipient = cleanText(recipient, 22) || 'Sandbox Recipient';
   const transfer = await increaseSandboxRequest('/ach_transfers', {
     method: 'POST',
     idempotencyKey: `galactic-sandbox-send-${crypto.randomUUID()}`,
@@ -249,7 +286,26 @@ export async function simulateIncreaseSandboxSend(amountCents, recipient, env = 
   if (transfer?.id) {
     await increaseSandboxRequest(`/simulations/ach_transfers/${encodeURIComponent(transfer.id)}/settle`, { method: 'POST', body: {} }, env);
   }
+}
+
+export async function simulateIncreaseSandboxSend(amountCents, recipient, env = process.env) {
+  const amount = Number(amountCents);
+  if (!Number.isInteger(amount) || amount < 100 || amount > 100000) {
+    throw new Error('Sandbox transfer must be between $1 and $1,000.');
+  }
+  const account = await resolvePrimaryAccount(env);
+  await simulateSendForAccount(amount, recipient, account, env);
   return getIncreaseSandboxDashboard(env);
+}
+
+export async function simulateIncreaseSandboxSendForAccount(amountCents, recipient, accountId, env = process.env) {
+  const amount = Number(amountCents);
+  if (!Number.isInteger(amount) || amount < 100 || amount > 100000) {
+    throw new Error('Sandbox transfer must be between $1 and $1,000.');
+  }
+  const account = await resolveBoundAccount(accountId, env);
+  await simulateSendForAccount(amount, recipient, account, env);
+  return getIncreaseSandboxDashboardForAccount(account.id, env);
 }
 
 export async function inspectIncreaseSandbox(env = process.env) {

--- a/lib/real-estate/provider-account-binding.js
+++ b/lib/real-estate/provider-account-binding.js
@@ -1,6 +1,8 @@
+import { getIncreaseSandboxConfig } from '../banking/increase-sandbox.js';
 import { getDinariConfig } from './dinari.js';
 
 const TABLE = 'vault_provider_account_bindings';
+const BINDING_COLUMNS = 'user_id,provider,environment,entity_id,account_id,binding_status,binding_source,provider_kyc_status,verified_at';
 
 function clean(value) {
   return String(value ?? '').trim();
@@ -40,6 +42,35 @@ function tableMissing(error) {
   return code === '42P01' || /vault_provider_account_bindings|relation .* does not exist/i.test(message);
 }
 
+function increaseProviderConstraintMissing(error) {
+  const code = clean(error?.code);
+  const message = clean(error?.message);
+  return code === '23514' && /vault_provider_account_bindings_provider_check|provider/i.test(message);
+}
+
+async function upsertBinding(admin, row, providerLabel) {
+  const { data, error } = await admin
+    .from(TABLE)
+    .upsert(row, { onConflict: 'user_id,provider,environment' })
+    .select(BINDING_COLUMNS)
+    .single();
+
+  if (error) {
+    if (tableMissing(error)) {
+      throw new Error('Provider account was verified, but identity binding storage is not installed yet. Apply Supabase migration 014_provider_account_bindings.sql, then bind again.');
+    }
+    if (providerLabel === 'Increase' && increaseProviderConstraintMissing(error)) {
+      throw new Error('Increase account binding storage is not enabled yet. Apply Supabase migration 025_galactic_increase_account_bindings.sql, then bind again.');
+    }
+    if (clean(error.code) === '23505') {
+      throw new Error(`This ${providerLabel} account is already bound to another Voxel Vault user. Voxel Vault refuses to reassign it automatically.`);
+    }
+    throw new Error(`Could not bind ${providerLabel} account to Voxel Vault user: ${error.message}`);
+  }
+
+  return normalizeBinding(data);
+}
+
 export async function getProviderAccountBinding(admin, userId, {
   provider = 'dinari',
   environment = 'sandbox',
@@ -50,7 +81,7 @@ export async function getProviderAccountBinding(admin, userId, {
 
   const { data, error } = await admin
     .from(TABLE)
-    .select('user_id,provider,environment,entity_id,account_id,binding_status,binding_source,provider_kyc_status,verified_at')
+    .select(BINDING_COLUMNS)
     .eq('user_id', uid)
     .eq('provider', normalizedProvider)
     .eq('environment', normalizedEnvironment)
@@ -88,7 +119,8 @@ export async function bindDinariSandboxAccount(admin, userId, {
   const normalizedKyc = clean(kycStatus).toUpperCase();
   if (normalizedKyc !== 'PASS') throw new Error('Dinari KYC must be PASS before Voxel Vault binds the provider account to a user.');
 
-  const row = {
+  const now = new Date().toISOString();
+  return upsertBinding(admin, {
     user_id: uid,
     provider: 'dinari',
     environment: 'sandbox',
@@ -97,27 +129,43 @@ export async function bindDinariSandboxAccount(admin, userId, {
     binding_status: 'verified',
     binding_source: clean(source || 'provider-onboarding').slice(0, 80),
     provider_kyc_status: 'PASS',
-    verified_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-  };
+    verified_at: now,
+    updated_at: now,
+  }, 'Dinari');
+}
 
-  const { data, error } = await admin
-    .from(TABLE)
-    .upsert(row, { onConflict: 'user_id,provider,environment' })
-    .select('user_id,provider,environment,entity_id,account_id,binding_status,binding_source,provider_kyc_status,verified_at')
-    .single();
-
-  if (error) {
-    if (tableMissing(error)) {
-      throw new Error('Provider account was verified, but identity binding storage is not installed yet. Apply Supabase migration 014_provider_account_bindings.sql, then bind again.');
-    }
-    if (clean(error.code) === '23505') {
-      throw new Error('This Dinari account is already bound to another Voxel Vault user. Voxel Vault refuses to reassign it automatically.');
-    }
-    throw new Error(`Could not bind Dinari account to Voxel Vault user: ${error.message}`);
+export async function bindIncreaseSandboxAccount(admin, userId, {
+  entityId = '',
+  accountId = '',
+  validationStatus = '',
+  source = 'increase-hosted-sandbox-onboarding',
+} = {}, env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured || config.environment !== 'sandbox' || config.canMoveRealMoney) {
+    throw new Error('Galactic Trust only writes Increase identity bindings from the configured pretend-money sandbox workflow.');
   }
 
-  return normalizeBinding(data);
+  const uid = validId(userId, 'Voxel Vault user ID');
+  const entity = validId(entityId, 'Increase Entity ID');
+  const account = validId(accountId, 'Increase Account ID');
+  const normalizedValidation = clean(validationStatus).toLowerCase();
+  if (normalizedValidation !== 'valid') {
+    throw new Error('Increase sandbox Entity validation must be valid before Galactic Trust binds the provider account to a user.');
+  }
+
+  const now = new Date().toISOString();
+  return upsertBinding(admin, {
+    user_id: uid,
+    provider: 'increase',
+    environment: 'sandbox',
+    entity_id: entity,
+    account_id: account,
+    binding_status: 'verified',
+    binding_source: clean(source || 'increase-hosted-sandbox-onboarding').slice(0, 80),
+    provider_kyc_status: 'SANDBOX_VALID_SIMULATION',
+    verified_at: now,
+    updated_at: now,
+  }, 'Increase');
 }
 
 export function buildReadOnlyDinariEnvForBinding(binding, env = process.env) {

--- a/lib/real-estate/provider-account-binding.js
+++ b/lib/real-estate/provider-account-binding.js
@@ -39,7 +39,8 @@ function normalizeBinding(row = {}) {
 function tableMissing(error) {
   const code = clean(error?.code);
   const message = clean(error?.message);
-  return code === '42P01' || /vault_provider_account_bindings|relation .* does not exist/i.test(message);
+  return code === '42P01'
+    || /relation ["']?vault_provider_account_bindings["']? does not exist/i.test(message);
 }
 
 function increaseProviderConstraintMissing(error) {

--- a/scripts/test-galactic-trust-increase-onboarding.mjs
+++ b/scripts/test-galactic-trust-increase-onboarding.mjs
@@ -8,6 +8,11 @@ import {
   simulateIncreaseSandboxEntityValid,
   submitIncreaseSandboxOnboardingSession,
 } from '../lib/banking/increase-onboarding-sandbox.js';
+import {
+  getIncreaseSandboxDashboardForAccount,
+  simulateIncreaseSandboxDepositForAccount,
+  simulateIncreaseSandboxSendForAccount,
+} from '../lib/banking/increase-sandbox.js';
 
 const env = {
   GALACTIC_INCREASE_SANDBOX_ENABLED: 'true',
@@ -91,8 +96,19 @@ globalThis.fetch = async (input, options = {}) => {
       name: body.name,
       status: 'open',
       currency: 'USD',
+      bank: 'increase_bank',
     };
     return jsonResponse(account);
+  }
+
+  if (method === 'GET' && account && url.pathname === `/accounts/${account.id}`) return jsonResponse(account);
+
+  if (method === 'GET' && account && url.pathname === `/accounts/${account.id}/balance`) {
+    return jsonResponse({ current_balance: 125000, available_balance: 120000 });
+  }
+
+  if (method === 'GET' && url.pathname === '/transactions' && account && url.searchParams.get('account_id') === account.id) {
+    return jsonResponse({ data: [] });
   }
 
   if (method === 'GET' && url.pathname === '/account_numbers' && url.searchParams.get('account_id') === account?.id) {
@@ -110,6 +126,20 @@ globalThis.fetch = async (input, options = {}) => {
       routing_number: '101050001',
     };
     return jsonResponse(accountNumber);
+  }
+
+  if (method === 'POST' && url.pathname === '/simulations/inbound_ach_transfers') {
+    assert.equal(body.account_number_id, accountNumber?.id, 'bound sandbox funding must use the Account Number attached to the bound Account');
+    return jsonResponse({ id: 'sandbox_inbound_ach_transfer_test' });
+  }
+
+  if (method === 'POST' && url.pathname === '/ach_transfers') {
+    assert.equal(body.account_id, account?.id, 'bound sandbox send must use the exact bound Account ID');
+    return jsonResponse({ id: 'sandbox_ach_transfer_test' });
+  }
+
+  if (method === 'POST' && url.pathname === '/simulations/ach_transfers/sandbox_ach_transfer_test/settle') {
+    return jsonResponse({ id: 'sandbox_ach_transfer_test', status: 'settled' });
   }
 
   throw new Error(`Unexpected mocked Increase request: ${method} ${url}`);
@@ -158,6 +188,19 @@ assert.equal(bootstrapped.accountNumber.detailsWithheld, true);
 assert.equal('account_number' in bootstrapped.accountNumber, false, 'raw account number must not leave bootstrap helper');
 assert.equal('routing_number' in bootstrapped.accountNumber, false, 'raw routing number must not leave bootstrap helper');
 
+const boundDashboard = await getIncreaseSandboxDashboardForAccount(bootstrapped.account.id, env);
+assert.equal(boundDashboard.boundAccount, true, 'owner-bound dashboard must identify that it is scoped to a binding');
+assert.equal(boundDashboard.accounts.length, 1, 'owner-bound dashboard must never append unrelated sandbox Accounts');
+assert.equal(boundDashboard.accounts[0].currentBalance, 1250);
+
+const fundedDashboard = await simulateIncreaseSandboxDepositForAccount(50000, bootstrapped.account.id, env);
+assert.equal(fundedDashboard.boundAccount, true);
+assert.equal(fundedDashboard.accounts.length, 1);
+
+const sentDashboard = await simulateIncreaseSandboxSendForAccount(2500, 'Sandbox Recipient', bootstrapped.account.id, env);
+assert.equal(sentDashboard.boundAccount, true);
+assert.equal(sentDashboard.accounts.length, 1);
+
 const requestBodies = JSON.stringify(calls.map((call) => call.body));
 for (const sensitiveField of ['social_security_number', 'tax_identifier', 'date_of_birth', 'identification', 'address']) {
   assert.equal(requestBodies.includes(sensitiveField), false, `Galactic Trust must not collect hosted-onboarding PII field: ${sensitiveField}`);
@@ -190,25 +233,47 @@ assert.match(bindingSource, /provider_kyc_status: 'SANDBOX_VALID_SIMULATION'/, '
 assert.match(bindingSource, /provider: 'increase',[\s\S]*environment: 'sandbox'/, 'Increase binding must remain sandbox-scoped');
 assert.match(bindingSource, /migration 025_galactic_increase_account_bindings/, 'stale provider allowlist must fail closed with the required migration');
 
+const dashboardRouteSource = await readFile(new URL('../app/api/admin/bank/increase/dashboard/route.ts', import.meta.url), 'utf8');
+assert.match(dashboardRouteSource, /getProviderAccountBinding/, 'sandbox dashboard route must load the authenticated owner binding');
+assert.match(dashboardRouteSource, /auth\.user\.id/, 'sandbox dashboard binding lookup must use the verified session user ID');
+assert.match(dashboardRouteSource, /getIncreaseSandboxDashboardForAccount\(bindingState\.binding\.accountId/, 'sandbox dashboard must read exactly the bound Account rather than a global provider account list');
+assert.match(dashboardRouteSource, /No Increase sandbox Account is bound to this signed-in Galactic Trust owner yet/, 'unbound owner dashboard must fail closed');
+assert.doesNotMatch(dashboardRouteSource, /getIncreaseSandboxDashboard\(process\.env\)/, 'owner dashboard must not fall back to the old global sandbox dashboard');
+
+const fundRouteSource = await readFile(new URL('../app/api/admin/bank/increase/fund/route.ts', import.meta.url), 'utf8');
+assert.match(fundRouteSource, /getProviderAccountBinding/, 'sandbox funding route must require the authenticated owner binding');
+assert.match(fundRouteSource, /simulateIncreaseSandboxDepositForAccount/, 'sandbox funding must target the bound Account explicitly');
+assert.match(fundRouteSource, /bindingState\.binding\.accountId/, 'sandbox funding must source Account ID from server-side binding storage');
+
+const transferRouteSource = await readFile(new URL('../app/api/admin/bank/increase/transfer/route.ts', import.meta.url), 'utf8');
+assert.match(transferRouteSource, /getProviderAccountBinding/, 'sandbox transfer route must require the authenticated owner binding');
+assert.match(transferRouteSource, /simulateIncreaseSandboxSendForAccount/, 'sandbox transfers must target the bound Account explicitly');
+assert.match(transferRouteSource, /bindingState\.binding\.accountId/, 'sandbox transfer must source Account ID from server-side binding storage');
+
 const setupSource = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
 assert.match(setupSource, /\/api\/admin\/bank\/increase\/onboarding/, 'owner UI must use the owner-only onboarding endpoint');
 assert.match(setupSource, /Start hosted sandbox onboarding/, 'owner UI should launch Increase-hosted onboarding');
+assert.match(setupSource, /Start owner-scoped sandbox onboarding/, 'existing unbound provider Accounts must trigger owner-scoped onboarding instead of being inherited');
 assert.match(setupSource, /This is not real KYC approval/, 'owner UI must label sandbox validation simulation honestly');
+assert.match(setupSource, /const bindingReady = Boolean\(binding\?\.provider === 'increase'/, 'owner UI must require an authenticated Increase sandbox binding');
 assert.match(setupSource, /const needsAccount = connected && accountCount === 0;/, 'connected sandbox with no account must be an explicit setup-required state');
-assert.match(setupSource, /const blockingSetup = returnedFromOnboarding \|\| needsAccount;/, 'incomplete sandbox setup must block the illustrative dashboard');
-assert.match(setupSource, /position: 'fixed',[\s\S]*inset: 0,[\s\S]*backdropFilter: 'blur\(12px\)'/, 'setup-required state must use a full-screen interaction blocker');
-assert.match(setupSource, /Increase sandbox connected/, 'setup UI must identify the connected provider state');
-assert.match(setupSource, /Account setup required/, 'setup UI must identify the missing-account state');
-assert.match(setupSource, /Sandbox dashboard ready/, 'setup UI must identify the provider-backed ready state');
-assert.match(setupSource, /Demo balances and transfer controls stay blocked until a provider-backed test Account exists/, 'demo balances must not remain actionable while provider setup is incomplete');
-assert.match(setupSource, /if \(!returnedFromOnboarding && connected && accountCount > 0\) return null;/, 'setup blocker must disappear once a sandbox account exists');
+assert.match(setupSource, /const needsBinding = connected && accountCount > 0 && !bindingReady && !needsBindingStorage;/, 'existing global sandbox Accounts must not be treated as owner-scoped without a binding');
+assert.match(setupSource, /const blockingSetup = returnedFromOnboarding \|\| needsAccount \|\| needsBinding \|\| needsBindingStorage;/, 'incomplete account or identity binding setup must block the illustrative dashboard');
+assert.match(setupSource, /Existing unbound provider Accounts are deliberately ignored/, 'owner UI must explain that unbound provider Accounts are ignored');
+assert.match(setupSource, /Owner-scoped sandbox dashboard ready/, 'setup UI must identify the bound-account ready state');
+assert.match(setupSource, /Provider balances and transfer controls stay blocked until a sandbox Account is bound server-side to your signed-in user/, 'provider controls must remain blocked until binding exists');
+assert.match(setupSource, /if \(!returnedFromOnboarding && connected && accountCount > 0 && bindingReady\) return null;/, 'setup blocker must disappear only after provider Account and owner binding both exist');
 assert.equal(setupSource.includes('INCREASE_SANDBOX_API_KEY'), false, 'client UI must never read the Increase API key');
 assert.equal(setupSource.includes('account_number'), false, 'client setup UI must not handle raw account-number data');
 assert.equal(setupSource.includes('routing_number'), false, 'client setup UI must not handle raw routing-number data');
 
 const dashboardSource = await readFile(new URL('../lib/banking/increase-sandbox.js', import.meta.url), 'utf8');
 assert.match(dashboardSource, /connected: true,[\s\S]*accounts: \[\],[\s\S]*setupRequired: true/, 'provider helper must preserve connected-but-needs-account state');
-assert.match(dashboardSource, /setupRequired: false,[\s\S]*syncedAt:/, 'provider helper must expose a distinct ready state after accounts load');
+assert.match(dashboardSource, /getIncreaseSandboxDashboardForAccount/, 'provider helper must expose an exact-account dashboard path');
+assert.match(dashboardSource, /resolveBoundAccount/, 'bound provider operations must resolve the exact persisted Account');
+assert.match(dashboardSource, /boundAccount: true/, 'bound dashboard response must identify exact-account scoping');
+assert.match(dashboardSource, /simulateIncreaseSandboxDepositForAccount/, 'provider helper must expose bound-account sandbox funding');
+assert.match(dashboardSource, /simulateIncreaseSandboxSendForAccount/, 'provider helper must expose bound-account sandbox transfers');
 
 const gateSource = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
 assert.match(gateSource, /GalacticSandboxSetup/, 'bank gate should mount the sandbox setup control');

--- a/scripts/test-galactic-trust-increase-onboarding.mjs
+++ b/scripts/test-galactic-trust-increase-onboarding.mjs
@@ -174,7 +174,21 @@ assert.match(routeSource, /requireVoxelVaultAdmin/, 'onboarding API must remain 
 assert.match(routeSource, /private, no-store/, 'onboarding API must prohibit caching');
 assert.match(routeSource, /complete_setup/, 'route should expose an explicit sandbox-completion action');
 assert.match(routeSource, /not a real KYC\/CIP\/AML decision/, 'sandbox validation simulation must be clearly disclosed');
+assert.match(routeSource, /bindIncreaseSandboxAccount/, 'successful Increase sandbox account creation must be bound to the authenticated Galactic Trust owner');
+assert.match(routeSource, /getProviderAccountBinding/, 'onboarding status must read the authenticated owner provider binding');
+assert.match(routeSource, /publicBindingSummary/, 'browser responses must use the masked provider binding summary');
+assert.match(routeSource, /auth\.user\.id/, 'provider binding must use the verified Supabase user ID rather than a client-supplied user identifier');
+assert.match(routeSource, /provider: 'increase',[\s\S]*environment: 'sandbox'/, 'Increase binding lookup must stay scoped to the sandbox environment');
+assert.match(routeSource, /binding = await bindOwnerSandboxAccount\(auth, result, 'increase-hosted-sandbox-onboarding'\)/, 'hosted onboarding completion must bind the resulting provider Account to the signed-in owner');
+assert.match(routeSource, /This is not real KYC approval/, 'bound sandbox setup must still disclaim real KYC approval');
 assert.equal(routeSource.includes('NEXT_PUBLIC_'), false, 'onboarding API must not use client-side provider credentials');
+
+const bindingSource = await readFile(new URL('../lib/real-estate/provider-account-binding.js', import.meta.url), 'utf8');
+assert.match(bindingSource, /bindIncreaseSandboxAccount/, 'trusted provider binding helper must support Increase sandbox');
+assert.match(bindingSource, /getIncreaseSandboxConfig/, 'Increase binding writes must verify the server-side sandbox configuration');
+assert.match(bindingSource, /provider_kyc_status: 'SANDBOX_VALID_SIMULATION'/, 'Increase sandbox validation must be stored as simulation, never real KYC PASS');
+assert.match(bindingSource, /provider: 'increase',[\s\S]*environment: 'sandbox'/, 'Increase binding must remain sandbox-scoped');
+assert.match(bindingSource, /migration 025_galactic_increase_account_bindings/, 'stale provider allowlist must fail closed with the required migration');
 
 const setupSource = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
 assert.match(setupSource, /\/api\/admin\/bank\/increase\/onboarding/, 'owner UI must use the owner-only onboarding endpoint');

--- a/scripts/test-provider-account-binding.mjs
+++ b/scripts/test-provider-account-binding.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import {
   bindDinariSandboxAccount,
+  bindIncreaseSandboxAccount,
   buildReadOnlyDinariEnvForBinding,
   getProviderAccountBinding,
   publicBindingSummary,
@@ -14,6 +15,11 @@ const sandboxEnv = {
   DINARI_SANDBOX_ORDER_EXECUTION_ENABLED: 'true',
   DINARI_SANDBOX_FAUCET_ENABLED: 'true',
   DINARI_PRODUCTION_TRADING_ENABLED: 'true',
+};
+
+const increaseSandboxEnv = {
+  GALACTIC_INCREASE_SANDBOX_ENABLED: 'true',
+  INCREASE_SANDBOX_API_KEY: 'increase-sandbox-test-key',
 };
 
 function makeAdmin() {
@@ -64,6 +70,11 @@ assert.doesNotMatch(migration, /for insert to authenticated/, 'browser users mus
 assert.doesNotMatch(migration, /for update to authenticated/, 'browser users must not get provider binding update rights');
 assert.doesNotMatch(migration, /for delete to authenticated/, 'browser users must not get provider binding delete rights');
 assert.match(migration, /unique \(provider, environment, account_id\)/, 'one provider account must not bind to multiple Voxel Vault users');
+
+const increaseMigration = readFileSync(new URL('../supabase/migrations/025_galactic_increase_account_bindings.sql', import.meta.url), 'utf8').toLowerCase();
+assert.match(increaseMigration, /provider in \('dinari', 'increase'\)/, 'Increase migration must extend the existing provider allowlist rather than create parallel identity storage');
+assert.doesNotMatch(increaseMigration, /create policy/, 'Increase migration must preserve the existing RLS policy set instead of adding browser write policies');
+assert.doesNotMatch(increaseMigration, /for insert to authenticated|for update to authenticated|for delete to authenticated/, 'Increase migration must not grant browser writes');
 
 const { admin, read } = makeAdmin();
 const userId = '11111111-1111-4111-8111-111111111111';
@@ -127,6 +138,103 @@ assert.throws(
   'a sandbox binding must not be read through live provider configuration'
 );
 
+const { admin: increaseAdmin, read: readIncrease } = makeAdmin();
+const increaseEntityId = 'entity_increase_sandbox_123';
+const increaseAccountId = 'account_increase_sandbox_abcdef123456';
+
+const increaseBefore = await getProviderAccountBinding(increaseAdmin, userId, { provider: 'increase', environment: 'sandbox' });
+assert.equal(increaseBefore.binding, null, 'an unbound Galactic Trust user must not inherit a global Increase sandbox account');
+
+await assert.rejects(
+  () => bindIncreaseSandboxAccount(increaseAdmin, userId, {
+    entityId: increaseEntityId,
+    accountId: increaseAccountId,
+    validationStatus: 'pending',
+  }, increaseSandboxEnv),
+  /validation must be valid/i,
+  'Increase account binding must fail closed until provider sandbox validation is explicitly valid'
+);
+
+await assert.rejects(
+  () => bindIncreaseSandboxAccount(increaseAdmin, userId, {
+    entityId: increaseEntityId,
+    accountId: increaseAccountId,
+    validationStatus: 'valid',
+  }, { ...increaseSandboxEnv, GALACTIC_INCREASE_SANDBOX_ENABLED: 'false' }),
+  /pretend-money sandbox workflow/i,
+  'Increase binding writes must remain disabled outside the explicitly enabled sandbox workflow'
+);
+
+await assert.rejects(
+  () => bindIncreaseSandboxAccount(increaseAdmin, userId, {
+    entityId: increaseEntityId,
+    accountId: increaseAccountId,
+    validationStatus: 'valid',
+  }, { GALACTIC_INCREASE_SANDBOX_ENABLED: 'true' }),
+  /pretend-money sandbox workflow/i,
+  'Increase binding writes must require server-side sandbox credentials'
+);
+
+const increaseBinding = await bindIncreaseSandboxAccount(increaseAdmin, userId, {
+  entityId: increaseEntityId,
+  accountId: increaseAccountId,
+  validationStatus: 'valid',
+  source: 'increase-hosted-sandbox-onboarding',
+}, increaseSandboxEnv);
+
+assert.equal(increaseBinding?.userId, userId);
+assert.equal(increaseBinding?.provider, 'increase');
+assert.equal(increaseBinding?.environment, 'sandbox');
+assert.equal(increaseBinding?.accountId, increaseAccountId);
+assert.equal(increaseBinding?.status, 'verified');
+assert.equal(readIncrease()?.provider_kyc_status, 'SANDBOX_VALID_SIMULATION', 'Increase sandbox validation must never be stored as real KYC PASS');
+
+const increaseLoaded = await getProviderAccountBinding(increaseAdmin, userId, { provider: 'increase', environment: 'sandbox' });
+assert.equal(increaseLoaded.binding?.entityId, increaseEntityId);
+assert.equal(increaseLoaded.binding?.accountId, increaseAccountId);
+assert.equal(increaseLoaded.binding?.kycStatus, 'SANDBOX_VALID_SIMULATION');
+
+const increaseSummary = publicBindingSummary(increaseBinding);
+assert.equal(increaseSummary?.provider, 'increase');
+assert.equal(increaseSummary?.kycStatus, 'SANDBOX_VALID_SIMULATION');
+assert.equal(increaseSummary?.accountSuffix, increaseAccountId.slice(-6));
+assert.equal('accountId' in increaseSummary, false, 'browser Increase summary must not expose the full provider account ID');
+assert.equal('entityId' in increaseSummary, false, 'browser Increase summary must not expose the full provider entity ID');
+
+const missingIncreaseMigrationAdmin = {
+  from() {
+    return {
+      upsert() {
+        return {
+          select() {
+            return {
+              async single() {
+                return {
+                  data: null,
+                  error: {
+                    code: '23514',
+                    message: 'new row violates check constraint vault_provider_account_bindings_provider_check',
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  },
+};
+
+await assert.rejects(
+  () => bindIncreaseSandboxAccount(missingIncreaseMigrationAdmin, userId, {
+    entityId: increaseEntityId,
+    accountId: increaseAccountId,
+    validationStatus: 'valid',
+  }, increaseSandboxEnv),
+  /migration 025_galactic_increase_account_bindings/i,
+  'Increase binding must fail closed with a concrete migration requirement when the provider allowlist is stale'
+);
+
 const missingTableAdmin = {
   from() {
     return {
@@ -148,4 +256,4 @@ assert.equal(missing.binding, null);
 assert.equal(missing.setupRequired, true, 'missing binding migration must fail closed and report setup required');
 assert.match(missing.error, /migration 014_provider_account_bindings/i);
 
-console.log('Provider binding safety checks passed: RLS has no client writes, global holdings are never inherited, binding is PASS-only and sandbox-only, browser summaries are private, suspended bindings fail closed, and user-bound reads force every trading/funding flag off.');
+console.log('Provider binding safety checks passed: RLS has no client writes, Dinari remains PASS-only and sandbox-only, Increase sandbox uses the same trusted binding table, Increase validation is explicitly recorded as simulation rather than KYC approval, stale migrations fail closed, global holdings are never inherited, browser summaries hide full provider IDs, and user-bound Dinari reads keep every trading/funding flag off.');

--- a/supabase/migrations/025_galactic_increase_account_bindings.sql
+++ b/supabase/migrations/025_galactic_increase_account_bindings.sql
@@ -1,0 +1,13 @@
+-- Extend the existing trusted provider-account binding model to Galactic Trust's
+-- Increase sandbox. Browser clients still have read-own access only; writes remain
+-- service-role/server-side through the existing RLS posture from migration 014.
+
+alter table public.vault_provider_account_bindings
+  drop constraint if exists vault_provider_account_bindings_provider_check;
+
+alter table public.vault_provider_account_bindings
+  add constraint vault_provider_account_bindings_provider_check
+  check (provider in ('dinari', 'increase'));
+
+comment on table public.vault_provider_account_bindings is
+  'Trusted server-written mapping from an authenticated Voxel Vault user to one provider Entity/Account per provider environment. Client writes are prohibited by RLS.';


### PR DESCRIPTION
## What changed
- extends the existing trusted `vault_provider_account_bindings` model to provider `increase` via migration `025_galactic_increase_account_bindings.sql`
- preserves the existing RLS model: authenticated users can read only their own binding and receive no client insert/update/delete policy
- binds successful Increase sandbox onboarding to the authenticated Supabase user through service-role server code
- records provider validation as `SANDBOX_VALID_SIMULATION`, never real KYC `PASS`
- fails closed when the binding table/provider allowlist migration is missing or when the provider Account is already bound elsewhere
- scopes `/api/admin/bank/increase/dashboard` to exactly the Account stored in the signed-in owner's binding
- scopes sandbox funding and transfer simulations to that same bound Account
- makes onboarding completion refresh only the created/reused Account instead of the old global sandbox account list
- keeps pre-existing unbound sandbox Accounts blocked in `/bank`; the owner must complete owner-scoped onboarding rather than inheriting global test data
- expands provider-binding and Galactic Trust onboarding regression tests and updates the sandbox runbook

## Safety / compliance boundary
- Increase remains pinned to sandbox and `canMoveRealMoney: false`
- live banking and live crypto implementation locks are untouched
- the user ID comes from verified server-side Supabase auth, never from request body input
- full provider Entity/Account IDs remain server-side; browser binding summaries expose only a suffix
- sandbox validation is explicitly stored and displayed as simulation, not KYC/CIP/AML approval
- no unrelated Voxel Vault product files were removed or moved

## Deployment prerequisite
Migration `025_galactic_increase_account_bindings.sql` must be applied before an Increase binding can be written. The repo's pending Supabase migration workflow therefore still depends on the existing repository-secret setup blocker before this can be exercised against the live sandbox environment.