### PR TITLE
Restore Galactic Trust legal links after cleanup

### DIFF
--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Privacy',
+  description: 'Privacy information for the Galactic Trust financial technology application.',
+  alternates: { canonical: '/privacy' },
+};
+
+const sectionStyle = {
+  padding: '22px 0',
+  borderTop: '1px solid rgba(255,255,255,0.12)',
+};
+
+export default function PrivacyPage() {
+  return (
+    <main style={{ minHeight: '100vh', background: '#07103d', color: '#f7f8ff', fontFamily: 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', padding: '48px 20px 80px' }}>
+      <article style={{ width: 'min(860px, 100%)', margin: '0 auto' }}>
+        <nav style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 44 }}>
+          <Link href="/" style={{ color: '#fff', textDecoration: 'none', fontWeight: 800, letterSpacing: '-0.02em' }}>✦ Galactic Trust</Link>
+          <Link href="/bank/readiness" style={{ color: '#b7c5ff', textDecoration: 'none', fontWeight: 700 }}>Launch status</Link>
+        </nav>
+
+        <p style={{ color: '#9fb0ff', fontWeight: 800, letterSpacing: '0.12em', fontSize: 12 }}>GALACTIC TRUST PRIVACY</p>
+        <h1 style={{ fontSize: 'clamp(42px, 8vw, 72px)', lineHeight: 0.96, letterSpacing: '-0.055em', margin: '12px 0 22px' }}>Collect less. Keep provider secrets off the client.</h1>
+        <p style={{ color: '#cbd3ff', fontSize: 18, lineHeight: 1.7, maxWidth: 760 }}>Effective August 30, 2026. This notice describes the current Galactic Trust demo and sandbox application. It is not a future sponsor bank&apos;s privacy notice.</p>
+
+        <section style={sectionStyle}>
+          <h2>1. Current account information</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>When you sign in, Galactic Trust uses authentication information needed to maintain your session, such as the account identifier, email address made available through the sign-in provider, and session credentials. Browser authentication may use local storage or similar browser mechanisms through the configured authentication provider.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>2. Increase sandbox information</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>For authorized owner testing, Galactic Trust may store server-side references that bind an authenticated user to an Increase sandbox Entity and Account. Browser responses are deliberately limited and do not expose full provider Entity or Account identifiers, API keys, raw account numbers, or routing numbers.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>3. Hosted sandbox onboarding</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>The current integration uses provider-hosted sandbox onboarding so Galactic Trust does not need ordinary application forms for sensitive identity fields. Sandbox validation is simulated test behavior and is not a real KYC, CIP, AML, sanctions, credit, or bank-account approval decision.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>4. Provider event and reconciliation records</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust records limited Increase sandbox event metadata needed for webhook verification, idempotency, reconciliation, and operational status. The application is designed to retain a payload fingerprint rather than raw webhook payloads in its reconciliation ledger.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>5. Service providers</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust currently relies on infrastructure providers for application hosting and authentication, and on Increase for the pretend-money banking sandbox. Those providers process information under their own applicable terms and privacy practices. A future live banking program would require its own approved privacy disclosures and sponsor-bank/provider responsibilities.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>6. Sensitive information and secrets</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Do not paste passwords, API keys, private keys, bank credentials, Social Security numbers, or other sensitive secrets into Galactic Trust chat or ordinary text fields. Increase provider credentials are intended to remain server-only and must not be exposed through browser-visible environment variables.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>7. Demo and sandbox data</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Current balances, cards, transfers, rewards, and provider-backed banking data are demo or pretend-money sandbox information. Galactic Trust does not currently use this application to hold real customer deposits or move real customer money.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>8. Future production changes</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>If Galactic Trust later launches an approved production banking program, this notice will need to be updated to reflect the actual sponsor bank, production providers, categories of information, retention practices, customer rights, required notices, and regulated data-handling responsibilities before those live services are represented as available.</p>
+        </section>
+
+        <footer style={{ ...sectionStyle, display: 'flex', flexWrap: 'wrap', gap: 18, color: '#9fb0ff' }}>
+          <Link href="/terms" style={{ color: '#b7c5ff' }}>Terms</Link>
+          <Link href="/bank/status" style={{ color: '#b7c5ff' }}>My account status</Link>
+          <Link href="/bank/readiness" style={{ color: '#b7c5ff' }}>Regulated launch status</Link>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/app/terms/page.js
+++ b/app/terms/page.js
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Terms',
+  description: 'Terms for the Galactic Trust financial technology application.',
+  alternates: { canonical: '/terms' },
+};
+
+const sectionStyle = {
+  padding: '22px 0',
+  borderTop: '1px solid rgba(255,255,255,0.12)',
+};
+
+export default function TermsPage() {
+  return (
+    <main style={{ minHeight: '100vh', background: '#07103d', color: '#f7f8ff', fontFamily: 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', padding: '48px 20px 80px' }}>
+      <article style={{ width: 'min(860px, 100%)', margin: '0 auto' }}>
+        <nav style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 44 }}>
+          <Link href="/" style={{ color: '#fff', textDecoration: 'none', fontWeight: 800, letterSpacing: '-0.02em' }}>✦ Galactic Trust</Link>
+          <Link href="/bank/readiness" style={{ color: '#b7c5ff', textDecoration: 'none', fontWeight: 700 }}>Launch status</Link>
+        </nav>
+
+        <p style={{ color: '#9fb0ff', fontWeight: 800, letterSpacing: '0.12em', fontSize: 12 }}>GALACTIC TRUST TERMS</p>
+        <h1 style={{ fontSize: 'clamp(42px, 8vw, 72px)', lineHeight: 0.96, letterSpacing: '-0.055em', margin: '12px 0 22px' }}>Clear terms for a product that is still sandbox-first.</h1>
+        <p style={{ color: '#cbd3ff', fontSize: 18, lineHeight: 1.7, maxWidth: 760 }}>Effective August 30, 2026. These terms apply to the Galactic Trust application and its current demo and sandbox features.</p>
+
+        <section style={sectionStyle}>
+          <h2>1. Galactic Trust is not a bank</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust is a financial technology product, not a bank. Galactic Trust does not currently accept or hold real customer deposits, open production deposit accounts, issue live payment cards, or move real customer money.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>2. Current financial features are demo or sandbox features</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Balances, transfers, cards, rewards, account activity, and similar experiences may be illustrative demo data or provider-backed test data. The connected Increase environment is a pretend-money sandbox. Sandbox transfers do not debit or credit real external bank accounts.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>3. No deposit-insurance representation</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust is not an FDIC-insured institution and does not currently make a deposit-insurance claim. If a live banking program is launched in the future, the actual sponsor bank, banking services, account terms, and any applicable deposit-insurance disclosure must be identified in separate bank-approved materials.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>4. Accounts and access</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>You are responsible for keeping access to your sign-in account and device secure. Do not provide API keys, passwords, private keys, bank credentials, Social Security numbers, or other sensitive secrets to Galactic Trust chat or ordinary application text fields.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>5. Sandbox onboarding is not real KYC approval</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Any current Increase sandbox onboarding, entity validation, account creation, account numbers, funding simulation, or transfer simulation is test infrastructure only. A sandbox validation state is not a real KYC, CIP, AML, sanctions, credit, or bank-account approval decision.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>6. Future regulated services require separate approval</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Environment variables, software switches, authentication, or an application status screen cannot make a regulated banking service live. A future production launch requires an approved provider and sponsor-bank program, production acceptance, required consumer disclosures, operational controls, and any separate terms required by those providers.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>7. Availability and changes</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Demo and sandbox features may change, be unavailable, be reset, or be removed. Galactic Trust may update these terms as the product changes. A material future production banking launch should be accompanied by the appropriate live-program agreements and disclosures rather than silently converting sandbox terms into bank-account terms.</p>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2>8. No investment, tax, or legal advice</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>The application and its demo information are provided for product use and evaluation. They are not personalized investment, tax, legal, or credit advice.</p>
+        </section>
+
+        <footer style={{ ...sectionStyle, display: 'flex', flexWrap: 'wrap', gap: 18, color: '#9fb0ff' }}>
+          <Link href="/privacy" style={{ color: '#b7c5ff' }}>Privacy</Link>
+          <Link href="/bank/status" style={{ color: '#b7c5ff' }}>My account status</Link>
+          <Link href="/bank/readiness" style={{ color: '#b7c5ff' }}>Regulated launch status</Link>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/scripts/test-galactic-trust-repo-scope.mjs
+++ b/scripts/test-galactic-trust-repo-scope.mjs
@@ -14,9 +14,18 @@ for (const path of ['app/marketplace', 'app/property', 'app/real-estate', 'app/f
 assert.equal(await absent('lib/real-estate'), true, 'mixed real-estate provider code must not remain in lib');
 
 const appEntries = (await readdir(new URL('../app', import.meta.url))).sort();
-assert.deepEqual(appEntries, ['api', 'bank', 'layout.js', 'page.js'].sort(), 'app must contain only Galactic Trust product surfaces');
+assert.deepEqual(appEntries, ['api', 'bank', 'layout.js', 'page.js', 'privacy', 'terms'].sort(), 'app must contain only Galactic Trust product and legal surfaces');
 const libEntries = (await readdir(new URL('../lib', import.meta.url))).sort();
 assert.deepEqual(libEntries, ['admin-auth.ts', 'banking', 'supabase-admin.ts', 'supabase-browser.js'].sort(), 'lib must contain only Galactic Trust banking/auth infrastructure');
+
+const terms = await readFile(new URL('../app/terms/page.js', import.meta.url), 'utf8');
+const privacy = await readFile(new URL('../app/privacy/page.js', import.meta.url), 'utf8');
+assert.match(terms, /Galactic Trust is not a bank/i, 'terms must preserve the nonbank boundary');
+assert.match(terms, /pretend-money sandbox/i, 'terms must identify current provider banking as sandbox-only');
+assert.match(terms, /not a real KYC, CIP, AML, sanctions, credit, or bank-account approval decision/i, 'terms must not turn sandbox validation into production approval');
+assert.match(privacy, /Galactic Trust does not currently use this application to hold real customer deposits or move real customer money/i, 'privacy notice must preserve the no-real-money boundary');
+assert.match(privacy, /server-only/i, 'privacy notice must state the provider-secret boundary');
+assert.doesNotMatch(`${terms}\n${privacy}`, /Voxel Vault|VoxelPop|marketplace|property token/i, 'Galactic Trust legal pages must not restore legacy product copy');
 
 const vercel = await readFile(new URL('../vercel.json', import.meta.url), 'utf8');
 assert.doesNotMatch(vercel, /catalog-3d|neural-core|voxel/i, 'Vercel config must not schedule old product jobs');


### PR DESCRIPTION
## Summary
- adds Galactic Trust-specific `/terms` and `/privacy` pages
- preserves the nonbank, sandbox-only, no-real-money boundary
- makes clear that Increase sandbox validation is not real KYC/CIP/AML or bank-account approval
- documents server-only provider-secret handling and limited reconciliation metadata
- updates repository-scope regression coverage so legal pages are allowed while legacy Voxel/product copy remains forbidden

## Why
PR #598 intentionally removed the old product legal surfaces. The surviving Galactic Trust regulated-launch page still links to Terms and Privacy, so these pages restore those destinations without bringing back Voxel Vault legal copy.

## Safety
These pages do not claim Galactic Trust is a bank, FDIC-insured institution, live deposit program, or production money-movement service.