### PR TITLE
Galactic Trust: surface personal account status

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -69,6 +69,8 @@ jobs:
         run: node scripts/test-galactic-trust-ui-truth.mjs
       - name: Galactic Trust account lifecycle
         run: node scripts/test-galactic-trust-account-lifecycle.mjs
+      - name: Galactic Trust account status UI
+        run: node scripts/test-galactic-trust-account-status-ui.mjs
       - name: Galactic Trust Increase onboarding
         run: node scripts/test-galactic-trust-increase-onboarding.mjs
       - name: Galactic Trust Increase webhooks

--- a/app/bank/GalacticDashboardEnhancements.js
+++ b/app/bank/GalacticDashboardEnhancements.js
@@ -12,7 +12,8 @@ const commands = [
   { id: 'cards', icon: '▤', label: 'Cards', hint: 'View Galactic cards' },
   { id: 'activity', icon: '≡', label: 'Transaction history', hint: 'Recent activity' },
   { id: 'security', icon: '✓', label: 'Security & privacy', hint: 'Protection details' },
-  { id: 'status', icon: '◉', label: 'Regulated launch status', hint: 'See what is required before live banking' },
+  { id: 'account-status', icon: '◉', label: 'My account status', hint: 'See what your signed-in account can do right now' },
+  { id: 'launch-status', icon: '🔒', label: 'Regulated launch status', hint: 'See what is required before live banking' },
   { id: 'rewards', icon: '✿', label: 'Rewards', hint: 'Galactic Stars' },
   { id: 'tour', icon: '✦', label: 'Explore the Stars', hint: 'Restart onboarding tour' },
 ];
