### PR TITLE
Make Galactic Trust demo crypto portfolio coherent

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Integration health
         if: always()
         run: node scripts/test-galactic-trust-integration-health.mjs
+      - name: Crypto practice
+        if: always()
+        run: node scripts/test-galactic-trust-crypto-practice.mjs
       - name: Production build
         if: always()
         run: npm run build

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { getSupabaseBrowserAsync } from '../../lib/supabase-browser';
 import BankClient from './BankClient';
+import GalacticCryptoPractice from './GalacticCryptoPractice';
 import GalacticDashboardAccountState from './GalacticDashboardAccountState';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
 import GalacticSandboxSetup from './GalacticSandboxSetup';
@@ -166,6 +167,7 @@ export default function GalacticBankGate() {
   return (
     <>
       <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={accessToken} />
+      <GalacticCryptoPractice />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
       <GalacticDashboardAccountState accessToken={accessToken} demoAccess={demoAccess} />
       {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}

--- a/app/bank/GalacticCryptoPractice.js
+++ b/app/bank/GalacticCryptoPractice.js
@@ -1,0 +1,161 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './crypto-practice.module.css';
+
+const STARTING_CASH = 5000;
+const STARTING_ASSETS = [
+  { symbol: 'BTC', name: 'Bitcoin', price: 68000, holding: 0.0142 },
+  { symbol: 'ETH', name: 'Ethereum', price: 3600, holding: 0.63 },
+  { symbol: 'USDC', name: 'USD Coin', price: 1, holding: 425.5 },
+];
+
+function money(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+}
+
+function units(value, symbol) {
+  return Number(value || 0).toLocaleString(undefined, { maximumFractionDigits: symbol === 'BTC' ? 8 : 6 });
+}
+
+function freshAssets() {
+  return STARTING_ASSETS.map((asset) => ({ ...asset }));
+}
+
+export default function GalacticCryptoPractice() {
+  const [target, setTarget] = useState(null);
+  const [assets, setAssets] = useState(freshAssets);
+  const [practiceCash, setPracticeCash] = useState(STARTING_CASH);
+  const [symbol, setSymbol] = useState('BTC');
+  const [side, setSide] = useState('buy');
+  const [amount, setAmount] = useState('100');
+  const [trades, setTrades] = useState([]);
+  const [notice, setNotice] = useState('');
+
+  useEffect(() => {
+    let frame;
+    const findPanel = () => {
+      const panel = document.querySelector('.gt-crypto-panel');
+      if (panel) {
+        panel.classList.add('gt-crypto-enhanced');
+        setTarget(panel);
+      } else {
+        frame = requestAnimationFrame(findPanel);
+      }
+    };
+    findPanel();
+    return () => {
+      cancelAnimationFrame(frame);
+      document.querySelector('.gt-crypto-panel')?.classList.remove('gt-crypto-enhanced');
+    };
+  }, []);
+
+  const active = assets.find((asset) => asset.symbol === symbol) || assets[0];
+  const usd = Number(amount);
+  const estimatedUnits = Number.isFinite(usd) && usd > 0 ? usd / active.price : 0;
+  const holdingsValue = useMemo(() => assets.reduce((sum, asset) => sum + (asset.holding * asset.price), 0), [assets]);
+  const practiceTotal = practiceCash + holdingsValue;
+
+  function submitTrade(event) {
+    event.preventDefault();
+    setNotice('');
+    if (!Number.isFinite(usd) || usd < 1 || usd > 5000) {
+      setNotice('Enter a practice trade amount between $1 and $5,000.');
+      return;
+    }
+    if (side === 'buy' && usd > practiceCash) {
+      setNotice(`Practice cash is too low. Available: ${money(practiceCash)}.`);
+      return;
+    }
+    if (side === 'sell' && estimatedUnits > active.holding) {
+      setNotice(`Your practice ${active.symbol} holding is too low for that sell.`);
+      return;
+    }
+
+    setAssets((current) => current.map((asset) => (
+      asset.symbol === active.symbol
+        ? { ...asset, holding: Math.max(0, asset.holding + (side === 'buy' ? estimatedUnits : -estimatedUnits)) }
+        : asset
+    )));
+    setPracticeCash((current) => side === 'buy' ? current - usd : current + usd);
+    setTrades((current) => [{
+      id: `${Date.now()}-${active.symbol}-${side}`,
+      side,
+      symbol: active.symbol,
+      usd,
+      units: estimatedUnits,
+    }, ...current].slice(0, 5));
+    setNotice(`Practice ${side} recorded. No real ${active.symbol} or money moved.`);
+  }
+
+  function resetPractice() {
+    setAssets(freshAssets());
+    setPracticeCash(STARTING_CASH);
+    setTrades([]);
+    setAmount('100');
+    setSide('buy');
+    setSymbol('BTC');
+    setNotice('Practice portfolio reset. No bank or provider data changed.');
+  }
+
+  if (!target) return null;
+
+  return createPortal(
+    <section className={styles.practice} aria-label="Galactic Trust demo crypto practice portfolio">
+      <div className={styles.boundary}>
+        <span>◎</span>
+        <p><b>Isolated practice portfolio</b><small>This demo cash and crypto never touch your Galactic Trust bank balance or any Increase sandbox balance.</small></p>
+      </div>
+
+      <div className={styles.summary}>
+        <div><span>Practice cash</span><b>{money(practiceCash)}</b></div>
+        <div><span>Demo crypto</span><b>{money(holdingsValue)}</b></div>
+        <div><span>Practice total</span><b>{money(practiceTotal)}</b></div>
+      </div>
+
+      <div className={styles.assets} aria-label="Choose demo crypto asset">
+        {assets.map((asset) => (
+          <button key={asset.symbol} type="button" className={asset.symbol === symbol ? styles.activeAsset : ''} onClick={() => setSymbol(asset.symbol)}>
+            <span className={styles.coin}>{asset.symbol === 'BTC' ? '₿' : asset.symbol === 'ETH' ? '◆' : '$'}</span>
+            <span><b>{asset.symbol}</b><small>{asset.name}</small></span>
+            <strong>{money(asset.price)}</strong>
+          </button>
+        ))}
+      </div>
+      <p className={styles.quoteNote}>Illustrative reference prices only · not live market quotes.</p>
+
+      <div className={styles.holding}>
+        <span><small>Your practice {active.name}</small><b>{units(active.holding, active.symbol)} {active.symbol}</b></span>
+        <strong>{money(active.holding * active.price)}</strong>
+      </div>
+
+      <form className={styles.trade} onSubmit={submitTrade}>
+        <div className={styles.toggle}>
+          <button type="button" className={side === 'buy' ? styles.activeToggle : ''} onClick={() => setSide('buy')}>Practice Buy</button>
+          <button type="button" className={side === 'sell' ? styles.activeToggle : ''} onClick={() => setSide('sell')}>Practice Sell</button>
+        </div>
+        <label>
+          <span>Practice amount in USD</span>
+          <div className={styles.amount}><span>$</span><input type="number" min="1" max="5000" step="1" value={amount} onChange={(event) => setAmount(event.target.value)} /></div>
+        </label>
+        <div className={styles.estimate}><span>Estimated {active.symbol}</span><b>{units(estimatedUnits, active.symbol)}</b></div>
+        <button className={styles.submit} type="submit">Simulate {side === 'buy' ? 'Buy' : 'Sell'} {active.symbol}</button>
+      </form>
+
+      {notice && <p className={styles.notice} role="status">{notice}</p>}
+
+      <div className={styles.ledgerHead}><div><span>PRACTICE LEDGER</span><b>{trades.length ? 'Recent simulated trades' : 'No trades yet'}</b></div><button type="button" onClick={resetPractice}>Reset</button></div>
+      {trades.length ? (
+        <div className={styles.ledger}>
+          {trades.map((trade) => (
+            <div key={trade.id}><span className={trade.side === 'buy' ? styles.buy : styles.sell}>{trade.side.toUpperCase()}</span><p><b>{trade.symbol}</b><small>{units(trade.units, trade.symbol)} units</small></p><strong>{money(trade.usd)}</strong></div>
+          ))}
+        </div>
+      ) : <p className={styles.empty}>Your simulated buys and sells will appear here. This ledger is local practice state only.</p>}
+
+      <p className={styles.disclosure}><b>Demo only.</b> No real crypto is purchased, sold, custodied, or transferred. No banking API or crypto provider is called by this practice panel. Crypto can lose value and the illustrative prices above are not investment information.</p>
+    </section>,
+    target
+  );
+}

--- a/app/bank/crypto-practice.module.css
+++ b/app/bank/crypto-practice.module.css
@@ -1,0 +1,441 @@
+:global(.gt-crypto-enhanced .gt-crypto-tabs),
+:global(.gt-crypto-enhanced .gt-crypto-holding),
+:global(.gt-crypto-enhanced .gt-crypto-form),
+:global(.gt-crypto-enhanced .gt-crypto-disclosure) {
+  display: none !important;
+}
+
+.practice {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.boundary {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 11px;
+  border: 1px solid #e6e9f7;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #f9faff, #f5f7ff);
+}
+
+.boundary > span {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: #ebeaff;
+  color: #6449e9;
+  font-weight: 900;
+}
+
+.boundary p,
+.ledgerHead > div,
+.holding span {
+  margin: 0;
+  min-width: 0;
+}
+
+.boundary b,
+.boundary small {
+  display: block;
+}
+
+.boundary b {
+  color: #262b5a;
+  font-size: 11px;
+}
+
+.boundary small {
+  margin-top: 2px;
+  color: #858dab;
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.summary > div {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid #eceef8;
+  border-radius: 13px;
+  background: #fff;
+}
+
+.summary span,
+.summary b {
+  display: block;
+}
+
+.summary span {
+  color: #8a91ae;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: .055em;
+  font-weight: 800;
+}
+
+.summary b {
+  margin-top: 4px;
+  color: #1f2556;
+  font-size: 13px;
+  letter-spacing: -.025em;
+}
+
+.assets {
+  display: grid;
+  gap: 7px;
+}
+
+.assets button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: 9px;
+  align-items: center;
+  padding: 9px 10px;
+  border: 1px solid #eceef8;
+  border-radius: 13px;
+  background: #fff;
+  text-align: left;
+  cursor: pointer;
+  transition: .16s ease;
+}
+
+.assets button:hover,
+.assets button:focus-visible {
+  outline: none;
+  border-color: #d7d0ff;
+  background: #f8f7ff;
+}
+
+.assets button.activeAsset {
+  border-color: #bfb2ff;
+  background: #f4f1ff;
+  box-shadow: inset 0 0 0 1px rgba(101, 69, 245, .06);
+}
+
+.coin {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  background: linear-gradient(145deg, #293b8f, #6835dd);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 900;
+}
+
+.assets button > span:nth-child(2) b,
+.assets button > span:nth-child(2) small {
+  display: block;
+}
+
+.assets button > span:nth-child(2) b {
+  color: #212654;
+  font-size: 11px;
+}
+
+.assets button > span:nth-child(2) small {
+  margin-top: 2px;
+  color: #8990ac;
+  font-size: 9px;
+}
+
+.assets button > strong {
+  color: #3f4775;
+  font-size: 11px;
+}
+
+.quoteNote {
+  margin: -5px 2px 0;
+  color: #9a7a42;
+  font-size: 8px;
+  line-height: 1.35;
+  font-weight: 750;
+}
+
+.holding {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 12px;
+  border: 1px solid #e9ebf6;
+  border-radius: 14px;
+  background: #fafbff;
+}
+
+.holding small,
+.holding b {
+  display: block;
+}
+
+.holding small {
+  color: #8a91ad;
+  font-size: 8px;
+}
+
+.holding b {
+  margin-top: 3px;
+  color: #222855;
+  font-size: 11px;
+}
+
+.holding > strong {
+  color: #4f3bd8;
+  font-size: 13px;
+}
+
+.trade {
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+  border: 1px solid #e8eaf7;
+  border-radius: 15px;
+  background: #fff;
+}
+
+.toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 11px;
+  background: #f2f3f9;
+}
+
+.toggle button {
+  min-height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #747d9d;
+  font-size: 9px;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.toggle button.activeToggle {
+  background: #fff;
+  color: #5136d6;
+  box-shadow: 0 4px 12px rgba(61, 51, 123, .08);
+}
+
+.trade label {
+  display: grid;
+  gap: 5px;
+}
+
+.trade label > span,
+.estimate span {
+  color: #8088a7;
+  font-size: 8px;
+  font-weight: 750;
+}
+
+.amount {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  height: 38px;
+  border: 1px solid #e3e6f2;
+  border-radius: 11px;
+  background: #fafbfe;
+}
+
+.amount > span {
+  color: #5f678d;
+  font-weight: 850;
+}
+
+.amount input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #1c2250;
+  font-weight: 800;
+}
+
+.estimate {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 2px;
+}
+
+.estimate b {
+  color: #303761;
+  font-size: 10px;
+}
+
+.submit {
+  min-height: 38px;
+  border: 0;
+  border-radius: 11px;
+  background: linear-gradient(90deg, #5638e3, #7b4df0);
+  color: #fff !important;
+  font-size: 10px;
+  font-weight: 900;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(88, 61, 222, .18);
+}
+
+.notice {
+  margin: 0;
+  padding: 9px 10px;
+  border: 1px solid #e3ddff;
+  border-radius: 11px;
+  background: #f6f3ff;
+  color: #5d4a9e;
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.ledgerHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 2px;
+}
+
+.ledgerHead span,
+.ledgerHead b {
+  display: block;
+}
+
+.ledgerHead span {
+  color: #9399b0;
+  font-size: 7px;
+  letter-spacing: .11em;
+  font-weight: 900;
+}
+
+.ledgerHead b {
+  margin-top: 3px;
+  color: #2d3260;
+  font-size: 10px;
+}
+
+.ledgerHead button {
+  border: 0;
+  background: transparent;
+  color: #6545df;
+  font-size: 8px;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.ledger {
+  display: grid;
+  gap: 6px;
+}
+
+.ledger > div {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 9px;
+  border: 1px solid #eceef7;
+  border-radius: 11px;
+  background: #fff;
+}
+
+.ledger > div > span {
+  display: grid;
+  place-items: center;
+  min-height: 22px;
+  border-radius: 7px;
+  font-size: 7px;
+  font-weight: 900;
+}
+
+.buy {
+  background: #eaf8f0;
+  color: #22714a;
+}
+
+.sell {
+  background: #fff0f4;
+  color: #a43d61;
+}
+
+.ledger p {
+  margin: 0;
+}
+
+.ledger p b,
+.ledger p small {
+  display: block;
+}
+
+.ledger p b {
+  color: #2a305e;
+  font-size: 9px;
+}
+
+.ledger p small {
+  margin-top: 1px;
+  color: #9399af;
+  font-size: 8px;
+}
+
+.ledger > div > strong {
+  color: #3a416b;
+  font-size: 9px;
+}
+
+.empty {
+  margin: 0;
+  padding: 10px;
+  border: 1px dashed #dfe2ef;
+  border-radius: 11px;
+  color: #8c93ad;
+  font-size: 8px;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.disclosure {
+  margin: 0;
+  color: #8b92aa;
+  font-size: 8px;
+  line-height: 1.45;
+}
+
+.disclosure b {
+  color: #505778;
+}
+
+@media (max-width: 520px) {
+  .summary {
+    grid-template-columns: 1fr;
+  }
+
+  .summary > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .summary b {
+    margin-top: 0;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs"
+    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs && node scripts/test-galactic-trust-crypto-practice.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/scripts/test-galactic-trust-crypto-practice.mjs
+++ b/scripts/test-galactic-trust-crypto-practice.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const practice = await readFile(new URL('../app/bank/GalacticCryptoPractice.js', import.meta.url), 'utf8');
+const styles = await readFile(new URL('../app/bank/crypto-practice.module.css', import.meta.url), 'utf8');
+const gate = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
+
+assert.match(practice, /const STARTING_CASH = 5000/, 'crypto practice must have its own explicit demo cash balance');
+assert.match(practice, /setPracticeCash\(\(current\) => side === 'buy' \? current - usd : current \+ usd\)/, 'practice buys and sells must debit/credit only the practice cash ledger');
+assert.match(practice, /side === 'buy' && usd > practiceCash/, 'practice buys must reject insufficient demo cash');
+assert.match(practice, /side === 'sell' && estimatedUnits > active\.holding/, 'practice sells must reject insufficient demo holdings');
+assert.match(practice, /setTrades\(\(current\) => \[\{/, 'practice trades must create a visible local demo ledger');
+assert.match(practice, /Illustrative reference prices only · not live market quotes/, 'crypto reference prices must be labeled as illustrative rather than current market quotes');
+assert.match(practice, /never touch your Galactic Trust bank balance or any Increase sandbox balance/, 'practice portfolio must explicitly remain separate from banking balances');
+assert.match(practice, /No banking API or crypto provider is called by this practice panel/, 'practice disclosure must deny provider/API execution');
+assert.match(practice, /No real crypto is purchased, sold, custodied, or transferred/, 'practice UI must explicitly deny real crypto execution and custody');
+assert.equal(practice.includes('fetch('), false, 'crypto practice must not call banking or crypto APIs');
+assert.equal(practice.includes('accessToken'), false, 'crypto practice must not receive or handle an authenticated banking token');
+assert.equal(practice.includes('/api/'), false, 'crypto practice must not reference application provider endpoints');
+assert.equal(practice.includes('INCREASE_'), false, 'crypto practice must not handle Increase configuration or credentials');
+assert.equal(practice.includes('NEXT_PUBLIC_'), false, 'crypto practice must not depend on client-exposed provider secrets');
+
+assert.match(styles, /gt-crypto-enhanced \.gt-crypto-form/, 'enhanced practice mode must hide the old disconnected demo trade form');
+assert.match(styles, /gt-crypto-enhanced \.gt-crypto-tabs/, 'enhanced practice mode must replace the old static-price asset tabs');
+assert.match(gate, /import GalacticCryptoPractice from '\.\/GalacticCryptoPractice'/, 'dashboard gate must load the isolated crypto practice component');
+assert.match(gate, /<GalacticCryptoPractice \/>/, 'crypto practice must mount alongside the existing dashboard without receiving banking credentials');
+
+console.log('Galactic Trust crypto practice checks passed: practice cash, holdings, and trade ledger reconcile locally, reference prices are explicitly illustrative, and no bank/provider balance, credential, or API is touched.');


### PR DESCRIPTION
Closes #609.

Replaces the disconnected Crypto demo controls with an isolated Galactic Trust practice portfolio inside the existing dashboard panel.

What changes:
- adds a dedicated $5,000 practice-cash balance
- practice buys debit practice cash; practice sells credit it
- insufficient practice cash and insufficient demo holdings fail clearly
- adds a recent simulated-trade ledger and reset control
- calculates practice cash + demo crypto into a coherent practice total
- replaces static-looking quote UI with clearly labeled `Illustrative reference prices only · not live market quotes`
- keeps the existing Crypto panel visual location and DEMO labeling

Isolation boundary:
- the practice component receives no access token
- makes no `fetch()` calls
- references no `/api/` routes
- never changes the Galactic Trust checking/savings balance
- never changes any Increase sandbox balance
- never buys, sells, custodies, or transfers real crypto

Adds a dedicated `Crypto practice` regression step to both `test:galactic` and GitHub Actions.