### PR TITLE
Galactic Trust: add fail-closed account lifecycle

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -67,6 +67,8 @@ jobs:
         run: node scripts/test-galactic-trust-provider-boundary.mjs
       - name: Galactic Trust truthful UI states
         run: node scripts/test-galactic-trust-ui-truth.mjs
+      - name: Galactic Trust account lifecycle
+        run: node scripts/test-galactic-trust-account-lifecycle.mjs
       - name: Galactic Trust Increase onboarding
         run: node scripts/test-galactic-trust-increase-onboarding.mjs
       - name: Galactic Trust Increase webhooks

--- a/app/api/bank/lifecycle/route.ts
+++ b/app/api/bank/lifecycle/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
+import { buildGalacticAccountLifecycle } from '../../../../lib/banking/account-lifecycle.js';
+import { getProviderAccountBinding } from '../../../../lib/real-estate/provider-account-binding.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}
+
+function bearerToken(request: Request) {
+  const authorization = String(request.headers.get('authorization') || '');
+  return authorization.startsWith('Bearer ') ? authorization.slice(7).trim() : '';
+}
+
+export async function GET(request: Request) {
+  const token = bearerToken(request);
+  if (!token) {
+    return response({
+      ok: false,
+      error: 'Sign in to view your Galactic Trust account lifecycle.',
+      lifecycle: buildGalacticAccountLifecycle({ signedIn: false, env: process.env }),
+    }, 401);
+  }
+
+  try {
+    const admin = getSupabaseAdmin();
+    const { data: { user }, error } = await admin.auth.getUser(token);
+    if (error || !user) {
+      return response({
+        ok: false,
+        error: 'Your Galactic Trust session is invalid or expired.',
+        lifecycle: buildGalacticAccountLifecycle({ signedIn: false, env: process.env }),
+      }, 401);
+    }
+
+    const bindingState = await getProviderAccountBinding(admin, user.id, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
+    const lifecycle = buildGalacticAccountLifecycle({
+      signedIn: true,
+      bindingState,
+      env: process.env,
+    });
+
+    return response({
+      ok: true,
+      lifecycle,
+      note: 'This lifecycle is derived server-side from verified authentication, trusted provider-binding state, and regulated-launch locks. It is not a bank-account approval or production eligibility decision.',
+    });
+  } catch (error) {
+    return response({
+      ok: false,
+      error: error instanceof Error ? error.message : 'Galactic Trust account lifecycle could not be loaded.',
+      lifecycle: buildGalacticAccountLifecycle({
+        signedIn: true,
+        bindingState: { binding: null, setupRequired: true },
+        env: process.env,
+      }),
+    }, 503);
+  }
+}

--- a/lib/banking/account-lifecycle.js
+++ b/lib/banking/account-lifecycle.js
@@ -1,0 +1,71 @@
+import { bankingLaunchSnapshot } from './regulated-launch.js';
+
+export const GALACTIC_ACCOUNT_LIFECYCLE_VERSION = '2026-08-account-lifecycle-v1';
+
+function clean(value) {
+  return String(value ?? '').trim();
+}
+
+function isVerifiedIncreaseSandboxBinding(binding) {
+  return Boolean(
+    binding
+    && clean(binding.provider).toLowerCase() === 'increase'
+    && clean(binding.environment).toLowerCase() === 'sandbox'
+    && clean(binding.status).toLowerCase() === 'verified'
+    && clean(binding.kycStatus).toUpperCase() === 'SANDBOX_VALID_SIMULATION'
+  );
+}
+
+export function buildGalacticAccountLifecycle({
+  signedIn = false,
+  bindingState = null,
+  env = process.env,
+} = {}) {
+  const launch = bankingLaunchSnapshot(env);
+  const binding = bindingState?.binding || null;
+  const bindingStorageReady = !bindingState?.setupRequired;
+  const sandboxOwnerBound = isVerifiedIncreaseSandboxBinding(binding);
+
+  let stage = 'signed-out';
+  let nextAction = 'Sign in to use Galactic Trust demo features.';
+
+  if (signedIn && !bindingStorageReady) {
+    stage = 'infrastructure-setup-required';
+    nextAction = 'Apply the trusted provider-binding database migrations before treating any provider account as user-owned.';
+  } else if (signedIn && sandboxOwnerBound) {
+    stage = 'sandbox-owner-bound';
+    nextAction = 'Continue testing with the owner-scoped Increase sandbox. Production banking remains unavailable.';
+  } else if (signedIn) {
+    stage = 'demo-only';
+    nextAction = 'Use Galactic Trust in demo mode. Provider-backed customer banking is not activated.';
+  }
+
+  return {
+    lifecycleVersion: GALACTIC_ACCOUNT_LIFECYCLE_VERSION,
+    stage,
+    signedIn: Boolean(signedIn),
+    demoAvailable: true,
+    sandbox: {
+      provider: 'Increase',
+      environment: 'sandbox',
+      ownerBindingReady: sandboxOwnerBound,
+      bindingStorageReady,
+      validationKind: sandboxOwnerBound ? 'sandbox-simulation' : 'none',
+      canMoveRealMoney: false,
+    },
+    production: {
+      status: launch.status,
+      implementationReady: launch.implementationReady,
+      evidenceAssertionsPresent: launch.allRequiredAssertionsPresent,
+      liveSwitchRequested: launch.liveSwitchRequested,
+      providerConfigured: launch.providerConfigured,
+      sponsorBankNamed: launch.sponsorBankNamed,
+      customerAccountOpeningSupported: false,
+      customerMoneyMovementSupported: false,
+      canMoveRealMoney: false,
+    },
+    canOpenProductionAccount: false,
+    canMoveRealMoney: false,
+    nextAction,
+  };
+}

--- a/scripts/test-galactic-trust-account-lifecycle.mjs
+++ b/scripts/test-galactic-trust-account-lifecycle.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  GALACTIC_ACCOUNT_LIFECYCLE_VERSION,
+  buildGalacticAccountLifecycle,
+} from '../lib/banking/account-lifecycle.js';
+
+const noBinding = { binding: null, setupRequired: false, error: '' };
+const sandboxBinding = {
+  binding: {
+    provider: 'increase',
+    environment: 'sandbox',
+    status: 'verified',
+    kycStatus: 'SANDBOX_VALID_SIMULATION',
+    accountId: 'sandbox_account_private',
+    entityId: 'sandbox_entity_private',
+  },
+  setupRequired: false,
+  error: '',
+};
+
+const signedOut = buildGalacticAccountLifecycle({ signedIn: false, bindingState: noBinding, env: {} });
+assert.equal(signedOut.lifecycleVersion, GALACTIC_ACCOUNT_LIFECYCLE_VERSION);
+assert.equal(signedOut.stage, 'signed-out');
+assert.equal(signedOut.canMoveRealMoney, false);
+assert.equal(signedOut.canOpenProductionAccount, false);
+
+const demoOnly = buildGalacticAccountLifecycle({ signedIn: true, bindingState: noBinding, env: {} });
+assert.equal(demoOnly.stage, 'demo-only');
+assert.equal(demoOnly.sandbox.ownerBindingReady, false);
+assert.equal(demoOnly.production.customerAccountOpeningSupported, false);
+assert.equal(demoOnly.production.customerMoneyMovementSupported, false);
+
+const infrastructureBlocked = buildGalacticAccountLifecycle({
+  signedIn: true,
+  bindingState: { binding: null, setupRequired: true, error: 'migration missing' },
+  env: {},
+});
+assert.equal(infrastructureBlocked.stage, 'infrastructure-setup-required');
+assert.equal(infrastructureBlocked.sandbox.bindingStorageReady, false);
+assert.equal(infrastructureBlocked.canMoveRealMoney, false);
+
+const sandboxOwner = buildGalacticAccountLifecycle({ signedIn: true, bindingState: sandboxBinding, env: {} });
+assert.equal(sandboxOwner.stage, 'sandbox-owner-bound');
+assert.equal(sandboxOwner.sandbox.ownerBindingReady, true);
+assert.equal(sandboxOwner.sandbox.validationKind, 'sandbox-simulation');
+assert.equal(sandboxOwner.sandbox.canMoveRealMoney, false);
+assert.equal(JSON.stringify(sandboxOwner).includes('sandbox_account_private'), false, 'lifecycle response must not expose full provider Account IDs');
+assert.equal(JSON.stringify(sandboxOwner).includes('sandbox_entity_private'), false, 'lifecycle response must not expose full provider Entity IDs');
+
+const misleadingBinding = buildGalacticAccountLifecycle({
+  signedIn: true,
+  bindingState: {
+    ...sandboxBinding,
+    binding: { ...sandboxBinding.binding, kycStatus: 'PASS' },
+  },
+  env: {},
+});
+assert.equal(misleadingBinding.stage, 'demo-only', 'Increase sandbox binding must require the explicit simulation marker');
+assert.equal(misleadingBinding.sandbox.ownerBindingReady, false);
+
+const allEvidenceEnv = {
+  GALACTIC_LIVE_BANKING_ENABLED: 'true',
+  GALACTIC_BANKING_PLATFORM: 'increase',
+  GALACTIC_SPONSOR_BANK_LEGAL_NAME: 'Example Sponsor Bank',
+  GALACTIC_SPONSOR_BANK_AGREEMENT_ACTIVE: 'true',
+  GALACTIC_PROGRAM_COMPLIANCE_APPROVED: 'true',
+  GALACTIC_KYC_CIP_AML_APPROVED: 'true',
+  GALACTIC_ACCOUNT_DISCLOSURES_APPROVED: 'true',
+  GALACTIC_REG_E_APPROVED: 'true',
+  GALACTIC_MONEY_MOVEMENT_APPROVED: 'true',
+  GALACTIC_CARD_PROGRAM_APPROVED: 'true',
+  GALACTIC_LEDGER_RECONCILIATION_APPROVED: 'true',
+  GALACTIC_DEPOSIT_INSURANCE_DISCLOSURE_APPROVED: 'true',
+  GALACTIC_PRIVACY_SECURITY_APPROVED: 'true',
+  GALACTIC_COMPLAINTS_DISPUTES_APPROVED: 'true',
+  GALACTIC_INCIDENT_RESPONSE_APPROVED: 'true',
+  GALACTIC_PROVIDER_PRODUCTION_ACCEPTED: 'true',
+};
+const envCannotPromoteUser = buildGalacticAccountLifecycle({
+  signedIn: true,
+  bindingState: sandboxBinding,
+  env: allEvidenceEnv,
+});
+assert.equal(envCannotPromoteUser.production.evidenceAssertionsPresent, true);
+assert.equal(envCannotPromoteUser.production.liveSwitchRequested, true);
+assert.equal(envCannotPromoteUser.production.implementationReady, false, 'reviewed production implementation lock must remain false');
+assert.equal(envCannotPromoteUser.production.status, 'production-gated');
+assert.equal(envCannotPromoteUser.production.customerAccountOpeningSupported, false);
+assert.equal(envCannotPromoteUser.production.customerMoneyMovementSupported, false);
+assert.equal(envCannotPromoteUser.canOpenProductionAccount, false);
+assert.equal(envCannotPromoteUser.canMoveRealMoney, false, 'environment assertions must never promote a sandbox user to real-money banking');
+
+const helperSource = await readFile(new URL('../lib/banking/account-lifecycle.js', import.meta.url), 'utf8');
+assert.match(helperSource, /bankingLaunchSnapshot/, 'lifecycle must derive production state from the regulated launch boundary');
+assert.match(helperSource, /customerAccountOpeningSupported: false/, 'customer production account opening must remain explicitly unsupported');
+assert.match(helperSource, /customerMoneyMovementSupported: false/, 'customer production money movement must remain explicitly unsupported');
+assert.match(helperSource, /canMoveRealMoney: false/, 'lifecycle must fail closed on real-money movement');
+assert.equal(helperSource.includes('GALACTIC_LIVE_BANKING_ENABLED ='), false, 'lifecycle must not mutate or redefine live-banking switches');
+
+const routeSource = await readFile(new URL('../app/api/bank/lifecycle/route.ts', import.meta.url), 'utf8');
+assert.match(routeSource, /admin\.auth\.getUser\(token\)/, 'lifecycle API must verify the bearer session server-side');
+assert.match(routeSource, /getProviderAccountBinding\(admin, user\.id/, 'binding lookup must use the verified auth user ID');
+assert.match(routeSource, /provider: 'increase',[\s\S]*environment: 'sandbox'/, 'lifecycle binding lookup must remain Increase sandbox scoped');
+assert.match(routeSource, /private, no-store/, 'lifecycle API must prohibit caching');
+assert.match(routeSource, /not a bank-account approval or production eligibility decision/, 'lifecycle API must disclose that the derived state is not approval');
+assert.equal(routeSource.includes('request.json()'), false, 'lifecycle GET must not accept client-supplied lifecycle or user state');
+assert.equal(routeSource.includes('accountId'), false, 'lifecycle route must not expose provider Account IDs');
+assert.equal(routeSource.includes('entityId'), false, 'lifecycle route must not expose provider Entity IDs');
+
+console.log('Galactic Trust account lifecycle checks passed: lifecycle is server-derived, auth-scoped, sandbox-aware, provider IDs stay private, missing binding infrastructure fails closed, and no environment assertion can promote a user into production banking or real-money movement.');


### PR DESCRIPTION
## What changed
- adds a server-derived Galactic Trust account lifecycle model instead of a mutable database/live flag
- derives lifecycle from verified sign-in state, trusted Increase sandbox binding state, and the regulated-launch snapshot
- exposes authenticated `GET /api/bank/lifecycle` for signed-in users
- keeps provider Entity/Account IDs out of lifecycle responses
- defines explicit stages for signed-out, demo-only, binding-infrastructure-required, and owner-scoped sandbox-bound states
- keeps production account opening and customer money movement explicitly unsupported even if every evidence environment assertion and the live switch are set
- adds a dedicated lifecycle regression to the main Quality Gate

## Safety boundary
- no live banking or crypto implementation lock changed
- no database row, client body, or environment variable can promote a user into real-money banking
- lifecycle API verifies the bearer token server-side and scopes provider binding lookup to the verified Supabase user ID
- lifecycle responses are private/no-store
- no new migration is required for this lifecycle model
