### PR TITLE
Verify and repair reconciliation heartbeat writes

### DIFF
--- a/app/bank/integrations/storage/page.js
+++ b/app/bank/integrations/storage/page.js
@@ -53,6 +53,8 @@ export default function ReconciliationStorageReadinessPage() {
   }, [load]);
 
   const databaseReady = readiness?.databaseReady === true;
+  const stateWritable = readiness?.reconciliationStateWritable === true;
+  const writeBlocked = readiness?.migration024Status === 'write-blocked';
 
   return (
     <main className={styles.page}>
@@ -74,7 +76,7 @@ export default function ReconciliationStorageReadinessPage() {
           <div>
             <span className={styles.kicker}>✦ OWNER CHECK · DEPLOYED SERVER</span>
             <h1>Verify reconciliation storage<br /><em>from the app itself.</em></h1>
-            <p>This check uses the Supabase admin connection already available to the deployed Galactic Trust server. It does not rely on GitHub Actions secrets and never returns credentials to the browser.</p>
+            <p>This check uses the Supabase admin connection already available to the deployed Galactic Trust server. It verifies both table reads and the sandbox heartbeat write path without returning credentials to the browser.</p>
           </div>
           <div className={styles.heroLock}>
             <span>🔒</span>
@@ -103,36 +105,37 @@ export default function ReconciliationStorageReadinessPage() {
                 <div className={styles.cardHead}><span>◎</span><Badge ready={readiness.eventLedgerReady}>{readiness.eventLedgerReady ? 'READY' : 'CHECK'}</Badge></div>
                 <h2>Increase event ledger</h2>
                 <p>Service-only storage for verified Increase sandbox events.</p>
-                <Metric label="Event ledger" value={readiness.eventLedgerReady ? 'READY' : 'NOT READY'} ready={readiness.eventLedgerReady} />
+                <Metric label="Event ledger read" value={readiness.eventLedgerReady ? 'READY' : 'NOT READY'} ready={readiness.eventLedgerReady} />
               </article>
 
               <article>
-                <div className={styles.cardHead}><span>↻</span><Badge ready={readiness.reconciliationStateReady}>{readiness.reconciliationStateReady ? 'READY' : 'CHECK'}</Badge></div>
+                <div className={styles.cardHead}><span>↻</span><Badge ready={readiness.reconciliationStateReady && stateWritable}>{readiness.reconciliationStateReady && stateWritable ? 'WRITE READY' : 'CHECK'}</Badge></div>
                 <h2>Reconciliation state</h2>
                 <p>Stores the sandbox event cursor, heartbeat, and owner-scoped reconciliation checkpoint.</p>
-                <Metric label="State table" value={readiness.reconciliationStateReady ? 'READY' : 'NOT READY'} ready={readiness.reconciliationStateReady} />
+                <Metric label="State table read" value={readiness.reconciliationStateReady ? 'READY' : 'NOT READY'} ready={readiness.reconciliationStateReady} />
+                <Metric label="Heartbeat write" value={stateWritable ? 'READY' : 'BLOCKED'} ready={stateWritable} />
               </article>
 
               <article className={databaseReady ? '' : styles.lockedCard}>
-                <div className={styles.cardHead}><span>{databaseReady ? '✓' : '!'}</span><Badge ready={databaseReady}>{databaseReady ? 'MIGRATION 024 READY' : 'MIGRATION 024 NEEDED'}</Badge></div>
+                <div className={styles.cardHead}><span>{databaseReady ? '✓' : '!'}</span><Badge ready={databaseReady}>{databaseReady ? 'RECONCILIATION STORAGE READY' : writeBlocked ? 'WRITE REPAIR NEEDED' : 'STORAGE SETUP NEEDED'}</Badge></div>
                 <h2>Automatic reconciliation</h2>
-                <p>Both tables must exist before webhook persistence and missed-event reconciliation can be durable.</p>
-                <Metric label="Storage" value={databaseReady ? 'READY' : 'NOT READY'} ready={databaseReady} />
+                <p>The tables must be readable and the backend must be able to persist the sandbox heartbeat before reconciliation is considered ready.</p>
+                <Metric label="Storage" value={databaseReady ? 'READ + WRITE READY' : writeBlocked ? 'READABLE · WRITE BLOCKED' : 'NOT READY'} ready={databaseReady} />
                 <Metric label="Real-money movement" value="NO" ready={false} />
               </article>
             </section>
 
             <section className={styles.queue}>
               <div className={styles.queueHead}>
-                <div><span>NEXT STEP</span><h2>{databaseReady ? 'Reconciliation storage is ready' : 'One infrastructure step remains'}</h2></div>
+                <div><span>NEXT STEP</span><h2>{databaseReady ? 'Reconciliation storage is ready' : writeBlocked ? 'Backend write permission needs repair' : 'One infrastructure step remains'}</h2></div>
                 <Badge ready={databaseReady}>{databaseReady ? 'READY' : 'ACTION NEEDED'}</Badge>
               </div>
-              <p className={styles.clearMessage}>{databaseReady ? 'The deployed app can see both migration-024 tables. Return to Integration Health and run owner-scoped sandbox reconciliation.' : readiness.nextStep}</p>
+              <p className={styles.clearMessage}>{databaseReady ? 'The deployed app can read both migration-024 tables and persist the sandbox reconciliation heartbeat. Return to Integration Health and run owner-scoped sandbox reconciliation.' : readiness.nextStep}</p>
             </section>
 
             <section className={styles.truthStrip}>
               <span>✓</span>
-              <p><b>Safe verification only</b><small>This page checks table readiness using the deployed server connection. It does not expose Supabase credentials, raw database errors, provider identifiers, or enable production banking.</small></p>
+              <p><b>Safe verification only</b><small>This page checks table readiness and a sandbox-only reconciliation-state upsert using the deployed server connection. It does not expose Supabase credentials, raw database errors, provider identifiers, or enable production banking.</small></p>
               <Link href="/bank/integrations">Integration Health →</Link>
             </section>
 

--- a/lib/banking/increase-reconciliation-readiness.ts
+++ b/lib/banking/increase-reconciliation-readiness.ts
@@ -6,6 +6,11 @@ type TableProbe = {
   unavailable: boolean;
 };
 
+type WriteProbe = {
+  writable: boolean;
+  unavailable: boolean;
+};
+
 function isMissingRelation(error: any) {
   const code = String(error?.code || '').trim();
   const message = String(error?.message || '').toLowerCase();
@@ -26,6 +31,22 @@ async function probeTable(client: any, table: string): Promise<TableProbe> {
   }
 }
 
+async function probeReconciliationWrite(client: any): Promise<WriteProbe> {
+  try {
+    const { error } = await client
+      .from('galactic_increase_reconciliation_state')
+      .upsert({
+        environment: 'sandbox',
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'environment' });
+    return error
+      ? { writable: false, unavailable: true }
+      : { writable: true, unavailable: false };
+  } catch {
+    return { writable: false, unavailable: true };
+  }
+}
+
 export async function inspectIncreaseReconciliationStorage() {
   let candidates: any[] = [];
   try {
@@ -39,6 +60,7 @@ export async function inspectIncreaseReconciliationStorage() {
       serverCredentialsPresent: false,
       eventLedgerReady: false,
       reconciliationStateReady: false,
+      reconciliationStateWritable: false,
       databaseReady: false,
       migration024Status: 'server-config-missing',
       nextStep: 'Configure the deployed server Supabase admin connection before checking reconciliation storage.',
@@ -47,6 +69,7 @@ export async function inspectIncreaseReconciliationStorage() {
   }
 
   let missingObservation: { eventLedger: TableProbe; reconciliationState: TableProbe } | null = null;
+  let readableButWriteBlocked = false;
 
   for (const client of candidates) {
     const [eventLedger, reconciliationState] = await Promise.all([
@@ -55,27 +78,69 @@ export async function inspectIncreaseReconciliationStorage() {
     ]);
 
     if (eventLedger.ready || reconciliationState.ready) {
-      const databaseReady = eventLedger.ready && reconciliationState.ready;
-      return {
-        ok: true,
-        environment: 'sandbox',
-        runtime: process.env.VERCEL ? 'vercel' : 'server',
-        source: 'deployed-server',
-        serverCredentialsPresent: true,
-        eventLedgerReady: eventLedger.ready,
-        reconciliationStateReady: reconciliationState.ready,
-        databaseReady,
-        migration024Status: databaseReady ? 'ready' : 'migration-needed',
-        nextStep: databaseReady
-          ? ''
-          : 'Apply migration 024 so both Increase sandbox reconciliation tables are present.',
-        canMoveRealMoney: false,
-      };
+      const writeProbe = reconciliationState.ready
+        ? await probeReconciliationWrite(client)
+        : { writable: false, unavailable: true };
+      const tablesReady = eventLedger.ready && reconciliationState.ready;
+      const databaseReady = tablesReady && writeProbe.writable;
+
+      if (databaseReady) {
+        return {
+          ok: true,
+          environment: 'sandbox',
+          runtime: process.env.VERCEL ? 'vercel' : 'server',
+          source: 'deployed-server',
+          serverCredentialsPresent: true,
+          eventLedgerReady: true,
+          reconciliationStateReady: true,
+          reconciliationStateWritable: true,
+          databaseReady: true,
+          migration024Status: 'ready',
+          nextStep: '',
+          canMoveRealMoney: false,
+        };
+      }
+
+      if (tablesReady && !writeProbe.writable) readableButWriteBlocked = true;
+
+      if (!tablesReady) {
+        return {
+          ok: true,
+          environment: 'sandbox',
+          runtime: process.env.VERCEL ? 'vercel' : 'server',
+          source: 'deployed-server',
+          serverCredentialsPresent: true,
+          eventLedgerReady: eventLedger.ready,
+          reconciliationStateReady: reconciliationState.ready,
+          reconciliationStateWritable: writeProbe.writable,
+          databaseReady: false,
+          migration024Status: 'migration-needed',
+          nextStep: 'Apply migration 024 so both Increase sandbox reconciliation tables are present.',
+          canMoveRealMoney: false,
+        };
+      }
     }
 
     if (eventLedger.missing || reconciliationState.missing) {
       missingObservation = { eventLedger, reconciliationState };
     }
+  }
+
+  if (readableButWriteBlocked) {
+    return {
+      ok: true,
+      environment: 'sandbox',
+      runtime: process.env.VERCEL ? 'vercel' : 'server',
+      source: 'deployed-server',
+      serverCredentialsPresent: true,
+      eventLedgerReady: true,
+      reconciliationStateReady: true,
+      reconciliationStateWritable: false,
+      databaseReady: false,
+      migration024Status: 'write-blocked',
+      nextStep: 'Apply migration 026 so the backend service role can write the sandbox reconciliation heartbeat while browser roles remain denied.',
+      canMoveRealMoney: false,
+    };
   }
 
   if (missingObservation) {
@@ -87,6 +152,7 @@ export async function inspectIncreaseReconciliationStorage() {
       serverCredentialsPresent: true,
       eventLedgerReady: false,
       reconciliationStateReady: false,
+      reconciliationStateWritable: false,
       databaseReady: false,
       migration024Status: 'migration-needed',
       nextStep: 'The deployed Supabase project is reachable, but migration 024 reconciliation storage is not fully present.',
@@ -102,6 +168,7 @@ export async function inspectIncreaseReconciliationStorage() {
     serverCredentialsPresent: true,
     eventLedgerReady: false,
     reconciliationStateReady: false,
+    reconciliationStateWritable: false,
     databaseReady: false,
     migration024Status: 'unavailable',
     nextStep: 'The deployed server has Supabase admin configuration, but reconciliation storage could not be verified. Check the server-side Supabase connection and project permissions.',

--- a/scripts/test-galactic-trust-integration-health.mjs
+++ b/scripts/test-galactic-trust-integration-health.mjs
@@ -7,6 +7,7 @@ const enhancements = await readFile(new URL('../app/bank/GalacticDashboardEnhanc
 const storagePage = await readFile(new URL('../app/bank/integrations/storage/page.js', import.meta.url), 'utf8');
 const storageRoute = await readFile(new URL('../app/api/admin/bank/increase/reconciliation-readiness/route.ts', import.meta.url), 'utf8');
 const storageProbe = await readFile(new URL('../lib/banking/increase-reconciliation-readiness.ts', import.meta.url), 'utf8');
+const repairMigration = await readFile(new URL('../supabase/migrations/026_galactic_increase_reconciliation_service_role.sql', import.meta.url), 'utf8');
 
 assert.match(route, /requireGalacticTrustAdmin/, 'integration health API must be owner/admin authenticated');
 assert.match(route, /inspectIncreaseSandbox/, 'integration health must inspect the configured Increase sandbox server-side');
@@ -51,7 +52,7 @@ assert.equal(page.includes('/api/admin/bank/increase/onboarding'), false, 'brows
 assert.equal(page.includes('/api/admin/bank/increase/reconciliation'), false, 'browser must not consume the raw reconciliation payload');
 assert.equal(page.includes('/api/admin/bank/increase/status'), false, 'browser must consume only the sanitized integration-health summary');
 assert.equal(page.includes('accountId'), false, 'integration health UI must not handle full provider Account IDs');
-assert.equal(page.includes('entityId'), false, 'integration health UI must not handle full provider Entity IDs');
+assert.equal(page.includes('entityId'), false, 'integration health UI must not handle provider Entity IDs');
 assert.equal(page.includes('programId'), false, 'integration health UI must not handle provider Program IDs');
 assert.equal(page.includes('apiKey'), false, 'integration health UI must never handle provider API keys');
 
@@ -62,16 +63,26 @@ assert.doesNotMatch(storageRoute, /SUPABASE_(?:SECRET|SERVICE|DB|ACCESS)/, 'stor
 assert.match(storageProbe, /getSupabaseAdminCandidates/, 'storage readiness must use the same server-side Supabase admin candidates as the deployed app');
 assert.match(storageProbe, /galactic_increase_webhook_events/, 'storage readiness must check the migration-024 event ledger');
 assert.match(storageProbe, /galactic_increase_reconciliation_state/, 'storage readiness must check the migration-024 reconciliation state table');
-assert.match(storageProbe, /migration024Status/, 'storage readiness must return a sanitized migration-024 status');
+assert.match(storageProbe, /probeReconciliationWrite/, 'storage readiness must verify the actual reconciliation heartbeat write path');
+assert.match(storageProbe, /reconciliationStateWritable/, 'storage readiness must report write readiness separately from table readability');
+assert.match(storageProbe, /write-blocked/, 'storage readiness must distinguish readable tables from blocked backend writes');
+assert.match(storageProbe, /migration024Status/, 'storage readiness must return a sanitized migration/storage status');
 assert.match(storageProbe, /canMoveRealMoney: false/, 'storage probe must preserve the sandbox-only boundary');
 assert.equal(storageProbe.includes('password'), false, 'storage probe must never expose or request database passwords');
 assert.match(storagePage, /DEPLOYED SERVER/, 'storage readiness UI must explain that it checks the deployed server configuration');
-assert.match(storagePage, /does not rely on GitHub Actions secrets/, 'storage readiness UI must distinguish deployed server configuration from GitHub Actions secrets');
-assert.match(storagePage, /MIGRATION 024/, 'storage readiness UI must make migration 024 status explicit');
+assert.match(storagePage, /Heartbeat write/, 'storage readiness UI must show whether the heartbeat can actually be persisted');
+assert.match(storagePage, /WRITE REPAIR NEEDED/, 'storage readiness UI must expose the readable-but-write-blocked state clearly');
+assert.match(storagePage, /READ \+ WRITE READY/, 'storage readiness UI must require both read and write before declaring reconciliation storage ready');
 assert.match(storagePage, /REAL MONEY[^]*LOCKED/, 'storage readiness UI must keep the real-money lock visible');
 assert.equal(storagePage.includes('SUPABASE_'), false, 'storage readiness browser UI must not contain server secret names');
+
+assert.match(repairMigration, /revoke all on table public\.galactic_increase_webhook_events from anon, authenticated/);
+assert.match(repairMigration, /revoke all on table public\.galactic_increase_reconciliation_state from anon, authenticated/);
+assert.match(repairMigration, /grant select, insert, update, delete on table public\.galactic_increase_webhook_events to service_role/);
+assert.match(repairMigration, /grant select, insert, update, delete on table public\.galactic_increase_reconciliation_state to service_role/);
+assert.doesNotMatch(repairMigration, /grant[^;]+to (?:anon|authenticated)/i, 'repair migration must never grant browser roles access to reconciliation storage');
 
 assert.match(enhancements, /id: 'integration-health'[^]*label: 'Integration health'/, 'dashboard command palette must expose the owner integration-health destination');
 assert.match(enhancements, /window\.location\.assign\('\/bank\/integrations'\)/, 'integration health command must route to /bank/integrations');
 
-console.log('Galactic Trust integration health checks passed: owner-only sanitized provider health and reconciliation are Account-scoped, webhook setup cannot block manual owner reconciliation, fallback path diagnostics are visible without secrets, deployed-server storage readiness is inspectable, and production remains fail-closed.');
+console.log('Galactic Trust integration health checks passed: owner-only reconciliation remains sandbox-scoped, webhook setup cannot block manual owner reconciliation, storage readiness verifies the actual heartbeat write path, backend table permissions are explicit while browser roles remain denied, and production stays fail-closed.');

--- a/supabase/migrations/026_galactic_increase_reconciliation_service_role.sql
+++ b/supabase/migrations/026_galactic_increase_reconciliation_service_role.sql
@@ -1,0 +1,15 @@
+-- Galactic Trust Increase sandbox reconciliation storage hardening.
+-- These tables contain sandbox-only event metadata and reconciliation checkpoints.
+-- Browser roles remain denied; only the backend service role receives explicit access.
+
+revoke all on table public.galactic_increase_webhook_events from anon, authenticated;
+revoke all on table public.galactic_increase_reconciliation_state from anon, authenticated;
+
+grant select, insert, update, delete on table public.galactic_increase_webhook_events to service_role;
+grant select, insert, update, delete on table public.galactic_increase_reconciliation_state to service_role;
+
+comment on table public.galactic_increase_webhook_events is
+  'Service-role-only Increase sandbox Event ledger. Browser roles are denied; stores metadata/hash only and has no real-money authority.';
+
+comment on table public.galactic_increase_reconciliation_state is
+  'Service-role-only Increase sandbox reconciliation checkpoint. Browser roles are denied and production money movement remains outside this table.';


### PR DESCRIPTION
Fixes the remaining reconciliation readiness blind spot that allowed read-only storage to appear READY.

Changes:
- storage readiness now performs a sandbox-only reconciliation-state UPSERT, not just SELECT probes
- exposes `reconciliationStateWritable` separately from table readability
- reports `write-blocked` when migration-024 tables exist but the backend cannot persist the heartbeat
- storage UI now shows `Heartbeat write: READY/BLOCKED` and requires READ + WRITE before declaring reconciliation storage ready
- adds migration 026 with explicit service-role read/write grants while keeping anon/authenticated fully revoked
- regression coverage locks in write verification and backend-only permissions

Safety boundary:
- Increase sandbox / pretend money only
- no browser database permissions added
- no provider IDs or credentials exposed
- real-money movement remains hard-locked