### PR TITLE
Add deployed Supabase reconciliation readiness check

### DIFF
--- a/app/api/admin/bank/increase/reconciliation-readiness/route.ts
+++ b/app/api/admin/bank/increase/reconciliation-readiness/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { requireGalacticTrustAdmin } from '../../../../../../lib/admin-auth';
+import { inspectIncreaseReconciliationStorage } from '../../../../../../lib/banking/increase-reconciliation-readiness';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function response(data: any, status = 200) {
+  return NextResponse.json(data, {
+    status,
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}
+
+export async function GET(request: Request) {
+  const auth = await requireGalacticTrustAdmin(request);
+  if (auth.ok === false) {
+    return response({
+      ok: false,
+      authorized: false,
+      error: auth.error,
+      setupRequired: auth.setupRequired || false,
+      canMoveRealMoney: false,
+    }, auth.status);
+  }
+
+  const readiness = await inspectIncreaseReconciliationStorage();
+  return response({
+    ...readiness,
+    authorized: true,
+    checkedAt: new Date().toISOString(),
+    note: 'Owner-only readiness probe. It checks the deployed server Supabase configuration and migration-024 tables without returning credentials, database URLs, or raw database errors.',
+    canMoveRealMoney: false,
+  });
+}

--- a/app/bank/integrations/storage/page.js
+++ b/app/bank/integrations/storage/page.js
@@ -1,0 +1,148 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { getSupabaseBrowserAsync } from '../../../../lib/supabase-browser';
+import styles from '../integration-health.module.css';
+
+function Badge({ ready, children }) {
+  return <span className={`${styles.badge} ${ready ? styles.good : styles.warn}`}>{children}</span>;
+}
+
+function Metric({ label, value, ready = true }) {
+  return (
+    <div className={styles.metric}>
+      <span>{label}</span>
+      <strong className={ready ? styles.goodText : styles.warnText}>{value}</strong>
+    </div>
+  );
+}
+
+export default function ReconciliationStorageReadinessPage() {
+  const [loading, setLoading] = useState(true);
+  const [readiness, setReadiness] = useState(null);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const client = await getSupabaseBrowserAsync();
+      const { data, error: sessionError } = await client.auth.getSession();
+      if (sessionError) throw sessionError;
+      const token = String(data?.session?.access_token || '');
+      if (!token) throw new Error('Sign in with the authorized Galactic Trust owner account to check storage readiness.');
+
+      const response = await fetch('/api/admin/bank/increase/reconciliation-readiness', {
+        cache: 'no-store',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(String(payload?.error || 'Storage readiness could not be checked.'));
+      setReadiness(payload);
+    } catch (loadError) {
+      setReadiness(null);
+      setError(loadError instanceof Error ? loadError.message : 'Storage readiness could not be checked.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const databaseReady = readiness?.databaseReady === true;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.aurora} aria-hidden="true" />
+      <div className={styles.stars} aria-hidden="true" />
+      <header className={styles.header}>
+        <Link className={styles.brand} href="/bank">
+          <span className={styles.brandMark}>✦</span>
+          <span><b>Galactic Trust</b><small>Storage Readiness</small></span>
+        </Link>
+        <nav>
+          <Link href="/bank/integrations">Integration Health</Link>
+          <Link className={styles.primaryLink} href="/bank">Dashboard</Link>
+        </nav>
+      </header>
+
+      <section className={styles.shell}>
+        <div className={styles.hero}>
+          <div>
+            <span className={styles.kicker}>✦ OWNER CHECK · DEPLOYED SERVER</span>
+            <h1>Verify reconciliation storage<br /><em>from the app itself.</em></h1>
+            <p>This check uses the Supabase admin connection already available to the deployed Galactic Trust server. It does not rely on GitHub Actions secrets and never returns credentials to the browser.</p>
+          </div>
+          <div className={styles.heroLock}>
+            <span>🔒</span>
+            <div><small>REAL MONEY</small><b>LOCKED</b><p>Sandbox readiness only.</p></div>
+          </div>
+        </div>
+
+        {loading ? (
+          <section className={styles.loading} aria-live="polite">
+            <span>◌</span><h2>Checking deployed Supabase storage…</h2><p>No secret values are returned.</p>
+          </section>
+        ) : error ? (
+          <div className={styles.error} role="status"><span>!</span><p><b>Readiness check needs attention</b><small>{error}</small></p></div>
+        ) : readiness ? (
+          <>
+            <section className={styles.overview} aria-label="Reconciliation storage readiness">
+              <article>
+                <div className={styles.cardHead}><span>◈</span><Badge ready={readiness.serverCredentialsPresent}>{readiness.serverCredentialsPresent ? 'CONFIGURED' : 'MISSING'}</Badge></div>
+                <h2>Deployed server</h2>
+                <p>Checks whether the running app can initialize its server-side Supabase admin connection.</p>
+                <Metric label="Runtime" value={String(readiness.runtime || 'server').toUpperCase()} />
+                <Metric label="Admin configuration" value={readiness.serverCredentialsPresent ? 'PRESENT' : 'MISSING'} ready={readiness.serverCredentialsPresent} />
+              </article>
+
+              <article>
+                <div className={styles.cardHead}><span>◎</span><Badge ready={readiness.eventLedgerReady}>{readiness.eventLedgerReady ? 'READY' : 'CHECK'}</Badge></div>
+                <h2>Increase event ledger</h2>
+                <p>Service-only storage for verified Increase sandbox events.</p>
+                <Metric label="Event ledger" value={readiness.eventLedgerReady ? 'READY' : 'NOT READY'} ready={readiness.eventLedgerReady} />
+              </article>
+
+              <article>
+                <div className={styles.cardHead}><span>↻</span><Badge ready={readiness.reconciliationStateReady}>{readiness.reconciliationStateReady ? 'READY' : 'CHECK'}</Badge></div>
+                <h2>Reconciliation state</h2>
+                <p>Stores the sandbox event cursor, heartbeat, and owner-scoped reconciliation checkpoint.</p>
+                <Metric label="State table" value={readiness.reconciliationStateReady ? 'READY' : 'NOT READY'} ready={readiness.reconciliationStateReady} />
+              </article>
+
+              <article className={databaseReady ? '' : styles.lockedCard}>
+                <div className={styles.cardHead}><span>{databaseReady ? '✓' : '!'}</span><Badge ready={databaseReady}>{databaseReady ? 'MIGRATION 024 READY' : 'MIGRATION 024 NEEDED'}</Badge></div>
+                <h2>Automatic reconciliation</h2>
+                <p>Both tables must exist before webhook persistence and missed-event reconciliation can be durable.</p>
+                <Metric label="Storage" value={databaseReady ? 'READY' : 'NOT READY'} ready={databaseReady} />
+                <Metric label="Real-money movement" value="NO" ready={false} />
+              </article>
+            </section>
+
+            <section className={styles.queue}>
+              <div className={styles.queueHead}>
+                <div><span>NEXT STEP</span><h2>{databaseReady ? 'Reconciliation storage is ready' : 'One infrastructure step remains'}</h2></div>
+                <Badge ready={databaseReady}>{databaseReady ? 'READY' : 'ACTION NEEDED'}</Badge>
+              </div>
+              <p className={styles.clearMessage}>{databaseReady ? 'The deployed app can see both migration-024 tables. Return to Integration Health and run owner-scoped sandbox reconciliation.' : readiness.nextStep}</p>
+            </section>
+
+            <section className={styles.truthStrip}>
+              <span>✓</span>
+              <p><b>Safe verification only</b><small>This page checks table readiness using the deployed server connection. It does not expose Supabase credentials, raw database errors, provider identifiers, or enable production banking.</small></p>
+              <Link href="/bank/integrations">Integration Health →</Link>
+            </section>
+
+            <div className={styles.actions}>
+              <button type="button" onClick={load}>Refresh storage readiness</button>
+              <Link href="/bank">Back to dashboard</Link>
+            </div>
+          </>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/lib/banking/increase-reconciliation-readiness.ts
+++ b/lib/banking/increase-reconciliation-readiness.ts
@@ -1,0 +1,110 @@
+import { getSupabaseAdminCandidates } from '../supabase-admin';
+
+type TableProbe = {
+  ready: boolean;
+  missing: boolean;
+  unavailable: boolean;
+};
+
+function isMissingRelation(error: any) {
+  const code = String(error?.code || '').trim();
+  const message = String(error?.message || '').toLowerCase();
+  return code === '42P01'
+    || code === 'PGRST205'
+    || message.includes('could not find the table')
+    || message.includes('relation') && message.includes('does not exist');
+}
+
+async function probeTable(client: any, table: string): Promise<TableProbe> {
+  try {
+    const { error } = await client.from(table).select('*', { head: true, count: 'exact' }).limit(1);
+    if (!error) return { ready: true, missing: false, unavailable: false };
+    if (isMissingRelation(error)) return { ready: false, missing: true, unavailable: false };
+    return { ready: false, missing: false, unavailable: true };
+  } catch {
+    return { ready: false, missing: false, unavailable: true };
+  }
+}
+
+export async function inspectIncreaseReconciliationStorage() {
+  let candidates: any[] = [];
+  try {
+    candidates = getSupabaseAdminCandidates();
+  } catch {
+    return {
+      ok: true,
+      environment: 'sandbox',
+      runtime: process.env.VERCEL ? 'vercel' : 'server',
+      source: 'deployed-server',
+      serverCredentialsPresent: false,
+      eventLedgerReady: false,
+      reconciliationStateReady: false,
+      databaseReady: false,
+      migration024Status: 'server-config-missing',
+      nextStep: 'Configure the deployed server Supabase admin connection before checking reconciliation storage.',
+      canMoveRealMoney: false,
+    };
+  }
+
+  let missingObservation: { eventLedger: TableProbe; reconciliationState: TableProbe } | null = null;
+
+  for (const client of candidates) {
+    const [eventLedger, reconciliationState] = await Promise.all([
+      probeTable(client, 'galactic_increase_webhook_events'),
+      probeTable(client, 'galactic_increase_reconciliation_state'),
+    ]);
+
+    if (eventLedger.ready || reconciliationState.ready) {
+      const databaseReady = eventLedger.ready && reconciliationState.ready;
+      return {
+        ok: true,
+        environment: 'sandbox',
+        runtime: process.env.VERCEL ? 'vercel' : 'server',
+        source: 'deployed-server',
+        serverCredentialsPresent: true,
+        eventLedgerReady: eventLedger.ready,
+        reconciliationStateReady: reconciliationState.ready,
+        databaseReady,
+        migration024Status: databaseReady ? 'ready' : 'migration-needed',
+        nextStep: databaseReady
+          ? ''
+          : 'Apply migration 024 so both Increase sandbox reconciliation tables are present.',
+        canMoveRealMoney: false,
+      };
+    }
+
+    if (eventLedger.missing || reconciliationState.missing) {
+      missingObservation = { eventLedger, reconciliationState };
+    }
+  }
+
+  if (missingObservation) {
+    return {
+      ok: true,
+      environment: 'sandbox',
+      runtime: process.env.VERCEL ? 'vercel' : 'server',
+      source: 'deployed-server',
+      serverCredentialsPresent: true,
+      eventLedgerReady: false,
+      reconciliationStateReady: false,
+      databaseReady: false,
+      migration024Status: 'migration-needed',
+      nextStep: 'The deployed Supabase project is reachable, but migration 024 reconciliation storage is not fully present.',
+      canMoveRealMoney: false,
+    };
+  }
+
+  return {
+    ok: true,
+    environment: 'sandbox',
+    runtime: process.env.VERCEL ? 'vercel' : 'server',
+    source: 'deployed-server',
+    serverCredentialsPresent: true,
+    eventLedgerReady: false,
+    reconciliationStateReady: false,
+    databaseReady: false,
+    migration024Status: 'unavailable',
+    nextStep: 'The deployed server has Supabase admin configuration, but reconciliation storage could not be verified. Check the server-side Supabase connection and project permissions.',
+    canMoveRealMoney: false,
+  };
+}

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -4,6 +4,9 @@ import { readFile } from 'node:fs/promises';
 const page = await readFile(new URL('../app/bank/integrations/page.js', import.meta.url), 'utf8');
 const route = await readFile(new URL('../app/api/admin/bank/integration-health/route.ts', import.meta.url), 'utf8');
 const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhancements.js', import.meta.url), 'utf8');
+const storagePage = await readFile(new URL('../app/bank/integrations/storage/page.js', import.meta.url), 'utf8');
+const storageRoute = await readFile(new URL('../app/api/admin/bank/increase/reconciliation-readiness/route.ts', import.meta.url), 'utf8');
+const storageProbe = await readFile(new URL('../lib/banking/increase-reconciliation-readiness.ts', import.meta.url), 'utf8');
 
 assert.match(route, /requireGalacticTrustAdmin/, 'integration health API must be owner/admin authenticated');
 assert.match(route, /inspectIncreaseSandbox/, 'integration health must inspect the configured Increase sandbox server-side');
@@ -38,7 +41,23 @@ assert.equal(page.includes('entityId'), false, 'integration health UI must not h
 assert.equal(page.includes('programId'), false, 'integration health UI must not handle provider Program IDs');
 assert.equal(page.includes('apiKey'), false, 'integration health UI must never handle provider API keys');
 
+assert.match(storageRoute, /requireGalacticTrustAdmin/, 'storage readiness API must remain owner/admin authenticated');
+assert.match(storageRoute, /inspectIncreaseReconciliationStorage/, 'storage readiness API must use the deployed-server reconciliation probe');
+assert.match(storageRoute, /canMoveRealMoney: false/, 'storage readiness API must remain unable to move real money');
+assert.doesNotMatch(storageRoute, /SUPABASE_(?:SECRET|SERVICE|DB|ACCESS)/, 'storage readiness route must not embed secret environment variable names');
+assert.match(storageProbe, /getSupabaseAdminCandidates/, 'storage readiness must use the same server-side Supabase admin candidates as the deployed app');
+assert.match(storageProbe, /galactic_increase_webhook_events/, 'storage readiness must check the migration-024 event ledger');
+assert.match(storageProbe, /galactic_increase_reconciliation_state/, 'storage readiness must check the migration-024 reconciliation state table');
+assert.match(storageProbe, /migration024Status/, 'storage readiness must return a sanitized migration-024 status');
+assert.match(storageProbe, /canMoveRealMoney: false/, 'storage probe must preserve the sandbox-only boundary');
+assert.equal(storageProbe.includes('password'), false, 'storage probe must never expose or request database passwords');
+assert.match(storagePage, /DEPLOYED SERVER/, 'storage readiness UI must explain that it checks the deployed server configuration');
+assert.match(storagePage, /does not rely on GitHub Actions secrets/, 'storage readiness UI must distinguish deployed server configuration from GitHub Actions secrets');
+assert.match(storagePage, /MIGRATION 024/, 'storage readiness UI must make migration 024 status explicit');
+assert.match(storagePage, /REAL MONEY[^]*LOCKED/, 'storage readiness UI must keep the real-money lock visible');
+assert.equal(storagePage.includes('SUPABASE_'), false, 'storage readiness browser UI must not contain server secret names');
+
 assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
 assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
 
-console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, while provider secrets/full identifiers stay out of browser responses and production remains fail-closed.');
+console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, deployed-server storage readiness is inspectable without exposing secrets, and production remains fail-closed.');


### PR DESCRIPTION
Adds an owner-only Galactic Trust readiness probe that uses the deployed app's existing server-side Supabase admin connection to verify whether migration 024 reconciliation storage is present, without relying on GitHub Actions secrets.

What changed:
- new server-side readiness probe for `galactic_increase_webhook_events` and `galactic_increase_reconciliation_state`
- new authenticated admin API that returns only sanitized readiness state
- new `/bank/integrations/storage` owner UI to show deployed-server configuration and migration-024 readiness
- regression coverage preventing secret names, passwords, raw database errors, provider identifiers, or real-money capability from entering the browser

Safety boundary:
- Increase sandbox / pretend money only
- owner/admin authenticated
- no secret values returned
- no production banking writes
- `canMoveRealMoney` remains false