### PR TITLE
Replace Galactic Trust header placeholder toasts

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Crypto practice
         if: always()
         run: node scripts/test-galactic-trust-crypto-practice.mjs
+      - name: Header center
+        if: always()
+        run: node scripts/test-galactic-trust-header-center.mjs
       - name: Production build
         if: always()
         run: npm run build

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -6,6 +6,7 @@ import BankClient from './BankClient';
 import GalacticCryptoPractice from './GalacticCryptoPractice';
 import GalacticDashboardAccountState from './GalacticDashboardAccountState';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
+import GalacticHeaderCenter from './GalacticHeaderCenter';
 import GalacticSandboxSetup from './GalacticSandboxSetup';
 
 function userLabel(user) {
@@ -170,6 +171,7 @@ export default function GalacticBankGate() {
       <GalacticCryptoPractice />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
       <GalacticDashboardAccountState accessToken={accessToken} demoAccess={demoAccess} />
+      <GalacticHeaderCenter accessToken={accessToken} demoAccess={demoAccess} accountLabel={label} onSignOut={activeSignOut} />
       {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}
     </>
   );

--- a/app/bank/GalacticHeaderCenter.js
+++ b/app/bank/GalacticHeaderCenter.js
@@ -1,0 +1,253 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './header-center.module.css';
+
+const demoLifecycle = {
+  stage: 'demo-only',
+  canMoveRealMoney: false,
+  sandbox: { ownerBindingReady: false, bindingStorageReady: true },
+  production: { customerMoneyMovementSupported: false, implementationReady: false },
+};
+
+function anchorPosition(node) {
+  if (!node || typeof window === 'undefined') return {};
+  const rect = node.getBoundingClientRect();
+  const width = Math.min(360, Math.max(280, window.innerWidth - 24));
+  const right = Math.max(12, window.innerWidth - rect.right);
+  return {
+    top: Math.min(window.innerHeight - 20, rect.bottom + 10),
+    right,
+    width,
+  };
+}
+
+function accountNotification(lifecycle, failed) {
+  if (failed) {
+    return {
+      tone: 'warn',
+      icon: '!',
+      title: 'Account status needs a refresh',
+      detail: 'The secure lifecycle check did not complete. No real-money capability was enabled.',
+      href: '/bank/status',
+      action: 'Review status',
+    };
+  }
+  if (lifecycle?.stage === 'sandbox-owner-bound') {
+    return {
+      tone: 'good',
+      icon: '✓',
+      title: 'Increase sandbox test account connected',
+      detail: 'Provider-backed test data is scoped to your signed-in account. The money is pretend.',
+      href: '/bank/status',
+      action: 'View account',
+    };
+  }
+  if (lifecycle?.stage === 'infrastructure-setup-required') {
+    return {
+      tone: 'warn',
+      icon: '!',
+      title: 'Account setup needs attention',
+      detail: 'Trusted provider-binding infrastructure must be ready before provider data is treated as yours.',
+      href: '/bank/status',
+      action: 'See next step',
+    };
+  }
+  return {
+    tone: 'neutral',
+    icon: '✦',
+    title: 'Demo mode is active',
+    detail: 'Balances and transfers are illustrative unless your signed-in account is explicitly bound to an Increase sandbox test account.',
+    href: '/bank/status',
+    action: 'View status',
+  };
+}
+
+function NotificationItem({ item }) {
+  return (
+    <article className={styles.notificationItem}>
+      <span className={`${styles.itemIcon} ${styles[item.tone]}`}>{item.icon}</span>
+      <div><b>{item.title}</b><p>{item.detail}</p>{item.href && <Link href={item.href}>{item.action || 'Open'} →</Link>}</div>
+    </article>
+  );
+}
+
+export default function GalacticHeaderCenter({ accessToken = '', demoAccess = false, accountLabel = 'Galactic member', onSignOut }) {
+  const [bell, setBell] = useState(null);
+  const [profile, setProfile] = useState(null);
+  const [notificationOpen, setNotificationOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [notificationAnchor, setNotificationAnchor] = useState({});
+  const [profileAnchor, setProfileAnchor] = useState({});
+  const [lifecycle, setLifecycle] = useState(demoLifecycle);
+  const [lifecycleFailed, setLifecycleFailed] = useState(false);
+
+  useEffect(() => {
+    let frame;
+    const find = () => {
+      const nextBell = document.querySelector('.gt-notification');
+      const nextProfile = document.querySelector('.gt-profile');
+      if (nextBell && nextProfile) {
+        setBell(nextBell);
+        setProfile(nextProfile);
+      } else {
+        frame = requestAnimationFrame(find);
+      }
+    };
+    find();
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    if (!accessToken || demoAccess) {
+      setLifecycle(demoLifecycle);
+      setLifecycleFailed(false);
+      return () => { active = false; };
+    }
+    fetch('/api/bank/lifecycle', {
+      cache: 'no-store',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }).then(async (response) => {
+      const payload = await response.json().catch(() => ({}));
+      if (!active) return;
+      if (payload?.lifecycle) setLifecycle(payload.lifecycle);
+      setLifecycleFailed(!response.ok);
+    }).catch(() => {
+      if (active) setLifecycleFailed(true);
+    });
+    return () => { active = false; };
+  }, [accessToken, demoAccess]);
+
+  const notifications = useMemo(() => {
+    const productionLocked = lifecycle?.canMoveRealMoney !== true
+      && lifecycle?.production?.customerMoneyMovementSupported !== true;
+    return [
+      accountNotification(lifecycle, lifecycleFailed),
+      {
+        tone: productionLocked ? 'locked' : 'warn',
+        icon: '🔒',
+        title: productionLocked ? 'Production banking is locked' : 'Production state requires review',
+        detail: productionLocked
+          ? 'No production account opening or real-money movement is enabled in this build.'
+          : 'An unexpected production-capable lifecycle was detected.',
+        href: '/bank/readiness',
+        action: 'Launch readiness',
+      },
+      {
+        tone: 'neutral',
+        icon: '◈',
+        title: 'Crypto is practice-only',
+        detail: 'The crypto portfolio uses isolated demo cash and illustrative reference prices. It never touches bank or Increase balances.',
+        href: null,
+      },
+    ];
+  }, [lifecycle, lifecycleFailed]);
+
+  useEffect(() => {
+    if (!bell || !profile) return undefined;
+
+    const bellClick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation?.();
+      setNotificationAnchor(anchorPosition(bell));
+      setNotificationOpen((value) => !value);
+      setProfileOpen(false);
+    };
+    const profileClick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation?.();
+      setProfileAnchor(anchorPosition(profile));
+      setProfileOpen((value) => !value);
+      setNotificationOpen(false);
+    };
+
+    bell.addEventListener('click', bellClick, true);
+    profile.addEventListener('click', profileClick, true);
+    bell.setAttribute('aria-haspopup', 'dialog');
+    profile.setAttribute('aria-haspopup', 'menu');
+
+    const badge = bell.querySelector('i');
+    if (badge) badge.textContent = String(notifications.length);
+
+    return () => {
+      bell.removeEventListener('click', bellClick, true);
+      profile.removeEventListener('click', profileClick, true);
+    };
+  }, [bell, notifications.length, profile]);
+
+  useEffect(() => {
+    if (!bell || !profile) return undefined;
+    bell.setAttribute('aria-expanded', notificationOpen ? 'true' : 'false');
+    profile.setAttribute('aria-expanded', profileOpen ? 'true' : 'false');
+
+    const reposition = () => {
+      if (notificationOpen) setNotificationAnchor(anchorPosition(bell));
+      if (profileOpen) setProfileAnchor(anchorPosition(profile));
+    };
+    const keydown = (event) => {
+      if (event.key === 'Escape') {
+        setNotificationOpen(false);
+        setProfileOpen(false);
+      }
+    };
+    const pointer = (event) => {
+      const insidePanel = event.target?.closest?.('[data-galactic-header-panel]');
+      if (insidePanel || bell.contains(event.target) || profile.contains(event.target)) return;
+      setNotificationOpen(false);
+      setProfileOpen(false);
+    };
+
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('keydown', keydown);
+    document.addEventListener('pointerdown', pointer);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('keydown', keydown);
+      document.removeEventListener('pointerdown', pointer);
+    };
+  }, [bell, notificationOpen, profile, profileOpen]);
+
+  if (!bell || !profile) return null;
+
+  const displayLabel = String(accountLabel || 'Galactic member').trim().slice(0, 80) || 'Galactic member';
+  const first = displayLabel.charAt(0).toUpperCase() || 'G';
+
+  return createPortal(
+    <>
+      {notificationOpen && (
+        <section data-galactic-header-panel className={styles.panel} style={notificationAnchor} role="dialog" aria-label="Galactic Trust notifications">
+          <header className={styles.panelHeader}>
+            <div><span>GALACTIC TRUST</span><h2>Notifications</h2></div>
+            <button type="button" onClick={() => setNotificationOpen(false)} aria-label="Close notifications">×</button>
+          </header>
+          <div className={styles.notificationList}>{notifications.map((item) => <NotificationItem item={item} key={item.title} />)}</div>
+          <footer className={styles.panelFooter}><span>Safe account summaries only</span><Link href="/bank/status">Account status →</Link></footer>
+        </section>
+      )}
+
+      {profileOpen && (
+        <section data-galactic-header-panel className={`${styles.panel} ${styles.profilePanel}`} style={profileAnchor} role="menu" aria-label="Galactic Trust profile menu">
+          <div className={styles.profileIdentity}>
+            <span>{first}</span>
+            <div><b>{displayLabel}</b><small>{demoAccess ? 'Demo Explorer' : 'Signed-in Galactic Trust account'}</small></div>
+          </div>
+          <nav className={styles.profileLinks}>
+            <Link role="menuitem" href="/bank/status"><span>◉</span><p><b>My account status</b><small>See exactly what your account can do</small></p></Link>
+            <Link role="menuitem" href="/privacy"><span>✓</span><p><b>Privacy Center</b><small>Review data and security boundaries</small></p></Link>
+            <Link role="menuitem" href="/bank/readiness"><span>🔒</span><p><b>Launch readiness</b><small>See why live banking remains gated</small></p></Link>
+          </nav>
+          <button className={styles.signOut} type="button" role="menuitem" onClick={() => { setProfileOpen(false); onSignOut?.(); }}><span>↪</span>{demoAccess ? 'Exit demo' : 'Log out securely'}</button>
+          <p className={styles.profileBoundary}>Galactic Trust is a financial technology product, not a bank. No real-money capability is enabled by this menu.</p>
+        </section>
+      )}
+    </>,
+    document.body
+  );
+}

