### PR TITLE
Fix Increase recovery handoff for owner sandbox

### DIFF
--- a/app/bank/GalacticIncreaseSandboxRecovery.js
+++ b/app/bank/GalacticIncreaseSandboxRecovery.js
@@ -10,12 +10,6 @@ function authHeaders(token, json = false) {
   return headers;
 }
 
-function hasPrivateFeatureRestriction(status) {
-  return Object.values(status?.capabilities || {}).some((capability) => (
-    capability?.available === false && capability?.issue?.type === 'private_feature_error'
-  ));
-}
-
 function hideLegacyBlockingSetup() {
   const panel = document.querySelector('[aria-label="Owner Increase sandbox setup"]');
   if (!panel) return;
@@ -69,17 +63,19 @@ export default function GalacticIncreaseSandboxRecovery() {
           return;
         }
 
-        const privateFeatureBlocked = statusResponse.ok && status?.connected && hasPrivateFeatureRestriction(status);
-        if (!privateFeatureBlocked) return;
-
-        const storageBlocked = Boolean(recovery?.setupRequired);
-        const canRecover = recoveryResponse.ok && recovery?.recoveryAvailable && !storageBlocked;
+        // The recovery endpoint is the source of truth for whether this signed-in owner can use
+        // Account-only sandbox recovery. Do not require Programs/Entities to fail with one exact
+        // provider error shape before offering the safe owner-scoped fallback.
+        const providerConnected = statusResponse.ok && Boolean(status?.connected);
+        const storageBlocked = recoveryResponse.ok && Boolean(recovery?.setupRequired);
+        const canRecover = providerConnected && recoveryResponse.ok && Boolean(recovery?.recoveryAvailable) && !storageBlocked;
+        if (!canRecover && !storageBlocked) return;
 
         setAccountCount(Number(status?.counts?.accounts || 0));
         setBindingStorageBlocked(storageBlocked);
         setRecoveryAvailable(Boolean(canRecover));
         setMessage(storageBlocked
-          ? String(recovery?.error || 'Trusted provider binding storage is not installed yet. Galactic Trust cannot safely bind the Increase sandbox Account until the required Supabase migration is applied.')
+          ? String(recovery?.error || recovery?.bindingStorageIssue || 'Trusted provider binding storage needs attention before owner recovery can continue.')
           : '');
         setVisible(true);
         takeOverLegacySetup();
@@ -121,8 +117,8 @@ export default function GalacticIncreaseSandboxRecovery() {
 
   if (!visible) return null;
 
-  const storageTitle = 'Galactic Trust database setup is the blocker.';
-  const recoveryTitle = 'We can bypass the blocked hosted-onboarding feature.';
+  const storageTitle = 'Galactic Trust sandbox storage needs attention.';
+  const recoveryTitle = 'Create your owner-scoped sandbox test account.';
 
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Increase sandbox recovery">
@@ -133,8 +129,8 @@ export default function GalacticIncreaseSandboxRecovery() {
           <div>
             <h2>{bindingStorageBlocked ? storageTitle : recoveryTitle}</h2>
             <p>{bindingStorageBlocked
-              ? 'Increase Accounts access is connected. The restricted hosted-onboarding feature is no longer the actionable blocker; trusted provider-binding storage must be installed before Galactic Trust can safely attach a sandbox Account to your signed-in user.'
-              : 'Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.'}</p>
+              ? 'Increase Accounts access is connected, but the owner recovery route reports that its trusted server-side state needs attention before it can continue.'
+              : 'Increase Accounts access is connected. Galactic Trust can create or reuse one dedicated owner test Account without requiring Programs, Entities, or hosted onboarding for this sandbox-only path.'}</p>
           </div>
         </div>
 
@@ -143,14 +139,14 @@ export default function GalacticIncreaseSandboxRecovery() {
           <ul>
             {bindingStorageBlocked ? (
               <>
-                <li>Apply the pending Galactic Trust Supabase provider-binding migration, including migration 025.</li>
-                <li>Keep database credentials in GitHub Actions secrets only; never paste them into chat or client code.</li>
-                <li>After the migration is actually applied, this panel will offer the one-click Increase sandbox Account recovery automatically.</li>
+                <li>Open Integration Health to review the sanitized server-side recovery status.</li>
+                <li>Keep provider and database credentials server-only; never paste them into chat or client code.</li>
+                <li>Production banking remains locked while this sandbox-only state is resolved.</li>
               </>
             ) : (
               <>
                 <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
-                <li>Binds only that Account to your Galactic Trust user on the server.</li>
+                <li>Scopes that Account to your verified Galactic Trust user on the server.</li>
                 <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
               </>
             )}
@@ -162,7 +158,7 @@ export default function GalacticIncreaseSandboxRecovery() {
           <p><b>This is not KYC or a real bank account.</b> Account-only recovery is stored as <code>SANDBOX_ACCOUNT_ONLY</code>. Production money movement remains locked.</p>
         </div>
 
-        {!bindingStorageBlocked && accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates/reuses a dedicated owner-scoped Account instead.</p>}
+        {!bindingStorageBlocked && accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates or reuses a dedicated owner-scoped Account instead.</p>}
 
         {recoveryAvailable && (
           <button className={styles.primary} type="button" onClick={recover} disabled={busy}>

--- a/scripts/test-galactic-trust-increase-recovery.mjs
+++ b/scripts/test-galactic-trust-increase-recovery.mjs
@@ -120,7 +120,8 @@ try {
   assert.match(gateSource, /session\?\.user && <GalacticIncreaseSandboxRecovery \/>/, 'recovery UI must actually be mounted for signed-in users');
 
   const uiSource = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
-  assert.match(uiSource, /private_feature_error/, 'recovery UI must activate for the private-feature restriction');
+  assert.match(uiSource, /recoveryResponse\.ok && Boolean\(recovery\?\.recoveryAvailable\)/, 'recovery UI must use the owner recovery endpoint as the positive handoff signal');
+  assert.equal(uiSource.includes('hasPrivateFeatureRestriction'), false, 'recovery UI must not depend on one exact Increase private-feature error shape');
   assert.match(uiSource, /Create sandbox test account/, 'recovery UI must provide the one-click account action');
   assert.match(uiSource, /takeOverLegacySetup/, 'recovery UI must hide the legacy hosted-onboarding blocker while it owns the recovery state');
   assert.match(uiSource, /This is not KYC or a real bank account/, 'recovery UI must disclose the account-only boundary');
@@ -132,7 +133,7 @@ try {
   assert.match(lifecycleRouteSource, /SANDBOX_ACCOUNT_ONLY/, 'lifecycle fallback must stay explicitly account-only, not KYC');
   assert.equal(lifecycleRouteSource.includes('accountId'), false, 'lifecycle route must not expose provider Account IDs');
 
-  console.log('Galactic Trust Increase recovery checks passed: the mounted private-feature fallback creates and rediscovers one owner-scoped sandbox Account via Increase idempotency-key lookup without Programs, Entities, hosted onboarding, or migration 025, while KYC and production money movement remain locked.');
+  console.log('Galactic Trust Increase recovery checks passed: the mounted owner fallback is driven by the recovery endpoint, creates and rediscovers one owner-scoped sandbox Account via Increase idempotency-key lookup without Programs, Entities, hosted onboarding, or migration 025, while KYC and production money movement remain locked.');
 } finally {
   globalThis.fetch = originalFetch;
 }


### PR DESCRIPTION
Closes #623

Fixes the remaining owner sandbox setup dead-end without weakening any production safeguards.

- Makes `/api/admin/bank/increase/recovery` the positive source of truth for whether Account-only recovery should take over.
- Stops requiring one exact `private_feature_error` capability shape before showing the recovery action.
- Keeps the legacy hosted-onboarding UI as fallback only when recovery itself is unavailable.
- Preserves deterministic owner scoping, `SANDBOX_ACCOUNT_ONLY`, pretend-money-only behavior, server-only credentials, and hard production money locks.
- Updates the Increase recovery regression test so this handoff cannot silently regress.

Expected signed-in owner behavior: when Increase Accounts are connected and recovery reports `recoveryAvailable: true`, the old hosted-onboarding blocker is hidden and Galactic Trust shows `Create sandbox test account`.