### PR TITLE
Surface Galactic Trust account state on dashboard

### DIFF
--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
 import BankClient from './BankClient';
+import GalacticDashboardAccountState from './GalacticDashboardAccountState';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
 import GalacticSandboxSetup from './GalacticSandboxSetup';
 
@@ -164,8 +165,9 @@ export default function GalacticBankGate() {
 
   return (
     <>
-      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={session?.access_token || ''} />
+      <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={accessToken} />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
+      <GalacticDashboardAccountState accessToken={accessToken} demoAccess={demoAccess} />
       {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}
     </>
   );

--- a/app/bank/GalacticDashboardAccountState.js
+++ b/app/bank/GalacticDashboardAccountState.js
@@ -1,0 +1,126 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './dashboard-account-state.module.css';
+
+const stageCopy = {
+  'demo-only': {
+    tone: 'demo',
+    icon: '✦',
+    eyebrow: 'DEMO MODE',
+    title: 'Illustrative money',
+    detail: 'No provider-backed account is active. Real money stays locked.',
+  },
+  'sandbox-owner-bound': {
+    tone: 'sandbox',
+    icon: '✓',
+    eyebrow: 'INCREASE SANDBOX',
+    title: 'Test account bound',
+    detail: 'Provider-backed test balance · pretend money only.',
+  },
+  'infrastructure-setup-required': {
+    tone: 'warn',
+    icon: '!',
+    eyebrow: 'SETUP REQUIRED',
+    title: 'Account setup needs attention',
+    detail: 'Trusted binding infrastructure must be ready before provider data is treated as yours.',
+  },
+  'signed-out': {
+    tone: 'demo',
+    icon: '◉',
+    eyebrow: 'SIGN IN REQUIRED',
+    title: 'Account state unavailable',
+    detail: 'Sign in to load your server-derived Galactic Trust account state.',
+  },
+};
+
+const demoLifecycle = {
+  stage: 'demo-only',
+  canMoveRealMoney: false,
+  sandbox: { ownerBindingReady: false, bindingStorageReady: true, canMoveRealMoney: false },
+  production: { customerMoneyMovementSupported: false, canMoveRealMoney: false },
+};
+
+function copyFor(stage, failed) {
+  if (failed) {
+    return {
+      tone: 'warn',
+      icon: '!',
+      eyebrow: 'STATUS CHECK',
+      title: 'Account state needs a refresh',
+      detail: 'The secure lifecycle check could not complete. No real-money capability was enabled.',
+    };
+  }
+  return stageCopy[stage] || stageCopy['demo-only'];
+}
+
+export default function GalacticDashboardAccountState({ accessToken = '', demoAccess = false }) {
+  const [target, setTarget] = useState(null);
+  const [lifecycle, setLifecycle] = useState(demoLifecycle);
+  const [loading, setLoading] = useState(Boolean(accessToken));
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let frame;
+    const findTarget = () => {
+      const hero = document.querySelector('.gt-balance-hero');
+      if (hero) setTarget(hero);
+      else frame = requestAnimationFrame(findTarget);
+    };
+    findTarget();
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    if (!accessToken || demoAccess) {
+      setLifecycle(demoLifecycle);
+      setLoading(false);
+      setFailed(false);
+      return () => { active = false; };
+    }
+
+    setLoading(true);
+    setFailed(false);
+    fetch('/api/bank/lifecycle', {
+      cache: 'no-store',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }).then(async (response) => {
+      const payload = await response.json().catch(() => ({}));
+      if (!active) return;
+      if (payload?.lifecycle) setLifecycle(payload.lifecycle);
+      if (!response.ok) setFailed(true);
+    }).catch(() => {
+      if (active) setFailed(true);
+    }).finally(() => {
+      if (active) setLoading(false);
+    });
+
+    return () => { active = false; };
+  }, [accessToken, demoAccess]);
+
+  const copy = useMemo(() => copyFor(lifecycle?.stage, failed), [failed, lifecycle?.stage]);
+  const productionLocked = lifecycle?.canMoveRealMoney !== true
+    && lifecycle?.production?.customerMoneyMovementSupported !== true
+    && lifecycle?.production?.canMoveRealMoney !== true;
+
+  if (!target) return null;
+
+  return createPortal(
+    <section className={`${styles.card} ${styles[copy.tone]}`} aria-label="Galactic Trust account state" aria-live="polite">
+      <div className={styles.topline}>
+        <span className={styles.icon}>{loading ? '◌' : copy.icon}</span>
+        <span className={styles.eyebrow}>{loading ? 'CHECKING ACCOUNT STATE' : copy.eyebrow}</span>
+      </div>
+      <strong>{loading ? 'Verifying your account…' : copy.title}</strong>
+      <p>{loading ? 'Reading your secure server-derived lifecycle.' : copy.detail}</p>
+      <div className={styles.footer}>
+        <span className={productionLocked ? styles.locked : styles.review}>{productionLocked ? '🔒 REAL MONEY LOCKED' : '! REVIEW REQUIRED'}</span>
+        <Link href="/bank/status">View status →</Link>
+      </div>
+    </section>,
+    target
+  );
+}