--- a/app/bank/header-center.module.css
+++ b/app/bank/header-center.module.css
@@ -1,0 +1,286 @@
+.panel {
+  position: fixed;
+  z-index: 12000;
+  overflow: hidden;
+  border: 1px solid rgba(218, 222, 241, .92);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, .985);
+  color: #202651;
+  box-shadow: 0 24px 70px rgba(21, 28, 76, .22);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 15px 16px 12px;
+  border-bottom: 1px solid #eceef7;
+  background: linear-gradient(180deg, #fff, #fafbff);
+}
+
+.panelHeader span {
+  color: #9299b2;
+  font-size: 7px;
+  font-weight: 900;
+  letter-spacing: .12em;
+}
+
+.panelHeader h2 {
+  margin: 3px 0 0;
+  font-size: 17px;
+  letter-spacing: -.035em;
+}
+
+.panelHeader button {
+  width: 31px;
+  height: 31px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: #f1f3f9;
+  color: #68708f;
+  font-size: 19px;
+  cursor: pointer;
+}
+
+.notificationList {
+  display: grid;
+  gap: 0;
+  padding: 5px 0;
+}
+
+.notificationItem {
+  display: grid;
+  grid-template-columns: 35px minmax(0, 1fr);
+  gap: 10px;
+  padding: 11px 15px;
+}
+
+.notificationItem + .notificationItem {
+  border-top: 1px solid #f0f1f7;
+}
+
+.itemIcon {
+  width: 35px;
+  height: 35px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.good {
+  background: #e9f8ef;
+  color: #23754c;
+}
+
+.warn {
+  background: #fff4df;
+  color: #96621e;
+}
+
+.locked {
+  background: #eef0ff;
+  color: #5044c7;
+}
+
+.neutral {
+  background: #f0f2f8;
+  color: #5d6685;
+}
+
+.notificationItem b {
+  display: block;
+  color: #252b59;
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.notificationItem p {
+  margin: 3px 0 0;
+  color: #7e86a3;
+  font-size: 8.5px;
+  line-height: 1.45;
+}
+
+.notificationItem a {
+  display: inline-block;
+  margin-top: 5px;
+  color: #5e45da;
+  font-size: 8px;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.panelFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 15px;
+  border-top: 1px solid #eceef7;
+  background: #fafbff;
+}
+
+.panelFooter span {
+  color: #9aa0b7;
+  font-size: 7.5px;
+}
+
+.panelFooter a {
+  color: #6047dd;
+  font-size: 8px;
+  font-weight: 850;
+  text-decoration: none;
+}
+
+.profilePanel {
+  max-width: 340px;
+}
+
+.profileIdentity {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 15px;
+  background: linear-gradient(145deg, #f9f9ff, #f4f5ff);
+  border-bottom: 1px solid #e9ebf5;
+}
+
+.profileIdentity > span {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  background: linear-gradient(145deg, #26388f, #6c39da 65%, #c744d8);
+  font-size: 14px;
+  font-weight: 900;
+  box-shadow: 0 7px 18px rgba(68, 54, 171, .22);
+}
+
+.profileIdentity b,
+.profileIdentity small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profileIdentity b {
+  color: #252b58;
+  font-size: 11px;
+}
+
+.profileIdentity small {
+  margin-top: 3px;
+  color: #8990aa;
+  font-size: 8px;
+}
+
+.profileLinks {
+  display: grid;
+  padding: 7px;
+}
+
+.profileLinks a {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 9px;
+  align-items: center;
+  padding: 9px;
+  border-radius: 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.profileLinks a:hover,
+.profileLinks a:focus-visible {
+  outline: none;
+  background: #f5f5ff;
+}
+
+.profileLinks a > span {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  background: #eef0ff;
+  color: #5943d8;
+  font-size: 12px;
+}
+
+.profileLinks p {
+  margin: 0;
+}
+
+.profileLinks b,
+.profileLinks small {
+  display: block;
+}
+
+.profileLinks b {
+  color: #2d3360;
+  font-size: 9px;
+}
+
+.profileLinks small {
+  margin-top: 2px;
+  color: #8c93ad;
+  font-size: 7.5px;
+  line-height: 1.35;
+}
+
+.signOut {
+  width: calc(100% - 14px);
+  min-height: 38px;
+  margin: 0 7px 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid #ececf5;
+  border-radius: 12px;
+  background: #fff;
+  color: #5b617d;
+  font-size: 9px;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.signOut:hover,
+.signOut:focus-visible {
+  outline: none;
+  background: #f8f8fc;
+}
+
+.profileBoundary {
+  margin: 0;
+  padding: 0 15px 13px;
+  color: #9aa0b4;
+  font-size: 7px;
+  line-height: 1.4;
+}
+
+@media (max-width: 560px) {
+  .panel {
+    left: 12px !important;
+    right: 12px !important;
+    top: 80px !important;
+    width: auto !important;
+    max-height: calc(100dvh - 96px);
+    overflow: auto;
+  }
+
+  .profilePanel {
+    max-width: none;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs && node scripts/test-galactic-trust-crypto-practice.mjs"
+    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs && node scripts/test-galactic-trust-crypto-practice.mjs && node scripts/test-galactic-trust-header-center.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/scripts/test-galactic-trust-header-center.mjs
+++ b/scripts/test-galactic-trust-header-center.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const center = await readFile(new URL('../app/bank/GalacticHeaderCenter.js', import.meta.url), 'utf8');
+const gate = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
+
+assert.match(center, /document\.querySelector\('\.gt-notification'\)/, 'header center must attach to the existing notification bell');
+assert.match(center, /document\.querySelector\('\.gt-profile'\)/, 'header center must attach to the existing profile control');
+assert.match(center, /fetch\('\/api\/bank\/lifecycle'/, 'notification state must reuse the sanitized personal lifecycle endpoint');
+assert.match(center, /Authorization: `Bearer \$\{accessToken\}`/, 'signed-in lifecycle notifications must authenticate with the existing session token');
+assert.match(center, /Increase sandbox test account connected/, 'notification center must clearly identify owner-bound sandbox state as test-only');
+assert.match(center, /Production banking is locked/, 'notification center must keep the production lock visible');
+assert.match(center, /Crypto is practice-only/, 'notification center must keep the crypto-practice boundary visible');
+assert.match(center, /No production account opening or real-money movement is enabled in this build/, 'notification copy must not imply live-money capability');
+assert.match(center, /href="\/bank\/status"/, 'header center must navigate to the personal account-status page');
+assert.match(center, /href="\/privacy"/, 'profile menu must provide Privacy Center navigation');
+assert.match(center, /href="\/bank\/readiness"/, 'profile menu must provide regulated launch-readiness navigation');
+assert.match(center, /onSignOut\?\.\(\)/, 'profile menu must use the existing authenticated sign-out callback');
+assert.equal(center.includes('/api/admin/'), false, 'header center must not consume owner/admin banking endpoints');
+assert.equal(center.includes('accountId'), false, 'header center must never handle full provider Account IDs');
+assert.equal(center.includes('entityId'), false, 'header center must never handle provider Entity IDs');
+assert.equal(center.includes('INCREASE_SANDBOX_API_KEY'), false, 'header center must never handle provider credentials');
+assert.equal(center.includes('NEXT_PUBLIC_'), false, 'header center must not depend on client-exposed banking secrets');
+
+assert.match(gate, /import GalacticHeaderCenter from '\.\/GalacticHeaderCenter'/, 'dashboard gate must load the polished header center');
+assert.match(gate, /<GalacticHeaderCenter accessToken=\{accessToken\} demoAccess=\{demoAccess\} accountLabel=\{label\} onSignOut=\{activeSignOut\} \/>/, 'dashboard gate must wire header center to the existing session and sign-out flow');
+
+console.log('Galactic Trust header center checks passed: the notification bell and profile control now provide safe lifecycle/status navigation using only the personal lifecycle endpoint, while provider IDs, admin APIs, and banking secrets remain out of the header UI.');


### PR DESCRIPTION
Closes #611.

Turns the main Galactic Trust notification bell and profile chip into real dashboard controls instead of placeholder toasts.

Notification center:
- reuses the sanitized `/api/bank/lifecycle` endpoint
- distinguishes demo, owner-bound Increase sandbox test account, setup-required, and status-check-failure states
- keeps production banking locked visibly
- keeps crypto clearly practice-only
- links to personal Account Status and Launch Readiness

Profile menu:
- shows the current Galactic Trust account label or Demo Explorer state
- links to My Account Status, Privacy Center, and Launch Readiness
- uses the existing secure sign-out / exit-demo callback

Security boundary:
- no `/api/admin/` calls
- no provider Account/Entity IDs
- no provider credentials or `NEXT_PUBLIC_*` banking secrets
- no new money-movement capability

Adds a dedicated `Header center` regression to both `test:galactic` and the named GitHub quality gate.