### PR TITLE
Add Orbit AI readiness status

### DIFF
--- a/app/api/bank/orbit/status/route.ts
+++ b/app/api/bank/orbit/status/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const aiConfigured = Boolean(String(process.env.OPENAI_API_KEY || '').trim());
+  return NextResponse.json({
+    ok: true,
+    assistant: 'Orbit',
+    mode: aiConfigured ? 'ai-enhanced' : 'local-fallback',
+    aiConfigured,
+    conversationalHistory: true,
+    canMoveRealMoney: false,
+    note: aiConfigured
+      ? 'Orbit can use the server-side conversational AI path. Banking actions remain separate and production money movement remains locked.'
+      : 'Orbit is using the local conversational fallback until the server-side AI credential is configured. Banking actions remain separate and production money movement remains locked.',
+  }, {
+    headers: { 'Cache-Control': 'private, no-store, max-age=0' },
+  });
+}


### PR DESCRIPTION
Adds a tiny read-only production status endpoint so we can verify whether Orbit is actually running the server-side AI path or the local fallback without exposing any credential values.

Returns only:
- ai-enhanced vs local-fallback
- whether conversational history is enabled
- canMoveRealMoney: false
- a safe explanatory note

No secrets, provider IDs, account IDs, or banking actions are exposed.