### PR TITLE
Make hosted sandbox setup defer to Account-only recovery

### DIFF
--- a/app/bank/GalacticSandboxSetup.js
+++ b/app/bank/GalacticSandboxSetup.js
@@ -104,6 +104,7 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
   const [onboardingRequestOk, setOnboardingRequestOk] = useState(true);
   const [providerMessage, setProviderMessage] = useState('');
   const [providerNextStep, setProviderNextStep] = useState('');
+  const [recoveryOwnsSetup, setRecoveryOwnsSetup] = useState(false);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -147,15 +148,20 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
         cache: 'no-store',
         headers: authHeaders(accessToken),
       }),
-    ]).then(async ([statusResponse, onboardingResponse]) => {
+      fetch('/api/admin/bank/increase/recovery', {
+        cache: 'no-store',
+        headers: authHeaders(accessToken),
+      }),
+    ]).then(async ([statusResponse, onboardingResponse, recoveryResponse]) => {
       if (!active) return;
-      if (statusResponse.status === 403 || onboardingResponse.status === 403) {
+      if (statusResponse.status === 403 || onboardingResponse.status === 403 || recoveryResponse.status === 403) {
         setAuthorized(false);
         return;
       }
-      const [statusPayload, onboardingPayload] = await Promise.all([
+      const [statusPayload, onboardingPayload, recoveryPayload] = await Promise.all([
         statusResponse.json().catch(() => ({})),
         onboardingResponse.json().catch(() => ({})),
+        recoveryResponse.json().catch(() => ({})),
       ]);
       if (!active) return;
       setAuthorized(Boolean(statusPayload?.authorized && onboardingPayload?.authorized));
@@ -166,6 +172,11 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
       setOnboardingRequestOk(onboardingResponse.ok);
       setProviderMessage(String(onboardingPayload?.error || statusPayload?.error || ''));
       setProviderNextStep(String(onboardingPayload?.nextStep || statusPayload?.nextStep || ''));
+      setRecoveryOwnsSetup(Boolean(
+        !returnedEntity
+          && recoveryResponse.ok
+          && (recoveryPayload?.binding?.status === 'verified' || recoveryPayload?.recoveryAvailable)
+      ));
       const nextPrograms = Array.isArray(onboardingPayload?.programs) ? onboardingPayload.programs : [];
       setPrograms(nextPrograms);
       if (nextPrograms.length === 1) setProgramId(nextPrograms[0].id);
@@ -238,7 +249,7 @@ export default function GalacticSandboxSetup({ accessToken = '' }) {
     }
   }
 
-  if (!accessToken || authorized !== true) return null;
+  if (!accessToken || authorized !== true || recoveryOwnsSetup) return null;
   if (!returnedFromOnboarding && connected && accountCount > 0 && bindingReady) return null;
 
   const canStartOwnerOnboarding = connected && onboardingReady && !returnedFromOnboarding && !needsBindingStorage && (needsAccount || needsBinding);

--- a/scripts/test-galactic-trust-recovery-takeover.mjs
+++ b/scripts/test-galactic-trust-recovery-takeover.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 const source = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
+const legacySetup = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
 
 assert.match(source, /const connected = Boolean\(statusResponse\.ok && status\?\.connected\)/, 'recovery takeover must require a confirmed Increase sandbox Accounts connection');
 assert.match(source, /recoveryResponse\.ok &&\s*recovery\?\.recoveryAvailable/, 'recovery takeover must honor the owner recovery endpoint instead of depending only on hosted-onboarding capability detection');
@@ -12,4 +13,11 @@ assert.match(source, /SANDBOX_ACCOUNT_ONLY/, 'the UI must preserve the account-o
 assert.match(source, /Production money movement remains locked/, 'the recovery flow must remain fail-closed for real money');
 assert.equal(source.includes('NEXT_PUBLIC_INCREASE'), false, 'the recovery UI must never depend on browser-exposed Increase credentials');
 
-console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use the dedicated Account-only recovery path without waiting for hosted-onboarding private-feature detection.');
+assert.match(legacySetup, /fetch\('\/api\/admin\/bank\/increase\/recovery'/, 'legacy hosted setup must consult the owner recovery endpoint directly');
+assert.match(legacySetup, /const \[statusPayload, onboardingPayload, recoveryPayload\]/, 'legacy setup must evaluate recovery status alongside its own read-only setup status');
+assert.match(legacySetup, /recoveryPayload\?\.binding\?\.status === 'verified' \|\| recoveryPayload\?\.recoveryAvailable/, 'verified or available owner recovery must own setup');
+assert.match(legacySetup, /if \(!accessToken \|\| authorized !== true \|\| recoveryOwnsSetup\) return null;/, 'legacy hosted setup must render nothing when Account-only recovery owns the flow');
+assert.match(legacySetup, /!returnedEntity/, 'a user returning from an already-started hosted onboarding session must still be allowed to finish that explicit flow');
+assert.equal(legacySetup.includes('NEXT_PUBLIC_INCREASE'), false, 'legacy setup must not introduce browser-exposed provider credentials');
+
+console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use the dedicated Account-only recovery path, and the legacy hosted-onboarding panel directly defers to that path instead of racing it.');


### PR DESCRIPTION
Closes #629

Hardens the exact owner setup screen that was still surfacing the hosted-onboarding private-feature blocker.

- `GalacticSandboxSetup` now reads `/api/admin/bank/increase/recovery` alongside its existing status/onboarding reads.
- When owner Account-only recovery is already verified or is available, the legacy hosted-onboarding component renders nothing and lets `GalacticIncreaseSandboxRecovery` own the flow directly.
- This eliminates the render race/flash that could still show `Start hosted sandbox onboarding` and `Enable the feature in Increase` even though the safer recovery path was available.
- A user returning from an explicitly started hosted onboarding session is not interrupted and can finish that path.
- Extends the dedicated recovery-takeover regression test.

No production banking capability is enabled. Account-only recovery remains `SANDBOX_ACCOUNT_ONLY`, hosted sandbox simulation remains distinct, provider secrets remain server-only, and all money remains pretend sandbox data.