### PR TITLE
Scope Increase reconciliation to owner sandbox account

### DIFF
--- a/app/api/admin/bank/increase/dashboard/route.ts
+++ b/app/api/admin/bank/increase/dashboard/route.ts
@@ -44,7 +44,14 @@ export async function GET(request: Request) {
   let reconciliationBackstop: any = null;
   let automationIssue: string | null = null;
   try { webhookAutomation = await ensureIncreaseSandboxWebhookSubscription(process.env); } catch { automationIssue = 'Increase sandbox webhook subscription needs attention.'; }
-  try { reconciliationBackstop = await pollIncreaseSandboxEvents({ maxPages: 2 }); } catch { automationIssue = automationIssue || 'Increase sandbox reconciliation backstop needs attention.'; }
+  try {
+    reconciliationBackstop = await pollIncreaseSandboxEvents({
+      accountId: resolution.accountId,
+      maxPages: 2,
+    });
+  } catch {
+    automationIssue = automationIssue || 'Increase sandbox reconciliation backstop needs attention.';
+  }
 
   try {
     const snapshot = await getIncreaseSandboxDashboardForAccount(resolution.accountId, process.env);
@@ -59,7 +66,7 @@ export async function GET(request: Request) {
       webhookAutomation,
       reconciliationBackstop,
       automationIssue,
-      note: 'Increase sandbox data is scoped server-side to this signed-in Galactic Trust owner through either trusted database binding storage or the owner-specific Increase idempotency key. Values are pretend money only.',
+      note: 'Increase sandbox data and reconciliation are scoped server-side to this signed-in Galactic Trust owner through either trusted database binding storage or the owner-specific Increase idempotency key. Values are pretend money only.',
     });
   } catch (error: any) {
     const provider = describeIncreaseSandboxError(error, error instanceof Error ? error.message : 'Increase sandbox dashboard sync failed.');

--- a/app/api/admin/bank/increase/reconciliation/route.ts
+++ b/app/api/admin/bank/increase/reconciliation/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
+import { resolveIncreaseSandboxOwnerAccount } from '../../../../../../lib/banking/increase-owner-account.js';
 import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../../lib/banking/increase-webhook-subscription.js';
 import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents } from '../../../../../../lib/banking/increase-reconciliation';
 
