### PR TITLE
Make manual reconciliation independent of webhook setup

### DIFF
--- a/app/api/admin/bank/integration-health/route.ts
+++ b/app/api/admin/bank/integration-health/route.ts
@@ -3,7 +3,7 @@ import { requireGalacticTrustAdmin } from '../../../../../lib/admin-auth';
 import { describeIncreaseSandboxError } from '../../../../../lib/banking/increase-api-errors.js';
 import { inspectIncreaseSandboxOnboarding } from '../../../../../lib/banking/increase-onboarding-sandbox.js';
 import { resolveIncreaseSandboxOwnerAccount } from '../../../../../lib/banking/increase-owner-account.js';
-import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents } from '../../../../../lib/banking/increase-reconciliation';
+import { getIncreaseReconciliationStatus, pollIncreaseSandboxEvents, reconcileIncreaseSandbox } from '../../../../../lib/banking/increase-reconciliation';
 import { getIncreaseSandboxConfig, inspectIncreaseSandbox } from '../../../../../lib/banking/increase-sandbox.js';
 import { ensureIncreaseSandboxWebhookSubscription } from '../../../../../lib/banking/increase-webhook-subscription.js';
 import { getProviderAccountBinding, publicBindingSummary } from '../../../../../lib/banking/provider-account-binding.js';
@@ -312,13 +312,43 @@ export async function POST(request: Request) {
         nextStep: 'Create the dedicated sandbox test account, then run reconciliation again.',
       }, 409);
     }
-    await ensureIncreaseSandboxWebhookSubscription(process.env);
-    const backstop = await pollIncreaseSandboxEvents({ accountId: resolution.accountId, maxPages: 5, forceReconcile: true });
+
+    let webhookSetupAvailable = true;
+    try {
+      await ensureIncreaseSandboxWebhookSubscription(process.env);
+    } catch {
+      webhookSetupAvailable = false;
+    }
+
+    let backstop: any;
+    try {
+      backstop = await pollIncreaseSandboxEvents({ accountId: resolution.accountId, maxPages: 5, forceReconcile: true });
+    } catch {
+      const direct = await reconcileIncreaseSandbox({ accountId: resolution.accountId, trigger: 'owner' });
+      backstop = {
+        ok: true,
+        environment: 'sandbox',
+        canMoveRealMoney: false,
+        scope: 'owner-account',
+        pages: 0,
+        scanned: 0,
+        observedEvents: 0,
+        newEvents: 0,
+        cursorStored: false,
+        eventPollingAvailable: false,
+        eventPollingIssue: 'poll_wrapper_unavailable',
+        mode: 'owner-snapshot-fallback',
+        reconciled: true,
+        reconciliation: direct,
+      };
+    }
+
     const health = await buildHealth(result.auth);
     return response({
       ...health,
       action: 'sandbox-reconciliation-complete',
       reconciliationRun: safeReconciliationRun(backstop),
+      webhookSetupAvailable,
     });
   } catch (error: any) {
     const issue = safeProviderError(error, 'Increase sandbox reconciliation could not run.');

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -20,6 +20,11 @@ assert.match(route, /safeReconciliationRun\(backstop\)/, 'manual owner reconcili
 assert.match(route, /owner-snapshot-fallback/, 'integration health must distinguish owner snapshot fallback from Events-backed reconciliation');
 assert.match(route, /events-plus-owner-snapshot/, 'integration health must identify Events plus owner snapshot mode');
 assert.match(route, /ok · owner snapshot/, 'persisted reconciliation status must identify owner snapshot fallback safely');
+assert.match(route, /let webhookSetupAvailable = true/, 'manual reconciliation must track webhook setup separately from owner reconciliation');
+assert.match(route, /try \{\s*await ensureIncreaseSandboxWebhookSubscription\(process\.env\);\s*\} catch \{\s*webhookSetupAvailable = false;/, 'restricted webhook setup must be non-blocking for manual owner reconciliation');
+assert.match(route, /const direct = await reconcileIncreaseSandbox\(\{ accountId: resolution\.accountId, trigger: 'owner' \}\)/, 'manual reconciliation must have a direct owner snapshot fallback if the polling wrapper fails');
+assert.match(route, /webhookSetupAvailable,/, 'manual reconciliation may expose only the safe webhook-setup boolean');
+assert.doesNotMatch(route, /await ensureIncreaseSandboxWebhookSubscription\(process\.env\);\s*const backstop = await pollIncreaseSandboxEvents/, 'webhook setup must never be a hard prerequisite for the owner reconciliation backstop');
 assert.match(route, /bankingLaunchSnapshot/, 'integration health must derive the production lock from the regulated-launch policy');
 assert.match(route, /canMoveRealMoney: false/, 'integration health must remain explicitly incapable of real-money movement');
 assert.match(route, /SANDBOX_VALID_SIMULATION and SANDBOX_ACCOUNT_ONLY are not real KYC\/CIP\/AML approval/, 'integration health API must preserve both sandbox-validation boundaries');
@@ -69,4 +74,4 @@ assert.equal(storagePage.includes('SUPABASE_'), false, 'storage readiness browse
 assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
 assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
 
-console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, fallback path diagnostics are visible without secrets, deployed-server storage readiness is inspectable, and production remains fail-closed.');
+console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, webhook setup cannot block manual owner reconciliation, fallback path diagnostics are visible without secrets, deployed-server storage readiness is inspectable, and production remains fail-closed.');


### PR DESCRIPTION
Fixes the remaining Galactic Trust owner reconciliation blocker.

Changes:
- webhook subscription setup is now best-effort during the manual owner reconciliation action
- restricted/unavailable webhook setup can no longer abort the owner reconciliation path
- if the Events polling wrapper itself fails, the route immediately falls back to a direct signed-in-owner Account snapshot reconciliation
- the response exposes only a safe boolean for webhook setup availability plus the existing sanitized reconciliation path diagnostics
- regression coverage prevents webhook setup from ever becoming a hard prerequisite again

Safety boundary:
- Increase sandbox / pretend money only
- signed-in owner Account only
- no provider IDs or secrets exposed
- production banking and real-money movement remain hard-locked