### PR TITLE
Fix sandbox reconciliation availability

### DIFF
--- a/lib/banking/increase-reconciliation.ts
+++ b/lib/banking/increase-reconciliation.ts
@@ -1,4 +1,4 @@
-import { getSupabaseAdmin } from '../supabase-admin';
+import { getSupabaseAdminCandidates } from '../supabase-admin';
 import { getIncreaseSandboxDashboardForAccount, increaseSandboxRequest } from './increase-sandbox.js';
 
 type IncreaseEvent = {
@@ -38,6 +38,26 @@ function requireOwnerAccountId(value: unknown) {
   return accountId;
 }
 
+async function withSupabaseAdmin(
+  operation: (client: any) => Promise<any>,
+  accept: (result: any) => boolean = (result) => !result?.error,
+) {
+  let lastError: any = null;
+  const candidates = getSupabaseAdminCandidates();
+
+  for (const client of candidates) {
+    try {
+      const result = await operation(client);
+      if (accept(result)) return result;
+      lastError = result?.error || lastError;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('Supabase reconciliation storage is unavailable.');
+}
+
 function validateEvent(event: IncreaseEvent) {
   const eventId = safeText(event?.id, 200);
   const category = safeText(event?.category, 160);
@@ -52,13 +72,11 @@ function validateEvent(event: IncreaseEvent) {
 }
 
 async function updateReconciliationState(values: Record<string, unknown>) {
-  const supabase = getSupabaseAdmin();
-  const { error } = await supabase.from('galactic_increase_reconciliation_state').upsert({
+  await withSupabaseAdmin((supabase) => supabase.from('galactic_increase_reconciliation_state').upsert({
     environment: 'sandbox',
     ...values,
     updated_at: new Date().toISOString(),
-  }, { onConflict: 'environment' });
-  if (error) throw error;
+  }, { onConflict: 'environment' }));
 }
 
 export async function recordIncreaseSandboxEvent(event: IncreaseEvent, options: {
@@ -67,21 +85,24 @@ export async function recordIncreaseSandboxEvent(event: IncreaseEvent, options: 
   payloadSha256?: string | null;
 }): Promise<{ duplicate: boolean; eventId: string }> {
   const normalized = validateEvent(event);
-  const supabase = getSupabaseAdmin();
   const now = new Date().toISOString();
-  const { error } = await supabase.from('galactic_increase_webhook_events').insert({
-    event_id: normalized.eventId,
-    category: normalized.category,
-    associated_object_type: normalized.associatedObjectType,
-    associated_object_id: normalized.associatedObjectId,
-    source: options.source,
-    webhook_message_id: safeText(options.webhookMessageId, 200) || null,
-    payload_sha256: safeText(options.payloadSha256, 64) || null,
-    provider_created_at: normalized.providerCreatedAt,
-    received_at: now,
-    processing_status: 'received',
-  });
+  const result = await withSupabaseAdmin(
+    (supabase) => supabase.from('galactic_increase_webhook_events').insert({
+      event_id: normalized.eventId,
+      category: normalized.category,
+      associated_object_type: normalized.associatedObjectType,
+      associated_object_id: normalized.associatedObjectId,
+      source: options.source,
+      webhook_message_id: safeText(options.webhookMessageId, 200) || null,
+      payload_sha256: safeText(options.payloadSha256, 64) || null,
+      provider_created_at: normalized.providerCreatedAt,
+      received_at: now,
+      processing_status: 'received',
+    }),
+    (candidateResult) => !candidateResult?.error || candidateResult?.error?.code === '23505',
+  );
 
+  const error = result?.error;
   if (error?.code === '23505') return { duplicate: true, eventId: normalized.eventId };
   if (error) throw error;
 
@@ -96,14 +117,12 @@ export async function recordIncreaseSandboxEvent(event: IncreaseEvent, options: 
 async function markEvents(eventIds: string[], status: 'processed' | 'failed', lastError: string | null = null) {
   const ids = Array.from(new Set(eventIds.map((id) => safeText(id, 200)).filter(Boolean)));
   if (!ids.length) return;
-  const supabase = getSupabaseAdmin();
   const update: Record<string, unknown> = {
     processing_status: status,
     processed_at: new Date().toISOString(),
     last_error: lastError,
   };
-  const { error } = await supabase.from('galactic_increase_webhook_events').update(update).in('event_id', ids);
-  if (error) throw error;
+  await withSupabaseAdmin((supabase) => supabase.from('galactic_increase_webhook_events').update(update).in('event_id', ids));
 }
 
 export async function reconcileIncreaseSandbox(options: {
@@ -176,13 +195,11 @@ export async function pollIncreaseSandboxEvents(options: {
 }) {
   const accountId = requireOwnerAccountId(options?.accountId);
   const maxPages = Math.max(1, Math.min(5, Number(options?.maxPages || 2)));
-  const supabase = getSupabaseAdmin();
-  const { data: state, error: stateError } = await supabase
+  const { data: state } = await withSupabaseAdmin((supabase) => supabase
     .from('galactic_increase_reconciliation_state')
     .select('event_cursor,last_reconciled_at')
     .eq('environment', 'sandbox')
-    .maybeSingle();
-  if (stateError) throw stateError;
+    .maybeSingle());
 
   let cursor = safeText(state?.event_cursor, 500);
   const observedEventIds: string[] = [];
@@ -235,23 +252,30 @@ export async function pollIncreaseSandboxEvents(options: {
 }
 
 export async function getIncreaseReconciliationStatus() {
-  const supabase = getSupabaseAdmin();
-  const [{ data: state, error: stateError }, { data: events, error: eventsError }] = await Promise.all([
-    supabase.from('galactic_increase_reconciliation_state').select('*').eq('environment', 'sandbox').maybeSingle(),
-    supabase
-      .from('galactic_increase_webhook_events')
-      .select('event_id,category,associated_object_type,source,provider_created_at,received_at,processed_at,processing_status,last_error')
-      .order('received_at', { ascending: false })
-      .limit(12),
-  ]);
-  if (stateError) throw stateError;
-  if (eventsError) throw eventsError;
+  const result = await withSupabaseAdmin(async (supabase) => {
+    const [stateResult, eventsResult] = await Promise.all([
+      supabase.from('galactic_increase_reconciliation_state').select('*').eq('environment', 'sandbox').maybeSingle(),
+      supabase
+        .from('galactic_increase_webhook_events')
+        .select('event_id,category,associated_object_type,source,provider_created_at,received_at,processed_at,processing_status,last_error')
+        .order('received_at', { ascending: false })
+        .limit(12),
+    ]);
+    return {
+      stateResult,
+      eventsResult,
+      error: stateResult?.error || eventsResult?.error || null,
+    };
+  });
+
+  const state = result?.stateResult?.data || null;
+  const events = result?.eventsResult?.data;
 
   return {
     environment: 'sandbox',
     canMoveRealMoney: false,
     scope: 'owner-account',
-    state: state || null,
+    state,
     recentEvents: Array.isArray(events) ? events : [],
   };
 }

--- a/lib/banking/increase-webhook-subscription.js
+++ b/lib/banking/increase-webhook-subscription.js
@@ -36,39 +36,66 @@ export async function ensureIncreaseSandboxWebhookSubscription(env = process.env
       environment: 'sandbox',
       canMoveRealMoney: false,
       reason: 'sandbox_not_configured',
+      status: 'not-configured',
     };
   }
 
-  const webhookUrl = getIncreaseSandboxWebhookUrl(env);
-  const secret = deriveIncreaseSandboxWebhookSecret(env);
-  const idempotencyKey = subscriptionIdempotencyKey(webhookUrl, secret);
-  const existingPayload = await increaseSandboxRequest(`/event_subscriptions?idempotency_key=${encodeURIComponent(idempotencyKey)}&limit=10`, {}, env);
-  let subscription = listData(existingPayload)[0] || null;
-
-  if (!subscription) {
-    subscription = await increaseSandboxRequest('/event_subscriptions', {
-      method: 'POST',
-      idempotencyKey,
-      body: {
-        url: webhookUrl,
-        shared_secret: secret,
-        status: 'active',
-      },
-    }, env);
-  } else if (subscription.status !== 'active') {
-    subscription = await increaseSandboxRequest(`/event_subscriptions/${encodeURIComponent(subscription.id)}`, {
-      method: 'PATCH',
-      body: { status: 'active' },
-    }, env);
+  let webhookUrl;
+  let secret;
+  try {
+    webhookUrl = getIncreaseSandboxWebhookUrl(env);
+    secret = deriveIncreaseSandboxWebhookSecret(env);
+  } catch {
+    return {
+      configured: false,
+      active: false,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      reason: 'webhook_configuration_unavailable',
+      status: 'unavailable',
+    };
   }
 
-  return {
-    configured: true,
-    active: subscription?.status === 'active',
-    environment: 'sandbox',
-    canMoveRealMoney: false,
-    id: String(subscription?.id || ''),
-    status: String(subscription?.status || 'unknown'),
-    url: webhookUrl,
-  };
+  try {
+    const idempotencyKey = subscriptionIdempotencyKey(webhookUrl, secret);
+    const existingPayload = await increaseSandboxRequest(`/event_subscriptions?idempotency_key=${encodeURIComponent(idempotencyKey)}&limit=10`, {}, env);
+    let subscription = listData(existingPayload)[0] || null;
+
+    if (!subscription) {
+      subscription = await increaseSandboxRequest('/event_subscriptions', {
+        method: 'POST',
+        idempotencyKey,
+        body: {
+          url: webhookUrl,
+          shared_secret: secret,
+          status: 'active',
+        },
+      }, env);
+    } else if (subscription.status !== 'active') {
+      subscription = await increaseSandboxRequest(`/event_subscriptions/${encodeURIComponent(subscription.id)}`, {
+        method: 'PATCH',
+        body: { status: 'active' },
+      }, env);
+    }
+
+    return {
+      configured: true,
+      active: subscription?.status === 'active',
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      id: String(subscription?.id || ''),
+      status: String(subscription?.status || 'unknown'),
+      url: webhookUrl,
+    };
+  } catch {
+    return {
+      configured: false,
+      active: false,
+      environment: 'sandbox',
+      canMoveRealMoney: false,
+      reason: 'event_subscription_unavailable',
+      status: 'unavailable',
+      url: webhookUrl,
+    };
+  }
 }

--- a/scripts/test-galactic-trust-increase-webhooks.mjs
+++ b/scripts/test-galactic-trust-increase-webhooks.mjs
@@ -51,6 +51,9 @@ assert.match(reconciliation, /event_cursor/);
 assert.match(reconciliation, /getIncreaseSandboxDashboardForAccount\(accountId, process\.env\)/, 'reconciliation snapshot must be account-scoped');
 assert.match(reconciliation, /accountId: string/, 'reconciliation APIs must require an explicit owner Account ID');
 assert.match(reconciliation, /scope: 'owner-account'/);
+assert.match(reconciliation, /getSupabaseAdminCandidates/, 'reconciliation storage must retry across the same server-side Supabase admin candidates as readiness checks');
+assert.match(reconciliation, /withSupabaseAdmin/, 'all reconciliation storage operations must use resilient admin fallback');
+assert.doesNotMatch(reconciliation, /getSupabaseAdmin\(\)/, 'reconciliation must not pin storage access to only the first configured admin credential');
 assert.doesNotMatch(reconciliation, /getIncreaseSandboxDashboard\(process\.env\)/, 'reconciliation must never aggregate every open Increase sandbox Account');
 assert.doesNotMatch(reconciliation, /raw_body|raw_payload|payload_json/i);
 assert.match(migration, /event_id text primary key/);
@@ -59,4 +62,4 @@ assert.match(migration, /payload_sha256/);
 assert.match(sandbox, /https:\/\/sandbox\.increase\.com/);
 assert.doesNotMatch(sandbox, /https:\/\/api\.increase\.com/);
 
-console.log('Galactic Trust Increase webhook boundary passed: verified Events are stored without selecting an Account, and authenticated reconciliation is scoped only to the signed-in owner sandbox Account.');
+console.log('Galactic Trust Increase webhook boundary passed: verified Events are stored without selecting an Account, authenticated reconciliation is scoped only to the signed-in owner sandbox Account, and storage retries across server-only Supabase admin credentials.');


### PR DESCRIPTION
Fixes the owner Integration Health reconciliation path that could remain UNAVAILABLE even when migration 024 storage was confirmed READY.

Changes:
- reconciliation storage now retries across the same server-only Supabase admin credential candidates used by the deployed readiness probe instead of pinning to only the first configured candidate
- Increase webhook subscription setup now degrades safely to an unavailable status instead of aborting manual owner reconciliation when the Event Subscription feature/configuration is unavailable
- regression coverage verifies reconciliation does not use only the first Supabase admin credential

Safety boundary:
- owner-scoped Increase sandbox only
- pretend money only
- no provider/database credentials returned to browser
- no production banking changes
- real-money movement remains hard-locked