### PR TITLE
Harden Increase Account-only recovery flow

### DIFF
--- a/app/api/admin/bank/increase/recovery/route.ts
+++ b/app/api/admin/bank/increase/recovery/route.ts
@@ -30,8 +30,9 @@ export async function GET(request: Request) {
   const auth = await requireGalacticTrustAdmin(request);
   if (auth.ok === false) return response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status);
 
+  let state: any = null;
   try {
-    const state = await bindingState(auth);
+    state = await bindingState(auth);
     const recovery = state.binding ? null : await getIncreaseSandboxOwnerRecoveryAccount(auth.user.id, process.env);
     const binding = state.binding
       ? publicBindingSummary(state.binding)
@@ -61,6 +62,8 @@ export async function GET(request: Request) {
       environment: 'sandbox',
       recoveryAvailable: false,
       setupRequired: true,
+      bindingStorageReady: state ? !state.setupRequired : false,
+      bindingStorageIssue: state?.setupRequired ? (state.error || 'Trusted provider-binding storage is not installed yet.') : '',
       canMoveRealMoney: false,
       providerStatus: provider.providerStatus,
       providerType: provider.providerType,
@@ -93,7 +96,7 @@ export async function POST(request: Request) {
 
     const recovered = await recoverIncreaseSandboxOwnerAccount(auth.user.id, process.env);
     let binding = null;
-    let bindingStorageReady = !before.setupRequired;
+    const bindingStorageReady = !before.setupRequired;
 
     if (bindingStorageReady) {
       const storedBinding = await bindIncreaseSandboxAccountOnly(auth.admin, auth.user.id, {
@@ -119,6 +122,8 @@ export async function POST(request: Request) {
       accountCreated: recovered.accountCreated,
       accountNumberReady: Boolean(recovered.accountNumber?.ready),
       accountNumberIssue: recovered.accountNumberIssue || '',
+      dashboardReady: Boolean(recovered.dashboard),
+      dashboardIssue: recovered.dashboardIssue || '',
       dashboard: recovered.dashboard,
       canMoveRealMoney: false,
       note: recovered.note,

--- a/app/bank/GalacticIncreaseSandboxRecovery.js
+++ b/app/bank/GalacticIncreaseSandboxRecovery.js
@@ -31,7 +31,8 @@ export default function GalacticIncreaseSandboxRecovery() {
   const [message, setMessage] = useState('');
   const [accountCount, setAccountCount] = useState(0);
   const [recoveryAvailable, setRecoveryAvailable] = useState(false);
-  const [bindingStorageBlocked, setBindingStorageBlocked] = useState(false);
+  const [bindingStorageReady, setBindingStorageReady] = useState(true);
+  const [bindingStorageIssue, setBindingStorageIssue] = useState('');
   const [restrictionDetected, setRestrictionDetected] = useState(false);
 
   useEffect(() => {
@@ -72,30 +73,25 @@ export default function GalacticIncreaseSandboxRecovery() {
 
         const connected = Boolean(statusResponse.ok && status?.connected);
         const privateFeatureBlocked = connected && hasPrivateFeatureRestriction(status);
-        const storageBlocked = Boolean(recovery?.setupRequired);
         const canRecover = Boolean(
           connected &&
           recoveryResponse.ok &&
-          recovery?.recoveryAvailable &&
-          !storageBlocked
+          recovery?.recoveryAvailable
         );
 
-        // Account-only recovery is intentionally not coupled to hosted-onboarding capability
-        // detection. Increase can permit Programs/Entities reads while rejecting the hosted
-        // onboarding session itself as a private feature. If Accounts are connected and the
-        // owner recovery route confirms a safe dedicated Account can be created, prefer that
-        // path immediately instead of leaving the owner trapped behind hosted onboarding.
+        // Account-only recovery is intentionally independent from the optional provider-binding
+        // migration. When durable database storage is absent, the server can safely derive the
+        // owner scope from the verified user ID plus Increase idempotency-key lookup instead.
         if (!canRecover && !privateFeatureBlocked) return;
 
         setAccountCount(Number(status?.counts?.accounts || 0));
-        setBindingStorageBlocked(storageBlocked);
+        setBindingStorageReady(recovery?.bindingStorageReady !== false);
+        setBindingStorageIssue(String(recovery?.bindingStorageIssue || ''));
         setRestrictionDetected(privateFeatureBlocked);
         setRecoveryAvailable(canRecover);
-        setMessage(storageBlocked
-          ? String(recovery?.error || 'Trusted provider binding storage is not installed yet. Galactic Trust cannot safely bind the Increase sandbox Account until the required Supabase migration is applied.')
-          : canRecover
-            ? ''
-            : String(recovery?.nextStep || recovery?.error || status?.nextStep || 'Owner sandbox Account recovery is not available yet.'));
+        setMessage(canRecover
+          ? ''
+          : String(recovery?.nextStep || recovery?.error || status?.nextStep || 'Owner sandbox Account recovery is not available yet.'));
         setVisible(true);
         takeOverLegacySetup();
       } catch {
@@ -136,10 +132,11 @@ export default function GalacticIncreaseSandboxRecovery() {
 
   if (!visible) return null;
 
-  const storageTitle = 'Galactic Trust database setup is the blocker.';
-  const recoveryTitle = restrictionDetected
-    ? 'We can bypass the blocked hosted-onboarding feature.'
-    : 'Create your dedicated sandbox test account.';
+  const recoveryTitle = recoveryAvailable
+    ? restrictionDetected
+      ? 'We can bypass the blocked hosted-onboarding feature.'
+      : 'Create your dedicated sandbox test account.'
+    : 'Account-only sandbox recovery needs attention.';
 
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label="Increase sandbox recovery">
@@ -148,43 +145,40 @@ export default function GalacticIncreaseSandboxRecovery() {
         <div className={styles.titleRow}>
           <span className={styles.icon}>🪐</span>
           <div>
-            <h2>{bindingStorageBlocked ? storageTitle : recoveryTitle}</h2>
-            <p>{bindingStorageBlocked
-              ? 'Increase Accounts access is connected. The restricted hosted-onboarding feature is no longer the actionable blocker; trusted provider-binding storage must be installed before Galactic Trust can safely attach a sandbox Account to your signed-in user.'
-              : restrictionDetected
+            <h2>{recoveryTitle}</h2>
+            <p>{recoveryAvailable
+              ? restrictionDetected
                 ? 'Increase Accounts access is connected. Galactic Trust can create a dedicated owner test Account without requiring the restricted Programs/Entities onboarding screen.'
-                : 'Increase Accounts access is connected and the owner recovery endpoint is ready. Galactic Trust can create a dedicated owner test Account without relying on hosted onboarding.'}</p>
+                : 'Increase Accounts access is connected and the owner recovery endpoint is ready. Galactic Trust can create a dedicated owner test Account without relying on hosted onboarding.'
+              : 'Increase Accounts is connected, but the dedicated owner recovery endpoint reported a provider or configuration issue. The message below shows the next actionable step.'}</p>
           </div>
         </div>
 
         <div className={styles.boundary}>
-          <strong>{bindingStorageBlocked ? 'What needs to happen' : 'What this does'}</strong>
+          <strong>What this path does</strong>
           <ul>
-            {bindingStorageBlocked ? (
-              <>
-                <li>Apply the pending Galactic Trust Supabase provider-binding migration, including migration 025.</li>
-                <li>Keep database credentials in GitHub Actions secrets only; never paste them into chat or client code.</li>
-                <li>After the migration is actually applied, this panel will offer the one-click Increase sandbox Account recovery automatically.</li>
-              </>
-            ) : (
-              <>
-                <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
-                <li>Scopes only that dedicated Account to your Galactic Trust user on the server.</li>
-                <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
-              </>
-            )}
+            <li>Creates or reuses one idempotent Increase sandbox checking Account for your signed-in owner.</li>
+            <li>Scopes only that dedicated Account to your Galactic Trust user on the server.</li>
+            <li>Keeps all balances and ACH activity pretend-money sandbox data.</li>
           </ul>
         </div>
+
+        {!bindingStorageReady && (
+          <div className={styles.notKyc}>
+            <span>💾</span>
+            <p><b>Durable database binding is optional for this sandbox recovery.</b> {bindingStorageIssue || 'Galactic Trust will use the verified owner ID plus Increase idempotency-key lookup until provider-binding storage is installed.'}</p>
+          </div>
+        )}
 
         <div className={styles.notKyc}>
           <span>🔒</span>
           <p><b>This is not KYC or a real bank account.</b> Account-only recovery is stored as <code>SANDBOX_ACCOUNT_ONLY</code>. Production money movement remains locked.</p>
         </div>
 
-        {!bindingStorageBlocked && accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates/reuses a dedicated owner-scoped Account instead.</p>}
+        {accountCount > 0 && <p className={styles.existing}>Existing unbound sandbox Accounts will not be adopted automatically; recovery creates/reuses a dedicated owner-scoped Account instead.</p>}
 
         {recoveryAvailable && (
-          <button className={styles.primary} type="button" onClick={recover} disabled={busy}>
+          <button className={styles.primary} type="button" onClick={recover} disabled={busy} aria-busy={busy}>
             {busy ? 'Creating sandbox test account…' : 'Create sandbox test account'}
           </button>
         )}

--- a/lib/banking/increase-sandbox-recovery.js
+++ b/lib/banking/increase-sandbox-recovery.js
@@ -126,7 +126,7 @@ export async function getIncreaseSandboxOwnerRecoveryAccount(userId, env = proce
 
 export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.env) {
   assertRecoveryConfig(env);
-  const { account, accountId, entityId, accountName, created } = await findOrCreateRecoveryAccount(userId, env);
+  const { accountId, entityId, accountName, created } = await findOrCreateRecoveryAccount(userId, env);
 
   let accountNumber = { ready: false, created: false, status: 'unavailable' };
   let accountNumberIssue = '';
@@ -136,7 +136,14 @@ export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.e
     accountNumberIssue = error instanceof Error ? error.message : 'Increase sandbox account-number setup needs attention.';
   }
 
-  const dashboard = await getIncreaseSandboxDashboardForAccount(accountId, env);
+  let dashboard = null;
+  let dashboardIssue = '';
+  try {
+    dashboard = await getIncreaseSandboxDashboardForAccount(accountId, env);
+  } catch (error) {
+    dashboardIssue = error instanceof Error ? error.message : 'Increase sandbox dashboard refresh needs attention.';
+  }
+
   return {
     provider: 'Increase',
     environment: 'sandbox',
@@ -149,6 +156,7 @@ export async function recoverIncreaseSandboxOwnerAccount(userId, env = process.e
     accountNumber,
     accountNumberIssue,
     dashboard,
+    dashboardIssue,
     note: 'Account-only Increase sandbox recovery. The owner scope is derived server-side from the verified Galactic Trust user ID and an Increase idempotency key; hosted Entity onboarding and KYC simulation were not used. This is pretend money only and cannot enable production banking.',
   };
 }

--- a/scripts/test-galactic-trust-recovery-takeover.mjs
+++ b/scripts/test-galactic-trust-recovery-takeover.mjs
@@ -3,15 +3,23 @@ import { readFile } from 'node:fs/promises';
 
 const source = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
 const legacySetup = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
+const recoveryRoute = await readFile(new URL('../app/api/admin/bank/increase/recovery/route.ts', import.meta.url), 'utf8');
 
 assert.match(source, /const connected = Boolean\(statusResponse\.ok && status\?\.connected\)/, 'recovery takeover must require a confirmed Increase sandbox Accounts connection');
 assert.match(source, /recoveryResponse\.ok &&\s*recovery\?\.recoveryAvailable/, 'recovery takeover must honor the owner recovery endpoint instead of depending only on hosted-onboarding capability detection');
 assert.match(source, /if \(!canRecover && !privateFeatureBlocked\) return;/, 'safe owner recovery must be allowed even when the status snapshot itself did not report a private_feature_error');
+assert.equal(source.includes('!storageBlocked'), false, 'provider-binding storage must not gate Account-only recovery');
+assert.match(source, /Durable database binding is optional for this sandbox recovery/, 'the UI must explain that durable database binding is optional for owner sandbox recovery');
 assert.match(source, /takeOverLegacySetup\(\)/, 'the recovery UI must hide the legacy hosted-onboarding blocker when it owns the setup state');
 assert.match(source, /Create sandbox test account/, 'the owner must get a direct sandbox Account recovery action');
+assert.match(source, /aria-busy=\{busy\}/, 'the recovery action must expose its busy state accessibly');
 assert.match(source, /SANDBOX_ACCOUNT_ONLY/, 'the UI must preserve the account-only, non-KYC marker');
 assert.match(source, /Production money movement remains locked/, 'the recovery flow must remain fail-closed for real money');
 assert.equal(source.includes('NEXT_PUBLIC_INCREASE'), false, 'the recovery UI must never depend on browser-exposed Increase credentials');
+
+assert.match(recoveryRoute, /bindingStorageReady: state \? !state\.setupRequired : false/, 'recovery status errors must distinguish provider trouble from durable binding-storage readiness');
+assert.match(recoveryRoute, /dashboardReady: Boolean\(recovered\.dashboard\)/, 'recovery POST must report whether the owner sandbox dashboard was immediately readable');
+assert.match(recoveryRoute, /canMoveRealMoney: false/, 'recovery API must remain sandbox-only and fail-closed for real money');
 
 assert.match(legacySetup, /fetch\('\/api\/admin\/bank\/increase\/recovery'/, 'legacy hosted setup must consult the owner recovery endpoint directly');
 assert.match(legacySetup, /const \[statusPayload, onboardingPayload, recoveryPayload\]/, 'legacy setup must evaluate recovery status alongside its own read-only setup status');
@@ -20,4 +28,4 @@ assert.match(legacySetup, /if \(!accessToken \|\| authorized !== true \|\| recov
 assert.match(legacySetup, /!returnedEntity/, 'a user returning from an already-started hosted onboarding session must still be allowed to finish that explicit flow');
 assert.equal(legacySetup.includes('NEXT_PUBLIC_INCREASE'), false, 'legacy setup must not introduce browser-exposed provider credentials');
 
-console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use the dedicated Account-only recovery path, and the legacy hosted-onboarding panel directly defers to that path instead of racing it.');
+console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use database-independent Account-only recovery, provider failures remain distinguishable, and the legacy hosted-onboarding panel defers to the dedicated owner path.');

--- a/scripts/test-galactic-trust-recovery-takeover.mjs
+++ b/scripts/test-galactic-trust-recovery-takeover.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 const source = await readFile(new URL('../app/bank/GalacticIncreaseSandboxRecovery.js', import.meta.url), 'utf8');
 const legacySetup = await readFile(new URL('../app/bank/GalacticSandboxSetup.js', import.meta.url), 'utf8');
 const recoveryRoute = await readFile(new URL('../app/api/admin/bank/increase/recovery/route.ts', import.meta.url), 'utf8');
+const recoveryLibrary = await readFile(new URL('../lib/banking/increase-sandbox-recovery.js', import.meta.url), 'utf8');
 
 assert.match(source, /const connected = Boolean\(statusResponse\.ok && status\?\.connected\)/, 'recovery takeover must require a confirmed Increase sandbox Accounts connection');
 assert.match(source, /recoveryResponse\.ok &&\s*recovery\?\.recoveryAvailable/, 'recovery takeover must honor the owner recovery endpoint instead of depending only on hosted-onboarding capability detection');
@@ -21,6 +22,10 @@ assert.match(recoveryRoute, /bindingStorageReady: state \? !state\.setupRequired
 assert.match(recoveryRoute, /dashboardReady: Boolean\(recovered\.dashboard\)/, 'recovery POST must report whether the owner sandbox dashboard was immediately readable');
 assert.match(recoveryRoute, /canMoveRealMoney: false/, 'recovery API must remain sandbox-only and fail-closed for real money');
 
+assert.match(recoveryLibrary, /let dashboard = null;/, 'dashboard enrichment must start as optional after the owner Account is created or recovered');
+assert.match(recoveryLibrary, /try \{\s*dashboard = await getIncreaseSandboxDashboardForAccount\(accountId, env\);\s*\} catch \(error\)/, 'dashboard refresh failures must not roll back a successfully recovered owner Account');
+assert.match(recoveryLibrary, /dashboardIssue,/, 'non-blocking dashboard refresh trouble must be reported to the server response');
+
 assert.match(legacySetup, /fetch\('\/api\/admin\/bank\/increase\/recovery'/, 'legacy hosted setup must consult the owner recovery endpoint directly');
 assert.match(legacySetup, /const \[statusPayload, onboardingPayload, recoveryPayload\]/, 'legacy setup must evaluate recovery status alongside its own read-only setup status');
 assert.match(legacySetup, /recoveryPayload\?\.binding\?\.status === 'verified' \|\| recoveryPayload\?\.recoveryAvailable/, 'verified or available owner recovery must own setup');
@@ -28,4 +33,4 @@ assert.match(legacySetup, /if \(!accessToken \|\| authorized !== true \|\| recov
 assert.match(legacySetup, /!returnedEntity/, 'a user returning from an already-started hosted onboarding session must still be allowed to finish that explicit flow');
 assert.equal(legacySetup.includes('NEXT_PUBLIC_INCREASE'), false, 'legacy setup must not introduce browser-exposed provider credentials');
 
-console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use database-independent Account-only recovery, provider failures remain distinguishable, and the legacy hosted-onboarding panel defers to the dedicated owner path.');
+console.log('Galactic Trust recovery takeover regression passed: connected owner sandbox Accounts can use database-independent Account-only recovery, dashboard enrichment is non-blocking, provider failures remain distinguishable, and the legacy hosted-onboarding panel defers to the dedicated owner path.');


### PR DESCRIPTION
Tightens the owner-only Increase sandbox recovery path without weakening the production lock.

What changed:
- removes the stale UI assumption that missing provider-binding storage blocks Account-only sandbox recovery
- keeps durable database binding optional in sandbox by relying on the verified owner ID + Increase idempotency-key fallback when needed
- distinguishes provider/configuration recovery failures from binding-storage readiness
- makes post-recovery dashboard enrichment non-blocking so an already-created owner sandbox Account is not treated as a failed recovery just because a follow-up read needs attention
- exposes the recovery button busy state accessibly
- extends recovery takeover regression coverage to lock in these invariants

Safety boundary:
- sandbox only
- no browser-exposed Increase credentials
- SANDBOX_ACCOUNT_ONLY remains explicitly non-KYC
- canMoveRealMoney remains false