### PR TITLE
Fallback reconciliation when Increase Events is unavailable

### DIFF
--- a/lib/banking/increase-reconciliation.ts
+++ b/lib/banking/increase-reconciliation.ts
@@ -27,6 +27,13 @@ function safeError(error: unknown) {
   return error instanceof Error ? safeText(error.message, 160) : 'reconciliation_failed';
 }
 
+function safeEventPollingIssue(error: unknown) {
+  if (error && typeof error === 'object' && 'status' in error && Number.isFinite(Number((error as any).status))) {
+    return `provider_status_${Number((error as any).status)}`;
+  }
+  return 'events_unavailable';
+}
+
 function dollarsToCents(value: unknown) {
   const number = Number(value);
   return Number.isFinite(number) ? Math.round(number * 100) : 0;
@@ -206,34 +213,54 @@ export async function pollIncreaseSandboxEvents(options: {
   let newEvents = 0;
   let pages = 0;
   let scanned = 0;
+  let eventPollingAvailable = true;
+  let eventPollingIssue = '';
+  const pollAttemptedAt = new Date().toISOString();
 
-  while (pages < maxPages) {
-    const params = new URLSearchParams();
-    params.set('order_by.field', 'created_at');
-    params.set('order_by.direction', 'ascending');
-    params.set('limit', '100');
-    if (cursor) params.set('cursor', cursor);
+  try {
+    while (pages < maxPages) {
+      const params = new URLSearchParams();
+      params.set('order_by.field', 'created_at');
+      params.set('order_by.direction', 'ascending');
+      params.set('limit', '100');
+      if (cursor) params.set('cursor', cursor);
 
-    const payload = await increaseSandboxRequest(`/events?${params.toString()}`, {}, process.env);
-    const events = listData(payload);
-    pages += 1;
-    scanned += events.length;
+      const payload = await increaseSandboxRequest(`/events?${params.toString()}`, {}, process.env);
+      const events = listData(payload);
+      pages += 1;
+      scanned += events.length;
 
-    for (const event of events) {
-      const recorded = await recordIncreaseSandboxEvent(event, { source: 'poll' });
-      observedEventIds.push(recorded.eventId);
-      if (!recorded.duplicate) newEvents += 1;
+      for (const event of events) {
+        const recorded = await recordIncreaseSandboxEvent(event, { source: 'poll' });
+        observedEventIds.push(recorded.eventId);
+        if (!recorded.duplicate) newEvents += 1;
+      }
+
+      const nextCursor = safeText(payload?.next_cursor, 500);
+      if (nextCursor) cursor = nextCursor;
+      await updateReconciliationState({ event_cursor: cursor || null, last_poll_at: new Date().toISOString() });
+      if (!events.length) break;
     }
-
-    const nextCursor = safeText(payload?.next_cursor, 500);
-    if (nextCursor) cursor = nextCursor;
-    await updateReconciliationState({ event_cursor: cursor || null, last_poll_at: new Date().toISOString() });
-    if (!events.length) break;
+  } catch (error) {
+    eventPollingAvailable = false;
+    eventPollingIssue = safeEventPollingIssue(error);
+    try {
+      await updateReconciliationState({ last_poll_at: pollAttemptedAt });
+    } catch {
+      // Reconciliation below will surface a database failure if storage is actually unavailable.
+    }
   }
 
-  const shouldReconcile = observedEventIds.length > 0 || Boolean(options?.forceReconcile) || !state?.last_reconciled_at;
+  const shouldReconcile = observedEventIds.length > 0
+    || Boolean(options?.forceReconcile)
+    || !state?.last_reconciled_at
+    || !eventPollingAvailable;
   const reconciliation = shouldReconcile
-    ? await reconcileIncreaseSandbox({ accountId, eventIds: observedEventIds, trigger: 'poll' })
+    ? await reconcileIncreaseSandbox({
+        accountId,
+        eventIds: observedEventIds,
+        trigger: eventPollingAvailable ? 'poll' : 'owner',
+      })
     : null;
 
   return {
@@ -246,6 +273,9 @@ export async function pollIncreaseSandboxEvents(options: {
     observedEvents: observedEventIds.length,
     newEvents,
     cursorStored: Boolean(cursor),
+    eventPollingAvailable,
+    eventPollingIssue,
+    mode: eventPollingAvailable ? 'events-plus-owner-snapshot' : 'owner-snapshot-fallback',
     reconciled: Boolean(reconciliation),
     reconciliation,
   };

--- a/scripts/test-galactic-trust-increase-webhooks.mjs
+++ b/scripts/test-galactic-trust-increase-webhooks.mjs
@@ -54,6 +54,10 @@ assert.match(reconciliation, /scope: 'owner-account'/);
 assert.match(reconciliation, /getSupabaseAdminCandidates/, 'reconciliation storage must retry across the same server-side Supabase admin candidates as readiness checks');
 assert.match(reconciliation, /withSupabaseAdmin/, 'all reconciliation storage operations must use resilient admin fallback');
 assert.doesNotMatch(reconciliation, /getSupabaseAdmin\(\)/, 'reconciliation must not pin storage access to only the first configured admin credential');
+assert.match(reconciliation, /eventPollingAvailable = false/, 'restricted Increase Events polling must be represented separately instead of failing the entire owner reconciliation');
+assert.match(reconciliation, /mode: eventPollingAvailable \? 'events-plus-owner-snapshot' : 'owner-snapshot-fallback'/, 'manual reconciliation must report when it safely fell back to the owner Account snapshot');
+assert.match(reconciliation, /trigger: eventPollingAvailable \? 'poll' : 'owner'/, 'fallback reconciliation must be recorded as an owner-scoped snapshot, not a successful Events poll');
+assert.match(reconciliation, /\|\| !eventPollingAvailable/, 'an unavailable Events endpoint must still force the owner Account snapshot reconciliation');
 assert.doesNotMatch(reconciliation, /getIncreaseSandboxDashboard\(process\.env\)/, 'reconciliation must never aggregate every open Increase sandbox Account');
 assert.doesNotMatch(reconciliation, /raw_body|raw_payload|payload_json/i);
 assert.match(migration, /event_id text primary key/);
@@ -62,4 +66,4 @@ assert.match(migration, /payload_sha256/);
 assert.match(sandbox, /https:\/\/sandbox\.increase\.com/);
 assert.doesNotMatch(sandbox, /https:\/\/api\.increase\.com/);
 
-console.log('Galactic Trust Increase webhook boundary passed: verified Events are stored without selecting an Account, authenticated reconciliation is scoped only to the signed-in owner sandbox Account, and storage retries across server-only Supabase admin credentials.');
+console.log('Galactic Trust Increase webhook boundary passed: verified Events are stored without selecting an Account, authenticated reconciliation is scoped only to the signed-in owner sandbox Account, storage retries across server-only Supabase admin credentials, and restricted Events polling safely falls back to an owner snapshot.');


### PR DESCRIPTION
Fixes the remaining owner Integration Health `UNAVAILABLE` state when Increase's Events polling endpoint is restricted or unavailable even though migration 024 storage and the owner sandbox Account are healthy.

Changes:
- `/events` polling is now attempted but no longer mandatory for owner reconciliation
- if Events polling fails, Galactic Trust records the poll attempt and falls back to a direct signed-in-owner Account snapshot
- fallback reconciliation is stored as an owner-scoped reconciliation with `last_reconciliation_status=ok` when the owner snapshot succeeds
- the returned backstop result clearly distinguishes `events-plus-owner-snapshot` from `owner-snapshot-fallback`
- polling failures are sanitized to a status code / `events_unavailable` and never expose credentials or raw provider payloads
- regression coverage verifies the fallback path

Safety boundary:
- Increase sandbox / pretend money only
- only the resolved signed-in owner Account is reconciled
- no live banking or real-money writes
- production banking remains hard-locked