### PR TITLE
Add Galactic Trust integration health center

### DIFF
--- a/app/api/admin/bank/integration-health/route.ts
+++ b/app/api/admin/bank/integration-health/route.ts
@@ -1,0 +1,278 @@
+import { NextResponse } from 'next/server';
+import { requireGalacticTrustAdmin } from '../../../../../lib/admin-auth';
+import { describeIncreaseSandboxError } from '../../../../../lib/banking/increase-api-errors.js';
+import { inspectIncreaseSandboxOnboarding } from '../../../../../lib/banking/increase-onboarding-sandbox.js';
+import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents } from '../../../../../lib/banking/increase-reconciliation';
+import { getIncreaseSandboxConfig, inspectIncreaseSandbox } from '../../../../../lib/banking/increase-sandbox.js';
+import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../lib/banking/increase-webhook-subscription.js';
+import { getProviderAccountBinding, publicBindingSummary } from '../../../../../lib/banking/provider-account-binding.js';
+import { bankingLaunchSnapshot } from '../../../../../lib/banking/regulated-launch.js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, { status, headers: { 'Cache-Control': 'private, no-store, max-age=0' } });
+}
+
+function safeCapability(value: any) {
+  return {
+    available: value?.available === true,
+    status: Number.isFinite(Number(value?.issue?.status)) ? Number(value.issue.status) : null,
+    type: typeof value?.issue?.type === 'string' ? value.issue.type.slice(0, 80) : '',
+  };
+}
+
+function safeProviderError(error: any, fallback: string) {
+  const provider = describeIncreaseSandboxError(error, fallback);
+  return {
+    providerStatus: provider.providerStatus,
+    providerType: provider.providerType,
+    error: provider.error,
+    nextStep: provider.nextStep,
+  };
+}
+
+function safeReconciliationState(payload: any) {
+  const state = payload?.state || null;
+  const recentEvents = Array.isArray(payload?.recentEvents) ? payload.recentEvents : [];
+  const latest = recentEvents[0] || null;
+  return {
+    databaseReady: true,
+    status: String(state?.last_reconciliation_status || 'not-run'),
+    lastReconciledAt: state?.last_reconciled_at || null,
+    lastWebhookAt: state?.last_webhook_at || null,
+    lastPollAt: state?.last_poll_at || null,
+    accountCount: Number.isFinite(Number(state?.account_count)) ? Number(state.account_count) : 0,
+    transactionCount: Number.isFinite(Number(state?.transaction_count)) ? Number(state.transaction_count) : 0,
+    eventCursorStored: Boolean(state?.event_cursor),
+    lastError: typeof state?.last_error === 'string' ? state.last_error.slice(0, 160) : '',
+    recentEventCount: recentEvents.length,
+    latestEvent: latest ? {
+      category: String(latest.category || '').slice(0, 120),
+      source: String(latest.source || '').slice(0, 40),
+      processingStatus: String(latest.processing_status || '').slice(0, 40),
+      receivedAt: latest.received_at || null,
+    } : null,
+  };
+}
+
+async function buildHealth(auth: any) {
+  const config = getIncreaseSandboxConfig(process.env);
+  const launch = bankingLaunchSnapshot(process.env);
+
+  let provider: any = {
+    provider: 'Increase',
+    environment: 'sandbox',
+    enabled: config.enabled,
+    credentialsConfigured: config.credentialsConfigured,
+    connected: false,
+    setupRequired: true,
+    counts: { programs: 0, accounts: 0, entities: 0 },
+    capabilities: {
+      accounts: { available: false, status: null, type: '' },
+      programs: { available: false, status: null, type: '' },
+      entities: { available: false, status: null, type: '' },
+    },
+    nextStep: config.credentialsConfigured
+      ? 'Set GALACTIC_INCREASE_SANDBOX_ENABLED=true in the server environment and redeploy.'
+      : 'Add an Increase sandbox API key to the server environment, then redeploy. Keep the key server-only.',
+  };
+
+  if (config.enabled && config.credentialsConfigured) {
+    try {
+      const snapshot: any = await inspectIncreaseSandbox(process.env);
+      const restricted = Object.entries(snapshot?.capabilities || {})
+        .filter(([, value]: any) => value?.available === false)
+        .map(([name]) => name);
+      provider = {
+        provider: 'Increase',
+        environment: 'sandbox',
+        enabled: true,
+        credentialsConfigured: true,
+        connected: snapshot?.connected === true,
+        setupRequired: restricted.length > 0,
+        counts: {
+          programs: Number(snapshot?.counts?.programs || 0),
+          accounts: Number(snapshot?.counts?.accounts || 0),
+          entities: Number(snapshot?.counts?.entities || 0),
+        },
+        capabilities: {
+          accounts: safeCapability(snapshot?.capabilities?.accounts),
+          programs: safeCapability(snapshot?.capabilities?.programs),
+          entities: safeCapability(snapshot?.capabilities?.entities),
+        },
+        nextStep: restricted.length
+          ? `Increase sandbox is connected for Accounts, but ${restricted.join(' and ')} access is restricted. Use a sandbox key with the required permissions before owner onboarding.`
+          : '',
+      };
+    } catch (error: any) {
+      provider = { ...provider, ...safeProviderError(error, 'Increase sandbox connection check failed.') };
+    }
+  }
+
+  let binding: any = {
+    storageReady: true,
+    bound: false,
+    status: 'not-bound',
+    validationKind: 'none',
+    accountSuffix: '',
+    verifiedAt: null,
+    nextStep: 'Complete owner-scoped Increase sandbox onboarding after the provider and binding migrations are ready.',
+  };
+  try {
+    const state = await getProviderAccountBinding(auth.admin, auth.user.id, { provider: 'increase', environment: 'sandbox' });
+    const summary: any = publicBindingSummary(state.binding);
+    binding = {
+      storageReady: state.setupRequired !== true,
+      bound: Boolean(summary),
+      status: summary?.status || (state.setupRequired ? 'setup-required' : 'not-bound'),
+      validationKind: summary?.kycStatus === 'SANDBOX_VALID_SIMULATION' ? 'sandbox-simulation' : 'none',
+      accountSuffix: summary?.accountSuffix || '',
+      verifiedAt: summary?.verifiedAt || null,
+      nextStep: state.setupRequired
+        ? 'Apply the Galactic Trust provider-binding migrations before binding an Increase sandbox test account.'
+        : summary
+          ? ''
+          : 'Complete owner-scoped Increase sandbox onboarding to bind a test account to this signed-in owner.',
+    };
+  } catch {
+    binding = {
+      ...binding,
+      storageReady: false,
+      status: 'unavailable',
+      nextStep: 'Verify the Supabase service-role configuration and Galactic Trust provider-binding migrations.',
+    };
+  }
+
+  let onboarding: any = {
+    available: false,
+    programCount: 0,
+    setupRequired: true,
+    nextStep: provider.connected ? 'Verify Increase sandbox Program access before owner onboarding.' : provider.nextStep,
+  };
+  if (provider.connected) {
+    try {
+      const snapshot: any = await inspectIncreaseSandboxOnboarding(process.env);
+      onboarding = {
+        available: snapshot?.connected === true,
+        programCount: Array.isArray(snapshot?.programs) ? snapshot.programs.length : 0,
+        setupRequired: snapshot?.setupRequired === true,
+        nextStep: snapshot?.setupRequired ? 'Make at least one Increase sandbox Program available to the configured sandbox key.' : '',
+      };
+    } catch (error: any) {
+      const issue = safeProviderError(error, 'Increase sandbox onboarding inspection failed.');
+      onboarding = { ...onboarding, ...issue, nextStep: issue.nextStep || onboarding.nextStep };
+    }
+  }
+
+  let webhook: any = {
+    configured: false,
+    active: false,
+    status: 'not-configured',
+    nextStep: provider.connected ? 'Configure the Increase sandbox event subscription after provider access is healthy.' : provider.nextStep,
+  };
+  if (provider.connected) {
+    try {
+      const subscription: any = await ensureIncreaseSandboxWebhookSubscription(process.env);
+      webhook = {
+        configured: subscription?.configured === true,
+        active: subscription?.active === true,
+        status: String(subscription?.status || (subscription?.configured ? 'inactive' : 'not-configured')).slice(0, 40),
+        nextStep: subscription?.active ? '' : 'Make the Galactic Trust Increase sandbox event subscription active.',
+      };
+    } catch (error: any) {
+      const issue = safeProviderError(error, 'Increase sandbox webhook status is unavailable.');
+      webhook = { ...webhook, status: 'unavailable', ...issue, nextStep: issue.nextStep || webhook.nextStep };
+    }
+  }
+
+  let reconciliation: any = {
+    databaseReady: false,
+    status: 'unavailable',
+    lastReconciledAt: null,
+    lastWebhookAt: null,
+    lastPollAt: null,
+    accountCount: 0,
+    transactionCount: 0,
+    eventCursorStored: false,
+    lastError: '',
+    recentEventCount: 0,
+    latestEvent: null,
+    nextStep: 'Apply the Galactic Trust Increase webhook/reconciliation migration, then verify the service-role configuration.',
+  };
+  try {
+    reconciliation = { ...safeReconciliationState(await getIncreaseReconciliationStatus()), nextStep: '' };
+  } catch {
+    // Keep the fail-closed migration/setup state. Do not leak database error details to the browser.
+  }
+
+  const assertedGateCount = Array.isArray(launch.gates) ? launch.gates.filter((gate: any) => gate?.asserted).length : 0;
+  const totalGateCount = Array.isArray(launch.gates) ? launch.gates.length : 0;
+  const production = {
+    status: launch.status,
+    implementationReady: launch.implementationReady === true,
+    liveSwitchRequested: launch.liveSwitchRequested === true,
+    assertedGateCount,
+    totalGateCount,
+    liveBankingEnabled: launch.liveBankingEnabled === true,
+    canMoveRealMoney: false,
+  };
+
+  const nextSteps = [
+    provider.nextStep,
+    onboarding.nextStep,
+    binding.nextStep,
+    webhook.nextStep,
+    reconciliation.nextStep,
+  ].map((value) => String(value || '').trim()).filter(Boolean);
+
+  return {
+    ok: true,
+    authorized: true,
+    generatedAt: new Date().toISOString(),
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    provider,
+    onboarding,
+    binding,
+    webhook,
+    reconciliation,
+    production,
+    readyForSandboxOperations: Boolean(
+      provider.connected
+      && provider.capabilities?.accounts?.available
+      && binding.storageReady
+      && reconciliation.databaseReady
+    ),
+    nextSteps: Array.from(new Set(nextSteps)).slice(0, 6),
+    note: 'Owner-only operational summary. Increase values are sandbox test data. SANDBOX_VALID_SIMULATION is not real KYC/CIP/AML approval, and production banking remains fail-closed.',
+  };
+}
+
+async function authorize(request: Request) {
+  const auth = await requireGalacticTrustAdmin(request);
+  if (auth.ok === false) return { ok: false as const, response: response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status) };
+  return { ok: true as const, auth };
+}
+
+export async function GET(request: Request) {
+  const result = await authorize(request);
+  if (!result.ok) return result.response;
+  return response(await buildHealth(result.auth));
+}
+
+export async function POST(request: Request) {
+  const result = await authorize(request);
+  if (!result.ok) return result.response;
+  try {
+    await ensureIncreaseSandboxWebhookSubscription(process.env);
+    await pollIncreaseSandboxEvents({ maxPages: 5, forceReconcile: true });
+    const health = await buildHealth(result.auth);
+    return response({ ...health, action: 'sandbox-reconciliation-complete' });
+  } catch (error: any) {
+    const issue = safeProviderError(error, 'Increase sandbox reconciliation could not run.');
+    const health = await buildHealth(result.auth);
+    return response({ ...health, ok: false, action: 'sandbox-reconciliation-failed', error: issue.error, nextStep: issue.nextStep || health.nextSteps?.[0] || '' }, 502);
+  }
+}

