### PR TITLE
Keep owner sandbox recovery alive when binding storage is unavailable

### DIFF
--- a/lib/banking/increase-owner-account.js
+++ b/lib/banking/increase-owner-account.js
@@ -8,10 +8,24 @@ import {
 } from './provider-account-binding.js';
 
 export async function resolveIncreaseSandboxOwnerAccount(admin, userId, env = process.env) {
-  const stored = await getProviderAccountBinding(admin, userId, {
-    provider: 'increase',
-    environment: 'sandbox',
-  });
+  let stored = {
+    binding: null,
+    setupRequired: false,
+    error: '',
+  };
+
+  try {
+    stored = await getProviderAccountBinding(admin, userId, {
+      provider: 'increase',
+      environment: 'sandbox',
+    });
+  } catch {
+    stored = {
+      binding: null,
+      setupRequired: true,
+      error: 'Trusted provider-binding storage could not be read. Galactic Trust is using the owner-scoped Increase sandbox recovery path instead.',
+    };
+  }
 
   if (stored.binding) {
     return {


### PR DESCRIPTION
Speed-focused sandbox reliability fix.

The owner Account resolver previously let any provider-binding storage read error abort the whole path before deterministic Increase Account-only recovery could run. Migration 025 is intentionally optional for the owner sandbox flow, so that behavior was too strict.

Changes:
- trusted database binding remains the preferred path when readable
- binding-storage read failures are now treated as advisory for sandbox owner recovery
- resolver continues to deterministic Increase idempotency-key discovery instead of aborting
- response still surfaces that binding storage needs attention
- no production banking behavior changes

Safety boundary: Increase sandbox / pretend money only. Production banking and real-money movement remain hard-locked.