@@ -13,28 +14,82 @@ function response(data: any, status = 200) {
 async function authorize(request: Request) {
   const auth = await requireGalacticTrustAdmin(request);
   if (auth.ok === false) return { ok: false as const, response: response({ ok: false, error: auth.error, setupRequired: auth.setupRequired || false }, auth.status) };
-  return { ok: true as const };
+  return { ok: true as const, auth };
+}
+
+async function ownerScope(auth: any) {
+  const resolution = await resolveIncreaseSandboxOwnerAccount(auth.admin, auth.user.id, process.env);
+  if (!resolution.accountId) {
+    return {
+      ok: false as const,
+      response: response({
+        ok: false,
+        authorized: true,
+        provider: 'Increase',
+        environment: 'sandbox',
+        canMoveRealMoney: false,
+        recoveryAvailable: true,
+        error: 'No owner-scoped Increase sandbox Account exists yet. Create the sandbox test account before reconciliation.',
+      }, 409),
+    };
+  }
+  return { ok: true as const, resolution };
 }
 
 export async function GET(request: Request) {
-  const auth = await authorize(request);
-  if (!auth.ok) return auth.response;
+  const authorized = await authorize(request);
+  if (!authorized.ok) return authorized.response;
+
   try {
-    const [subscription, reconciliation] = await Promise.all([ensureIncreaseSandboxWebhookSubscription(process.env), getIncreaseReconciliationStatus()]);
-    return response({ ok: true, authorized: true, provider: 'Increase', environment: 'sandbox', canMoveRealMoney: false, subscription, reconciliation });
+    const scope = await ownerScope(authorized.auth);
+    if (!scope.ok) return scope.response;
+    const [subscription, reconciliation] = await Promise.all([
+      ensureIncreaseSandboxWebhookSubscription(process.env),
+      getIncreaseReconciliationStatus(),
+    ]);
+    return response({
+      ok: true,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      scope: 'owner-account',
+      binding: scope.resolution.binding,
+      subscription,
+      reconciliation,
+    });
   } catch {
     return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', canMoveRealMoney: false, error: 'Increase sandbox reconciliation status is unavailable.' }, 502);
   }
 }
 
 export async function POST(request: Request) {
-  const auth = await authorize(request);
-  if (!auth.ok) return auth.response;
+  const authorized = await authorize(request);
+  if (!authorized.ok) return authorized.response;
+
   try {
+    const scope = await ownerScope(authorized.auth);
+    if (!scope.ok) return scope.response;
     const subscription = await ensureIncreaseSandboxWebhookSubscription(process.env);
-    const backstop = await pollIncreaseSandboxEvents({ maxPages: 5, forceReconcile: true });
+    const backstop = await pollIncreaseSandboxEvents({
+      accountId: scope.resolution.accountId,
+      maxPages: 5,
+      forceReconcile: true,
+    });
     const reconciliation = await getIncreaseReconciliationStatus();
-    return response({ ok: true, authorized: true, provider: 'Increase', environment: 'sandbox', canMoveRealMoney: false, subscription, backstop, reconciliation, note: 'Provider Events were polled oldest-first and the sandbox snapshot was reconciled. No real money moved.' });
+    return response({
+      ok: true,
+      authorized: true,
+      provider: 'Increase',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      scope: 'owner-account',
+      binding: scope.resolution.binding,
+      subscription,
+      backstop,
+      reconciliation,
+      note: 'Provider Events were polled oldest-first and only the signed-in owner sandbox Account snapshot was reconciled. No real money moved.',
+    });
   } catch {
     return response({ ok: false, authorized: true, provider: 'Increase', environment: 'sandbox', canMoveRealMoney: false, error: 'Increase sandbox reconciliation failed.' }, 502);
   }

--- a/app/api/admin/bank/integration-health/route.ts
+++ b/app/api/admin/bank/integration-health/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { requireGalacticTrustAdmin } from '../../../../../lib/admin-auth';
 import { describeIncreaseSandboxError } from '../../../../../lib/banking/increase-api-errors.js';
 import { inspectIncreaseSandboxOnboarding } from '../../../../../lib/banking/increase-onboarding-sandbox.js';
+import { resolveIncreaseSandboxOwnerAccount } from '../../../../../lib/banking/increase-owner-account.js';
 import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents } from '../../../../../lib/banking/increase-reconciliation';
 import { getIncreaseSandboxConfig, inspectIncreaseSandbox } from '../../../../../lib/banking/increase-sandbox.js';
 import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../lib/banking/increase-webhook-subscription.js';
@@ -103,7 +104,7 @@ async function buildHealth(auth: any) {
           entities: safeCapability(snapshot?.capabilities?.entities),
         },
         nextStep: restricted.length
-          ? `Increase sandbox is connected for Accounts, but ${restricted.join(' and ')} access is restricted. Use a sandbox key with the required permissions before owner onboarding.`
+          ? `Increase sandbox is connected for Accounts, but ${restricted.join(' and ')} access is restricted. Use the owner Account-only recovery path when hosted onboarding is unavailable.`
           : '',
       };
     } catch (error: any) {
@@ -118,7 +119,7 @@ async function buildHealth(auth: any) {
     validationKind: 'none',
     accountSuffix: '',
     verifiedAt: null,
-    nextStep: 'Complete owner-scoped Increase sandbox onboarding after the provider and binding migrations are ready.',
+    nextStep: 'Create the dedicated owner-scoped Increase sandbox test account.',
   };
   try {
     const state = await getProviderAccountBinding(auth.admin, auth.user.id, { provider: 'increase', environment: 'sandbox' });
@@ -131,17 +132,17 @@ async function buildHealth(auth: any) {
       accountSuffix: summary?.accountSuffix || '',
       verifiedAt: summary?.verifiedAt || null,
       nextStep: state.setupRequired
-        ? 'Apply the Galactic Trust provider-binding migrations before binding an Increase sandbox test account.'
+        ? 'Durable provider-binding storage is pending; Account-only recovery can still use the verified owner ID plus Increase idempotency-key scope.'
         : summary
           ? ''
-          : 'Complete owner-scoped Increase sandbox onboarding to bind a test account to this signed-in owner.',
+          : 'Create the dedicated owner-scoped Increase sandbox test account.',
     };
   } catch {
     binding = {
       ...binding,
       storageReady: false,
       status: 'unavailable',
-      nextStep: 'Verify the Supabase service-role configuration and Galactic Trust provider-binding migrations.',
+      nextStep: 'Verify the Supabase service-role configuration. Account-only recovery remains separate from production banking.',
     };
   }
 
@@ -149,7 +150,7 @@ async function buildHealth(auth: any) {
     available: false,
     programCount: 0,
     setupRequired: true,
-    nextStep: provider.connected ? 'Verify Increase sandbox Program access before owner onboarding.' : provider.nextStep,
+    nextStep: provider.connected ? 'Hosted onboarding is optional for Account-only sandbox recovery.' : provider.nextStep,
   };
   if (provider.connected) {
     try {
@@ -158,7 +159,7 @@ async function buildHealth(auth: any) {
         available: snapshot?.connected === true,
         programCount: Array.isArray(snapshot?.programs) ? snapshot.programs.length : 0,
         setupRequired: snapshot?.setupRequired === true,
-        nextStep: snapshot?.setupRequired ? 'Make at least one Increase sandbox Program available to the configured sandbox key.' : '',
+        nextStep: snapshot?.setupRequired ? 'Hosted onboarding is unavailable; use the dedicated Account-only owner recovery path instead.' : '',
       };
     } catch (error: any) {
       const issue = safeProviderError(error, 'Increase sandbox onboarding inspection failed.');
@@ -242,11 +243,10 @@ async function buildHealth(auth: any) {
     readyForSandboxOperations: Boolean(
       provider.connected
       && provider.capabilities?.accounts?.available
-      && binding.storageReady
       && reconciliation.databaseReady
     ),
     nextSteps: Array.from(new Set(nextSteps)).slice(0, 6),
-    note: 'Owner-only operational summary. Increase values are sandbox test data. SANDBOX_VALID_SIMULATION is not real KYC/CIP/AML approval, and production banking remains fail-closed.',
+    note: 'Owner-only operational summary. Increase values are sandbox test data. SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC/CIP/AML approval, and production banking remains fail-closed.',
   };
 }
 
@@ -266,8 +266,19 @@ export async function POST(request: Request) {
   const result = await authorize(request);
   if (!result.ok) return result.response;
   try {
+    const resolution = await resolveIncreaseSandboxOwnerAccount(result.auth.admin, result.auth.user.id, process.env);
+    if (!resolution.accountId) {
+      const health = await buildHealth(result.auth);
+      return response({
+        ...health,
+        ok: false,
+        action: 'sandbox-reconciliation-needs-owner-account',
+        error: 'No owner-scoped Increase sandbox Account exists yet.',
+        nextStep: 'Create the dedicated sandbox test account, then run reconciliation again.',
+      }, 409);
+    }
     await ensureIncreaseSandboxWebhookSubscription(process.env);
-    await pollIncreaseSandboxEvents({ maxPages: 5, forceReconcile: true });
+    await pollIncreaseSandboxEvents({ accountId: resolution.accountId, maxPages: 5, forceReconcile: true });
     const health = await buildHealth(result.auth);
     return response({ ...health, action: 'sandbox-reconciliation-complete' });
   } catch (error: any) {

--- a/app/api/bank/increase/webhook/route.ts
+++ b/app/api/bank/increase/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { hashIncreaseWebhookPayload, verifyIncreaseSandboxWebhookSignature } from '../../../../../lib/banking/increase-webhook-signature.js';
-import { reconcileIncreaseSandbox, recordIncreaseSandboxEvent } from '../../../../../lib/banking/increase-reconciliation';
+import { recordIncreaseSandboxEvent } from '../../../../../lib/banking/increase-reconciliation';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -58,34 +58,26 @@ export async function POST(request: Request) {
   }
 
   if (recorded.duplicate) {
-    return response({ received: true, duplicate: true, environment: 'sandbox', canMoveRealMoney: false });
-  }
-
-  try {
-    const reconciliation = await reconcileIncreaseSandbox({ eventIds: [recorded.eventId], trigger: 'webhook' });
     return response({
       received: true,
-      duplicate: false,
-      reconciled: true,
-      environment: 'sandbox',
-      canMoveRealMoney: false,
-      reconciledAt: reconciliation.reconciledAt,
-    });
-  } catch (error) {
-    // Increase does not retry failed sandbox webhooks. The durable Event row stays
-    // marked failed and the owner reconciliation poll can backfill from /events.
-    console.error('Galactic Trust Increase webhook reconciliation deferred', {
-      eventId: event.id,
-      category: event.category,
-      error: error instanceof Error ? error.message : 'unknown',
-    });
-    return response({
-      received: true,
-      duplicate: false,
+      duplicate: true,
       reconciled: false,
       backstopRequired: true,
       environment: 'sandbox',
       canMoveRealMoney: false,
     });
   }
+
+  // The public webhook has no authenticated Galactic Trust user context, so it must never
+  // choose a sandbox Account on its own. Persist the verified Event and let the owner-only
+  // dashboard/reconciliation route resolve the signed-in owner's Account before snapshotting.
+  return response({
+    received: true,
+    duplicate: false,
+    reconciled: false,
+    backstopRequired: true,
+    environment: 'sandbox',
+    canMoveRealMoney: false,
+    note: 'Verified Increase sandbox Event stored. Owner-scoped reconciliation is deferred until an authenticated Galactic Trust owner route resolves the dedicated sandbox Account.',
+  });
 }

--- a/lib/banking/increase-reconciliation.ts
+++ b/lib/banking/increase-reconciliation.ts
@@ -1,5 +1,5 @@
 import { getSupabaseAdmin } from '../supabase-admin';
-import { getIncreaseSandboxDashboard, increaseSandboxRequest } from './increase-sandbox.js';
+import { getIncreaseSandboxDashboardForAccount, increaseSandboxRequest } from './increase-sandbox.js';
 
 type IncreaseEvent = {
   id?: string;
@@ -30,6 +30,12 @@ function safeError(error: unknown) {
 function dollarsToCents(value: unknown) {
   const number = Number(value);
   return Number.isFinite(number) ? Math.round(number * 100) : 0;
+}
+
+function requireOwnerAccountId(value: unknown) {
+  const accountId = safeText(value, 200);
+  if (!accountId) throw new Error('Owner-scoped Increase sandbox Account is required for reconciliation.');
+  return accountId;
 }
 
 function validateEvent(event: IncreaseEvent) {
@@ -101,15 +107,17 @@ async function markEvents(eventIds: string[], status: 'processed' | 'failed', la
 }
 
 export async function reconcileIncreaseSandbox(options: {
+  accountId: string;
   eventIds?: string[];
   trigger?: 'webhook' | 'poll' | 'owner' | 'dashboard';
-} = {}) {
-  const eventIds = Array.isArray(options.eventIds) ? options.eventIds : [];
-  const trigger = options.trigger || 'owner';
+}) {
+  const accountId = requireOwnerAccountId(options?.accountId);
+  const eventIds = Array.isArray(options?.eventIds) ? options.eventIds : [];
+  const trigger = options?.trigger || 'owner';
   const startedAt = new Date().toISOString();
 
   try {
-    const snapshot = await getIncreaseSandboxDashboard(process.env);
+    const snapshot = await getIncreaseSandboxDashboardForAccount(accountId, process.env);
     const accounts = Array.isArray(snapshot?.accounts) ? snapshot.accounts : [];
     const transactions = Array.isArray(snapshot?.transactions) ? snapshot.transactions : [];
     const currentBalanceCents = accounts.reduce((sum: number, account: any) => sum + dollarsToCents(account?.currentBalance), 0);
@@ -134,6 +142,7 @@ export async function reconcileIncreaseSandbox(options: {
       ok: true,
       environment: 'sandbox',
       canMoveRealMoney: false,
+      scope: 'owner-account',
       trigger,
       startedAt,
       reconciledAt,
@@ -160,8 +169,13 @@ export async function reconcileIncreaseSandbox(options: {
   }
 }
 
-export async function pollIncreaseSandboxEvents(options: { maxPages?: number; forceReconcile?: boolean } = {}) {
-  const maxPages = Math.max(1, Math.min(5, Number(options.maxPages || 2)));
+export async function pollIncreaseSandboxEvents(options: {
+  accountId: string;
+  maxPages?: number;
+  forceReconcile?: boolean;
+}) {
+  const accountId = requireOwnerAccountId(options?.accountId);
+  const maxPages = Math.max(1, Math.min(5, Number(options?.maxPages || 2)));
   const supabase = getSupabaseAdmin();
   const { data: state, error: stateError } = await supabase
     .from('galactic_increase_reconciliation_state')
@@ -171,7 +185,8 @@ export async function pollIncreaseSandboxEvents(options: { maxPages?: number; fo
   if (stateError) throw stateError;
 
   let cursor = safeText(state?.event_cursor, 500);
-  const newEventIds: string[] = [];
+  const observedEventIds: string[] = [];
+  let newEvents = 0;
   let pages = 0;
   let scanned = 0;
 
@@ -189,7 +204,8 @@ export async function pollIncreaseSandboxEvents(options: { maxPages?: number; fo
 
     for (const event of events) {
       const recorded = await recordIncreaseSandboxEvent(event, { source: 'poll' });
-      if (!recorded.duplicate) newEventIds.push(recorded.eventId);
+      observedEventIds.push(recorded.eventId);
+      if (!recorded.duplicate) newEvents += 1;
     }
 
     const nextCursor = safeText(payload?.next_cursor, 500);
@@ -198,18 +214,20 @@ export async function pollIncreaseSandboxEvents(options: { maxPages?: number; fo
     if (!events.length) break;
   }
 
-  const shouldReconcile = newEventIds.length > 0 || Boolean(options.forceReconcile) || !state?.last_reconciled_at;
+  const shouldReconcile = observedEventIds.length > 0 || Boolean(options?.forceReconcile) || !state?.last_reconciled_at;
   const reconciliation = shouldReconcile
-    ? await reconcileIncreaseSandbox({ eventIds: newEventIds, trigger: 'poll' })
+    ? await reconcileIncreaseSandbox({ accountId, eventIds: observedEventIds, trigger: 'poll' })
     : null;
 
   return {
     ok: true,
     environment: 'sandbox',
     canMoveRealMoney: false,
+    scope: 'owner-account',
     pages,
     scanned,
-    newEvents: newEventIds.length,
+    observedEvents: observedEventIds.length,
+    newEvents,
     cursorStored: Boolean(cursor),
     reconciled: Boolean(reconciliation),
     reconciliation,
@@ -232,6 +250,7 @@ export async function getIncreaseReconciliationStatus() {
   return {
     environment: 'sandbox',
     canMoveRealMoney: false,
+    scope: 'owner-account',
     state: state || null,
     recentEvents: Array.isArray(events) ? events : [],
   };

--- a/scripts/test-galactic-trust-increase-webhooks.mjs
+++ b/scripts/test-galactic-trust-increase-webhooks.mjs
@@ -21,6 +21,7 @@ assert.equal(verifyIncreaseSandboxWebhookSignature({ rawBody, webhookId: event.i
 
 const webhookRoute = await read('app/api/bank/increase/webhook/route.ts');
 const reconciliationRoute = await read('app/api/admin/bank/increase/reconciliation/route.ts');
+const dashboardRoute = await read('app/api/admin/bank/increase/dashboard/route.ts');
 const reconciliation = await read('lib/banking/increase-reconciliation.ts');
 const subscription = await read('lib/banking/increase-webhook-subscription.js');
 const sandbox = await read('lib/banking/increase-sandbox.js');
@@ -29,13 +30,17 @@ const migration = await read('supabase/migrations/024_galactic_increase_webhooks
 assert.match(webhookRoute, /const rawBody = await request\.text\(\)/);
 assert.match(webhookRoute, /event\.id !== verification\.webhookId/);
 assert.match(webhookRoute, /hashIncreaseWebhookPayload\(rawBody\)/);
-assert.match(webhookRoute, /reconcileIncreaseSandbox/);
+assert.doesNotMatch(webhookRoute, /reconcileIncreaseSandbox\(/, 'public webhooks must not choose a sandbox Account without authenticated owner context');
+assert.match(webhookRoute, /backstopRequired: true/);
 assert.match(webhookRoute, /canMoveRealMoney: false/);
 assert.doesNotMatch(webhookRoute, /INCREASE_SANDBOX_API_KEY/);
 
 assert.match(reconciliationRoute, /requireGalacticTrustAdmin/, 'reconciliation controls must be Galactic Trust owner-authenticated');
+assert.match(reconciliationRoute, /resolveIncreaseSandboxOwnerAccount/, 'owner reconciliation must resolve the signed-in owner Account first');
+assert.match(reconciliationRoute, /accountId: scope\.resolution\.accountId/, 'owner reconciliation polling must receive the resolved owner Account ID');
 assert.match(reconciliationRoute, /private, no-store, max-age=0/);
 assert.match(reconciliationRoute, /pollIncreaseSandboxEvents/);
+assert.match(dashboardRoute, /accountId: resolution\.accountId/, 'dashboard polling backstop must reconcile only the resolved owner Account');
 assert.match(subscription, /\/event_subscriptions/);
 assert.match(subscription, /shared_secret: secret/);
 assert.doesNotMatch(subscription, /api\.increase\.com/);
@@ -43,6 +48,10 @@ assert.doesNotMatch(subscription, /api\.increase\.com/);
 assert.match(reconciliation, /galactic_increase_webhook_events/);
 assert.match(reconciliation, /galactic_increase_reconciliation_state/);
 assert.match(reconciliation, /event_cursor/);
+assert.match(reconciliation, /getIncreaseSandboxDashboardForAccount\(accountId, process\.env\)/, 'reconciliation snapshot must be account-scoped');
+assert.match(reconciliation, /accountId: string/, 'reconciliation APIs must require an explicit owner Account ID');
+assert.match(reconciliation, /scope: 'owner-account'/);
+assert.doesNotMatch(reconciliation, /getIncreaseSandboxDashboard\(process\.env\)/, 'reconciliation must never aggregate every open Increase sandbox Account');
 assert.doesNotMatch(reconciliation, /raw_body|raw_payload|payload_json/i);
 assert.match(migration, /event_id text primary key/);
 assert.match(migration, /enable row level security/g);
@@ -50,4 +59,4 @@ assert.match(migration, /payload_sha256/);
 assert.match(sandbox, /https:\/\/sandbox\.increase\.com/);
 assert.doesNotMatch(sandbox, /https:\/\/api\.increase\.com/);
 
-console.log('Galactic Trust Increase webhook boundary passed.');
+console.log('Galactic Trust Increase webhook boundary passed: verified Events are stored without selecting an Account, and authenticated reconciliation is scoped only to the signed-in owner sandbox Account.');

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -9,17 +9,18 @@ assert.match(route, /requireGalacticTrustAdmin/, 'integration health API must be
 assert.match(route, /inspectIncreaseSandbox/, 'integration health must inspect the configured Increase sandbox server-side');
 assert.match(route, /getProviderAccountBinding\(auth\.admin, auth\.user\.id/, 'owner binding health must be scoped to the verified signed-in owner');
 assert.match(route, /publicBindingSummary/, 'provider binding returned to the client must use the masked public summary');
+assert.match(route, /resolveIncreaseSandboxOwnerAccount\(result\.auth\.admin, result\.auth\.user\.id/, 'forced reconciliation must resolve the authenticated owner sandbox Account');
 assert.match(route, /ensureIncreaseSandboxWebhookSubscription/, 'integration health must inspect/ensure the sandbox webhook subscription server-side');
 assert.match(route, /getIncreaseReconciliationStatus/, 'integration health must report reconciliation state');
-assert.match(route, /pollIncreaseSandboxEvents\(\{ maxPages: 5, forceReconcile: true \}\)/, 'owner health center must support a bounded forced sandbox reconciliation');
+assert.match(route, /pollIncreaseSandboxEvents\(\{ accountId: resolution\.accountId, maxPages: 5, forceReconcile: true \}\)/, 'owner health center must run bounded reconciliation only for the resolved owner Account');
 assert.match(route, /bankingLaunchSnapshot/, 'integration health must derive the production lock from the regulated-launch policy');
 assert.match(route, /canMoveRealMoney: false/, 'integration health must remain explicitly incapable of real-money movement');
-assert.match(route, /SANDBOX_VALID_SIMULATION is not real KYC\/CIP\/AML approval/, 'integration health API must preserve the sandbox-validation boundary');
+assert.match(route, /SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC\/CIP\/AML approval/, 'integration health API must preserve both sandbox-validation boundaries');
 assert.equal(route.includes('INCREASE_SANDBOX_API_KEY'), false, 'integration health route must not embed or return provider secret names/values');
 assert.equal(route.includes('eventId:'), false, 'client health payload must not expose provider event IDs');
 assert.equal(route.includes('programId:'), false, 'client health payload must not expose provider Program IDs');
 assert.equal(route.includes('entityId:'), false, 'client health payload must not expose provider Entity IDs');
-assert.equal(route.includes('accountId:'), false, 'client health payload must not expose full provider Account IDs');
+assert.doesNotMatch(route, /response\(\{[^}]*accountId:/, 'client health responses must not expose full provider Account IDs');
 
 assert.match(page, /getSupabaseBrowserAsync/, 'integration health page must derive its bearer token from the authenticated Supabase session');
 assert.match(page, /fetch\('\/api\/admin\/bank\/integration-health'/, 'integration health page must use the sanitized owner API');
@@ -40,4 +41,4 @@ assert.equal(page.includes('apiKey'), false, 'integration health UI must never h
 assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
 assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
 
-console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health, binding status, webhook/reconciliation operations, and fail-closed production state are available without exposing provider secrets or full provider identifiers to the browser.');
+console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, while provider secrets/full identifiers stay out of browser responses and production remains fail-closed.');


### PR DESCRIPTION
Hardens Galactic Trust Increase sandbox reconciliation so only the signed-in owner's dedicated sandbox Account can drive reconciled balances and activity.

What changed:
- reconciliation now requires an explicit owner Account ID and snapshots with getIncreaseSandboxDashboardForAccount
- owner reconciliation route resolves the authenticated Galactic Trust owner Account before polling/reconciling
- dashboard polling backstop passes the same resolved owner Account
- public Increase webhooks verify and persist Events but never choose a sandbox Account without authenticated owner context
- duplicate webhook Events are still observed by polling so deferred Events can be marked after owner-scoped reconciliation
- regression tests prevent a return to global multi-account reconciliation

Safety boundary:
- Increase sandbox only
- pretend money only
- no raw webhook bodies or browser-exposed provider credentials
- canMoveRealMoney remains false
- production banking remains locked