--- a/app/bank/dashboard-account-state.module.css
+++ b/app/bank/dashboard-account-state.module.css
@@ -1,0 +1,175 @@
+.card {
+  position: absolute;
+  top: 18px;
+  right: 20px;
+  z-index: 7;
+  width: min(250px, 32%);
+  padding: 12px 13px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+  background: rgba(8, 17, 67, 0.34);
+  color: #fff;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 28px rgba(4, 11, 49, 0.12);
+}
+
+.demo {
+  border-color: rgba(213, 204, 255, 0.28);
+}
+
+.sandbox {
+  border-color: rgba(180, 255, 212, 0.38);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 30px rgba(28, 120, 80, 0.12);
+}
+
+.warn {
+  border-color: rgba(255, 221, 153, 0.45);
+  background: rgba(71, 44, 12, 0.34);
+}
+
+.topline {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 6px;
+}
+
+.icon {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.eyebrow {
+  font-size: 8px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  font-weight: 900;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.card > strong {
+  display: block;
+  font-size: 13px;
+  letter-spacing: -0.015em;
+}
+
+.card > p {
+  margin: 4px 0 0;
+  color: rgba(240, 243, 255, 0.77);
+  font-size: 9px;
+  line-height: 1.42;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 9px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.11);
+}
+
+.footer > span {
+  font-size: 7px;
+  line-height: 1;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.locked {
+  color: #d9e2ff;
+}
+
+.review {
+  color: #ffe1a5;
+}
+
+.footer a {
+  color: #fff;
+  font-size: 8px;
+  font-weight: 850;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.footer a:hover,
+.footer a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 980px) {
+  .card {
+    width: 220px;
+  }
+}
+
+@media (max-width: 820px) {
+  .card {
+    top: 12px;
+    right: 12px;
+    width: 195px;
+    padding: 10px 11px;
+    border-radius: 14px;
+  }
+
+  .card > strong {
+    font-size: 12px;
+  }
+
+  .card > p {
+    font-size: 8px;
+  }
+}
+
+@media (max-width: 560px) {
+  .card {
+    width: 158px;
+    padding: 9px 10px;
+  }
+
+  .topline {
+    gap: 5px;
+    margin-bottom: 4px;
+  }
+
+  .icon {
+    width: 19px;
+    height: 19px;
+    border-radius: 7px;
+    font-size: 9px;
+  }
+
+  .eyebrow {
+    font-size: 6.5px;
+  }
+
+  .card > strong {
+    font-size: 10px;
+  }
+
+  .card > p {
+    display: none;
+  }
+
+  .footer {
+    margin-top: 6px;
+    padding-top: 6px;
+  }
+
+  .footer > span {
+    font-size: 6px;
+  }
+
+  .footer a {
+    font-size: 7px;
+  }
+}

--- a/scripts/test-galactic-trust-account-status-ui.mjs
+++ b/scripts/test-galactic-trust-account-status-ui.mjs
@@ -3,6 +3,8 @@ import { readFile } from 'node:fs/promises';
 
 const page = await readFile(new URL('../app/bank/status/page.js', import.meta.url), 'utf8');
 const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhancements.js', import.meta.url), 'utf8');
+const dashboardState = await readFile(new URL('../app/bank/GalacticDashboardAccountState.js', import.meta.url), 'utf8');
+const bankGate = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
 const lifecycleRoute = await readFile(new URL('../app/api/bank/lifecycle/route.ts', import.meta.url), 'utf8');
 
 assert.match(page, /getSupabaseBrowserAsync/, 'account status UI must derive its bearer session from the authenticated Supabase browser session');
@@ -31,8 +33,22 @@ assert.match(enhancements, /View your account status →/, 'dashboard trust stri
 assert.match(enhancements, /View regulated launch status →/, 'dashboard trust strip must separately link to regulated launch readiness');
 assert.match(enhancements, /Illustrative demo trend/, 'balance enhancement must label its synthetic trend as illustrative demo data');
 
+assert.match(dashboardState, /document\.querySelector\('\.gt-balance-hero'\)/, 'dashboard account state must attach to the primary balance hero');
+assert.match(dashboardState, /fetch\('\/api\/bank\/lifecycle'/, 'dashboard account state must reuse the server-derived lifecycle endpoint');
+assert.match(dashboardState, /Authorization: `Bearer \$\{accessToken\}`/, 'dashboard account state must authenticate lifecycle reads with the signed-in session token');
+assert.match(dashboardState, /DEMO MODE/, 'dashboard must visibly distinguish demo mode');
+assert.match(dashboardState, /INCREASE SANDBOX/, 'dashboard must visibly distinguish an Increase sandbox test-account state');
+assert.match(dashboardState, /SETUP REQUIRED/, 'dashboard must visibly distinguish infrastructure setup-required state');
+assert.match(dashboardState, /REAL MONEY LOCKED/, 'dashboard account-state indicator must keep the real-money lock visible');
+assert.match(dashboardState, /href="\/bank\/status"/, 'dashboard account-state indicator must link to the full personal status page');
+assert.equal(dashboardState.includes('accountId'), false, 'dashboard account-state indicator must not handle full provider Account IDs');
+assert.equal(dashboardState.includes('entityId'), false, 'dashboard account-state indicator must not handle provider Entity IDs');
+assert.equal(dashboardState.includes('INCREASE_SANDBOX_API_KEY'), false, 'dashboard account-state indicator must not read provider credentials');
+assert.equal(dashboardState.includes('NEXT_PUBLIC_'), false, 'dashboard account-state indicator must not depend on client-exposed banking secrets');
+assert.match(bankGate, /GalacticDashboardAccountState accessToken=\{accessToken\} demoAccess=\{demoAccess\}/, 'authenticated dashboard gate must mount the server-derived account-state indicator');
+
 assert.match(lifecycleRoute, /admin\.auth\.getUser\(token\)/, 'status UI source endpoint must continue to verify the session server-side');
 assert.match(lifecycleRoute, /getProviderAccountBinding\(admin, user\.id/, 'status UI source endpoint must scope binding to the verified user');
 assert.match(lifecycleRoute, /not a bank-account approval or production eligibility decision/, 'server lifecycle source must retain the production-eligibility disclaimer');
 
-console.log('Galactic Trust account status UI checks passed: personal lifecycle and regulated launch readiness stay distinct, sandbox ownership is labeled as test-only, production banking remains visibly unsupported, provider IDs/secrets stay out of the client, and the dashboard exposes both destinations clearly.');
+console.log('Galactic Trust account status UI checks passed: personal lifecycle and regulated launch readiness stay distinct, the main dashboard shows server-derived demo/sandbox/setup state, production banking remains visibly unsupported, provider IDs/secrets stay out of the client, and the dashboard exposes the correct status destinations.');


### PR DESCRIPTION
Closes #605.

Adds a compact server-derived account-state indicator directly to the main Galactic Trust balance hero.

States shown clearly:
- Demo mode — illustrative money only
- Increase sandbox — owner-bound test account with pretend money only
- Setup required — trusted binding infrastructure needs attention
- Safe status-check fallback if lifecycle verification cannot complete

Implementation details:
- reuses `/api/bank/lifecycle` rather than inventing client-side banking state
- mounts as a small dedicated component instead of further expanding the large `BankClient.js`
- links to `/bank/status` for the full personal lifecycle view
- keeps `REAL MONEY LOCKED` visible whenever production money movement is unsupported
- exposes no provider Account/Entity IDs, provider credentials, or `NEXT_PUBLIC_*` banking secrets
- extends the existing Galactic Trust account-status regression coverage

Production banking and crypto locks are unchanged.