### PR TITLE
Ship Week 3 demo polish and refresh AI context

### DIFF
--- a/GALACTIC_CONTEXT.md
+++ b/GALACTIC_CONTEXT.md
@@ -1,0 +1,121 @@
+# Galactic Trust – Permanent AI Context
+
+## Product truth
+
+Galactic Trust is a galaxy-themed financial technology product. It is not a bank.
+
+The current product has two safe testing states:
+
+- **Demo UI:** local illustrative balances, cards, transfers, rewards, activity, and crypto practice.
+- **Increase sandbox:** provider-backed test data and ACH simulations using pretend money only.
+
+Production banking and live crypto are not implemented or enabled. Never imply otherwise.
+
+## Current repository architecture
+
+The GitHub repository is still named `hartensteindominic/Voxel-Vault` for compatibility, but the active product is Galactic Trust.
+
+Primary product surface:
+
+- `app/bank/page.js` – `/bank` entry point and styles.
+- `app/bank/GalacticBankGate.js` – Supabase session gate; mounts the signed-in/demo dashboard surfaces.
+- `app/bank/BankClient.js` – primary Galactic Trust dashboard and local demo interactions.
+- `app/bank/GalacticDashboardEnhancements.js` – existing dashboard refinements.
+- `app/bank/GalacticDashboardAccountState.js` – server-derived Demo / Increase sandbox / setup-required state.
+- `app/bank/GalacticHeaderCenter.js` – notifications and profile controls.
+- `app/bank/GalacticCryptoPractice.js` – isolated local crypto practice; no live crypto provider and no real trades.
+- `app/bank/GalacticSandboxSetup.js` – owner Increase sandbox setup when provider capabilities permit it.
+- `app/bank/GalacticIncreaseSandboxRecovery.js` – owner-only Increase sandbox recovery when Programs/Entities are private features.
+- `app/bank/galactic-trust.css`, `enhancements.css`, and component CSS modules – existing visual system to extend before inventing new styling.
+
+Banking server boundaries:
+
+- `app/api/bank/lifecycle/route.ts` – signed-in lifecycle summary used by dashboard status UI.
+- `app/api/admin/bank/increase/status/route.ts` – sanitized Increase sandbox capability status.
+- `app/api/admin/bank/increase/dashboard/route.ts` – sanitized owner sandbox dashboard snapshot.
+- `app/api/admin/bank/increase/fund/route.ts` – owner-only Increase sandbox inbound ACH simulation.
+- `app/api/admin/bank/increase/transfer/route.ts` – owner-only Increase sandbox ACH simulation.
+- `app/api/admin/bank/increase/recovery/route.ts` – owner-only Account recovery that avoids restricted Programs/Entities APIs.
+- `lib/banking/increase-owner-account.js` – resolves the owner sandbox Account from the preferred database binding or the deterministic Increase idempotency-key fallback.
+- `lib/banking/increase-sandbox-recovery.js` – creates/rediscovers the dedicated owner sandbox Account without hosted onboarding when allowed.
+- `lib/banking/regulated-launch.js` – hard production launch locks. Do not weaken or bypass it.
+- `lib/banking/orbit-chat.js` – Orbit product-support response logic.
+
+## Sacred safety rules
+
+1. **Real customer money stays locked.** Do not add or enable live deposits, withdrawals, transfers, card issuance, or production banking writes.
+2. **Live crypto stays locked.** `GalacticCryptoPractice` is local practice only. Never claim a real asset was bought, sold, held, or transferred.
+3. **Do not call Galactic Trust a bank.** Describe it as a financial technology product/application.
+4. **Never claim FDIC insurance, bank insurance, approval, KYC completion, CIP completion, AML approval, sanctions approval, or credit approval.**
+5. **Increase sandbox uses pretend money.** Provider-backed sandbox data is still not real customer money.
+6. `SANDBOX_VALID_SIMULATION` means provider sandbox validation only; it is not real KYC/CIP/AML approval.
+7. `SANDBOX_ACCOUNT_ONLY` means the owner sandbox Account was created/recovered without an Entity onboarding decision. It is explicitly not KYC.
+8. Keep provider credentials server-only. Never expose API keys, full provider Account/Entity IDs, raw account numbers, routing numbers, secrets, or private keys to browser code or chat output.
+9. Never put provider secrets in `NEXT_PUBLIC_*` variables.
+10. Preserve owner/admin authorization on all `/api/admin/bank/*` routes.
+
+## Increase sandbox facts
+
+- Sandbox API origin: `https://sandbox.increase.com`.
+- Server configuration currently uses `INCREASE_SANDBOX_API_KEY` and `GALACTIC_INCREASE_SANDBOX_ENABLED=true` when sandbox testing is enabled.
+- Programs and Entities can be unavailable as private features. That must not automatically block owner sandbox Account testing.
+- Owner recovery uses a deterministic, user-scoped Increase idempotency key to find or create one dedicated sandbox Account.
+- Database provider binding is preferred when available, but migration 025 is not a blocker for owner dashboard/fund/transfer sandbox testing because the idempotency lookup is the fallback.
+- The legacy database table name `vault_provider_account_bindings` is retained for migration compatibility. Do not rename it casually.
+- Account Number creation is optional for recovery; a restricted Account Number feature must not be confused with failure to recover the Account itself.
+
+## External setup that code cannot fake
+
+- GitHub Actions Supabase migration secrets still need to be configured before pending migrations can be applied reliably: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, and `SUPABASE_DB_PASSWORD`.
+- Do not ask users to paste secrets into chat.
+- A future production banking launch requires an actual approved provider/sponsor-bank program plus the required compliance, operational, legal, privacy, and customer-support work. Code must not simulate those approvals.
+
+## UI and product rules
+
+- Extend existing Galactic Trust components and CSS before creating new architecture.
+- Keep the galaxy visual language, responsive behavior, and current information hierarchy.
+- Make Demo / Increase sandbox wording obvious near actions and balances.
+- All primary actions need clear disabled, loading, success, and failure states where applicable.
+- Use accessible labels and preserve visible keyboard focus.
+- Prefer small vertical slices and the fewest files that safely achieve the outcome.
+- Keep Orbit limited to product support and privacy-aware guidance. It must never request passwords, PINs, CVVs, recovery codes, one-time codes, API keys, or banking secrets.
+- Sample data must remain professional but unmistakably simulated.
+
+## Verification ritual
+
+This repository does **not** currently define `npm run typecheck` or `npm run test:safety`.
+
+Use the repository's real checks:
+
+```bash
+npm run test:galactic
+npm run build
+```
+
+`npm run test:galactic` is the canonical Galactic Trust guardrail suite and currently covers repository scope, UI truth, provider boundaries, regulated launch locks, Increase onboarding, webhooks, account lifecycle/status UI, integration health, crypto practice, header behavior, and Increase recovery.
+
+A change is not done until the relevant checks are green and the resulting UI still states the demo/sandbox truth accurately.
+
+## Working method for AI coding sessions
+
+Before editing:
+
+1. Read this file.
+2. Read the current target component/API route instead of assuming old filenames or environment variables.
+3. Check `main` for concurrent changes before opening a branch.
+4. Define one user-visible outcome and its verification.
+
+During editing:
+
+1. Reuse existing patterns.
+2. Do not invent a new state manager, design system, provider abstraction, or folder structure unless the current code truly requires it.
+3. Reject any change that weakens production locks or turns sandbox/demo language into live-money language.
+4. Do not add real financial claims merely to make the interface feel more bank-like.
+
+Before merging:
+
+1. Run `npm run test:galactic`.
+2. Run `npm run build`.
+3. Review desktop and mobile behavior for the touched flow.
+4. Confirm no secrets, raw provider identifiers, or misleading live-money claims were introduced.
+5. Keep the commit/PR description explicit about demo/sandbox behavior and production locks.

