### PR TITLE
Prefer owner sandbox Account recovery over hosted-onboarding blocker

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Increase recovery
         if: always()
         run: node scripts/test-galactic-trust-increase-recovery.mjs
+      - name: Recovery takeover
+        if: always()
+        run: node scripts/test-galactic-trust-recovery-takeover.mjs
       - name: Production build
         if: always()
         run: npm run build

--- a/app/bank/GalacticIncreaseSandboxRecovery.js
+++ b/app/bank/GalacticIncreaseSandboxRecovery.js
@@ -32,6 +32,7 @@ export default function GalacticIncreaseSandboxRecovery() {
   const [accountCount, setAccountCount] = useState(0);
   const [recoveryAvailable, setRecoveryAvailable] = useState(false);
   const [bindingStorageBlocked, setBindingStorageBlocked] = useState(false);
+  const [restrictionDetected, setRestrictionDetected] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -69,18 +70,32 @@ export default function GalacticIncreaseSandboxRecovery() {
           return;
         }
 
-        const privateFeatureBlocked = statusResponse.ok && status?.connected && hasPrivateFeatureRestriction(status);
-        if (!privateFeatureBlocked) return;
-
+        const connected = Boolean(statusResponse.ok && status?.connected);
+        const privateFeatureBlocked = connected && hasPrivateFeatureRestriction(status);
         const storageBlocked = Boolean(recovery?.setupRequired);
-        const canRecover = recoveryResponse.ok && recovery?.recoveryAvailable && !storageBlocked;
+        const canRecover = Boolean(
+          connected &&
+          recoveryResponse.ok &&
+          recovery?.recoveryAvailable &&
+          !storageBlocked
+        );
+
+        // Account-only recovery is intentionally not coupled to hosted-onboarding capability
+        // detection. Increase can permit Programs/Entities reads while rejecting the hosted
+        // onboarding session itself as a private feature. If Accounts are connected and the
+        // owner recovery route confirms a safe dedicated Account can be created, prefer that
+        // path immediately instead of leaving the owner trapped behind hosted onboarding.
+        if (!canRecover && !privateFeatureBlocked) return;
 
         setAccountCount(Number(status?.counts?.accounts || 0));
         setBindingStorageBlocked(storageBlocked);
-        setRecoveryAvailable(Boolean(canRecover));
+        setRestrictionDetected(privateFeatureBlocked);
+        setRecoveryAvailable(canRecover);
         setMessage(storageBlocked
           ? String(recovery?.error || 'Trusted provider binding storage is not installed yet. Galactic Trust cannot safely bind the Increase sandbox Account until the required Supabase migration is applied.')
-          : '');
+          : canRecover
+            ? ''
+            : String(recovery?.nextStep || recovery?.error || status?.nextStep || 'Owner sandbox Account recovery is not available yet.'));
         setVisible(true);
         takeOverLegacySetup();
       } catch {
@@ -122,7 +137,9 @@ export default function GalacticIncreaseSandboxRecovery() {
   if (!visible) return null;
 
   const storageTitle = 'Galactic Trust database setup is the blocker.';
-  const recoveryTitle = 'We can bypass the blocked hosted-onboarding feature.';
+  const recoveryTitle = restrictionDetected
+    ? 'We can bypass the blocked hosted-onboarding feature.'
+    : 'Create your dedicated sandbox test account.';
 
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Increase sandbox recovery">
@@ -134,7 +151,9 @@ export default function GalacticIncreaseSandboxRecovery() {
             <h2>{bindingStorageBlocked ? storageTitle : recoveryTitle}</h2>
             <p>{bindingStorageBlocked
               ? 'Increase Accounts access is connected. The restricted hosted-onboarding feature is no longer the actionable blocker; trusted provider-binding storage must be installed before Galactic Trust can safely attach a sandbox Account to your signed-in user.'
-              : 'Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.'}</p>
+              : restrictionDetected
+                ? 'Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.'
+                : 'Increase Accounts access is connected and the owner recovery endpoint is ready. Galactic Trust can create a dedicated owner test Account without relying on hosted onboarding.'}</p>
           </div>
         </div>
 
@@ -150,7 +169,7 @@ export default function GalacticIncreaseSandboxRecovery() {
             ) : (
               <>
                 <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
-                <li>Binds only that Account to your Galactic Trust user on the server.</li>
+                <li>Scopes only that dedicated Account to your Galactic Trust user on the server.</li>
                 <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
               </>
             )}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs && node scripts/test-galactic-trust-crypto-practice.mjs && node scripts/test-galactic-trust-header-center.mjs && node scripts/test-galactic-trust-increase-recovery.mjs"
+    "test:galactic": "node scripts/test-galactic-trust-repo-scope.mjs && node scripts/test-galactic-trust-ui-truth.mjs && node scripts/test-galactic-trust-provider-boundary.mjs && node scripts/test-galactic-trust-regulated-launch.mjs && node scripts/test-galactic-trust-increase-onboarding.mjs && node scripts/test-galactic-trust-increase-webhooks.mjs && node scripts/test-galactic-trust-account-lifecycle.mjs && node scripts/test-galactic-trust-account-status-ui.mjs && node scripts/test-galactic-trust-integration-health.mjs && node scripts/test-galactic-trust-crypto-practice.mjs && node scripts/test-galactic-trust-header-center.mjs && node scripts/test-galactic-trust-increase-recovery.mjs && node scripts/test-galactic-trust-recovery-takeover.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/scripts/test-galactic-trust-recovery-takeover.mjs
+++ b/scripts/test-galactic-trust-recovery-takeover.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const source = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
+
+assert.match(source, /const connected = Boolean\(statusResponse\.ok && status\?\.connected\)/, 'recovery takeover must require a confirmed Increase sandbox Accounts connection');
+assert.match(source, /recoveryResponse\.ok &&\s*recovery\?\.recoveryAvailable/, 'recovery takeover must honor the owner recovery endpoint instead of depending only on hosted-onboarding capability detection');
+assert.match(source, /if \(!canRecover && !privateFeatureBlocked\) return;/, 'safe owner recovery must be allowed even when the status snapshot itself did not report a private_feature_error');
+assert.match(source, /takeOverLegacySetup\(\)/, 'the recovery UI must hide the legacy hosted-onboarding blocker when it owns the setup state');
+assert.match(source, /Create sandbox test account/, 'the owner must get a direct sandbox Account recovery action');
+assert.match(source, /SANDBOX_ACCOUNT_ONLY/, 'the UI must preserve the account-only, non-KYC marker');
+assert.match(source, /Production money movement remains locked/, 'the recovery flow must remain fail-closed for real money');
+assert.equal(source.includes('NEXT_PUBLIC_INCREASE'), false, 'the recovery UI must never depend on browser-exposed Increase credentials');
+
+console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use the dedicated Account-only recovery path without waiting for hosted-onboarding private-feature detection.');


### PR DESCRIPTION
Closes #619

Fixes the owner setup case where Increase Accounts is connected and `/api/admin/bank/increase/recovery` can safely create a dedicated owner Account, but hosted onboarding may fail later as a private feature even though Programs/Entities reads looked available.

Changes:
- owner recovery no longer depends exclusively on `private_feature_error` appearing in the status snapshot;
- recovery takes over when Accounts is connected, no verified owner binding exists, and the recovery endpoint reports `recoveryAvailable`;
- existing unbound Accounts are still never adopted;
- `SANDBOX_ACCOUNT_ONLY` remains explicitly non-KYC;
- production money movement and live crypto remain locked;
- adds a regression test to the canonical `test:galactic` gate.

No new provider permissions, environment variables, or secrets are introduced.