### PR TITLE
Show sandbox reconciliation path diagnostics

### DIFF
--- a/app/api/admin/bank/integration-health/route.ts
+++ b/app/api/admin/bank/integration-health/route.ts
@@ -34,13 +34,26 @@ function safeProviderError(error: any, fallback: string) {
   };
 }
 
+function safeReconciliationStatus(state: any) {
+  const status = String(state?.last_reconciliation_status || 'not-run');
+  if (status !== 'ok') return status;
+  const trigger = String(state?.last_reconciliation_trigger || '');
+  if (trigger === 'owner') return 'ok · owner snapshot';
+  if (trigger === 'poll') return 'ok · events + snapshot';
+  if (trigger === 'dashboard') return 'ok · dashboard snapshot';
+  if (trigger === 'webhook') return 'ok · webhook snapshot';
+  return 'ok';
+}
+
 function safeReconciliationState(payload: any) {
   const state = payload?.state || null;
   const recentEvents = Array.isArray(payload?.recentEvents) ? payload.recentEvents : [];
   const latest = recentEvents[0] || null;
+  const trigger = String(state?.last_reconciliation_trigger || '').slice(0, 24);
   return {
     databaseReady: true,
-    status: String(state?.last_reconciliation_status || 'not-run'),
+    status: safeReconciliationStatus(state),
+    lastTrigger: trigger,
     lastReconciledAt: state?.last_reconciled_at || null,
     lastWebhookAt: state?.last_webhook_at || null,
     lastPollAt: state?.last_poll_at || null,
@@ -55,6 +68,27 @@ function safeReconciliationState(payload: any) {
       processingStatus: String(latest.processing_status || '').slice(0, 40),
       receivedAt: latest.received_at || null,
     } : null,
+  };
+}
+
+function safeReconciliationRun(backstop: any) {
+  const rawMode = String(backstop?.mode || '');
+  const mode = rawMode === 'owner-snapshot-fallback'
+    ? 'owner-snapshot-fallback'
+    : rawMode === 'events-plus-owner-snapshot'
+      ? 'events-plus-owner-snapshot'
+      : 'owner-snapshot';
+  const issue = String(backstop?.eventPollingIssue || '').slice(0, 80);
+  return {
+    mode,
+    eventPollingAvailable: backstop?.eventPollingAvailable === true,
+    eventPollingIssue: issue,
+    reconciled: backstop?.reconciled === true,
+    pages: Number.isFinite(Number(backstop?.pages)) ? Number(backstop.pages) : 0,
+    scanned: Number.isFinite(Number(backstop?.scanned)) ? Number(backstop.scanned) : 0,
+    observedEvents: Number.isFinite(Number(backstop?.observedEvents)) ? Number(backstop.observedEvents) : 0,
+    newEvents: Number.isFinite(Number(backstop?.newEvents)) ? Number(backstop.newEvents) : 0,
+    canMoveRealMoney: false,
   };
 }
 
@@ -191,6 +225,7 @@ async function buildHealth(auth: any) {
   let reconciliation: any = {
     databaseReady: false,
     status: 'unavailable',
+    lastTrigger: '',
     lastReconciledAt: null,
     lastWebhookAt: null,
     lastPollAt: null,
@@ -278,9 +313,13 @@ export async function POST(request: Request) {
       }, 409);
     }
     await ensureIncreaseSandboxWebhookSubscription(process.env);
-    await pollIncreaseSandboxEvents({ accountId: resolution.accountId, maxPages: 5, forceReconcile: true });
+    const backstop = await pollIncreaseSandboxEvents({ accountId: resolution.accountId, maxPages: 5, forceReconcile: true });
     const health = await buildHealth(result.auth);