--- a/app/bank/GalacticBankGate.js
+++ b/app/bank/GalacticBankGate.js
@@ -6,6 +6,7 @@ import BankClient from './BankClient';
 import GalacticCryptoPractice from './GalacticCryptoPractice';
 import GalacticDashboardAccountState from './GalacticDashboardAccountState';
 import GalacticDashboardEnhancements from './GalacticDashboardEnhancements';
+import GalacticDemoHint from './GalacticDemoHint';
 import GalacticHeaderCenter from './GalacticHeaderCenter';
 import GalacticIncreaseSandboxRecovery from './GalacticIncreaseSandboxRecovery';
 import GalacticSandboxSetup from './GalacticSandboxSetup';
@@ -169,6 +170,7 @@ export default function GalacticBankGate() {
   return (
     <>
       <BankClient galacticUser={session?.user || null} demoAccess={demoAccess} onSignOut={activeSignOut} accountLabel={label} accessToken={accessToken} />
+      <GalacticDemoHint />
       <GalacticCryptoPractice />
       <GalacticDashboardEnhancements onSignOut={activeSignOut} accountLabel={label} />
       <GalacticDashboardAccountState accessToken={accessToken} demoAccess={demoAccess} />

--- a/app/bank/GalacticDemoHint.js
+++ b/app/bank/GalacticDemoHint.js
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import styles from './demo-hint.module.css';
+
+const DISMISSED_KEY = 'galactic-trust-demo-hint-dismissed-v1';
+
+export default function GalacticDemoHint() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      setVisible(window.localStorage.getItem(DISMISSED_KEY) !== '1');
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  function dismiss() {
+    try {
+      window.localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // The hint remains dismissible for this page load even if storage is unavailable.
+    }
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <aside className={styles.hint} role="note" aria-label="Galactic Trust demo mode notice">
+      <span className={styles.icon} aria-hidden="true">✦</span>
+      <div className={styles.copy}>
+        <strong>Demo and sandbox mode</strong>
+        <p>Balances, cards, crypto, and transfers are simulated or use Increase sandbox pretend money. No real deposits or real crypto move in this build.</p>
+      </div>
+      <button className={styles.dismiss} type="button" onClick={dismiss} aria-label="Dismiss demo mode notice">Got it</button>
+    </aside>
+  );
+}

--- a/app/bank/a11y.css
+++ b/app/bank/a11y.css
@@ -1,0 +1,34 @@
+.gt-app :is(button, a, input, select, textarea):focus-visible,
+.gt-auth-page :is(button, a, input, select, textarea):focus-visible {
+  outline: 3px solid rgba(131, 106, 255, 0.52);
+  outline-offset: 3px;
+}
+
+.gt-app :is(button, a):focus-visible,
+.gt-auth-page :is(button, a):focus-visible {
+  box-shadow: 0 0 0 5px rgba(131, 106, 255, 0.14);
+}
+
+.gt-app :is(input, select, textarea):focus-visible,
+.gt-auth-page :is(input, select, textarea):focus-visible {
+  border-color: rgba(107, 80, 232, 0.82);
+}
+
+.gt-app button:disabled,
+.gt-auth-page button:disabled {
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gt-app *,
+  .gt-app *::before,
+  .gt-app *::after,
+  .gt-auth-page *,
+  .gt-auth-page *::before,
+  .gt-auth-page *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/bank/demo-hint.module.css
+++ b/app/bank/demo-hint.module.css
@@ -1,0 +1,91 @@
+.hint {
+  position: fixed;
+  left: max(18px, env(safe-area-inset-left));
+  bottom: max(18px, env(safe-area-inset-bottom));
+  z-index: 92;
+  width: min(430px, calc(100vw - 36px));
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 14px 14px 13px;
+  border: 1px solid rgba(139, 119, 255, 0.28);
+  border-radius: 18px;
+  background: rgba(17, 22, 61, 0.96);
+  color: #f8f9ff;
+  box-shadow: 0 20px 50px rgba(7, 10, 37, 0.28);
+  backdrop-filter: blur(16px);
+}
+
+.icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: rgba(139, 119, 255, 0.16);
+  color: #cfc4ff;
+  font-size: 16px;
+}
+
+.copy {
+  min-width: 0;
+}
+
+.copy strong {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 12px;
+  letter-spacing: -0.01em;
+}
+
+.copy p {
+  margin: 0;
+  color: #c8d0f5;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.dismiss {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.dismiss:hover {
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.dismiss:focus-visible {
+  outline: 3px solid rgba(185, 171, 255, 0.48);
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .hint {
+    left: 12px;
+    right: 12px;
+    bottom: calc(12px + env(safe-area-inset-bottom));
+    width: auto;
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .dismiss {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hint,
+  .dismiss {
+    transition: none;
+  }
+}

--- a/app/bank/page.js
+++ b/app/bank/page.js
@@ -1,10 +1,10 @@
 import GalacticBankGate from './GalacticBankGate';
-import GalacticIncreaseSandboxRecovery from './GalacticIncreaseSandboxRecovery';
 import './bank.css';
 import './galactic.css';
 import './galactic-trust.css';
 import './auth.css';
 import './enhancements.css';
+import './a11y.css';
 
 export const metadata = {
   title: 'Dashboard',
@@ -13,10 +13,5 @@ export const metadata = {
 };
 
 export default function BankPage() {
-  return (
-    <>
-      <GalacticBankGate />
-      <GalacticIncreaseSandboxRecovery />
-    </>
-  );
+  return <GalacticBankGate />;
 }

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -31,7 +31,7 @@ export default function PrivacyPage() {
 
         <section style={sectionStyle}>
           <h2>2. Demo data stays demo data</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Illustrative balances, cards, rewards, activity, crypto practice, and ordinary demo transfers are simulated product data. The current application does not hold real customer deposits, execute real crypto trades, or move real customer money.</p>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Illustrative balances, cards, rewards, activity, crypto practice, and ordinary demo transfers are simulated product data. Galactic Trust does not currently use this application to hold real customer deposits or move real customer money. The current application also does not execute real crypto trades.</p>
         </section>
 
         <section style={sectionStyle}>

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export const metadata = {
   title: 'Privacy',
-  description: 'Privacy information for the Galactic Trust financial technology application.',
+  description: 'Privacy information for the current Galactic Trust demo and Increase sandbox experience.',
   alternates: { canonical: '/privacy' },
 };
 
@@ -15,57 +15,58 @@ export default function PrivacyPage() {
   return (
     <main style={{ minHeight: '100vh', background: '#07103d', color: '#f7f8ff', fontFamily: 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', padding: '48px 20px 80px' }}>
       <article style={{ width: 'min(860px, 100%)', margin: '0 auto' }}>
-        <nav style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 44 }}>
+        <nav aria-label="Privacy navigation" style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 44 }}>
           <Link href="/" style={{ color: '#fff', textDecoration: 'none', fontWeight: 800, letterSpacing: '-0.02em' }}>✦ Galactic Trust</Link>
           <Link href="/bank/readiness" style={{ color: '#b7c5ff', textDecoration: 'none', fontWeight: 700 }}>Launch status</Link>
         </nav>
 
         <p style={{ color: '#9fb0ff', fontWeight: 800, letterSpacing: '0.12em', fontSize: 12 }}>GALACTIC TRUST PRIVACY</p>
-        <h1 style={{ fontSize: 'clamp(42px, 8vw, 72px)', lineHeight: 0.96, letterSpacing: '-0.055em', margin: '12px 0 22px' }}>Collect less. Keep provider secrets off the client.</h1>
-        <p style={{ color: '#cbd3ff', fontSize: 18, lineHeight: 1.7, maxWidth: 760 }}>Effective August 30, 2026. This notice describes the current Galactic Trust demo and sandbox application. It is not a future sponsor bank&apos;s privacy notice.</p>
+        <h1 style={{ fontSize: 'clamp(42px, 8vw, 72px)', lineHeight: 0.96, letterSpacing: '-0.055em', margin: '12px 0 22px' }}>Privacy in the current demo.</h1>
+        <p style={{ color: '#cbd3ff', fontSize: 18, lineHeight: 1.7, maxWidth: 760 }}>Effective August 30, 2026. This page describes the Galactic Trust demo and authorized Increase sandbox testing that exist today. It is not a bank privacy notice, and it does not describe a future live banking program.</p>
 
         <section style={sectionStyle}>
-          <h2>1. Current account information</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>When you sign in, Galactic Trust uses authentication information needed to maintain your session, such as the account identifier, email address made available through the sign-in provider, and session credentials. Browser authentication may use local storage or similar browser mechanisms through the configured authentication provider.</p>
+          <h2>1. What the app uses when you sign in</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust uses the authentication information needed to keep you signed in, such as an account identifier, an email address made available by the sign-in provider, and session credentials. The configured authentication provider may use local storage or similar browser mechanisms to maintain that session.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>2. Increase sandbox information</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>For authorized owner testing, Galactic Trust may store server-side references that bind an authenticated user to an Increase sandbox Entity and Account. Browser responses are deliberately limited and do not expose full provider Entity or Account identifiers, API keys, raw account numbers, or routing numbers.</p>
+          <h2>2. Demo data stays demo data</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Illustrative balances, cards, rewards, activity, crypto practice, and ordinary demo transfers are simulated product data. The current application does not hold real customer deposits, execute real crypto trades, or move real customer money.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>3. Hosted sandbox onboarding</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>The current integration uses provider-hosted sandbox onboarding so Galactic Trust does not need ordinary application forms for sensitive identity fields. Sandbox validation is simulated test behavior and is not a real KYC, CIP, AML, sanctions, credit, or bank-account approval decision.</p>
+          <h2>3. Increase sandbox owner testing</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Authorized owner testing can connect Galactic Trust to Increase&apos;s sandbox, where all balances and ACH activity use pretend money. When a durable provider binding is available, Galactic Trust can store limited server-side references that associate the signed-in owner with the sandbox Account. Browser responses are intentionally sanitized and do not expose API keys, full provider Account or Entity identifiers, raw account numbers, or routing numbers.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>4. Provider event and reconciliation records</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust records limited Increase sandbox event metadata needed for webhook verification, idempotency, reconciliation, and operational status. The application is designed to retain a payload fingerprint rather than raw webhook payloads in its reconciliation ledger.</p>
+          <h2>4. Sandbox recovery without hosted onboarding</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>If Increase Programs or Entities are unavailable as private sandbox features, the owner recovery flow can use a deterministic, user-scoped idempotency key to find or create one dedicated sandbox Account. That fallback can work without storing a database binding. The marker <code>SANDBOX_ACCOUNT_ONLY</code> describes this test-account path only; it is not KYC, CIP, AML, sanctions, credit, or bank-account approval.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>5. Service providers</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust currently relies on infrastructure providers for application hosting and authentication, and on Increase for the pretend-money banking sandbox. Those providers process information under their own applicable terms and privacy practices. A future live banking program would require its own approved privacy disclosures and sponsor-bank/provider responsibilities.</p>
+          <h2>5. Hosted sandbox onboarding, when available</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Where provider-hosted sandbox onboarding is available, Galactic Trust can use it instead of collecting ordinary identity fields directly in the application. Any sandbox validation remains simulated provider test behavior. It must not be treated as a real identity, compliance, credit, or banking approval decision.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>6. Sensitive information and secrets</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Do not paste passwords, API keys, private keys, bank credentials, Social Security numbers, or other sensitive secrets into Galactic Trust chat or ordinary text fields. Increase provider credentials are intended to remain server-only and must not be exposed through browser-visible environment variables.</p>
+          <h2>6. Operational records</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust may keep limited Increase sandbox event metadata needed for webhook verification, idempotency, reconciliation, account status, and operational troubleshooting. The reconciliation design favors fingerprints and limited metadata instead of retaining raw provider webhook payloads unnecessarily.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>7. Demo and sandbox data</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Current balances, cards, transfers, rewards, and provider-backed banking data are demo or pretend-money sandbox information. Galactic Trust does not currently use this application to hold real customer deposits or move real customer money.</p>
+          <h2>7. Service providers and secrets</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>Galactic Trust currently relies on infrastructure providers for hosting and authentication and on Increase for authorized pretend-money sandbox testing. Provider credentials are intended to remain server-only. Do not paste passwords, API keys, private keys, bank credentials, Social Security numbers, PINs, CVVs, recovery codes, or one-time codes into Orbit or ordinary text fields.</p>
         </section>
 
         <section style={sectionStyle}>
-          <h2>8. Future production changes</h2>
-          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>If Galactic Trust later launches an approved production banking program, this notice will need to be updated to reflect the actual sponsor bank, production providers, categories of information, retention practices, customer rights, required notices, and regulated data-handling responsibilities before those live services are represented as available.</p>
+          <h2>8. What must change before any live customer program</h2>
+          <p style={{ color: '#cbd3ff', lineHeight: 1.75 }}>A future live banking or crypto program would require separate provider approvals and a fresh privacy/compliance review before launch. The privacy notice would need to be updated for the actual sponsor bank or regulated provider, production data flows, retention practices, customer rights, required disclosures, security operations, and support responsibilities. The current demo privacy posture is not a substitute for that work.</p>
         </section>
 
         <footer style={{ ...sectionStyle, display: 'flex', flexWrap: 'wrap', gap: 18, color: '#9fb0ff' }}>
           <Link href="/terms" style={{ color: '#b7c5ff' }}>Terms</Link>
+          <Link href="/bank" style={{ color: '#b7c5ff' }}>Dashboard</Link>
           <Link href="/bank/status" style={{ color: '#b7c5ff' }}>My account status</Link>
           <Link href="/bank/readiness" style={{ color: '#b7c5ff' }}>Regulated launch status</Link>
         </footer>


### PR DESCRIPTION
Closes #617

Ships three low-risk Galactic Trust Week 3 slices against the current repo architecture:

- Slice 25: adds a dismissible first-visit Demo + Increase sandbox notice backed by localStorage only.
- Slice 27: strengthens visible keyboard focus and reduced-motion behavior across the dashboard/auth surface.
- Slice 36: refreshes `/privacy` for the current demo, owner Increase sandbox, idempotency-key recovery, and future-live policy gap.
- Adds `GALACTIC_CONTEXT.md` with the actual current files, environment names, safety invariants, and verification commands.
- Removes the duplicate top-level `GalacticIncreaseSandboxRecovery` mount from `/bank`; the signed-in gate remains the single owner-only mount.

Safety invariants preserved: Galactic Trust remains a fintech product, not a bank; Increase is sandbox/pretend money only; live banking and live crypto stay locked; no provider secrets or raw provider identifiers are exposed.