### PR TITLE
Actually mount Increase sandbox recovery UI

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -18,21 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check migration credentials
-        id: credentials
         shell: bash
         run: |
-          if [ -n "$SUPABASE_ACCESS_TOKEN" ] && [ -n "$SUPABASE_PROJECT_REF" ] && [ -n "$SUPABASE_DB_PASSWORD" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "Supabase migration secrets are not configured in GitHub; skipping automatic database migration."
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_PROJECT_REF" ] || [ -z "$SUPABASE_DB_PASSWORD" ]; then
+            echo "::error::Supabase migration secrets are not configured in GitHub. No database migration was applied. Configure SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_REF, and SUPABASE_DB_PASSWORD as repository Actions secrets, then re-run this workflow."
+            exit 1
           fi
       - name: Install Supabase CLI
-        if: steps.credentials.outputs.ready == 'true'
         run: npm install --global supabase
       - name: Link production project
-        if: steps.credentials.outputs.ready == 'true'
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
       - name: Apply pending migrations
-        if: steps.credentials.outputs.ready == 'true'
         run: supabase db push --password "$SUPABASE_DB_PASSWORD"

--- a/app/api/admin/bank/increase/dashboard/route.ts
+++ b/app/api/admin/bank/increase/dashboard/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
 import { describeIncreaseSandboxError } from '../../../../../../lib/banking/increase-api-errors.js';
+import { resolveIncreaseSandboxOwnerAccount } from '../../../../../../lib/banking/increase-owner-account.js';
 import { getIncreaseSandboxDashboardForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
 import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../../lib/banking/increase-webhook-subscription.js';
 import { pollIncreaseSandboxEvents } from '../../../../../../lib/banking/increase-reconciliation';
-import {
-  getProviderAccountBinding,
-  publicBindingSummary,
-} from '../../../../../../lib/banking/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -20,18 +17,27 @@ export async function GET(request: Request) {
   const auth = await requireGalacticTrustAdmin(request);
   if (auth.ok === false) return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
 
-  let bindingState: any;
+  let resolution: any;
   try {
-    bindingState = await getProviderAccountBinding(auth.admin, auth.user.id);
+    resolution = await resolveIncreaseSandboxOwnerAccount(auth.admin, auth.user.id, process.env);
   } catch (error: any) {
-    return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', connected: false, setupRequired: true, canMoveRealMoney: false, error: error instanceof Error ? error.message : 'Increase sandbox identity binding could not be read.' }, 500);
+    return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', connected: false, setupRequired: true, canMoveRealMoney: false, error: error instanceof Error ? error.message : 'Increase sandbox owner Account could not be resolved.' }, 500);
   }
 
-  if (bindingState.setupRequired) {
-    return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', connected: false, setupRequired: true, canMoveRealMoney: false, error: bindingState.error || 'Provider identity binding storage is not ready.' }, 503);
-  }
-  if (!bindingState.binding) {
-    return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', connected: true, setupRequired: true, canMoveRealMoney: false, error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner yet. Complete owner-scoped sandbox onboarding before provider balances or transactions are shown.' }, 409);
+  if (!resolution.accountId) {
+    return response({
+      ok: false,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      connected: true,
+      setupRequired: true,
+      recoveryAvailable: true,
+      canMoveRealMoney: false,
+      bindingStorageReady: resolution.bindingStorageReady,
+      bindingStorageIssue: resolution.bindingStorageIssue,
+      error: 'No owner-scoped Increase sandbox Account exists yet. Use the Galactic Trust sandbox recovery control to create one.',
+    }, 409);
   }
 
   let webhookAutomation: any = null;
@@ -41,8 +47,20 @@ export async function GET(request: Request) {
   try { reconciliationBackstop = await pollIncreaseSandboxEvents({ maxPages: 2 }); } catch { automationIssue = automationIssue || 'Increase sandbox reconciliation backstop needs attention.'; }
 
   try {
-    const snapshot = await getIncreaseSandboxDashboardForAccount(bindingState.binding.accountId, process.env);
-    return response({ ok: true, authorized: true, ...snapshot, binding: publicBindingSummary(bindingState.binding), webhookAutomation, reconciliationBackstop, automationIssue, note: 'Increase sandbox data is scoped to the Account bound server-side to this signed-in owner. Values are pretend money and cannot represent live customer funds.' });
+    const snapshot = await getIncreaseSandboxDashboardForAccount(resolution.accountId, process.env);
+    return response({
+      ok: true,
+      authorized: true,
+      ...snapshot,
+      binding: resolution.binding,
+      bindingPersistence: resolution.persistence,
+      bindingStorageReady: resolution.bindingStorageReady,
+      bindingStorageIssue: resolution.bindingStorageIssue,
+      webhookAutomation,
+      reconciliationBackstop,
+      automationIssue,
+      note: 'Increase sandbox data is scoped server-side to this signed-in Galactic Trust owner through either trusted database binding storage or the owner-specific Increase idempotency key. Values are pretend money only.',
+    });
   } catch (error: any) {
     const provider = describeIncreaseSandboxError(error, error instanceof Error ? error.message : 'Increase sandbox dashboard sync failed.');
     return response({
@@ -52,7 +70,7 @@ export async function GET(request: Request) {
       environment: 'sandbox',
       connected: false,
       canMoveRealMoney: false,
-      binding: publicBindingSummary(bindingState.binding),
+      binding: resolution.binding,
       webhookAutomation,
       reconciliationBackstop,
       automationIssue,

--- a/app/api/admin/bank/increase/fund/route.ts
+++ b/app/api/admin/bank/increase/fund/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
+import { resolveIncreaseSandboxOwnerAccount } from '../../../../../../lib/banking/increase-owner-account.js';
 import { simulateIncreaseSandboxDepositForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
-import { getProviderAccountBinding, publicBindingSummary } from '../../../../../../lib/banking/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -19,12 +19,31 @@ export async function POST(request: Request) {
   if (!Number.isFinite(amount) || amount < 1 || amount > 5000) return response({ ok: false, error: 'Sandbox deposit must be between $1 and $5,000.' }, 400);
 
   try {
-    const bindingState = await getProviderAccountBinding(auth.admin, auth.user.id);
-    if (bindingState.setupRequired) return response({ ok: false, authorized: true, setupRequired: true, canMoveRealMoney: false, error: bindingState.error || 'Provider identity binding storage is not ready.' }, 503);
-    if (!bindingState.binding) return response({ ok: false, authorized: true, setupRequired: true, canMoveRealMoney: false, error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner. Complete owner-scoped sandbox onboarding before simulating funding.' }, 409);
+    const resolution = await resolveIncreaseSandboxOwnerAccount(auth.admin, auth.user.id, process.env);
+    if (!resolution.accountId) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        recoveryAvailable: true,
+        canMoveRealMoney: false,
+        bindingStorageReady: resolution.bindingStorageReady,
+        bindingStorageIssue: resolution.bindingStorageIssue,
+        error: 'No owner-scoped Increase sandbox Account exists yet. Create the sandbox test account before simulating funding.',
+      }, 409);
+    }
 
-    const snapshot = await simulateIncreaseSandboxDepositForAccount(Math.round(amount * 100), bindingState.binding.accountId, process.env);
-    return response({ ok: true, authorized: true, ...snapshot, binding: publicBindingSummary(bindingState.binding), action: 'sandbox-inbound-ach-simulation', canMoveRealMoney: false, note: 'Pretend Increase sandbox funds only, scoped to the Account bound server-side to this signed-in owner. No external bank account was debited.' });
+    const snapshot = await simulateIncreaseSandboxDepositForAccount(Math.round(amount * 100), resolution.accountId, process.env);
+    return response({
+      ok: true,
+      authorized: true,
+      ...snapshot,
+      binding: resolution.binding,
+      bindingPersistence: resolution.persistence,
+      action: 'sandbox-inbound-ach-simulation',
+      canMoveRealMoney: false,
+      note: 'Pretend Increase sandbox funds only, scoped server-side to this signed-in owner. No external bank account was debited.',
+    });
   } catch (error: any) {
     return response({ ok: false, authorized: true, canMoveRealMoney: false, providerStatus: Number.isFinite(error?.status) ? error.status : null, error: error instanceof Error ? error.message : 'Increase sandbox funding simulation failed.' }, 502);
   }

--- a/app/api/admin/bank/increase/recovery/route.ts
+++ b/app/api/admin/bank/increase/recovery/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
 import { describeIncreaseSandboxError } from '../../../../../../lib/banking/increase-api-errors.js';
-import { recoverIncreaseSandboxOwnerAccount } from '../../../../../../lib/banking/increase-sandbox-recovery.js';
+import {
+  getIncreaseSandboxOwnerRecoveryAccount,
+  publicIncreaseRecoveryBindingSummary,
+  recoverIncreaseSandboxOwnerAccount,
+} from '../../../../../../lib/banking/increase-sandbox-recovery.js';
 import {
   bindIncreaseSandboxAccountOnly,
   getProviderAccountBinding,
@@ -28,19 +32,28 @@ export async function GET(request: Request) {
 
   try {
     const state = await bindingState(auth);
+    const recovery = state.binding ? null : await getIncreaseSandboxOwnerRecoveryAccount(auth.user.id, process.env);
+    const binding = state.binding
+      ? publicBindingSummary(state.binding)
+      : publicIncreaseRecoveryBindingSummary(recovery);
+
     return response({
       ok: true,
       authorized: true,
       provider: 'Increase',
       environment: 'sandbox',
-      recoveryAvailable: !state.setupRequired && !state.binding,
-      setupRequired: Boolean(state.setupRequired),
-      binding: publicBindingSummary(state.binding),
-      error: state.error || '',
+      recoveryAvailable: !binding,
+      setupRequired: false,
+      bindingStorageReady: !state.setupRequired,
+      bindingStorageIssue: state.setupRequired ? (state.error || 'Trusted provider-binding storage is not installed yet.') : '',
+      binding,
       canMoveRealMoney: false,
-      note: 'This owner-only recovery path creates a dedicated Increase sandbox Account without hosted Entity onboarding. It never enables production banking.',
+      note: binding
+        ? 'A verified owner-scoped Increase sandbox Account is available. The owner scope is derived from either trusted database binding storage or the verified Galactic Trust user ID plus Increase idempotency-key lookup.'
+        : 'This owner-only recovery path can create a dedicated Increase sandbox Account without hosted Entity onboarding or the provider-binding database migration. It never enables production banking.',
     });
-  } catch (error) {
+  } catch (error: any) {
+    const provider = describeIncreaseSandboxError(error, error instanceof Error ? error.message : 'Increase sandbox recovery status could not be loaded.');
     return response({
       ok: false,
       authorized: true,
@@ -49,8 +62,11 @@ export async function GET(request: Request) {
       recoveryAvailable: false,
       setupRequired: true,
       canMoveRealMoney: false,
-      error: error instanceof Error ? error.message : 'Increase sandbox recovery status could not be loaded.',
-    }, 500);
+      providerStatus: provider.providerStatus,
+      providerType: provider.providerType,
+      error: provider.error,
+      nextStep: provider.nextStep,
+    }, Number.isFinite(error?.status) ? 502 : 500);
   }
 }
 
@@ -60,19 +76,6 @@ export async function POST(request: Request) {
 
   try {
     const before = await bindingState(auth);
-    if (before.setupRequired) {
-      return response({
-        ok: false,
-        authorized: true,
-        provider: 'Increase',
-        environment: 'sandbox',
-        recoveryAvailable: false,
-        setupRequired: true,
-        canMoveRealMoney: false,
-        error: before.error || 'Trusted provider binding storage must be installed before sandbox recovery can bind an Account.',
-      }, 503);
-    }
-
     if (before.binding) {
       return response({
         ok: true,
@@ -81,6 +84,7 @@ export async function POST(request: Request) {
         environment: 'sandbox',
         recovered: false,
         alreadyBound: true,
+        bindingStorageReady: true,
         binding: publicBindingSummary(before.binding),
         canMoveRealMoney: false,
         note: 'A verified owner-scoped Increase sandbox Account is already bound. No recovery action was needed.',
@@ -88,11 +92,19 @@ export async function POST(request: Request) {
     }
 
     const recovered = await recoverIncreaseSandboxOwnerAccount(auth.user.id, process.env);
-    const binding = await bindIncreaseSandboxAccountOnly(auth.admin, auth.user.id, {
-      entityId: recovered.entityId,
-      accountId: recovered.accountId,
-      source: 'increase-sandbox-account-recovery',
-    }, process.env);
+    let binding = null;
+    let bindingStorageReady = !before.setupRequired;
+
+    if (bindingStorageReady) {
+      const storedBinding = await bindIncreaseSandboxAccountOnly(auth.admin, auth.user.id, {
+        entityId: recovered.entityId,
+        accountId: recovered.accountId,
+        source: 'increase-sandbox-account-recovery',
+      }, process.env);
+      binding = publicBindingSummary(storedBinding);
+    } else {
+      binding = publicIncreaseRecoveryBindingSummary(recovered);
+    }
 
     return response({
       ok: true,
@@ -101,7 +113,9 @@ export async function POST(request: Request) {
       environment: 'sandbox',
       recovered: true,
       alreadyBound: false,
-      binding: publicBindingSummary(binding),
+      bindingStorageReady,
+      bindingStorageIssue: bindingStorageReady ? '' : (before.error || 'Database binding storage is still pending; sandbox owner scope is being derived from the verified user ID and Increase idempotency key instead.'),
+      binding,
       accountCreated: recovered.accountCreated,
       accountNumberReady: Boolean(recovered.accountNumber?.ready),
       accountNumberIssue: recovered.accountNumberIssue || '',

--- a/app/api/admin/bank/increase/transfer/route.ts
+++ b/app/api/admin/bank/increase/transfer/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
+import { resolveIncreaseSandboxOwnerAccount } from '../../../../../../lib/banking/increase-owner-account.js';
 import { simulateIncreaseSandboxSendForAccount } from '../../../../../../lib/banking/increase-sandbox.js';
-import { getProviderAccountBinding, publicBindingSummary } from '../../../../../../lib/banking/provider-account-binding.js';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -21,12 +21,31 @@ export async function POST(request: Request) {
   if (!Number.isFinite(amount) || amount < 1 || amount > 1000) return response({ ok: false, error: 'Sandbox transfer must be between $1 and $1,000.' }, 400);
 
   try {
-    const bindingState = await getProviderAccountBinding(auth.admin, auth.user.id);
-    if (bindingState.setupRequired) return response({ ok: false, authorized: true, setupRequired: true, canMoveRealMoney: false, error: bindingState.error || 'Provider identity binding storage is not ready.' }, 503);
-    if (!bindingState.binding) return response({ ok: false, authorized: true, setupRequired: true, canMoveRealMoney: false, error: 'No Increase sandbox Account is bound to this signed-in Galactic Trust owner. Complete owner-scoped sandbox onboarding before simulating transfers.' }, 409);
+    const resolution = await resolveIncreaseSandboxOwnerAccount(auth.admin, auth.user.id, process.env);
+    if (!resolution.accountId) {
+      return response({
+        ok: false,
+        authorized: true,
+        setupRequired: true,
+        recoveryAvailable: true,
+        canMoveRealMoney: false,
+        bindingStorageReady: resolution.bindingStorageReady,
+        bindingStorageIssue: resolution.bindingStorageIssue,
+        error: 'No owner-scoped Increase sandbox Account exists yet. Create the sandbox test account before simulating transfers.',
+      }, 409);
+    }
 
-    const snapshot = await simulateIncreaseSandboxSendForAccount(Math.round(amount * 100), recipient, bindingState.binding.accountId, process.env);
-    return response({ ok: true, authorized: true, ...snapshot, binding: publicBindingSummary(bindingState.binding), action: 'sandbox-ach-transfer-simulation', canMoveRealMoney: false, note: 'This transfer is scoped to the Increase sandbox Account bound server-side to this signed-in owner and routes only to sandbox test coordinates. No real recipient or bank account is used.' });
+    const snapshot = await simulateIncreaseSandboxSendForAccount(Math.round(amount * 100), recipient, resolution.accountId, process.env);
+    return response({
+      ok: true,
+      authorized: true,
+      ...snapshot,
+      binding: resolution.binding,
+      bindingPersistence: resolution.persistence,
+      action: 'sandbox-ach-transfer-simulation',
+      canMoveRealMoney: false,
+      note: 'This transfer is scoped server-side to this signed-in owner and routes only to Increase sandbox test coordinates. No real recipient or bank account is used.',
+    });
   } catch (error: any) {
     return response({ ok: false, authorized: true, canMoveRealMoney: false, providerStatus: Number.isFinite(error?.status) ? error.status : null, error: error instanceof Error ? error.message : 'Increase sandbox transfer simulation failed.' }, 502);
   }

--- a/app/api/bank/lifecycle/route.ts
+++ b/app/api/bank/lifecycle/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request) {
     const { data: { user }, error } = await admin.auth.getUser(token);
     if (error || !user) return response({ ok: false, error: 'Your Galactic Trust session is invalid or expired.', lifecycle: buildGalacticAccountLifecycle({ signedIn: false, env: process.env }) }, 401);
 
-    let bindingState = await getProviderAccountBinding(admin, user.id, {
+    let bindingState: any = await getProviderAccountBinding(admin, user.id, {
       provider: 'increase',
       environment: 'sandbox',
     });

--- a/app/api/bank/lifecycle/route.ts
+++ b/app/api/bank/lifecycle/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '../../../../lib/supabase-admin';
 import { buildGalacticAccountLifecycle } from '../../../../lib/banking/account-lifecycle.js';
+import { getIncreaseSandboxOwnerRecoveryAccount } from '../../../../lib/banking/increase-sandbox-recovery.js';
 import { getProviderAccountBinding } from '../../../../lib/banking/provider-account-binding.js';
 
 export const runtime = 'nodejs';
@@ -24,12 +25,33 @@ export async function GET(request: Request) {
     const { data: { user }, error } = await admin.auth.getUser(token);
     if (error || !user) return response({ ok: false, error: 'Your Galactic Trust session is invalid or expired.', lifecycle: buildGalacticAccountLifecycle({ signedIn: false, env: process.env }) }, 401);
 
-    const bindingState = await getProviderAccountBinding(admin, user.id, {
+    let bindingState = await getProviderAccountBinding(admin, user.id, {
       provider: 'increase',
       environment: 'sandbox',
     });
+
+    if (!bindingState.binding) {
+      try {
+        const recovery = await getIncreaseSandboxOwnerRecoveryAccount(user.id, process.env);
+        if (recovery) {
+          bindingState = {
+            binding: {
+              provider: 'increase',
+              environment: 'sandbox',
+              status: 'verified',
+              kycStatus: 'SANDBOX_ACCOUNT_ONLY',
+            },
+            setupRequired: false,
+            error: '',
+          };
+        }
+      } catch {
+        // Demo lifecycle remains available when the optional Increase sandbox lookup is unavailable.
+      }
+    }
+
     const lifecycle = buildGalacticAccountLifecycle({ signedIn: true, bindingState, env: process.env });
-    return response({ ok: true, lifecycle, note: 'This lifecycle is derived server-side from verified authentication, trusted provider-binding state, and regulated-launch locks. It is not a bank-account approval or production eligibility decision.' });
+    return response({ ok: true, lifecycle, note: 'This lifecycle is derived server-side from verified authentication, trusted provider-binding state or owner-specific Increase sandbox recovery state, and regulated-launch locks. It is not a bank-account approval or production eligibility decision.' });
   } catch (error) {
     return response({ ok: false, error: error instanceof Error ? error.message : 'Galactic Trust account lifecycle could not be loaded.', lifecycle: buildGalacticAccountLifecycle({ signedIn: true, bindingState: { binding: null, setupRequired: true }, env: process.env }) }, 503);
   }

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -7,6 +7,7 @@ import GalacticCryptoPractice from './GalacticCryptoPractice';
 import GalacticDashboardAccountState from './GalacticDashboardAccountState';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
 import GalacticHeaderCenter from './GalacticHeaderCenter';
+import GalacticIncreaseSandboxRecovery from './GalacticIncreaseSandboxRecovery';
 import GalacticSandboxSetup from './GalacticSandboxSetup';
 
 function userLabel(user) {
@@ -173,6 +174,7 @@ export default function GalacticBankGate() {
       <GalacticDashboardAccountState accessToken={accessToken} demoAccess={demoAccess} />
       <GalacticHeaderCenter accessToken={accessToken} demoAccess={demoAccess} accountLabel={label} onSignOut={activeSignOut} />
       {session?.user && <GalacticSandboxSetup accessToken={accessToken} />}
+      {session?.user && <GalacticIncreaseSandboxRecovery />}
     </>
   );
 }

--- a/app/bank/GalacticIncreaseSandboxRecovery.js
+++ b/app/bank/GalacticIncreaseSandboxRecovery.js
@@ -30,10 +30,19 @@ export default function GalacticIncreaseSandboxRecovery() {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
   const [accountCount, setAccountCount] = useState(0);
+  const [recoveryAvailable, setRecoveryAvailable] = useState(false);
+  const [bindingStorageBlocked, setBindingStorageBlocked] = useState(false);
 
   useEffect(() => {
     let active = true;
     let observer;
+
+    function takeOverLegacySetup() {
+      hideLegacyBlockingSetup();
+      observer = new MutationObserver(hideLegacyBlockingSetup);
+      observer.observe(document.body, { childList: true, subtree: true });
+      window.setTimeout(() => observer?.disconnect(), 5000);
+    }
 
     async function inspect() {
       try {
@@ -56,18 +65,24 @@ export default function GalacticIncreaseSandboxRecovery() {
         if (!active) return;
 
         if (lifecycle?.lifecycle?.sandbox?.ownerBindingReady || recovery?.binding?.status === 'verified') {
-          hideLegacyBlockingSetup();
-          observer = new MutationObserver(hideLegacyBlockingSetup);
-          observer.observe(document.body, { childList: true, subtree: true });
-          window.setTimeout(() => observer?.disconnect(), 5000);
+          takeOverLegacySetup();
           return;
         }
 
         const privateFeatureBlocked = statusResponse.ok && status?.connected && hasPrivateFeatureRestriction(status);
-        const canRecover = recoveryResponse.ok && recovery?.recoveryAvailable && !recovery?.setupRequired;
+        if (!privateFeatureBlocked) return;
+
+        const storageBlocked = Boolean(recovery?.setupRequired);
+        const canRecover = recoveryResponse.ok && recovery?.recoveryAvailable && !storageBlocked;
+
         setAccountCount(Number(status?.counts?.accounts || 0));
-        setVisible(Boolean(privateFeatureBlocked && canRecover));
-        if (recovery?.setupRequired && recovery?.error) setMessage(String(recovery.error));
+        setBindingStorageBlocked(storageBlocked);
+        setRecoveryAvailable(Boolean(canRecover));
+        setMessage(storageBlocked
+          ? String(recovery?.error || 'Trusted provider binding storage is not installed yet. Galactic Trust cannot safely bind the Increase sandbox Account until the required Supabase migration is applied.')
+          : '');
+        setVisible(true);
+        takeOverLegacySetup();
       } catch {
         // The existing setup UI remains the fallback if recovery inspection itself cannot load.
       }
@@ -81,7 +96,7 @@ export default function GalacticIncreaseSandboxRecovery() {
   }, []);
 
   async function recover() {
-    if (!token || busy) return;
+    if (!token || busy || !recoveryAvailable) return;
     setBusy(true);
     setMessage('');
     try {
@@ -106,6 +121,9 @@ export default function GalacticIncreaseSandboxRecovery() {
 
   if (!visible) return null;
 
+  const storageTitle = 'Galactic Trust database setup is the blocker.';
+  const recoveryTitle = 'We can bypass the blocked hosted-onboarding feature.';
+
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Increase sandbox recovery">
       <section className={styles.card}>
@@ -113,30 +131,44 @@ export default function GalacticIncreaseSandboxRecovery() {
         <div className={styles.titleRow}>
           <span className={styles.icon}>🪐</span>
           <div>
-            <h2>We can bypass the blocked hosted-onboarding feature.</h2>
-            <p>Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.</p>
+            <h2>{bindingStorageBlocked ? storageTitle : recoveryTitle}</h2>
+            <p>{bindingStorageBlocked
+              ? 'Increase Accounts access is connected. The restricted hosted-onboarding feature is no longer the actionable blocker; trusted provider-binding storage must be installed before Galactic Trust can safely attach a sandbox Account to your signed-in user.'
+              : 'Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.'}</p>
           </div>
         </div>
 
         <div className={styles.boundary}>
-          <strong>What this does</strong>
+          <strong>{bindingStorageBlocked ? 'What needs to happen' : 'What this does'}</strong>
           <ul>
-            <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
-            <li>Binds only that Account to your Galactic Trust user on the server.</li>
-            <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
+            {bindingStorageBlocked ? (
+              <>
+                <li>Apply the pending Galactic Trust Supabase provider-binding migration, including migration 025.</li>
+                <li>Keep database credentials in GitHub Actions secrets only; never paste them into chat or client code.</li>
+                <li>After the migration is actually applied, this panel will offer the one-click Increase sandbox Account recovery automatically.</li>
+              </>
+            ) : (
+              <>
+                <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
+                <li>Binds only that Account to your Galactic Trust user on the server.</li>
+                <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
+              </>
+            )}
           </ul>
         </div>
 
         <div className={styles.notKyc}>
           <span>🔒</span>
-          <p><b>This is not KYC or a real bank account.</b> The binding is stored as <code>SANDBOX_ACCOUNT_ONLY</code>. Production money movement remains locked.</p>
+          <p><b>This is not KYC or a real bank account.</b> Account-only recovery is stored as <code>SANDBOX_ACCOUNT_ONLY</code>. Production money movement remains locked.</p>
         </div>
 
-        {accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates/reuses a dedicated owner-scoped Account instead.</p>}
+        {!bindingStorageBlocked && accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates/reuses a dedicated owner-scoped Account instead.</p>}
 
-        <button className={styles.primary} type="button" onClick={recover} disabled={busy}>
-          {busy ? 'Creating sandbox test account…' : 'Create sandbox test account'}
-        </button>
+        {recoveryAvailable && (
+          <button className={styles.primary} type="button" onClick={recover} disabled={busy}>
+            {busy ? 'Creating sandbox test account…' : 'Create sandbox test account'}
+          </button>
+        )}
         <a className={styles.secondary} href="/bank/integrations">Open Integration Health</a>
         {message && <p className={styles.message} role="status">{message}</p>}
       </section>

--- a/lib/banking/increase-owner-account.js
+++ b/lib/banking/increase-owner-account.js
@@ -1,0 +1,54 @@
+import {
+  getIncreaseSandboxOwnerRecoveryAccount,
+  publicIncreaseRecoveryBindingSummary,
+} from './increase-sandbox-recovery.js';
+import {
+  getProviderAccountBinding,
+  publicBindingSummary,
+} from './provider-account-binding.js';
+
+export async function resolveIncreaseSandboxOwnerAccount(admin, userId, env = process.env) {
+  const stored = await getProviderAccountBinding(admin, userId, {
+    provider: 'increase',
+    environment: 'sandbox',
+  });
+
+  if (stored.binding) {
+    return {
+      accountId: stored.binding.accountId,
+      binding: publicBindingSummary(stored.binding),
+      bindingStorageReady: true,
+      bindingStorageIssue: '',
+      persistence: 'database',
+    };
+  }
+
+  const recovery = await getIncreaseSandboxOwnerRecoveryAccount(userId, env);
+  if (recovery) {
+    return {
+      accountId: recovery.accountId,
+      binding: publicIncreaseRecoveryBindingSummary(recovery),
+      bindingStorageReady: !stored.setupRequired,
+      bindingStorageIssue: stored.setupRequired ? (stored.error || 'Trusted provider-binding storage is not installed yet.') : '',
+      persistence: 'increase-idempotency-key',
+    };
+  }
+
+  return {
+    accountId: '',
+    binding: null,
+    bindingStorageReady: !stored.setupRequired,
+    bindingStorageIssue: stored.setupRequired ? (stored.error || 'Trusted provider-binding storage is not installed yet.') : '',
+    persistence: 'none',
+  };
+}
+
+export function ownerAccountLifecycleBinding(resolution) {
+  if (!resolution?.binding || !resolution?.accountId) return null;
+  return {
+    provider: 'increase',
+    environment: 'sandbox',
+    status: 'verified',
+    kycStatus: String(resolution.binding.kycStatus || 'SANDBOX_ACCOUNT_ONLY'),
+  };
+}

--- a/lib/banking/increase-sandbox-recovery.js
+++ b/lib/banking/increase-sandbox-recovery.js
@@ -18,35 +18,57 @@ function providerId(value, prefix, label) {
   return id;
 }
 
+function assertRecoveryConfig(env = process.env) {
+  const config = getIncreaseSandboxConfig(env);
+  if (!config.enabled || !config.credentialsConfigured || config.environment !== 'sandbox' || config.canMoveRealMoney) {
+    throw new Error('Increase sandbox recovery is unavailable until the server-only sandbox configuration is active.');
+  }
+  return config;
+}
+
 function ownerRecoveryKey(userId) {
-  const digest = createHash('sha256').update(String(userId || '')).digest('hex').slice(0, 32);
+  const normalizedUserId = String(userId || '').trim();
+  if (!normalizedUserId || normalizedUserId.length > 128) throw new Error('Galactic Trust owner user ID is invalid.');
+  const digest = createHash('sha256').update(normalizedUserId).digest('hex').slice(0, 32);
   return `galactic-sandbox-owner-${digest}`;
 }
 
-async function findOrCreateRecoveryAccount(userId, env = process.env) {
-  const idempotencyKey = ownerRecoveryKey(userId);
-  const existingPayload = await increaseSandboxRequest(`/accounts?idempotency_key=${encodeURIComponent(idempotencyKey)}&limit=10`, {}, env);
-  let account = listData(existingPayload).find((item) => item?.status === 'open' && item?.currency === 'USD');
-  let created = false;
-
-  if (!account) {
-    account = await increaseSandboxRequest('/accounts', {
-      method: 'POST',
-      idempotencyKey,
-      body: {
-        name: 'Galactic Trust Sandbox Checking',
-      },
-    }, env);
-    created = true;
-  }
-
+function sanitizeRecoveryAccount(account) {
   const accountId = providerId(account?.id, 'account_', 'Increase sandbox Account ID');
   const entityId = providerId(account?.entity_id, 'entity_', 'Increase sandbox Account Entity ID');
   if (account?.status !== 'open' || account?.currency !== 'USD') {
     throw new Error('Increase returned a sandbox Account that is not an open USD account.');
   }
+  return {
+    account,
+    accountId,
+    entityId,
+    accountName: String(account?.name || 'Galactic Trust Sandbox Checking').slice(0, 120),
+  };
+}
 
-  return { account, accountId, entityId, created };
+async function findRecoveryAccount(userId, env = process.env) {
+  assertRecoveryConfig(env);
+  const idempotencyKey = ownerRecoveryKey(userId);
+  const existingPayload = await increaseSandboxRequest(`/accounts?idempotency_key=${encodeURIComponent(idempotencyKey)}&limit=10`, {}, env);
+  const account = listData(existingPayload).find((item) => item?.status === 'open' && item?.currency === 'USD');
+  return account ? { ...sanitizeRecoveryAccount(account), idempotencyKey } : null;
+}
+
+async function findOrCreateRecoveryAccount(userId, env = process.env) {
+  const existing = await findRecoveryAccount(userId, env);
+  if (existing) return { ...existing, created: false };
+
+  const idempotencyKey = ownerRecoveryKey(userId);
+  const account = await increaseSandboxRequest('/accounts', {
+    method: 'POST',
+    idempotencyKey,
+    body: {
+      name: 'Galactic Trust Sandbox Checking',
+    },
+  }, env);
+
+  return { ...sanitizeRecoveryAccount(account), idempotencyKey, created: true };
 }
 
 async function ensureRecoveryAccountNumber(accountId, env = process.env) {
@@ -73,13 +95,38 @@ async function ensureRecoveryAccountNumber(accountId, env = process.env) {
   };
 }
 
-export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.env) {
-  const config = getIncreaseSandboxConfig(env);
-  if (!config.enabled || !config.credentialsConfigured || config.environment !== 'sandbox' || config.canMoveRealMoney) {
-    throw new Error('Increase sandbox recovery is unavailable until the server-only sandbox configuration is active.');
-  }
+export function publicIncreaseRecoveryBindingSummary(recovery) {
+  if (!recovery?.accountId) return null;
+  const accountId = String(recovery.accountId);
+  return {
+    provider: 'increase',
+    environment: 'sandbox',
+    status: 'verified',
+    source: 'increase-sandbox-owner-idempotency',
+    kycStatus: 'SANDBOX_ACCOUNT_ONLY',
+    verifiedAt: null,
+    accountSuffix: accountId.length > 6 ? accountId.slice(-6) : accountId,
+    persistence: 'increase-idempotency-key',
+  };
+}
 
-  const { account, accountId, entityId, created } = await findOrCreateRecoveryAccount(userId, env);
+export async function getIncreaseSandboxOwnerRecoveryAccount(userId, env = process.env) {
+  const recovery = await findRecoveryAccount(userId, env);
+  if (!recovery) return null;
+  return {
+    provider: 'Increase',
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    bindingKind: 'SANDBOX_ACCOUNT_ONLY',
+    entityId: recovery.entityId,
+    accountId: recovery.accountId,
+    accountName: recovery.accountName,
+  };
+}
+
+export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.env) {
+  assertRecoveryConfig(env);
+  const { account, accountId, entityId, accountName, created } = await findOrCreateRecoveryAccount(userId, env);
 
   let accountNumber = { ready: false, created: false, status: 'unavailable' };
   let accountNumberIssue = '';
@@ -98,10 +145,10 @@ export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.e
     entityId,
     accountId,
     accountCreated: created,
-    accountName: String(account?.name || 'Galactic Trust Sandbox Checking').slice(0, 120),
+    accountName,
     accountNumber,
     accountNumberIssue,
     dashboard,
-    note: 'Account-only Increase sandbox recovery. Hosted Entity onboarding and KYC simulation were not used. This is pretend money only and cannot enable production banking.',
+    note: 'Account-only Increase sandbox recovery. The owner scope is derived server-side from the verified Galactic Trust user ID and an Increase idempotency key; hosted Entity onboarding and KYC simulation were not used. This is pretend money only and cannot enable production banking.',
   };
 }

--- a/scripts/test-galactic-trust-increase-recovery.mjs
+++ b/scripts/test-galactic-trust-increase-recovery.mjs
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import { recoverIncreaseSandboxOwnerAccount } from '../lib/banking/increase-sandbox-recovery.js';
+import {
+  getIncreaseSandboxOwnerRecoveryAccount,
+  recoverIncreaseSandboxOwnerAccount,
+} from '../lib/banking/increase-sandbox-recovery.js';
 
 const requests = [];
 const originalFetch = globalThis.fetch;
+let createdAccount = null;
+let createdAccountNumber = null;
 
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -18,11 +23,11 @@ globalThis.fetch = async (input, init = {}) => {
   requests.push({ method, pathname: url.pathname, search: url.search, body: init.body ? JSON.parse(init.body) : null });
 
   if (method === 'GET' && url.pathname === '/accounts' && url.searchParams.has('idempotency_key')) {
-    return json({ data: [], next_cursor: null });
+    return json({ data: createdAccount ? [createdAccount] : [], next_cursor: null });
   }
   if (method === 'POST' && url.pathname === '/accounts') {
     assert.deepEqual(JSON.parse(init.body), { name: 'Galactic Trust Sandbox Checking' }, 'recovery Account creation must not require Program or Entity input');
-    return json({
+    createdAccount = {
       id: 'sandbox_account_recovery123',
       entity_id: 'sandbox_entity_default123',
       program_id: 'sandbox_program_default123',
@@ -30,24 +35,18 @@ globalThis.fetch = async (input, init = {}) => {
       status: 'open',
       currency: 'USD',
       bank: 'increase_bank',
-    });
+    };
+    return json(createdAccount);
   }
   if (method === 'GET' && url.pathname === '/account_numbers') {
-    return json({ data: [], next_cursor: null });
+    return json({ data: createdAccountNumber ? [createdAccountNumber] : [], next_cursor: null });
   }
   if (method === 'POST' && url.pathname === '/account_numbers') {
-    return json({ id: 'sandbox_account_number_recovery123', status: 'active' });
+    createdAccountNumber = { id: 'sandbox_account_number_recovery123', status: 'active' };
+    return json(createdAccountNumber);
   }
   if (method === 'GET' && url.pathname === '/accounts/sandbox_account_recovery123') {
-    return json({
-      id: 'sandbox_account_recovery123',
-      entity_id: 'sandbox_entity_default123',
-      program_id: 'sandbox_program_default123',
-      name: 'Galactic Trust Sandbox Checking',
-      status: 'open',
-      currency: 'USD',
-      bank: 'increase_bank',
-    });
+    return json(createdAccount);
   }
   if (method === 'GET' && url.pathname === '/accounts/sandbox_account_recovery123/balance') {
     return json({ account_id: 'sandbox_account_recovery123', current_balance: 0, available_balance: 0 });
@@ -60,11 +59,13 @@ globalThis.fetch = async (input, init = {}) => {
 };
 
 try {
-  const result = await recoverIncreaseSandboxOwnerAccount('00000000-0000-4000-8000-000000000123', {
+  const env = {
     GALACTIC_INCREASE_SANDBOX_ENABLED: 'true',
     INCREASE_SANDBOX_API_KEY: 'sandbox_test_key_not_secret',
-  });
+  };
+  const userId = '00000000-0000-4000-8000-000000000123';
 
+  const result = await recoverIncreaseSandboxOwnerAccount(userId, env);
   assert.equal(result.provider, 'Increase');
   assert.equal(result.environment, 'sandbox');
   assert.equal(result.bindingKind, 'SANDBOX_ACCOUNT_ONLY');
@@ -74,19 +75,41 @@ try {
   assert.equal(result.dashboard.connected, true);
   assert.equal(result.dashboard.canMoveRealMoney, false);
 
+  const rediscovered = await getIncreaseSandboxOwnerRecoveryAccount(userId, env);
+  assert.equal(rediscovered.accountId, 'sandbox_account_recovery123', 'the owner Account must be rediscoverable by deterministic idempotency key without database binding storage');
+  assert.equal(rediscovered.bindingKind, 'SANDBOX_ACCOUNT_ONLY');
+  assert.equal(rediscovered.canMoveRealMoney, false);
+
+  const accountCreates = requests.filter((entry) => entry.method === 'POST' && entry.pathname === '/accounts');
+  assert.equal(accountCreates.length, 1, 'deterministic owner recovery must create at most one sandbox Account');
   const requestedPaths = requests.map((entry) => entry.pathname).join('\n');
   assert.equal(requestedPaths.includes('/programs'), false, 'account-only recovery must not call Programs');
   assert.equal(requestedPaths.includes('/entities'), false, 'account-only recovery must not call Entities');
   assert.equal(requestedPaths.includes('entity_onboarding_sessions'), false, 'account-only recovery must not call hosted onboarding');
-  assert.equal(requests.some((entry) => entry.method === 'POST' && entry.pathname === '/accounts'), true, 'recovery must create the sandbox Account when no idempotent Account exists');
   assert.equal(requests.some((entry) => entry.method === 'POST' && entry.pathname === '/account_numbers'), true, 'recovery should create an Account Number for sandbox ACH simulation when available');
 
-  const routeSource = await readFile(new URL('../app/api/admin/bank/increase/recovery/route.ts', import.meta.url), 'utf8');
-  assert.match(routeSource, /requireGalacticTrustAdmin/, 'recovery route must be owner/admin authenticated');
-  assert.match(routeSource, /bindIncreaseSandboxAccountOnly/, 'recovery must use the explicit account-only binding path');
-  assert.match(routeSource, /publicBindingSummary/, 'browser response must use the sanitized binding summary');
-  assert.match(routeSource, /canMoveRealMoney: false/, 'recovery route must stay fail-closed for real money');
-  assert.equal(routeSource.includes('INCREASE_SANDBOX_API_KEY'), false, 'recovery route must never expose or read a client-visible provider key');
+  const recoveryRouteSource = await readFile(new URL('../app/api/admin/bank/increase/recovery/route.ts', import.meta.url), 'utf8');
+  assert.match(recoveryRouteSource, /requireGalacticTrustAdmin/, 'recovery route must be owner/admin authenticated');
+  assert.match(recoveryRouteSource, /getIncreaseSandboxOwnerRecoveryAccount/, 'recovery GET must rediscover owner-scoped sandbox Accounts without database binding storage');
+  assert.match(recoveryRouteSource, /publicIncreaseRecoveryBindingSummary/, 'migration-free recovery must expose only a sanitized virtual binding summary');
+  assert.match(recoveryRouteSource, /bindIncreaseSandboxAccountOnly/, 'database binding remains the preferred path when storage is available');
+  assert.match(recoveryRouteSource, /canMoveRealMoney: false/, 'recovery route must stay fail-closed for real money');
+  assert.equal(recoveryRouteSource.includes('INCREASE_SANDBOX_API_KEY'), false, 'recovery route must never expose or read a client-visible provider key');
+
+  const resolverSource = await readFile(new URL('../lib/banking/increase-owner-account.js', import.meta.url), 'utf8');
+  assert.match(resolverSource, /getProviderAccountBinding/, 'owner resolver should prefer trusted database bindings when available');
+  assert.match(resolverSource, /getIncreaseSandboxOwnerRecoveryAccount/, 'owner resolver must fall back to Increase idempotency-key discovery');
+  assert.match(resolverSource, /increase-idempotency-key/, 'fallback persistence must be explicit');
+
+  for (const path of [
+    '../app/api/admin/bank/increase/dashboard/route.ts',
+    '../app/api/admin/bank/increase/fund/route.ts',
+    '../app/api/admin/bank/increase/transfer/route.ts',
+  ]) {
+    const source = await readFile(new URL(path, import.meta.url), 'utf8');
+    assert.match(source, /resolveIncreaseSandboxOwnerAccount/, `${path} must use the migration-free owner Account resolver`);
+    assert.match(source, /canMoveRealMoney: false/, `${path} must remain sandbox-only`);
+  }
 
   const bindingSource = await readFile(new URL('../lib/banking/provider-account-binding.js', import.meta.url), 'utf8');
   assert.match(bindingSource, /SANDBOX_ACCOUNT_ONLY/, 'binding layer must preserve the account-only marker separately from KYC simulation');
@@ -98,15 +121,18 @@ try {
 
   const uiSource = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
   assert.match(uiSource, /private_feature_error/, 'recovery UI must activate for the private-feature restriction');
-  assert.match(uiSource, /Create sandbox test account/, 'recovery UI must provide the one-click account action once binding storage is ready');
-  assert.match(uiSource, /Galactic Trust database setup is the blocker/, 'missing binding storage must replace the misleading Increase-support dead end');
-  assert.match(uiSource, /migration 025/, 'database blocker UI must name the pending provider-binding migration');
+  assert.match(uiSource, /Create sandbox test account/, 'recovery UI must provide the one-click account action');
   assert.match(uiSource, /takeOverLegacySetup/, 'recovery UI must hide the legacy hosted-onboarding blocker while it owns the recovery state');
   assert.match(uiSource, /This is not KYC or a real bank account/, 'recovery UI must disclose the account-only boundary');
   assert.equal(uiSource.includes('/api/admin/bank/increase/recovery'), true);
   assert.equal(uiSource.includes('NEXT_PUBLIC_INCREASE'), false, 'recovery UI must not reference client-exposed Increase credentials');
 
-  console.log('Galactic Trust Increase recovery checks passed: the mounted private-feature fallback takes over the legacy warning, distinguishes missing binding storage from Increase access, creates an owner-scoped sandbox Account without Programs/Entities/hosted onboarding, and remains pretend-money only.');
+  const lifecycleRouteSource = await readFile(new URL('../app/api/bank/lifecycle/route.ts', import.meta.url), 'utf8');
+  assert.match(lifecycleRouteSource, /getIncreaseSandboxOwnerRecoveryAccount/, 'lifecycle should recognize recovered Account state even before database migration 025');
+  assert.match(lifecycleRouteSource, /SANDBOX_ACCOUNT_ONLY/, 'lifecycle fallback must stay explicitly account-only, not KYC');
+  assert.equal(lifecycleRouteSource.includes('accountId'), false, 'lifecycle route must not expose provider Account IDs');
+
+  console.log('Galactic Trust Increase recovery checks passed: the mounted private-feature fallback creates and rediscovers one owner-scoped sandbox Account via Increase idempotency-key lookup without Programs, Entities, hosted onboarding, or migration 025, while KYC and production money movement remain locked.');
 } finally {
   globalThis.fetch = originalFetch;
 }

--- a/scripts/test-galactic-trust-increase-recovery.mjs
+++ b/scripts/test-galactic-trust-increase-recovery.mjs
@@ -92,14 +92,21 @@ try {
   assert.match(bindingSource, /SANDBOX_ACCOUNT_ONLY/, 'binding layer must preserve the account-only marker separately from KYC simulation');
   assert.match(bindingSource, /SANDBOX_VALID_SIMULATION/, 'hosted/simulated KYC marker must remain available for the normal onboarding path');
 
+  const gateSource = await readFile(new URL('../app/bank/GalacticBankGate.js', import.meta.url), 'utf8');
+  assert.match(gateSource, /import GalacticIncreaseSandboxRecovery from '\.\/GalacticIncreaseSandboxRecovery'/, 'dashboard gate must import the recovery UI');
+  assert.match(gateSource, /session\?\.user && <GalacticIncreaseSandboxRecovery \/>/, 'recovery UI must actually be mounted for signed-in users');
+
   const uiSource = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
-  assert.match(uiSource, /private_feature_error/, 'recovery UI must only activate for the private-feature restriction');
-  assert.match(uiSource, /Create sandbox test account/, 'recovery UI must provide the one-click account action');
+  assert.match(uiSource, /private_feature_error/, 'recovery UI must activate for the private-feature restriction');
+  assert.match(uiSource, /Create sandbox test account/, 'recovery UI must provide the one-click account action once binding storage is ready');
+  assert.match(uiSource, /Galactic Trust database setup is the blocker/, 'missing binding storage must replace the misleading Increase-support dead end');
+  assert.match(uiSource, /migration 025/, 'database blocker UI must name the pending provider-binding migration');
+  assert.match(uiSource, /takeOverLegacySetup/, 'recovery UI must hide the legacy hosted-onboarding blocker while it owns the recovery state');
   assert.match(uiSource, /This is not KYC or a real bank account/, 'recovery UI must disclose the account-only boundary');
   assert.equal(uiSource.includes('/api/admin/bank/increase/recovery'), true);
   assert.equal(uiSource.includes('NEXT_PUBLIC_INCREASE'), false, 'recovery UI must not reference client-exposed Increase credentials');
 
-  console.log('Galactic Trust Increase recovery checks passed: the private-feature fallback creates an owner-scoped sandbox Account without Programs, Entities, or hosted onboarding, keeps KYC semantics separate, and remains pretend-money only.');
+  console.log('Galactic Trust Increase recovery checks passed: the mounted private-feature fallback takes over the legacy warning, distinguishes missing binding storage from Increase access, creates an owner-scoped sandbox Account without Programs/Entities/hosted onboarding, and remains pretend-money only.');
 } finally {
   globalThis.fetch = originalFetch;
 }


### PR DESCRIPTION
Closes #615.

The Increase private-feature recovery introduced in #614 was deployed but never mounted in `GalacticBankGate`, so users still saw the legacy hosted-onboarding dead end.

This fix:
- imports and mounts `GalacticIncreaseSandboxRecovery` for signed-in users
- lets the recovery UI take over the exact `private_feature_error` state
- when trusted binding storage is ready, offers `Create sandbox test account`
- when binding storage is not ready, replaces the misleading Increase-support text with the actual migration 025 database blocker
- keeps `SANDBOX_ACCOUNT_ONLY` separate from KYC simulation
- adds regression coverage that the recovery component is actually mounted
- changes the Supabase migration workflow so missing credentials fail the job instead of silently reporting success while skipping the database push

Production banking and real-money movement remain locked.