### PR TITLE
Harden primary demo and sandbox action states

### DIFF
--- a/app/bank/BankClient.js
+++ b/app/bank/BankClient.js
@@ -71,7 +71,7 @@ function GalacticCard({ pink = false, frozen = false, onFreeze }) {
       <div className="gt-card-number">•••• {pink ? '8756' : '4532'}</div>
       <div className="gt-card-footer"><span>DEMO CARD</span><strong>PREVIEW</strong></div>
       {frozen && <span className="gt-frozen-label">FROZEN</span>}
-      {onFreeze && <button className="gt-card-freeze" type="button" onClick={onFreeze}>{frozen ? 'Unfreeze' : 'Freeze'}</button>}
+      {onFreeze && <button className="gt-card-freeze" type="button" aria-pressed={frozen} onClick={onFreeze}>{frozen ? 'Unfreeze' : 'Freeze'}</button>}
     </article>
   );
 }
@@ -159,6 +159,22 @@ export default function GalacticApp({ galacticUser = null, demoAccess = false, o
   const activeCrypto = cryptoAssets.find((asset) => asset.symbol === cryptoSymbol) || cryptoAssets[0];
   const cryptoUsd = Number(cryptoAmount);
   const cryptoUnits = Number.isFinite(cryptoUsd) && cryptoUsd > 0 ? cryptoUsd / activeCrypto.price : 0;
+  const transferAmount = Number(transfer.amount);
+  const transferMin = sandboxConnected ? 1 : 0.01;
+  const transferMax = sandboxConnected ? 1000 : 10000;
+  const transferReady = Boolean(
+    transfer.recipient.trim()
+      && Number.isFinite(transferAmount)
+      && transferAmount >= transferMin
+      && transferAmount <= transferMax
+      && transferAmount <= checking
+  );
+  const cryptoTradeReady = Boolean(
+    Number.isFinite(cryptoUsd)
+      && cryptoUsd >= 1
+      && cryptoUsd <= 10000
+      && (cryptoSide !== 'sell' || cryptoUnits <= activeCrypto.holding)
+  );
   const spending = useMemo(() => transactions.filter((item) => item.amount < 0).reduce((sum, item) => sum + Math.abs(item.amount), 0), [transactions]);
   const spendingCategories = useMemo(() => {
     const totals = new Map();
@@ -371,9 +387,9 @@ export default function GalacticApp({ galacticUser = null, demoAccess = false, o
               <div className="gt-mode-banner"><span className="gt-mode-dot" /><b>{sandboxConnected ? 'INCREASE SANDBOX' : 'DEMO BANKING'}</b><span>{sandboxConnected ? 'Provider-backed test data with pretend money only. No real money moves.' : 'No real deposits are held and no real money moves in this build.'}</span></div>
               {sandboxNotice && galacticUser && <div className="gt-mode-banner"><span className="gt-mode-dot" /><b>SANDBOX STATUS</b><span>{sandboxNotice}</span></div>}
               <div className="gt-quick-actions">
-                <button type="button" onClick={() => openSheet('transfer')}><span className="gt-quick-icon send">↗</span><span><b>Transfer</b><small>{sandboxConnected ? 'Sandbox ACH' : 'Simulate transfer'}</small></span></button>
-                <button type="button" onClick={() => openSheet('add-money')}><span className="gt-quick-icon add">＋</span><span><b>Add Money</b><small>{sandboxConnected ? 'Sandbox inbound ACH' : 'Add demo funds'}</small></span></button>
-                <button type="button" onClick={() => { const next = !blueFrozen; setBlueFrozen(next); notify(next ? 'Demo card frozen.' : 'Demo card unfrozen.'); }}><span className="gt-quick-icon freeze">❄</span><span><b>{blueFrozen ? 'Unfreeze Card' : 'Freeze Card'}</b><small>Demo Nebula Blue</small></span></button>
+                <button type="button" disabled={sandboxBusy} onClick={() => openSheet('transfer')}><span className="gt-quick-icon send">↗</span><span><b>Transfer</b><small>{sandboxConnected ? 'Sandbox ACH' : 'Simulate transfer'}</small></span></button>
+                <button type="button" disabled={sandboxBusy} onClick={() => openSheet('add-money')}><span className="gt-quick-icon add">＋</span><span><b>Add Money</b><small>{sandboxConnected ? 'Sandbox inbound ACH' : 'Add demo funds'}</small></span></button>
+                <button type="button" aria-pressed={blueFrozen} onClick={() => { const next = !blueFrozen; setBlueFrozen(next); notify(next ? 'Demo card frozen.' : 'Demo card unfrozen.'); }}><span className="gt-quick-icon freeze">❄</span><span><b>{blueFrozen ? 'Unfreeze Card' : 'Freeze Card'}</b><small>Demo Nebula Blue</small></span></button>
                 <button type="button" onClick={() => document.getElementById('cards')?.scrollIntoView({ behavior: 'smooth' })}><span className="gt-quick-icon card">▤</span><span><b>View Card</b><small>Demo card preview</small></span></button>
               </div>
 
@@ -384,14 +400,14 @@ export default function GalacticApp({ galacticUser = null, demoAccess = false, o
                     <form onSubmit={submitTransfer}>
                       <label>Recipient<input value={transfer.recipient} onChange={(event) => setTransfer((current) => ({ ...current, recipient: event.target.value }))} maxLength={80} placeholder="Sandbox recipient name" /></label>
                       <label>Amount<div className="gt-money-input"><span>$</span><input type="number" min={sandboxConnected ? '1' : '0.01'} max={sandboxConnected ? '1000' : '10000'} step="0.01" value={transfer.amount} onChange={(event) => setTransfer((current) => ({ ...current, amount: event.target.value }))} placeholder="0.00" /></div></label>
-                      <button className="gt-primary" type="submit" disabled={sandboxBusy}>{sandboxBusy ? 'Processing sandbox…' : sandboxConnected ? 'Run Sandbox ACH' : 'Simulate Transfer'}</button>
+                      <button className="gt-primary" type="submit" disabled={sandboxBusy || !transferReady} aria-busy={sandboxBusy}>{sandboxBusy ? 'Processing sandbox…' : sandboxConnected ? 'Run Sandbox ACH' : 'Simulate Transfer'}</button>
                       <p>{sandboxConnected ? 'Routes only to Increase sandbox test coordinates. No real recipient or bank account is used.' : 'Demo transfers never move real money.'}</p>
                     </form>
                   ) : (
                     <div className="gt-funding-options">
-                      <button type="button" disabled={sandboxBusy} onClick={addDemoMoney}><span>▣</span><b>{sandboxConnected ? 'Increase sandbox ACH' : 'Bank transfer'}</b><small>{sandboxConnected ? 'Simulate +$500' : 'Add $500 demo funds'}</small></button>
-                      <button type="button" disabled={sandboxConnected || sandboxBusy} onClick={addDemoMoney}><span>▤</span><b>Debit card</b><small>{sandboxConnected ? 'Not wired to sandbox yet' : 'Simulated funding'}</small></button>
-                      <button type="button" disabled={sandboxConnected || sandboxBusy} onClick={addDemoMoney}><span>↯</span><b>Direct deposit</b><small>{sandboxConnected ? 'Not wired to sandbox yet' : 'Preview flow'}</small></button>
+                      <button type="button" disabled={sandboxBusy} aria-busy={sandboxBusy} onClick={addDemoMoney}><span>▣</span><b>{sandboxConnected ? 'Increase sandbox ACH' : 'Bank transfer'}</b><small>{sandboxBusy ? 'Processing sandbox…' : sandboxConnected ? 'Simulate +$500' : 'Add $500 demo funds'}</small></button>
+                      <button type="button" disabled={sandboxConnected || sandboxBusy} aria-busy={sandboxBusy} onClick={addDemoMoney}><span>▤</span><b>Debit card</b><small>{sandboxConnected ? 'Not wired to sandbox yet' : 'Simulated funding'}</small></button>
+                      <button type="button" disabled={sandboxConnected || sandboxBusy} aria-busy={sandboxBusy} onClick={addDemoMoney}><span>↯</span><b>Direct deposit</b><small>{sandboxConnected ? 'Not wired to sandbox yet' : 'Preview flow'}</small></button>
                     </div>
                   )}
                 </div>
@@ -445,7 +461,7 @@ export default function GalacticApp({ galacticUser = null, demoAccess = false, o
                 <div className="gt-trade-toggle"><button type="button" className={cryptoSide === 'buy' ? 'active' : ''} onClick={() => setCryptoSide('buy')}>Buy</button><button type="button" className={cryptoSide === 'sell' ? 'active' : ''} onClick={() => setCryptoSide('sell')}>Sell</button></div>
                 <label>Amount in USD<div className="gt-crypto-amount"><span>$</span><input type="number" min="1" max="10000" step="1" value={cryptoAmount} onChange={(event) => setCryptoAmount(event.target.value)} /></div></label>
                 <div className="gt-crypto-estimate"><span>Estimated {activeCrypto.symbol}</span><b>{cryptoUnits.toLocaleString(undefined, { maximumFractionDigits: activeCrypto.symbol === 'BTC' ? 8 : 6 })}</b></div>
-                <button className={`gt-crypto-submit ${cryptoSide}`} type="submit">Simulate {cryptoSide === 'buy' ? 'Buy' : 'Sell'} {activeCrypto.symbol}</button>
+                <button className={`gt-crypto-submit ${cryptoSide}`} type="submit" disabled={!cryptoTradeReady}>Simulate {cryptoSide === 'buy' ? 'Buy' : 'Sell'} {activeCrypto.symbol}</button>
               </form>
               <p className="gt-crypto-disclosure">Crypto trading is in demo mode. No real assets are purchased or sold. Crypto can lose value and returns are never guaranteed.</p>
             </section>

--- a/app/bank/GalacticCryptoPractice.js
+++ b/app/bank/GalacticCryptoPractice.js
@@ -56,6 +56,12 @@ export default function GalacticCryptoPractice() {
   const estimatedUnits = Number.isFinite(usd) && usd > 0 ? usd / active.price : 0;
   const holdingsValue = useMemo(() => assets.reduce((sum, asset) => sum + (asset.holding * asset.price), 0), [assets]);
   const practiceTotal = practiceCash + holdingsValue;
+  const practiceTradeReady = Boolean(
+    Number.isFinite(usd)
+      && usd >= 1
+      && usd <= 5000
+      && (side === 'buy' ? usd <= practiceCash : estimatedUnits <= active.holding)
+  );
 
   function submitTrade(event) {
     event.preventDefault();
@@ -132,15 +138,15 @@ export default function GalacticCryptoPractice() {
 
       <form className={styles.trade} onSubmit={submitTrade}>
         <div className={styles.toggle}>
-          <button type="button" className={side === 'buy' ? styles.activeToggle : ''} onClick={() => setSide('buy')}>Practice Buy</button>
-          <button type="button" className={side === 'sell' ? styles.activeToggle : ''} onClick={() => setSide('sell')}>Practice Sell</button>
+          <button type="button" className={side === 'buy' ? styles.activeToggle : ''} aria-pressed={side === 'buy'} onClick={() => setSide('buy')}>Practice Buy</button>
+          <button type="button" className={side === 'sell' ? styles.activeToggle : ''} aria-pressed={side === 'sell'} onClick={() => setSide('sell')}>Practice Sell</button>
         </div>
         <label>
           <span>Practice amount in USD</span>
           <div className={styles.amount}><span>$</span><input type="number" min="1" max="5000" step="1" value={amount} onChange={(event) => setAmount(event.target.value)} /></div>
         </label>
         <div className={styles.estimate}><span>Estimated {active.symbol}</span><b>{units(estimatedUnits, active.symbol)}</b></div>
-        <button className={styles.submit} type="submit">Simulate {side === 'buy' ? 'Buy' : 'Sell'} {active.symbol}</button>
+        <button className={styles.submit} type="submit" disabled={!practiceTradeReady}>Simulate {side === 'buy' ? 'Buy' : 'Sell'} {active.symbol}</button>
       </form>
 
       {notice && <p className={styles.notice} role="status">{notice}</p>}

--- a/app/bank/a11y.css
+++ b/app/bank/a11y.css
@@ -17,6 +17,13 @@
 .gt-app button:disabled,
 .gt-auth-page button:disabled {
   cursor: not-allowed;
+  opacity: 0.58;
+  transform: none !important;
+  box-shadow: none;
+}
+
+.gt-app button[aria-busy="true"] {
+  cursor: progress;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/scripts/test-galactic-trust-week3-polish.mjs
+++ b/scripts/test-galactic-trust-week3-polish.mjs
@@ -4,6 +4,9 @@ import { readFile } from 'node:fs/promises';
 const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhancements.js', import.meta.url), 'utf8');
 const polish = await readFile(new URL('../app/bank/week3-polish.css', import.meta.url), 'utf8');
 const page = await readFile(new URL('../app/bank/page.js', import.meta.url), 'utf8');
+const bankClient = await readFile(new URL('../app/bank/BankClient.js', import.meta.url), 'utf8');
+const cryptoPractice = await readFile(new URL('../app/bank/GalacticCryptoPractice.js', import.meta.url), 'utf8');
+const a11y = await readFile(new URL('../app/bank/a11y.css', import.meta.url), 'utf8');
 
 assert.match(enhancements, /event\.key === 'Escape'/, 'dashboard keyboard handling must include Escape');
 assert.match(enhancements, /\.gt-action-sheet \.gt-sheet-header > button/, 'Escape must close the existing transfer/add-money action sheet through its close control');
@@ -16,6 +19,24 @@ assert.match(polish, /@media\(max-width:620px\)/, 'mobile typography and spacing
 assert.match(polish, /env\(safe-area-inset-bottom\)/, 'mobile spacing must respect device safe areas');
 assert.match(polish, /\.gt-dashboard-header h1\{font-size:23px/, 'mobile heading typography must be intentionally tightened');
 assert.match(page, /import '\.\/week3-polish\.css'/, 'the dashboard must load the Week 3 polish styles');
-assert.equal(enhancements.includes('real money moved'), false, 'polish code must not introduce misleading real-money success claims');
 
-console.log('Galactic Trust Week 3 polish checks passed: action sheets support Escape, Recent Activity has demo-safe filters, and responsive typography/spacing is intentionally tightened.');
+assert.match(bankClient, /const transferReady = Boolean\(/, 'transfer form must derive a ready state before enabling submission');
+assert.match(bankClient, /transferAmount <= checking/, 'transfer ready state must reject amounts above the currently loaded checking balance');
+assert.match(bankClient, /disabled=\{sandboxBusy \|\| !transferReady\}/, 'transfer submit must stay disabled while invalid or while a sandbox request is running');
+assert.match(bankClient, /aria-busy=\{sandboxBusy\}/, 'sandbox primary actions must expose their busy state');
+assert.match(bankClient, /aria-pressed=\{blueFrozen\}/, 'quick freeze control must expose its current demo frozen state');
+assert.match(bankClient, /aria-pressed=\{frozen\}/, 'card freeze controls must expose their current demo frozen state');
+assert.match(bankClient, /const cryptoTradeReady = Boolean\(/, 'dashboard demo crypto must derive whether a simulated order is possible');
+assert.match(bankClient, /disabled=\{!cryptoTradeReady\}/, 'dashboard demo crypto submit must be disabled for invalid or impossible simulated trades');
+
+assert.match(cryptoPractice, /const practiceTradeReady = Boolean\(/, 'isolated crypto practice must derive a valid trade state');
+assert.match(cryptoPractice, /side === 'buy' \? usd <= practiceCash : estimatedUnits <= active\.holding/, 'practice trade readiness must respect both demo cash and demo holdings');
+assert.match(cryptoPractice, /disabled=\{!practiceTradeReady\}/, 'practice crypto submit must disable impossible simulated trades');
+assert.match(cryptoPractice, /aria-pressed=\{side === 'buy'\}/, 'practice buy/sell toggle must expose pressed state');
+
+assert.match(a11y, /button:disabled[^]*opacity: 0\.58/, 'disabled actions must have a visible shared disabled state');
+assert.match(a11y, /button\[aria-busy="true"\][^]*cursor: progress/, 'busy sandbox actions must have a consistent progress affordance');
+assert.equal(enhancements.includes('real money moved'), false, 'polish code must not introduce misleading real-money success claims');
+assert.equal(bankClient.includes('real money was transferred'), false, 'action-state polish must not introduce live-money claims');
+
+console.log('Galactic Trust Week 3 polish checks passed: action sheets support Escape, Recent Activity has demo-safe filters, responsive typography is tightened, and primary transfer/funding/freeze/crypto controls expose honest disabled, busy, or pressed states.');


### PR DESCRIPTION
Closes #627

Ships slice 34 using existing Galactic Trust controls and CSS only.

- Disables transfer submission until recipient, amount limits, and current checking balance are valid; keeps server-side validation as defense in depth.
- Exposes the real Increase sandbox busy state on transfer and funding actions and prevents opening competing transfer/add-money actions while a sandbox call is running.
- Adds `aria-pressed` to demo freeze/unfreeze controls instead of inventing loading for instant local state.
- Disables invalid/impossible simulated crypto trades in both the dashboard demo form and the isolated crypto-practice panel.
- Adds a consistent visible disabled state and progress cursor for `aria-busy` controls.
- Extends the existing Week 3 regression test.

No real-money or live-crypto capability is introduced. Increase remains sandbox/pretend money only and production remains locked.