--- a/app/bank/GalacticDashboardEnhancements.js
+++ b/app/bank/GalacticDashboardEnhancements.js
@@ -13,6 +13,7 @@ const commands = [
   { id: 'activity', icon: '≡', label: 'Transaction history', hint: 'Recent activity' },
   { id: 'security', icon: '✓', label: 'Security & privacy', hint: 'Protection details' },
   { id: 'account-status', icon: '◉', label: 'My account status', hint: 'See what your signed-in account can do right now' },
+  { id: 'integration-health', icon: '↻', label: 'Integration health', hint: 'Owner-only provider, webhook and reconciliation status' },
   { id: 'launch-status', icon: '🔒', label: 'Regulated launch status', hint: 'See what is required before live banking' },
   { id: 'rewards', icon: '✿', label: 'Rewards', hint: 'Galactic Stars' },
   { id: 'tour', icon: '✦', label: 'Explore the Stars', hint: 'Restart onboarding tour' },
@@ -194,6 +195,7 @@ export default function GalacticDashboardEnhancements({ onSignOut, accountLabel 
     else if (id === 'activity') scrollTo('#activity');
     else if (id === 'security') scrollTo('#security');
     else if (id === 'account-status') window.location.assign('/bank/status');
+    else if (id === 'integration-health') window.location.assign('/bank/integrations');
     else if (id === 'launch-status') window.location.assign('/bank/readiness');
     else if (id === 'rewards') scrollTo('#rewards');
     else if (id === 'tour') { setTourIndex(0); setTourOpen(true); }

--- a/app/bank/integrations/integration-health.module.css
+++ b/app/bank/integrations/integration-health.module.css
@@ -1,0 +1,479 @@
+.page {
+  min-height: 100vh;
+  color: #f7f7fb;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(115, 83, 255, 0.18), transparent 34rem),
+    radial-gradient(circle at 88% 0%, rgba(80, 221, 184, 0.11), transparent 30rem),
+    linear-gradient(180deg, #08090f 0%, #0c0d15 48%, #090a10 100%);
+  position: relative;
+  overflow-x: hidden;
+}
+
+.aurora {
+  position: fixed;
+  inset: -20% -20% auto 35%;
+  height: 26rem;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, rgba(128, 92, 255, 0.18), transparent 65%);
+  filter: blur(24px);
+}
+
+.stars {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.28;
+  background-image:
+    radial-gradient(circle at 12% 18%, white 0 1px, transparent 1.5px),
+    radial-gradient(circle at 72% 12%, white 0 1px, transparent 1.5px),
+    radial-gradient(circle at 46% 54%, white 0 1px, transparent 1.5px),
+    radial-gradient(circle at 88% 72%, white 0 1px, transparent 1.5px),
+    radial-gradient(circle at 22% 82%, white 0 1px, transparent 1.5px);
+  background-size: 240px 240px, 310px 310px, 280px 280px, 340px 340px, 300px 300px;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 4vw, 3.5rem);
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  background: rgba(8, 9, 15, 0.8);
+  backdrop-filter: blur(18px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: .75rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brandMark {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: linear-gradient(145deg, #8d6cff, #6247ea);
+  box-shadow: 0 10px 30px rgba(103, 74, 238, .3);
+  font-size: 1.05rem;
+}
+
+.brand b,
+.brand small { display: block; }
+.brand b { font-size: .98rem; letter-spacing: -.015em; }
+.brand small { margin-top: .1rem; color: #9699aa; font-size: .72rem; }
+
+.header nav {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+}
+
+.header nav a {
+  color: #b6b8c8;
+  text-decoration: none;
+  font-size: .82rem;
+  padding: .62rem .78rem;
+  border-radius: 12px;
+  transition: .18s ease;
+}
+
+.header nav a:hover { color: white; background: rgba(255,255,255,.06); }
+.header nav .primaryLink { color: white; background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.08); }
+
+.shell {
+  position: relative;
+  z-index: 1;
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: clamp(2.4rem, 7vw, 5.6rem) 0 5rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(260px, .6fr);
+  gap: clamp(1.5rem, 5vw, 5rem);
+  align-items: end;
+  margin-bottom: 2rem;
+}
+
+.kicker,
+.panelHead span,
+.queueHead span {
+  display: block;
+  color: #9e91ff;
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .13em;
+}
+
+.hero h1 {
+  margin: .8rem 0 .9rem;
+  font-size: clamp(2.35rem, 6vw, 5.15rem);
+  line-height: .94;
+  letter-spacing: -.055em;
+}
+
+.hero h1 em {
+  color: #b8a8ff;
+  font-style: normal;
+}
+
+.hero > div > p {
+  max-width: 720px;
+  margin: 0;
+  color: #a8aabb;
+  font-size: clamp(.96rem, 1.5vw, 1.08rem);
+  line-height: 1.7;
+}
+
+.heroLock {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.05rem 1.15rem;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 20px;
+  background: rgba(255,255,255,.04);
+}
+
+.heroLock > span {
+  width: 3.2rem;
+  height: 3.2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  background: rgba(255, 128, 128, .08);
+  font-size: 1.25rem;
+}
+
+.heroLock small,
+.heroLock b,
+.heroLock p { display: block; }
+.heroLock small { color: #8d8f9e; font-size: .66rem; letter-spacing: .12em; }
+.heroLock b { margin-top: .16rem; color: #ffb8b8; font-size: 1.05rem; }
+.heroLock p { margin: .18rem 0 0; color: #8f91a1; font-size: .75rem; }
+
+.loading,
+.accessCard {
+  min-height: 310px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2.2rem;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 28px;
+  background: rgba(255,255,255,.035);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.03), 0 28px 80px rgba(0,0,0,.2);
+}
+
+.loading > span,
+.accessCard > span {
+  width: 3.5rem;
+  height: 3.5rem;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  background: rgba(135, 104, 255, .14);
+  font-size: 1.6rem;
+  color: #b7a7ff;
+}
+
+.loading h2,
+.accessCard h2 { margin: 1rem 0 .4rem; font-size: 1.45rem; }
+.loading p,
+.accessCard p { margin: 0; max-width: 620px; color: #9698a9; line-height: 1.6; }
+.accessCard a { margin-top: 1.1rem; color: white; text-decoration: none; padding: .78rem 1rem; border-radius: 12px; background: #7258ed; }
+
+.error {
+  display: flex;
+  gap: .8rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+  padding: .95rem 1rem;
+  border: 1px solid rgba(255, 178, 96, .22);
+  border-radius: 16px;
+  background: rgba(255, 164, 76, .08);
+}
+
+.error > span {
+  width: 1.8rem;
+  height: 1.8rem;
+  display: grid;
+  place-items: center;
+  border-radius: 9px;
+  color: #ffc286;
+  background: rgba(255,255,255,.06);
+  font-weight: 900;
+}
+
+.error p { margin: 0; }
+.error b,
+.error small { display: block; }
+.error b { color: #ffd0a5; font-size: .86rem; }
+.error small { margin-top: .12rem; color: #c4aa94; line-height: 1.45; }
+
+.overview {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: .85rem;
+}
+
+.overview article,
+.panel,
+.queue {
+  border: 1px solid rgba(255,255,255,.075);
+  background: linear-gradient(180deg, rgba(255,255,255,.052), rgba(255,255,255,.025));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.03), 0 24px 70px rgba(0,0,0,.16);
+}
+
+.overview article {
+  padding: 1.15rem;
+  border-radius: 22px;
+  min-width: 0;
+}
+
+.overview article h2 { margin: .95rem 0 .3rem; font-size: 1.08rem; letter-spacing: -.02em; }
+.overview article > p { min-height: 3.1rem; margin: 0 0 .75rem; color: #8f91a2; font-size: .78rem; line-height: 1.48; }
+.lockedCard { background: linear-gradient(180deg, rgba(125, 73, 116, .12), rgba(255,255,255,.022)) !important; }
+
+.cardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .6rem;
+}
+
+.cardHead > span {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: rgba(255,255,255,.055);
+  color: #c0b5ff;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.55rem;
+  padding: 0 .5rem;
+  border-radius: 999px;
+  font-size: .61rem;
+  font-weight: 900;
+  letter-spacing: .07em;
+  white-space: nowrap;
+}
+
+.good { color: #7cf0c7; background: rgba(69, 208, 158, .11); border: 1px solid rgba(96, 229, 180, .16); }
+.warn { color: #ffd08b; background: rgba(255, 170, 76, .1); border: 1px solid rgba(255, 180, 88, .16); }
+.locked { color: #ffb1bc; background: rgba(255, 111, 133, .09); border: 1px solid rgba(255, 130, 149, .15); }
+.neutral { color: #c0c2cf; background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.08); }
+
+.metric {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+  padding: .52rem 0;
+  border-top: 1px solid rgba(255,255,255,.055);
+}
+.metric span { color: #858797; font-size: .7rem; }
+.metric strong { color: #d8d9e2; font-size: .68rem; text-align: right; }
+.goodText { color: #77eac1 !important; }
+.warnText { color: #ffc985 !important; }
+.lockedText { color: #ffadb9 !important; }
+
+.detailGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: .9rem;
+  margin-top: .9rem;
+}
+
+.panel {
+  min-width: 0;
+  padding: 1.25rem;
+  border-radius: 24px;
+}
+
+.panelHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: .95rem;
+}
+.panelHead h2,
+.queueHead h2 { margin: .3rem 0 0; font-size: 1.16rem; letter-spacing: -.025em; }
+
+.capabilities { border-top: 1px solid rgba(255,255,255,.055); }
+.capability {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: .72rem;
+  align-items: center;
+  padding: .78rem 0;
+  border-bottom: 1px solid rgba(255,255,255,.055);
+}
+.capability b,
+.capability small { display: block; }
+.capability b { font-size: .83rem; }
+.capability small { margin-top: .12rem; color: #858797; font-size: .69rem; line-height: 1.4; }
+.dotGood,
+.dotWarn { width: .55rem; height: .55rem; border-radius: 50%; box-shadow: 0 0 0 4px rgba(255,255,255,.025); }
+.dotGood { background: #5edaa9; }
+.dotWarn { background: #f3b15d; }
+
+.counts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: .6rem;
+  margin-top: .85rem;
+}
+.counts div { padding: .8rem; border-radius: 14px; background: rgba(255,255,255,.035); }
+.counts b,
+.counts span { display: block; }
+.counts b { font-size: 1.1rem; }
+.counts span { margin-top: .16rem; color: #858797; font-size: .65rem; }
+
+.syncGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: .55rem;
+}
+.syncGrid div { padding: .75rem; border: 1px solid rgba(255,255,255,.055); border-radius: 14px; background: rgba(255,255,255,.025); }
+.syncGrid span,
+.syncGrid b { display: block; }
+.syncGrid span { color: #7f8191; font-size: .66rem; }
+.syncGrid b { margin-top: .18rem; font-size: .77rem; font-weight: 700; }
+
+.latestEvent {
+  margin-top: .7rem;
+  padding: .8rem;
+  border-radius: 14px;
+  background: rgba(115, 89, 233, .08);
+  border: 1px solid rgba(139, 111, 255, .12);
+}
+.latestEvent > span { color: #9687ef; font-size: .62rem; font-weight: 800; letter-spacing: .08em; }
+.latestEvent p { margin: .35rem 0 0; }
+.latestEvent b,
+.latestEvent small { display: block; }
+.latestEvent b { font-size: .78rem; }
+.latestEvent small { margin-top: .12rem; color: #9294a5; font-size: .68rem; }
+
+.reconcileButton {
+  width: 100%;
+  margin-top: .75rem;
+  border: 0;
+  border-radius: 14px;
+  padding: .82rem 1rem;
+  color: white;
+  background: linear-gradient(135deg, #7258ef, #5d48ca);
+  box-shadow: 0 14px 32px rgba(96, 72, 209, .2);
+  font: inherit;
+  font-size: .78rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+.reconcileButton:disabled { opacity: .42; cursor: not-allowed; box-shadow: none; }
+.buttonNote { display: block; margin-top: .45rem; color: #717383; font-size: .64rem; text-align: center; line-height: 1.4; }
+
+.queue {
+  margin-top: .9rem;
+  padding: 1.25rem;
+  border-radius: 24px;
+}
+.queueHead { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; }
+.steps { margin-top: 1rem; border-top: 1px solid rgba(255,255,255,.055); }
+.step { display: grid; grid-template-columns: auto 1fr; gap: .8rem; align-items: start; padding: .82rem 0; border-bottom: 1px solid rgba(255,255,255,.055); }
+.step > span { width: 1.7rem; height: 1.7rem; display: grid; place-items: center; border-radius: 9px; background: rgba(255, 180, 84, .1); color: #ffcc85; font-size: .7rem; font-weight: 900; }
+.step p { margin: .15rem 0 0; color: #b2b4c1; font-size: .78rem; line-height: 1.5; }
+.clearMessage { margin: 1rem 0 0; color: #a6a8b7; line-height: 1.6; }
+
+.truthStrip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: .9rem;
+  align-items: center;
+  margin-top: .9rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(96, 224, 180, .13);
+  border-radius: 18px;
+  background: rgba(65, 190, 148, .055);
+}
+.truthStrip > span { width: 2rem; height: 2rem; display: grid; place-items: center; border-radius: 10px; color: #70e2b9; background: rgba(73, 207, 158, .1); }
+.truthStrip p { margin: 0; }
+.truthStrip b,
+.truthStrip small { display: block; }
+.truthStrip b { font-size: .78rem; color: #bff0de; }
+.truthStrip small { margin-top: .15rem; color: #82968f; font-size: .68rem; line-height: 1.45; }
+.truthStrip a { color: #9cddc4; text-decoration: none; font-size: .72rem; font-weight: 800; white-space: nowrap; }
+
+.actions {
+  display: flex;
+  gap: .7rem;
+  justify-content: center;
+  margin-top: 1.2rem;
+}
+.actions button,
+.actions a {
+  min-height: 2.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 13px;
+  padding: 0 .95rem;
+  font: inherit;
+  font-size: .75rem;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+}
+.actions button { border: 1px solid rgba(255,255,255,.09); color: white; background: rgba(255,255,255,.065); }
+.actions a { color: #c2b9ff; border: 1px solid rgba(132, 104, 255, .16); background: rgba(119, 90, 238, .08); }
+.updated { margin: .65rem 0 0; color: #606271; font-size: .63rem; text-align: center; }
+
+@media (max-width: 980px) {
+  .overview { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .hero { grid-template-columns: 1fr; align-items: start; }
+  .heroLock { max-width: 360px; }
+}
+
+@media (max-width: 760px) {
+  .header { align-items: flex-start; }
+  .header nav { overflow-x: auto; max-width: 58vw; justify-content: flex-end; }
+  .header nav a { white-space: nowrap; }
+  .detailGrid { grid-template-columns: 1fr; }
+  .truthStrip { grid-template-columns: auto 1fr; }
+  .truthStrip a { grid-column: 2; }
+}
+
+@media (max-width: 560px) {
+  .header { padding: .8rem .85rem; }
+  .brand small { display: none; }
+  .header nav a:not(.primaryLink) { display: none; }
+  .shell { width: min(100% - 1rem, 1180px); padding-top: 2rem; }
+  .hero h1 { font-size: clamp(2.2rem, 14vw, 3.6rem); }
+  .overview { grid-template-columns: 1fr; }
+  .overview article > p { min-height: 0; }
+  .counts { grid-template-columns: 1fr; }
+  .syncGrid { grid-template-columns: 1fr; }
+  .queueHead { flex-direction: column; }
+  .actions { flex-direction: column; }
+  .actions button,
+  .actions a { width: 100%; }
+  .truthStrip { grid-template-columns: 1fr; text-align: left; }
+  .truthStrip a { grid-column: auto; }
+}

--- a/app/bank/integrations/page.js
+++ b/app/bank/integrations/page.js
@@ -1,0 +1,269 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../lib/supabase-browser';
+import styles from './integration-health.module.css';
+
+function displayTime(value) {
+  if (!value) return 'Not yet';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unavailable';
+  return date.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function stateLabel(ok, ready = false) {
+  if (ok) return ready ? 'READY' : 'HEALTHY';
+  return 'SETUP NEEDED';
+}
+
+function HealthBadge({ tone = 'neutral', children }) {
+  return <span className={`${styles.badge} ${styles[tone]}`}>{children}</span>;
+}
+
+function Metric({ label, value, tone = 'neutral' }) {
+  return (
+    <div className={styles.metric}>
+      <span>{label}</span>
+      <strong className={styles[tone]}>{value}</strong>
+    </div>
+  );
+}
+
+function Capability({ name, capability }) {
+  const available = capability?.available === true;
+  return (
+    <div className={styles.capability}>
+      <span className={available ? styles.dotGood : styles.dotWarn} />
+      <div>
+        <b>{name}</b>
+        <small>{available ? 'Available to the configured sandbox key' : capability?.status ? `Restricted · provider status ${capability.status}` : 'Not available yet'}</small>
+      </div>
+      <HealthBadge tone={available ? 'good' : 'warn'}>{available ? 'ON' : 'CHECK'}</HealthBadge>
+    </div>
+  );
+}
+
+export default function GalacticIntegrationHealthPage() {
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [health, setHealth] = useState(null);
+  const [error, setError] = useState('');
+  const [signedIn, setSignedIn] = useState(false);
+
+  const requestHealth = useCallback(async (method = 'GET') => {
+    const client = await getSupabaseBrowserAsync();
+    const { data, error: sessionError } = await client.auth.getSession();
+    if (sessionError) throw sessionError;
+    const token = String(data?.session?.access_token || '');
+    setSignedIn(Boolean(token));
+    if (!token) {
+      setHealth(null);
+      throw new Error('Sign in with the authorized Galactic Trust owner account to view integration health.');
+    }
+
+    const response = await fetch('/api/admin/bank/integration-health', {
+      method,
+      cache: 'no-store',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (payload?.provider || payload?.production) setHealth(payload);
+    if (!response.ok) throw new Error(String(payload?.error || 'Integration health could not be loaded.'));
+    return payload;
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      await requestHealth('GET');
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Integration health could not be loaded.');
+    } finally {
+      setLoading(false);
+    }
+  }, [requestHealth]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const runReconciliation = useCallback(async () => {
+    setRunning(true);
+    setError('');
+    try {
+      await requestHealth('POST');
+    } catch (runError) {
+      setError(runError instanceof Error ? runError.message : 'Sandbox reconciliation could not run.');
+    } finally {
+      setRunning(false);
+    }
+  }, [requestHealth]);
+
+  const summary = useMemo(() => {
+    const providerHealthy = health?.provider?.connected === true && health?.provider?.capabilities?.accounts?.available === true;
+    const bindingHealthy = health?.binding?.storageReady === true && health?.binding?.bound === true;
+    const webhookHealthy = health?.webhook?.active === true;
+    const reconciliationHealthy = health?.reconciliation?.databaseReady === true && health?.reconciliation?.status !== 'failed';
+    const productionLocked = health?.production?.liveBankingEnabled !== true && health?.production?.implementationReady !== true && health?.canMoveRealMoney !== true;
+    return { providerHealthy, bindingHealthy, webhookHealthy, reconciliationHealthy, productionLocked };
+  }, [health]);
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.aurora} aria-hidden="true" />
+      <div className={styles.stars} aria-hidden="true" />
+
+      <header className={styles.header}>
+        <Link className={styles.brand} href="/bank">
+          <span className={styles.brandMark}>✦</span>
+          <span><b>Galactic Trust</b><small>Integration Health</small></span>
+        </Link>
+        <nav>
+          <Link href="/bank/status">My Account</Link>
+          <Link href="/bank/readiness">Launch Readiness</Link>
+          <Link className={styles.primaryLink} href="/bank">Dashboard</Link>
+        </nav>
+      </header>
+
+      <section className={styles.shell}>
+        <div className={styles.hero}>
+          <div>
+            <span className={styles.kicker}>✦ OWNER OPERATIONS · SANDBOX ONLY</span>
+            <h1>One screen for the<br /><em>banking integration stack.</em></h1>
+            <p>Provider access, owner binding, webhook delivery, reconciliation, migrations, and the production lock are summarized here without exposing provider secrets or full provider identifiers to the browser.</p>
+          </div>
+          <div className={styles.heroLock}>
+            <span>🔒</span>
+            <div><small>REAL MONEY</small><b>LOCKED</b><p>Production banking remains fail-closed.</p></div>
+          </div>
+        </div>
+
+        {loading ? (
+          <section className={styles.loading} aria-live="polite">
+            <span>◌</span><h2>Checking the Galactic Trust stack…</h2><p>Reading owner-authorized server health without loading provider credentials into the browser.</p>
+          </section>
+        ) : (
+          <>
+            {error && <div className={styles.error} role="status"><span>!</span><p><b>Attention needed</b><small>{error}</small></p></div>}
+
+            {!health ? (
+              <section className={styles.accessCard}>
+                <span>◉</span>
+                <h2>{signedIn ? 'Owner access is required.' : 'Sign in to continue.'}</h2>
+                <p>This page only loads operational banking integration data for the authorized Galactic Trust owner account.</p>
+                <Link href="/bank">Return to Galactic Trust</Link>
+              </section>
+            ) : (
+              <>
+                <section className={styles.overview} aria-label="Integration health overview">
+                  <article>
+                    <div className={styles.cardHead}><span>◈</span><HealthBadge tone={summary.providerHealthy ? 'good' : 'warn'}>{stateLabel(summary.providerHealthy)}</HealthBadge></div>
+                    <h2>Increase sandbox</h2>
+                    <p>The server-only provider connection and minimum account-read capability.</p>
+                    <Metric label="Connection" value={health.provider?.connected ? 'CONNECTED' : 'NOT CONNECTED'} tone={health.provider?.connected ? 'goodText' : 'warnText'} />
+                    <Metric label="Sandbox enabled" value={health.provider?.enabled ? 'YES' : 'NO'} tone={health.provider?.enabled ? 'goodText' : 'warnText'} />
+                    <Metric label="Credentials" value={health.provider?.credentialsConfigured ? 'CONFIGURED' : 'MISSING'} tone={health.provider?.credentialsConfigured ? 'goodText' : 'warnText'} />
+                  </article>
+
+                  <article>
+                    <div className={styles.cardHead}><span>◎</span><HealthBadge tone={summary.bindingHealthy ? 'good' : 'warn'}>{summary.bindingHealthy ? 'BOUND' : 'SETUP NEEDED'}</HealthBadge></div>
+                    <h2>Owner binding</h2>
+                    <p>The signed-in owner is mapped server-side to one Increase sandbox test account.</p>
+                    <Metric label="Binding storage" value={health.binding?.storageReady ? 'READY' : 'MIGRATION NEEDED'} tone={health.binding?.storageReady ? 'goodText' : 'warnText'} />
+                    <Metric label="Test account" value={health.binding?.bound ? `BOUND · •••${health.binding?.accountSuffix || ''}` : 'NOT BOUND'} tone={health.binding?.bound ? 'goodText' : 'warnText'} />
+                    <Metric label="Validation" value={health.binding?.validationKind === 'sandbox-simulation' ? 'SANDBOX SIMULATION' : 'NONE'} />
+                  </article>
+
+                  <article>
+                    <div className={styles.cardHead}><span>↻</span><HealthBadge tone={summary.webhookHealthy && summary.reconciliationHealthy ? 'good' : 'warn'}>{summary.webhookHealthy && summary.reconciliationHealthy ? 'SYNC READY' : 'CHECK SYNC'}</HealthBadge></div>
+                    <h2>Events & reconciliation</h2>
+                    <p>Webhook subscription plus the database-backed missed-event reconciliation backstop.</p>
+                    <Metric label="Webhook" value={health.webhook?.active ? 'ACTIVE' : String(health.webhook?.status || 'NOT READY').toUpperCase()} tone={health.webhook?.active ? 'goodText' : 'warnText'} />
+                    <Metric label="Reconciliation DB" value={health.reconciliation?.databaseReady ? 'READY' : 'MIGRATION NEEDED'} tone={health.reconciliation?.databaseReady ? 'goodText' : 'warnText'} />
+                    <Metric label="Last reconciliation" value={displayTime(health.reconciliation?.lastReconciledAt)} />
+                  </article>
+
+                  <article className={styles.lockedCard}>
+                    <div className={styles.cardHead}><span>🔒</span><HealthBadge tone="locked">LOCKED</HealthBadge></div>
+                    <h2>Production banking</h2>
+                    <p>Sandbox success cannot unlock real customer money or production account opening.</p>
+                    <Metric label="Implementation ready" value={health.production?.implementationReady ? 'YES · REVIEW' : 'NO'} tone={health.production?.implementationReady ? 'warnText' : 'lockedText'} />
+                    <Metric label="Evidence gates" value={`${health.production?.assertedGateCount || 0} / ${health.production?.totalGateCount || 0}`} />
+                    <Metric label="Real-money movement" value="NO" tone="lockedText" />
+                  </article>
+                </section>
+
+                <section className={styles.detailGrid}>
+                  <article className={styles.panel}>
+                    <div className={styles.panelHead}><div><span>PROVIDER CAPABILITIES</span><h2>What the sandbox key can access</h2></div><HealthBadge tone={summary.providerHealthy ? 'good' : 'warn'}>{health.provider?.connected ? 'CONNECTED' : 'OFFLINE'}</HealthBadge></div>
+                    <div className={styles.capabilities}>
+                      <Capability name="Accounts" capability={health.provider?.capabilities?.accounts} />
+                      <Capability name="Programs" capability={health.provider?.capabilities?.programs} />
+                      <Capability name="Entities" capability={health.provider?.capabilities?.entities} />
+                    </div>
+                    <div className={styles.counts}>
+                      <div><b>{health.provider?.counts?.accounts || 0}</b><span>Accounts visible</span></div>
+                      <div><b>{health.onboarding?.programCount || 0}</b><span>Programs available</span></div>
+                      <div><b>{health.provider?.counts?.entities || 0}</b><span>Entities visible</span></div>
+                    </div>
+                  </article>
+
+                  <article className={styles.panel}>
+                    <div className={styles.panelHead}><div><span>RECONCILIATION</span><h2>Event-sync heartbeat</h2></div><HealthBadge tone={summary.reconciliationHealthy ? 'good' : 'warn'}>{String(health.reconciliation?.status || 'NOT RUN').toUpperCase()}</HealthBadge></div>
+                    <div className={styles.syncGrid}>
+                      <div><span>Last webhook</span><b>{displayTime(health.reconciliation?.lastWebhookAt)}</b></div>
+                      <div><span>Last poll</span><b>{displayTime(health.reconciliation?.lastPollAt)}</b></div>
+                      <div><span>Recent events</span><b>{health.reconciliation?.recentEventCount || 0}</b></div>
+                      <div><span>Transactions seen</span><b>{health.reconciliation?.transactionCount || 0}</b></div>
+                    </div>
+                    {health.reconciliation?.latestEvent && (
+                      <div className={styles.latestEvent}>
+                        <span>Latest safe event summary</span>
+                        <p><b>{health.reconciliation.latestEvent.category || 'Increase sandbox event'}</b><small>{health.reconciliation.latestEvent.source || 'provider'} · {health.reconciliation.latestEvent.processingStatus || 'received'} · {displayTime(health.reconciliation.latestEvent.receivedAt)}</small></p>
+                      </div>
+                    )}
+                    <button className={styles.reconcileButton} type="button" onClick={runReconciliation} disabled={running || !health.provider?.connected}>
+                      {running ? 'Reconciling sandbox…' : '↻ Run sandbox reconciliation'}
+                    </button>
+                    <small className={styles.buttonNote}>This checks pretend-money Increase sandbox events only. It cannot move real money.</small>
+                  </article>
+                </section>
+
+                <section className={styles.queue}>
+                  <div className={styles.queueHead}>
+                    <div><span>SETUP QUEUE</span><h2>{health.nextSteps?.length ? 'What still needs attention' : 'Sandbox integration is operationally clean'}</h2></div>
+                    <HealthBadge tone={health.nextSteps?.length ? 'warn' : 'good'}>{health.nextSteps?.length ? `${health.nextSteps.length} ITEMS` : 'CLEAR'}</HealthBadge>
+                  </div>
+                  {health.nextSteps?.length ? (
+                    <div className={styles.steps}>
+                      {health.nextSteps.map((step, index) => (
+                        <div className={styles.step} key={`${index}-${step}`}><span>{index + 1}</span><p>{step}</p></div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className={styles.clearMessage}>Provider access, owner binding, webhook delivery, and reconciliation are ready for Galactic Trust sandbox testing. Production banking still remains separately locked.</p>
+                  )}
+                </section>
+
+                <section className={styles.truthStrip}>
+                  <span>✓</span>
+                  <p><b>Truthful operating boundary</b><small>Increase data shown here is sandbox test data. SANDBOX_VALID_SIMULATION is not real KYC/CIP/AML approval. Galactic Trust is a financial technology product, not a bank, and this build cannot accept or move real customer deposits.</small></p>
+                  <Link href="/bank/readiness">Review production gates →</Link>
+                </section>
+
+                <div className={styles.actions}>
+                  <button type="button" onClick={load}>Refresh integration health</button>
+                  <Link href="/bank/status">View my account status</Link>
+                </div>
+
+                <p className={styles.updated}>Last checked {displayTime(health.generatedAt)}</p>
+              </>
+            )}
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs"
+    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const page = await readFile(new URL('../app/bank/integrations/page.js', import.meta.url), 'utf8');
+const route = await readFile(new URL('../app/api/admin/bank/integration-health/route.ts', import.meta.url), 'utf8');
+const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhancements.js', import.meta.url), 'utf8');
+
+assert.match(route, /requireGalacticTrustAdmin/, 'integration health API must be owner/admin authenticated');
+assert.match(route, /inspectIncreaseSandbox/, 'integration health must inspect the configured Increase sandbox server-side');
+assert.match(route, /getProviderAccountBinding\(auth\.admin, auth\.user\.id/, 'owner binding health must be scoped to the verified signed-in owner');
+assert.match(route, /publicBindingSummary/, 'provider binding returned to the client must use the masked public summary');
+assert.match(route, /ensureIncreaseSandboxWebhookSubscription/, 'integration health must inspect/ensure the sandbox webhook subscription server-side');
+assert.match(route, /getIncreaseReconciliationStatus/, 'integration health must report reconciliation state');
+assert.match(route, /pollIncreaseSandboxEvents\(\{ maxPages: 5, forceReconcile: true \}\)/, 'owner health center must support a bounded forced sandbox reconciliation');
+assert.match(route, /bankingLaunchSnapshot/, 'integration health must derive the production lock from the regulated-launch policy');
+assert.match(route, /canMoveRealMoney: false/, 'integration health must remain explicitly incapable of real-money movement');
+assert.match(route, /SANDBOX_VALID_SIMULATION is not real KYC\/CIP\/AML approval/, 'integration health API must preserve the sandbox-validation boundary');
+assert.equal(route.includes('INCREASE_SANDBOX_API_KEY'), false, 'integration health route must not embed or return provider secret names/values');
+assert.equal(route.includes('eventId:'), false, 'client health payload must not expose provider event IDs');
+assert.equal(route.includes('programId:'), false, 'client health payload must not expose provider Program IDs');
+assert.equal(route.includes('entityId:'), false, 'client health payload must not expose provider Entity IDs');
+assert.equal(route.includes('accountId:'), false, 'client health payload must not expose full provider Account IDs');
+
+assert.match(page, /getSupabaseBrowserAsync/, 'integration health page must derive its bearer token from the authenticated Supabase session');
+assert.match(page, /fetch\('\/api\/admin\/bank\/integration-health'/, 'integration health page must use the sanitized owner API');
+assert.match(page, /Authorization: `Bearer \$\{token\}`/, 'integration health request must carry the verified session token');
+assert.match(page, /OWNER OPERATIONS · SANDBOX ONLY/, 'owner operations surface must clearly identify the sandbox boundary');
+assert.match(page, /REAL MONEY[^]*LOCKED/, 'integration health UI must visibly show real money as locked');
+assert.match(page, /Production banking remains fail-closed/, 'integration health UI must preserve fail-closed production messaging');
+assert.match(page, /Run sandbox reconciliation/, 'owner operations UI must expose the safe sandbox reconciliation action');
+assert.match(page, /SANDBOX_VALID_SIMULATION is not real KYC\/CIP\/AML approval/, 'integration UI must not portray sandbox validation as regulated approval');
+assert.equal(page.includes('/api/admin/bank/increase/onboarding'), false, 'browser must not consume the raw onboarding payload');
+assert.equal(page.includes('/api/admin/bank/increase/reconciliation'), false, 'browser must not consume the raw reconciliation payload');
+assert.equal(page.includes('/api/admin/bank/increase/status'), false, 'browser must consume only the sanitized integration-health summary');
+assert.equal(page.includes('accountId'), false, 'integration health UI must not handle full provider Account IDs');
+assert.equal(page.includes('entityId'), false, 'integration health UI must not handle full provider Entity IDs');
+assert.equal(page.includes('programId'), false, 'integration health UI must not handle provider Program IDs');
+assert.equal(page.includes('apiKey'), false, 'integration health UI must never handle provider API keys');
+
+assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
+assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
+
+console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health, binding status, webhook/reconciliation operations, and fail-closed production state are available without exposing provider secrets or full provider identifiers to the browser.');


### PR DESCRIPTION
Closes #601.

Adds an owner-only Galactic Trust Integration Health center at `/bank/integrations` with a sanitized server API at `/api/admin/bank/integration-health`.

What it adds:
- Increase sandbox connectivity and capability health
- owner-scoped provider binding status with masked account suffix only
- webhook subscription and reconciliation heartbeat
- bounded owner-triggered sandbox reconciliation
- clear setup queue for remaining integration work
- dashboard command-palette access
- Galactic Trust regression coverage in `test:galactic`

Security and product boundary:
- provider secrets and full provider Account/Entity/Program/Event IDs stay server-side
- browser consumes only sanitized status/count/timestamp summaries
- Increase remains sandbox/pretend-money only
- `SANDBOX_VALID_SIMULATION` is not real KYC/CIP/AML approval
- `canMoveRealMoney` remains false
- production banking remains fail-closed behind the regulated-launch implementation lock and evidence gates

External setup blockers #586 and #590 remain separate and are not bypassed by this PR.