### PR TITLE
Harden Galactic Trust browser security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,5 +9,18 @@ const nextConfig = {
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 86400,
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+          },
+        ],
+      },
+    ];
+  },
 };
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,17 +9,5 @@ const nextConfig = {
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 86400,
   },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          { key: 'X-Frame-Options', value: 'DENY' },
-          { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
-          { key: 'X-Permitted-Cross-Domain-Policies', value: 'none' },
-        ],
-      },
-    ];
-  },
 };
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,6 @@ const nextConfig = {
         headers: [
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
-          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()' },
           { key: 'X-Permitted-Cross-Domain-Policies', value: 'none' },
         ],
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,10 +14,10 @@ const nextConfig = {
       {
         source: '/:path*',
         headers: [
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
-          },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Strict-Transport-Security', value: 'max-age=31536000' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()' },
+          { key: 'X-Permitted-Cross-Domain-Policies', value: 'none' },
         ],
       },
     ];

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -70,10 +70,10 @@ assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Googl
 
 assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled in the proven-safe Vercel config');
 assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious in the proven-safe Vercel config');
-assert.doesNotMatch(vercelSource, /X-Frame-Options|Strict-Transport-Security|Permissions-Policy|X-Permitted-Cross-Domain-Policies/, 'new security headers must stay in Next config so Vercel project-config validation cannot reject them');
+assert.doesNotMatch(vercelSource, /X-Frame-Options|Strict-Transport-Security|Permissions-Policy|X-Permitted-Cross-Domain-Policies/, 'new security headers must stay out of Vercel project config');
 assert.match(nextConfigSource, /key: 'X-Frame-Options', value: 'DENY'/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
 assert.match(nextConfigSource, /key: 'Strict-Transport-Security', value: 'max-age=31536000'/, 'Galactic Trust responses must instruct browsers to keep using HTTPS');
-assert.match(nextConfigSource, /key: 'Permissions-Policy', value: 'camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)'/, 'unused sensitive browser capabilities must be disabled by policy');
 assert.match(nextConfigSource, /key: 'X-Permitted-Cross-Domain-Policies', value: 'none'/, 'legacy cross-domain policy files must be disabled');
+assert.doesNotMatch(nextConfigSource, /Permissions-Policy/, 'Permissions-Policy remains deferred because the current Vercel deployment adapter rejects that header configuration');
 
-console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and security headers are hardened through the Next response layer while Vercel project config stays on its proven-safe header set.');
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and compatible response security headers remain hardened while the Vercel-incompatible Permissions-Policy is deferred.');

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -58,7 +58,6 @@ const productionSource = read('lib/banking/providers/increase/production.js');
 const resolverSource = read('lib/banking/providers/index.js');
 const gateSource = read('app/bank/GalacticBankGate.js');
 const vercelSource = read('vercel.json');
-const nextConfigSource = read('next.config.mjs');
 
 assert.doesNotMatch(productionSource, /increase-sandbox/i, 'production adapter must not import or reuse sandbox request code');
 assert.doesNotMatch(productionSource, /INCREASE_SANDBOX_API_KEY/, 'production adapter must not accept sandbox credentials');
@@ -68,12 +67,10 @@ assert.match(sandboxSource, /\.\.\/\.\.\/increase-sandbox\.js/, 'sandbox provide
 assert.match(resolverSource, /launch\.liveBankingEnabled && platform === 'increase'/, 'resolver must require the regulated launch snapshot before production selection');
 assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Google and OTP auth must return directly to the Galactic Trust dashboard');
 
-assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled in the proven-safe Vercel config');
-assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious in the proven-safe Vercel config');
-assert.doesNotMatch(vercelSource, /X-Frame-Options|Strict-Transport-Security|Permissions-Policy|X-Permitted-Cross-Domain-Policies/, 'new security headers must stay out of Vercel project config');
-assert.match(nextConfigSource, /key: 'X-Frame-Options', value: 'DENY'/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
-assert.match(nextConfigSource, /key: 'Strict-Transport-Security', value: 'max-age=31536000'/, 'Galactic Trust responses must instruct browsers to keep using HTTPS');
-assert.match(nextConfigSource, /key: 'X-Permitted-Cross-Domain-Policies', value: 'none'/, 'legacy cross-domain policy files must be disabled');
-assert.doesNotMatch(nextConfigSource, /Permissions-Policy/, 'Permissions-Policy remains deferred because the current Vercel deployment adapter rejects that header configuration');
+assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled');
+assert.match(vercelSource, /"X-Frame-Options", "value": "DENY"/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
+assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious');
+assert.doesNotMatch(vercelSource, /Strict-Transport-Security/, 'Vercel already supplies platform-managed HSTS and the app must not override it here');
+assert.doesNotMatch(vercelSource, /Permissions-Policy/, 'Permissions-Policy remains deferred until it can be deployed without Vercel adapter rejection');
 
-console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and compatible response security headers remain hardened while the Vercel-incompatible Permissions-Policy is deferred.');
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and Vercel-supported clickjacking/MIME/referrer protections remain regression-locked without overriding platform HSTS.');

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -57,6 +57,7 @@ const sandboxSource = read('lib/banking/providers/increase/sandbox.js');
 const productionSource = read('lib/banking/providers/increase/production.js');
 const resolverSource = read('lib/banking/providers/index.js');
 const gateSource = read('app/bank/GalacticBankGate.js');
+const vercelSource = read('vercel.json');
 
 assert.doesNotMatch(productionSource, /increase-sandbox/i, 'production adapter must not import or reuse sandbox request code');
 assert.doesNotMatch(productionSource, /INCREASE_SANDBOX_API_KEY/, 'production adapter must not accept sandbox credentials');
@@ -66,4 +67,11 @@ assert.match(sandboxSource, /\.\.\/\.\.\/increase-sandbox\.js/, 'sandbox provide
 assert.match(resolverSource, /launch\.liveBankingEnabled && platform === 'increase'/, 'resolver must require the regulated launch snapshot before production selection');
 assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Google and OTP auth must return directly to the Galactic Trust dashboard');
 
-console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated and auth returns to /bank.');
+assert.match(vercelSource, /"X-Frame-Options", "value": "DENY"/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
+assert.match(vercelSource, /"Strict-Transport-Security", "value": "max-age=31536000"/, 'Galactic Trust deployment must instruct browsers to keep using HTTPS');
+assert.match(vercelSource, /"Permissions-Policy", "value": "camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)"/, 'unused sensitive browser capabilities must be disabled by policy');
+assert.match(vercelSource, /"X-Permitted-Cross-Domain-Policies", "value": "none"/, 'legacy cross-domain policy files must be disabled');
+assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled');
+assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious');
+
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and deployment security headers remain hardened.');

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -68,13 +68,12 @@ assert.match(sandboxSource, /\.\.\/\.\.\/increase-sandbox\.js/, 'sandbox provide
 assert.match(resolverSource, /launch\.liveBankingEnabled && platform === 'increase'/, 'resolver must require the regulated launch snapshot before production selection');
 assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Google and OTP auth must return directly to the Galactic Trust dashboard');
 
-assert.match(vercelSource, /"X-Frame-Options", "value": "DENY"/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
-assert.match(vercelSource, /"Strict-Transport-Security", "value": "max-age=31536000"/, 'Galactic Trust deployment must instruct browsers to keep using HTTPS');
-assert.match(vercelSource, /"X-Permitted-Cross-Domain-Policies", "value": "none"/, 'legacy cross-domain policy files must be disabled');
-assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled');
-assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious');
-assert.doesNotMatch(vercelSource, /Permissions-Policy/, 'parenthesized Permissions-Policy must stay out of vercel.json to avoid deployment-schema rejection');
-assert.match(nextConfigSource, /key: 'Permissions-Policy'/, 'Next response headers must set the browser permissions policy');
-assert.match(nextConfigSource, /camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)/, 'unused sensitive browser capabilities must be disabled by policy');
+assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled in the proven-safe Vercel config');
+assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious in the proven-safe Vercel config');
+assert.doesNotMatch(vercelSource, /X-Frame-Options|Strict-Transport-Security|Permissions-Policy|X-Permitted-Cross-Domain-Policies/, 'new security headers must stay in Next config so Vercel project-config validation cannot reject them');
+assert.match(nextConfigSource, /key: 'X-Frame-Options', value: 'DENY'/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
+assert.match(nextConfigSource, /key: 'Strict-Transport-Security', value: 'max-age=31536000'/, 'Galactic Trust responses must instruct browsers to keep using HTTPS');
+assert.match(nextConfigSource, /key: 'Permissions-Policy', value: 'camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)'/, 'unused sensitive browser capabilities must be disabled by policy');
+assert.match(nextConfigSource, /key: 'X-Permitted-Cross-Domain-Policies', value: 'none'/, 'legacy cross-domain policy files must be disabled');
 
-console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and deployment security headers remain hardened without relying on a Vercel-incompatible Permissions-Policy value.');
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and security headers are hardened through the Next response layer while Vercel project config stays on its proven-safe header set.');

--- a/scripts/test-galactic-trust-provider-boundary.mjs
+++ b/scripts/test-galactic-trust-provider-boundary.mjs
@@ -58,6 +58,7 @@ const productionSource = read('lib/banking/providers/increase/production.js');
 const resolverSource = read('lib/banking/providers/index.js');
 const gateSource = read('app/bank/GalacticBankGate.js');
 const vercelSource = read('vercel.json');
+const nextConfigSource = read('next.config.mjs');
 
 assert.doesNotMatch(productionSource, /increase-sandbox/i, 'production adapter must not import or reuse sandbox request code');
 assert.doesNotMatch(productionSource, /INCREASE_SANDBOX_API_KEY/, 'production adapter must not accept sandbox credentials');
@@ -69,9 +70,11 @@ assert.match(gateSource, /new URL\('\/bank', window\.location\.origin\)/, 'Googl
 
 assert.match(vercelSource, /"X-Frame-Options", "value": "DENY"/, 'Galactic Trust pages must deny framing to reduce clickjacking risk');
 assert.match(vercelSource, /"Strict-Transport-Security", "value": "max-age=31536000"/, 'Galactic Trust deployment must instruct browsers to keep using HTTPS');
-assert.match(vercelSource, /"Permissions-Policy", "value": "camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)"/, 'unused sensitive browser capabilities must be disabled by policy');
 assert.match(vercelSource, /"X-Permitted-Cross-Domain-Policies", "value": "none"/, 'legacy cross-domain policy files must be disabled');
 assert.match(vercelSource, /"X-Content-Type-Options", "value": "nosniff"/, 'MIME sniffing protection must remain enabled');
 assert.match(vercelSource, /"Referrer-Policy", "value": "strict-origin-when-cross-origin"/, 'referrer policy must remain privacy-conscious');
+assert.doesNotMatch(vercelSource, /Permissions-Policy/, 'parenthesized Permissions-Policy must stay out of vercel.json to avoid deployment-schema rejection');
+assert.match(nextConfigSource, /key: 'Permissions-Policy'/, 'Next response headers must set the browser permissions policy');
+assert.match(nextConfigSource, /camera=\(\), microphone=\(\), geolocation=\(\), payment=\(\), usb=\(\)/, 'unused sensitive browser capabilities must be disabled by policy');
 
-console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and deployment security headers remain hardened.');
+console.log('Galactic Trust provider boundary checks passed: demo, Increase sandbox, and locked production remain explicitly separated, auth returns to /bank, and deployment security headers remain hardened without relying on a Vercel-incompatible Permissions-Policy value.');

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,6 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=31536000" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=()" },
         { "key": "X-Permitted-Cross-Domain-Policies", "value": "none" }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,11 @@
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=()" },
+        { "key": "X-Permitted-Cross-Domain-Policies", "value": "none" }
       ]
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,7 @@
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000" },
-        { "key": "X-Permitted-Cross-Domain-Policies", "value": "none" }
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
       ]
     }
   ]


### PR DESCRIPTION
Closed without merge after deployment verification.

Goal: strengthen the Galactic Trust response-header baseline.

What verification showed:
- Galactic Trust regression suite: PASS
- Next production build: PASS
- Vercel preview deployment: FAILS when the additional header override is introduced on this project deployment path
- existing production deployment remains green and unchanged

Vercel already supplies platform-managed HSTS. Broader header variants, including Permissions-Policy, were also tested on this branch and deliberately backed out after Vercel adapter rejection.

This PR is intentionally not merged. Security hardening should be revisited through a deployment-compatible mechanism rather than forcing an override that prevents Vercel deployment.