@@ -44,9 +45,9 @@ function BalanceTrend() {
   const [range, setRange] = useState('1M');
   const trend = trends[range];
   return (
-    <div className="gt-balance-interactive" aria-label="Demo balance trend">
-      <div className="gt-balance-trend-head"><span>Demo trend</span><b>{trend.change}</b></div>
-      <svg viewBox="0 0 220 50" role="img" aria-label={`${range} balance trend`}><path d={trend.path} /></svg>
+    <div className="gt-balance-interactive" aria-label="Illustrative demo balance trend">
+      <div className="gt-balance-trend-head"><span>Illustrative demo trend</span><b>{trend.change}</b></div>
+      <svg viewBox="0 0 220 50" role="img" aria-label={`${range} illustrative demo balance trend`}><path d={trend.path} /></svg>
       <div className="gt-balance-ranges">
         {Object.keys(trends).map((item) => <button key={item} type="button" className={item === range ? 'active' : ''} onClick={(event) => { event.stopPropagation(); setRange(item); }}>{item}</button>)}
       </div>
@@ -66,9 +67,9 @@ function PriorityActions({ run }) {
 
 function TrustStrip() {
   return (
-    <section className="gt-trust-strip" aria-label="Galactic Trust regulated launch status">
+    <section className="gt-trust-strip" aria-label="Galactic Trust account and regulated launch status">
       <div className="gt-trust-badges"><span>🔒 Protected session</span><span>▣ Masked card data</span><span>◈ Live banking locked</span></div>
-      <p><b>Galactic Trust is a financial technology product, not a bank.</b> No real customer deposits are accepted or held in this build. Banking services can become live only through an approved sponsor-bank program with bank-approved disclosures and controls. <a href="/bank/readiness">View regulated launch status →</a></p>
+      <p><b>Galactic Trust is a financial technology product, not a bank.</b> No real customer deposits are accepted or held in this build. Banking services can become live only through an approved sponsor-bank program with bank-approved disclosures and controls. <a href="/bank/status">View your account status →</a> <a href="/bank/readiness">View regulated launch status →</a></p>
     </section>
   );
 }
@@ -192,7 +193,8 @@ export default function GalacticDashboardEnhancements({ onSignOut, accountLabel 
     else if (id === 'cards') scrollTo('#cards');
     else if (id === 'activity') scrollTo('#activity');
     else if (id === 'security') scrollTo('#security');
-    else if (id === 'status') window.location.assign('/bank/readiness');
+    else if (id === 'account-status') window.location.assign('/bank/status');
+    else if (id === 'launch-status') window.location.assign('/bank/readiness');
     else if (id === 'rewards') scrollTo('#rewards');
     else if (id === 'tour') { setTourIndex(0); setTourOpen(true); }
   }

--- a/app/bank/status/page.js
+++ b/app/bank/status/page.js
@@ -1,0 +1,168 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import styles from './status.module.css';
+
+const stageCopy = {
+  'demo-only': {
+    eyebrow: 'DEMO ONLY',
+    title: 'Your Galactic Trust account is in demo mode.',
+    detail: 'You can explore the product, but no provider-backed bank account or real-money access is active for this signed-in account.',
+    icon: '✦',
+  },
+  'sandbox-owner-bound': {
+    eyebrow: 'INCREASE SANDBOX · TEST ACCOUNT',
+    title: 'Your signed-in account is bound to an Increase sandbox test account.',
+    detail: 'Provider balances and ACH simulations are scoped to your server-side test binding. The money is pretend and this is not a production bank account.',
+    icon: '✓',
+  },
+  'infrastructure-setup-required': {
+    eyebrow: 'SETUP REQUIRED',
+    title: 'The trusted provider-binding infrastructure needs setup.',
+    detail: 'Galactic Trust is refusing to treat any provider account as yours until the required server-side database migrations are installed.',
+    icon: '!',
+  },
+  'signed-out': {
+    eyebrow: 'SIGN IN REQUIRED',
+    title: 'Sign in to view your Galactic Trust account status.',
+    detail: 'Account status is derived from your verified session and trusted provider binding, never from a browser-supplied user ID.',
+    icon: '◉',
+  },
+};
+
+function statusCopy(stage) {
+  return stageCopy[stage] || stageCopy['demo-only'];
+}
+
+function StatusRow({ label, value, state = 'neutral' }) {
+  return (
+    <div className={styles.statusRow}>
+      <span>{label}</span>
+      <strong className={styles[state]}>{value}</strong>
+    </div>
+  );
+}
+
+export default function GalacticAccountStatusPage() {
+  const [loading, setLoading] = useState(true);
+  const [lifecycle, setLifecycle] = useState(null);
+  const [error, setError] = useState('');
+  const [signedIn, setSignedIn] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const client = await getSupabaseBrowserAsync();
+      const { data, error: sessionError } = await client.auth.getSession();
+      if (sessionError) throw sessionError;
+      const token = String(data?.session?.access_token || '');
+      setSignedIn(Boolean(token));
+      if (!token) {
+        setLifecycle({
+          stage: 'signed-out',
+          canMoveRealMoney: false,
+          canOpenProductionAccount: false,
+          sandbox: { ownerBindingReady: false, bindingStorageReady: true, canMoveRealMoney: false, validationKind: 'none' },
+          production: { status: 'production-gated', implementationReady: false, customerAccountOpeningSupported: false, customerMoneyMovementSupported: false, canMoveRealMoney: false },
+        });
+        return;
+      }
+
+      const response = await fetch('/api/bank/lifecycle', {
+        cache: 'no-store',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (payload?.lifecycle) setLifecycle(payload.lifecycle);
+      if (!response.ok) setError(String(payload?.error || 'Account status could not be loaded.'));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Account status could not be loaded.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const copy = useMemo(() => statusCopy(lifecycle?.stage), [lifecycle?.stage]);
+  const productionLocked = lifecycle?.production?.customerAccountOpeningSupported !== true
+    && lifecycle?.production?.customerMoneyMovementSupported !== true
+    && lifecycle?.canMoveRealMoney !== true;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.stars} aria-hidden="true" />
+      <header className={styles.header}>
+        <Link className={styles.brand} href="/bank"><span className={styles.planet}>✦</span><span><b>Galactic Trust</b><small>Account Status</small></span></Link>
+        <div className={styles.headerActions}>
+          <Link href="/bank/readiness">Launch Readiness</Link>
+          <Link className={styles.primaryLink} href="/bank">Back to Dashboard</Link>
+        </div>
+      </header>
+
+      <section className={styles.shell}>
+        <div className={styles.intro}>
+          <span className={styles.kicker}>✦ SERVER-DERIVED ACCOUNT STATE</span>
+          <h1>Know exactly what your<br /><em>Galactic Trust account</em> can do.</h1>
+          <p>This page reads your verified session, trusted provider binding, and Galactic Trust&apos;s regulated-launch locks. It does not infer banking access from a button, balance card, environment switch, or marketing copy.</p>
+        </div>
+
+        <section className={styles.statusCard} aria-live="polite">
+          {loading ? (
+            <div className={styles.loading}><span>◌</span><h2>Checking your account state…</h2><p>Verifying your signed-in lifecycle.</p></div>
+          ) : (
+            <>
+              <div className={styles.statusHero}>
+                <span className={styles.statusIcon}>{copy.icon}</span>
+                <div><small>{copy.eyebrow}</small><h2>{copy.title}</h2><p>{copy.detail}</p></div>
+              </div>
+
+              {error && <div className={styles.error} role="status">{error}</div>}
+
+              <div className={styles.grid}>
+                <article>
+                  <span className={styles.cardIcon}>◈</span>
+                  <h3>Provider test account</h3>
+                  <StatusRow label="Increase sandbox binding" value={lifecycle?.sandbox?.ownerBindingReady ? 'BOUND' : 'NOT BOUND'} state={lifecycle?.sandbox?.ownerBindingReady ? 'good' : 'neutral'} />
+                  <StatusRow label="Binding storage" value={lifecycle?.sandbox?.bindingStorageReady === false ? 'SETUP REQUIRED' : 'READY'} state={lifecycle?.sandbox?.bindingStorageReady === false ? 'warn' : 'good'} />
+                  <StatusRow label="Validation kind" value={lifecycle?.sandbox?.validationKind === 'sandbox-simulation' ? 'SANDBOX SIMULATION' : 'NONE'} />
+                  <StatusRow label="Real money" value="NO" state="locked" />
+                  <p className={styles.cardNote}>A sandbox binding proves only that test data is scoped to the signed-in user. It is not KYC approval, a deposit account, or permission to move real money.</p>
+                </article>
+
+                <article>
+                  <span className={styles.cardIcon}>🔒</span>
+                  <h3>Production banking</h3>
+                  <StatusRow label="Launch status" value={lifecycle?.production?.status === 'live' ? 'LIVE' : 'GATED'} state={lifecycle?.production?.status === 'live' ? 'warn' : 'locked'} />
+                  <StatusRow label="Implementation ready" value={lifecycle?.production?.implementationReady ? 'YES' : 'NO'} state={lifecycle?.production?.implementationReady ? 'warn' : 'locked'} />
+                  <StatusRow label="Customer account opening" value={lifecycle?.production?.customerAccountOpeningSupported ? 'SUPPORTED' : 'NOT SUPPORTED'} state={lifecycle?.production?.customerAccountOpeningSupported ? 'warn' : 'locked'} />
+                  <StatusRow label="Real-money movement" value={lifecycle?.production?.customerMoneyMovementSupported ? 'SUPPORTED' : 'NOT SUPPORTED'} state={lifecycle?.production?.customerMoneyMovementSupported ? 'warn' : 'locked'} />
+                  <p className={styles.cardNote}>Production access requires an approved sponsor-bank/provider program plus the reviewed production implementation. Environment flags alone cannot enable it.</p>
+                </article>
+              </div>
+
+              <div className={`${styles.bottomState} ${productionLocked ? styles.safe : styles.alert}`}>
+                <span>{productionLocked ? '✓' : '!'}</span>
+                <p><b>{productionLocked ? 'Production remains fail-closed.' : 'Production status requires immediate review.'}</b><small>{productionLocked ? 'No production account opening or real-money movement is enabled for this lifecycle.' : 'This page detected an unexpected production-capable lifecycle.'}</small></p>
+              </div>
+
+              <div className={styles.actions}>
+                {!signedIn ? <Link className={styles.button} href="/bank">Sign in to Galactic Trust</Link> : <button className={styles.button} type="button" onClick={load}>Refresh account status</button>}
+                <Link className={styles.secondaryButton} href="/bank/readiness">See regulated launch requirements</Link>
+              </div>
+            </>
+          )}
+        </section>
+
+        <footer className={styles.disclosure}>
+          <b>Galactic Trust is a financial technology product, not a bank.</b> This status page is not a bank-account approval, KYC decision, credit decision, or representation that deposits are insured. Increase sandbox values are test data with pretend money only.
+        </footer>
+      </section>
+    </main>
+  );
+}

--- a/app/bank/status/page.js
+++ b/app/bank/status/page.js
@@ -15,7 +15,7 @@ const stageCopy = {
   'sandbox-owner-bound': {
     eyebrow: 'INCREASE SANDBOX · TEST ACCOUNT',
     title: 'Your signed-in account is bound to an Increase sandbox test account.',
-    detail: 'Provider balances and ACH simulations are scoped to your server-side test binding. The money is pretend and this is not a production bank account.',
+    detail: 'Provider balances and ACH simulations are scoped to your server-side test binding. The money is pretend. This is not a production bank account.',
     icon: '✓',
   },
   'infrastructure-setup-required': {

--- a/app/bank/status/status.module.css
+++ b/app/bank/status/status.module.css
@@ -1,0 +1,410 @@
+.page {
+  min-height: 100vh;
+  background: radial-gradient(circle at 12% 10%, rgba(138, 111, 255, 0.16), transparent 32%), radial-gradient(circle at 88% 16%, rgba(67, 200, 194, 0.13), transparent 28%), #f8f8fc;
+  color: #241f3b;
+  position: relative;
+  overflow: hidden;
+}
+
+.stars {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.42;
+  background-image: radial-gradient(circle, rgba(113, 86, 245, 0.35) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(to bottom, #000, transparent 72%);
+}
+
+.header {
+  position: relative;
+  z-index: 2;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 22px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand b,
+.brand small {
+  display: block;
+}
+
+.brand b {
+  font-size: 16px;
+}
+
+.brand small {
+  margin-top: 2px;
+  color: #77708e;
+  font-size: 11px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.planet {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: white;
+  background: linear-gradient(145deg, #7a5ff6, #4d3ac6);
+  box-shadow: 0 10px 30px rgba(91, 67, 214, 0.28);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.headerActions a {
+  padding: 10px 14px;
+  border-radius: 12px;
+  color: #584e77;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.headerActions .primaryLink {
+  color: white;
+  background: #6f55f5;
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 54px 24px 64px;
+}
+
+.intro {
+  max-width: 760px;
+  margin-bottom: 34px;
+}
+
+.kicker {
+  display: inline-flex;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #eeeaff;
+  color: #6149d9;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.intro h1 {
+  margin: 18px 0 14px;
+  font-size: clamp(38px, 6vw, 68px);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.intro h1 em {
+  color: #6f55f5;
+  font-style: normal;
+}
+
+.intro p {
+  max-width: 700px;
+  margin: 0;
+  color: #676078;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.statusCard {
+  padding: 26px;
+  border-radius: 28px;
+  border: 1px solid rgba(98, 79, 190, 0.14);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 30px 90px rgba(55, 40, 118, 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.loading {
+  min-height: 360px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  text-align: center;
+}
+
+.loading span {
+  font-size: 38px;
+  animation: spin 1.1s linear infinite;
+}
+
+.loading h2 {
+  margin: 14px 0 5px;
+}
+
+.loading p {
+  margin: 0;
+  color: #77708e;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.statusHero {
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding-bottom: 22px;
+  border-bottom: 1px solid #eceaf3;
+}
+
+.statusIcon {
+  width: 58px;
+  height: 58px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  color: white;
+  font-size: 26px;
+  font-weight: 900;
+  background: linear-gradient(145deg, #755bf2, #5942cf);
+}
+
+.statusHero small {
+  color: #6f55f5;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+}
+
+.statusHero h2 {
+  margin: 5px 0 7px;
+  font-size: clamp(23px, 3vw, 32px);
+  letter-spacing: -0.03em;
+}
+
+.statusHero p {
+  margin: 0;
+  max-width: 780px;
+  color: #6c657c;
+  line-height: 1.55;
+}
+
+.error {
+  margin-top: 18px;
+  padding: 12px 14px;
+  border: 1px solid #f0cbd7;
+  border-radius: 12px;
+  background: #fff5f8;
+  color: #9c3155;
+  font-size: 13px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.grid article {
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid #ebe8f5;
+  background: #fbfaff;
+}
+
+.cardIcon {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  background: #eeeaff;
+}
+
+.grid h3 {
+  margin: 12px 0 14px;
+  font-size: 18px;
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 11px 0;
+  border-top: 1px solid #eeecf5;
+  font-size: 12px;
+}
+
+.statusRow span {
+  color: #77708e;
+}
+
+.statusRow strong {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-align: right;
+}
+
+.good { color: #177245; }
+.warn { color: #a6620d; }
+.locked { color: #8d3151; }
+.neutral { color: #5d5571; }
+
+.cardNote {
+  margin: 12px 0 0;
+  color: #746d85;
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.bottomState {
+  margin-top: 20px;
+  padding: 15px 16px;
+  border-radius: 16px;
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.bottomState > span {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 900;
+}
+
+.bottomState p,
+.bottomState b,
+.bottomState small {
+  margin: 0;
+  display: block;
+}
+
+.bottomState small {
+  margin-top: 3px;
+  line-height: 1.45;
+}
+
+.safe {
+  border: 1px solid #cce8dc;
+  background: #f1fbf6;
+  color: #27684e;
+}
+
+.safe > span {
+  background: #d9f3e7;
+}
+
+.alert {
+  border: 1px solid #efc9d5;
+  background: #fff4f7;
+  color: #8d3151;
+}
+
+.alert > span {
+  background: #f8dce5;
+}
+
+.actions {
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.button,
+.secondaryButton {
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 850;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.button {
+  color: white;
+  background: #6f55f5;
+}
+
+.secondaryButton {
+  color: #5d4ed2;
+  background: #eeeaff;
+}
+
+.disclosure {
+  margin-top: 20px;
+  padding: 17px 18px;
+  border-radius: 16px;
+  color: #6f687e;
+  background: rgba(255, 255, 255, 0.64);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.disclosure b {
+  color: #453e58;
+}
+
+@media (max-width: 760px) {
+  .header {
+    padding: 16px;
+    align-items: flex-start;
+  }
+
+  .headerActions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .headerActions a {
+    padding: 8px 10px;
+    text-align: center;
+    font-size: 11px;
+  }
+
+  .shell {
+    padding: 34px 16px 44px;
+  }
+
+  .statusCard {
+    padding: 18px;
+    border-radius: 22px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .statusHero {
+    grid-template-columns: 46px 1fr;
+  }
+
+  .statusIcon {
+    width: 46px;
+    height: 46px;
+    border-radius: 14px;
+  }
+}

--- a/scripts/test-galactic-trust-account-status-ui.mjs
+++ b/scripts/test-galactic-trust-account-status-ui.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const page = await readFile(new URL('../app/bank/status/page.js', import.meta.url), 'utf8');
+const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhancements.js', import.meta.url), 'utf8');
+const lifecycleRoute = await readFile(new URL('../app/api/bank/lifecycle/route.ts', import.meta.url), 'utf8');
+
+assert.match(page, /getSupabaseBrowserAsync/, 'account status UI must derive its bearer session from the authenticated Supabase browser session');
+assert.match(page, /fetch\('\/api\/bank\/lifecycle'/, 'account status UI must read the server-derived lifecycle endpoint');
+assert.match(page, /Authorization: `Bearer \$\{token\}`/, 'lifecycle request must send the authenticated session token');
+assert.match(page, /DEMO ONLY/, 'account status UI must explicitly represent demo-only users');
+assert.match(page, /INCREASE SANDBOX · TEST ACCOUNT/, 'owner-scoped sandbox state must be labeled as a test account');
+assert.match(page, /SETUP REQUIRED/, 'binding infrastructure failure must have a visible setup-required state');
+assert.match(page, /This is not a production bank account/, 'sandbox-bound state must disclaim production banking');
+assert.match(page, /Real money[^]*NO/, 'sandbox provider card must explicitly deny real-money capability');
+assert.match(page, /Customer account opening[^]*NOT SUPPORTED/, 'production account opening must be shown as unsupported by default');
+assert.match(page, /Real-money movement[^]*NOT SUPPORTED/, 'production money movement must be shown as unsupported by default');
+assert.match(page, /Production remains fail-closed/, 'status page must show a fail-closed production summary');
+assert.match(page, /not a bank-account approval, KYC decision, credit decision/, 'status page must disclose that lifecycle state is not regulated approval');
+assert.match(page, /href="\/bank\/readiness"/, 'account status UI must keep regulated launch readiness as a separate destination');
+assert.equal(page.includes('accountId'), false, 'personal status UI must never handle full provider Account IDs');
+assert.equal(page.includes('entityId'), false, 'personal status UI must never handle full provider Entity IDs');
+assert.equal(page.includes('INCREASE_SANDBOX_API_KEY'), false, 'personal status UI must never read provider credentials');
+assert.equal(page.includes('NEXT_PUBLIC_'), false, 'personal status UI must not depend on client-exposed banking secrets');
+
+assert.match(enhancements, /id: 'account-status'[^]*label: 'My account status'/, 'dashboard command palette must expose the personal account-status destination');
+assert.match(enhancements, /id: 'launch-status'[^]*label: 'Regulated launch status'/, 'dashboard must preserve a separate launch-readiness destination');
+assert.match(enhancements, /window\.location\.assign\('\/bank\/status'\)/, 'personal account-status command must route to /bank/status');
+assert.match(enhancements, /window\.location\.assign\('\/bank\/readiness'\)/, 'regulated launch command must route to /bank/readiness');
+assert.match(enhancements, /View your account status →/, 'dashboard trust strip must link to personal account status');
+assert.match(enhancements, /View regulated launch status →/, 'dashboard trust strip must separately link to regulated launch readiness');
+assert.match(enhancements, /Illustrative demo trend/, 'balance enhancement must label its synthetic trend as illustrative demo data');
+
+assert.match(lifecycleRoute, /admin\.auth\.getUser\(token\)/, 'status UI source endpoint must continue to verify the session server-side');
+assert.match(lifecycleRoute, /getProviderAccountBinding\(admin, user\.id/, 'status UI source endpoint must scope binding to the verified user');
+assert.match(lifecycleRoute, /not a bank-account approval or production eligibility decision/, 'server lifecycle source must retain the production-eligibility disclaimer');
+
+console.log('Galactic Trust account status UI checks passed: personal lifecycle and regulated launch readiness stay distinct, sandbox ownership is labeled as test-only, production banking remains visibly unsupported, provider IDs/secrets stay out of the client, and the dashboard exposes both destinations clearly.');


### PR DESCRIPTION
## What changed
- adds `/bank/status`, a personal Galactic Trust account-status page backed by the server-derived lifecycle API
- clearly separates personal lifecycle state from `/bank/readiness` regulated launch readiness
- represents signed-out, demo-only, owner-scoped Increase sandbox test account, and binding-infrastructure-required states
- shows production account opening and real-money movement as unsupported while the regulated launch remains fail-closed
- never handles or displays full provider Entity/Account IDs or provider credentials in the client
- adds dashboard trust-strip links and command-palette destinations for both personal account status and regulated launch status
- labels the existing synthetic hero trend explicitly as an illustrative demo trend
- adds a dedicated account-status UI regression to the Quality Gate

## Safety / compliance boundary
- sandbox ownership is labeled as a test account, not a production bank account
- page states explicitly that lifecycle is not bank-account approval, KYC, credit approval, or deposit-insurance representation
- no live banking or crypto implementation lock changed
- no database migrations or money-movement behavior changed