-    return response({ ...health, action: 'sandbox-reconciliation-complete' });
+    return response({
+      ...health,
+      action: 'sandbox-reconciliation-complete',
+      reconciliationRun: safeReconciliationRun(backstop),
+    });
   } catch (error: any) {
     const issue = safeProviderError(error, 'Increase sandbox reconciliation could not run.');
     const health = await buildHealth(result.auth);

--- a/app/bank/integrations/page.js
+++ b/app/bank/integrations/page.js
@@ -17,6 +17,12 @@ function stateLabel(ok, ready = false) {
   return 'SETUP NEEDED';
 }
 
+function runModeLabel(mode) {
+  if (mode === 'owner-snapshot-fallback') return 'OWNER SNAPSHOT FALLBACK';
+  if (mode === 'events-plus-owner-snapshot') return 'EVENTS + OWNER SNAPSHOT';
+  return 'OWNER SNAPSHOT';
+}
+
 function HealthBadge({ tone = 'neutral', children }) {
   return <span className={`${styles.badge} ${styles[tone]}`}>{children}</span>;
 }
@@ -50,6 +56,7 @@ export default function GalacticIntegrationHealthPage() {
   const [health, setHealth] = useState(null);
   const [error, setError] = useState('');
   const [signedIn, setSignedIn] = useState(false);
+  const [reconciliationRun, setReconciliationRun] = useState(null);
 
   const requestHealth = useCallback(async (method = 'GET') => {
     const client = await getSupabaseBrowserAsync();
@@ -92,8 +99,10 @@ export default function GalacticIntegrationHealthPage() {
   const runReconciliation = useCallback(async () => {
     setRunning(true);
     setError('');
+    setReconciliationRun(null);
     try {
-      await requestHealth('POST');
+      const payload = await requestHealth('POST');
+      setReconciliationRun(payload?.reconciliationRun || null);
     } catch (runError) {
       setError(runError instanceof Error ? runError.message : 'Sandbox reconciliation could not run.');
     } finally {
@@ -105,7 +114,7 @@ export default function GalacticIntegrationHealthPage() {
     const providerHealthy = health?.provider?.connected === true && health?.provider?.capabilities?.accounts?.available === true;
     const bindingHealthy = health?.binding?.storageReady === true && health?.binding?.bound === true;
     const webhookHealthy = health?.webhook?.active === true;
-    const reconciliationHealthy = health?.reconciliation?.databaseReady === true && health?.reconciliation?.status !== 'failed';
+    const reconciliationHealthy = health?.reconciliation?.databaseReady === true && health?.reconciliation?.status !== 'failed' && health?.reconciliation?.status !== 'unavailable';
     const productionLocked = health?.production?.liveBankingEnabled !== true && health?.production?.implementationReady !== true && health?.canMoveRealMoney !== true;
     return { providerHealthy, bindingHealthy, webhookHealthy, reconciliationHealthy, productionLocked };
   }, [health]);
@@ -218,16 +227,31 @@ export default function GalacticIntegrationHealthPage() {
                       <div><span>Recent events</span><b>{health.reconciliation?.recentEventCount || 0}</b></div>
                       <div><span>Transactions seen</span><b>{health.reconciliation?.transactionCount || 0}</b></div>
                     </div>
+                    {health.reconciliation?.lastTrigger && (
+                      <div className={styles.latestEvent}>
+                        <span>Last persisted reconciliation path</span>
+                        <p><b>{health.reconciliation.lastTrigger === 'owner' ? 'Owner account snapshot' : health.reconciliation.lastTrigger === 'poll' ? 'Events + owner snapshot' : `${health.reconciliation.lastTrigger} snapshot`}</b><small>{displayTime(health.reconciliation.lastReconciledAt)} · sandbox only</small></p>
+                      </div>
+                    )}
+                    {reconciliationRun && (
+                      <div className={styles.latestEvent} role="status">
+                        <span>Latest manual run</span>
+                        <p>
+                          <b>{runModeLabel(reconciliationRun.mode)}</b>
+                          <small>{reconciliationRun.reconciled ? 'Owner reconciliation completed' : 'Reconciliation did not complete'} · Events polling {reconciliationRun.eventPollingAvailable ? 'available' : 'restricted/unavailable'} · {reconciliationRun.observedEvents || 0} events observed</small>
+                        </p>
+                      </div>
+                    )}
                     {health.reconciliation?.latestEvent && (
                       <div className={styles.latestEvent}>
                         <span>Latest safe event summary</span>
                         <p><b>{health.reconciliation.latestEvent.category || 'Increase sandbox event'}</b><small>{health.reconciliation.latestEvent.source || 'provider'} · {health.reconciliation.latestEvent.processingStatus || 'received'} · {displayTime(health.reconciliation.latestEvent.receivedAt)}</small></p>
                       </div>
                     )}
-                    <button className={styles.reconcileButton} type="button" onClick={runReconciliation} disabled={running || !health.provider?.connected}>
+                    <button className={styles.reconcileButton} type="button" onClick={runReconciliation} disabled={running || !health.provider?.connected} aria-busy={running}>
                       {running ? 'Reconciling sandbox…' : '↻ Run sandbox reconciliation'}
                     </button>
-                    <small className={styles.buttonNote}>This checks pretend-money Increase sandbox events only. It cannot move real money.</small>
+                    <small className={styles.buttonNote}>This checks pretend-money Increase sandbox events and, when Events access is restricted, falls back to the signed-in owner sandbox Account snapshot. It cannot move real money.</small>
                   </article>
                 </section>
 
@@ -243,13 +267,13 @@ export default function GalacticIntegrationHealthPage() {
                       ))}
                     </div>
                   ) : (
-                    <p className={styles.clearMessage}>Provider access, owner binding, webhook delivery, and reconciliation are ready for Galactic Trust sandbox testing. Production banking still remains separately locked.</p>
+                    <p className={styles.clearMessage}>Provider access, owner scope, reconciliation storage, and the owner snapshot backstop are ready for Galactic Trust sandbox testing. Webhook/Event availability remains a separate provider capability. Production banking still remains separately locked.</p>
                   )}
                 </section>
 
                 <section className={styles.truthStrip}>
                   <span>✓</span>
-                  <p><b>Truthful operating boundary</b><small>Increase data shown here is sandbox test data. SANDBOX_VALID_SIMULATION is not real KYC/CIP/AML approval. Galactic Trust is a financial technology product, not a bank, and this build cannot accept or move real customer deposits.</small></p>
+                  <p><b>Truthful operating boundary</b><small>Increase data shown here is sandbox test data. SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC/CIP/AML approval. Galactic Trust is a financial technology product, not a bank, and this build cannot accept or move real customer deposits.</small></p>
                   <Link href="/bank/readiness">Review production gates →</Link>
                 </section>
 

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -16,6 +16,10 @@ assert.match(route, /resolveIncreaseSandboxOwnerAccount\(result\.auth\.admin, re
 assert.match(route, /ensureIncreaseSandboxWebhookSubscription/, 'integration health must inspect/ensure the sandbox webhook subscription server-side');
 assert.match(route, /getIncreaseReconciliationStatus/, 'integration health must report reconciliation state');
 assert.match(route, /pollIncreaseSandboxEvents\(\{ accountId: resolution\.accountId, maxPages: 5, forceReconcile: true \}\)/, 'owner health center must run bounded reconciliation only for the resolved owner Account');
+assert.match(route, /safeReconciliationRun\(backstop\)/, 'manual owner reconciliation must return sanitized path diagnostics');
+assert.match(route, /owner-snapshot-fallback/, 'integration health must distinguish owner snapshot fallback from Events-backed reconciliation');
+assert.match(route, /events-plus-owner-snapshot/, 'integration health must identify Events plus owner snapshot mode');
+assert.match(route, /ok · owner snapshot/, 'persisted reconciliation status must identify owner snapshot fallback safely');
 assert.match(route, /bankingLaunchSnapshot/, 'integration health must derive the production lock from the regulated-launch policy');
 assert.match(route, /canMoveRealMoney: false/, 'integration health must remain explicitly incapable of real-money movement');
 assert.match(route, /SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC\/CIP\/AML approval/, 'integration health API must preserve both sandbox-validation boundaries');
@@ -32,7 +36,12 @@ assert.match(page, /OWNER OPERATIONS · SANDBOX ONLY/, 'owner operations surface
 assert.match(page, /REAL MONEY[^]*LOCKED/, 'integration health UI must visibly show real money as locked');
 assert.match(page, /Production banking remains fail-closed/, 'integration health UI must preserve fail-closed production messaging');
 assert.match(page, /Run sandbox reconciliation/, 'owner operations UI must expose the safe sandbox reconciliation action');
-assert.match(page, /SANDBOX_VALID_SIMULATION is not real KYC\/CIP\/AML approval/, 'integration UI must not portray sandbox validation as regulated approval');
+assert.match(page, /Latest manual run/, 'manual reconciliation must surface immediate sanitized diagnostics');
+assert.match(page, /OWNER SNAPSHOT FALLBACK/, 'UI must clearly label owner snapshot fallback mode');
+assert.match(page, /Events polling[^]*restricted\/unavailable/, 'UI must truthfully distinguish restricted Events polling from successful owner snapshot reconciliation');
+assert.match(page, /Last persisted reconciliation path/, 'UI must show the durable reconciliation path from stored state');
+assert.match(page, /aria-busy=\{running\}/, 'manual reconciliation button must expose busy state accessibly');
+assert.match(page, /SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC\/CIP\/AML approval/, 'integration UI must not portray sandbox validation as regulated approval');
 assert.equal(page.includes('/api/admin/bank/increase/onboarding'), false, 'browser must not consume the raw onboarding payload');
 assert.equal(page.includes('/api/admin/bank/increase/reconciliation'), false, 'browser must not consume the raw reconciliation payload');
 assert.equal(page.includes('/api/admin/bank/increase/status'), false, 'browser must consume only the sanitized integration-health summary');
@@ -60,4 +69,4 @@ assert.equal(storagePage.includes('SUPABASE_'), false, 'storage readiness browse
 assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
 assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
 
-console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, deployed-server storage readiness is inspectable without exposing secrets, and production remains fail-closed.');
+console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, fallback path diagnostics are visible without secrets, deployed-server storage readiness is inspectable, and production remains fail-closed.');


### PR DESCRIPTION
Makes Galactic Trust Integration Health self-diagnosing for the owner sandbox reconciliation flow.

Changes:
- returns a sanitized `reconciliationRun` result after manual reconciliation
- distinguishes `events-plus-owner-snapshot` from `owner-snapshot-fallback`
- persists a safe human-readable reconciliation status based on the last trigger
- shows the last persisted reconciliation path and the latest manual run directly in `/bank/integrations`
- keeps provider IDs, database errors, and credentials out of the browser
- adds `aria-busy` to the reconciliation action and regression coverage for the diagnostics

Safety boundary:
- Increase sandbox / pretend money only
- owner-scoped Account only
- no production banking changes
- real-money movement remains hard-locked