### PR TITLE
Simplify no-Mac App Store Connect release

### DIFF
--- a/.github/workflows/app-store-release.yml
+++ b/.github/workflows/app-store-release.yml
@@ -2,12 +2,6 @@ name: App Store Release (No Mac Required)
 
 on:
   workflow_dispatch:
-    inputs:
-      upload_to_app_store:
-        description: Validate and upload the signed IPA to App Store Connect
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -18,11 +12,10 @@ concurrency:
 
 env:
   IOS_DIR: ios/GalacticTrustBusiness
-  BUNDLE_ID: com.hartensteindominic.galactictrustbusiness
 
 jobs:
   release:
-    name: Build, sign, and upload iOS app
+    name: Build, sign, and upload Galactic Trust Business
     runs-on: macos-15
     timeout-minutes: 45
 
@@ -35,22 +28,27 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Verify required secrets
+      - name: Verify Xcode 26 or newer
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          major="$(xcodebuild -version | awk '/^Xcode / { split($2, v, "."); print v[1] }')"
+          if [[ -z "$major" || "$major" -lt 26 ]]; then
+            echo "::error::Current App Store submissions require Xcode 26 or newer."
+            exit 1
+          fi
+
+      - name: Verify App Store Connect credentials
         shell: bash
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_DISTRIBUTION_P12_BASE64: ${{ secrets.APPLE_DISTRIBUTION_P12_BASE64 }}
-          APPLE_DISTRIBUTION_P12_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_P12_PASSWORD }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-          APPSTORE_API_PRIVATE_KEY_BASE64: ${{ secrets.APPSTORE_API_PRIVATE_KEY_BASE64 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          required=(APPLE_TEAM_ID APPLE_DISTRIBUTION_P12_BASE64 APPLE_DISTRIBUTION_P12_PASSWORD APPLE_PROVISIONING_PROFILE_BASE64)
-          if [[ "${{ inputs.upload_to_app_store }}" == "true" ]]; then
-            required+=(APPSTORE_API_KEY_ID APPSTORE_ISSUER_ID APPSTORE_API_PRIVATE_KEY_BASE64)
-          fi
+          required=(APPLE_TEAM_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_PRIVATE_KEY)
           missing=0
           for name in "${required[@]}"; do
             if [[ -z "${!name:-}" ]]; then
@@ -60,19 +58,10 @@ jobs:
           done
           exit "$missing"
 
-      - name: Confirm Xcode meets current App Store requirement
-        shell: bash
+      - name: Install build tools
         run: |
-          set -euo pipefail
-          xcodebuild -version
-          major="$(xcodebuild -version | awk '/^Xcode / { split($2, v, "."); print v[1] }')"
-          if [[ -z "$major" || "$major" -lt 26 ]]; then
-            echo "::error::This release workflow requires Xcode 26 or newer for current App Store submissions."
-            exit 1
-          fi
-
-      - name: Install XcodeGen
-        run: brew install xcodegen
+          brew install xcodegen
+          sudo gem install fastlane -NV
 
       - name: Generate app icon and Xcode project
         working-directory: ${{ env.IOS_DIR }}
@@ -107,172 +96,23 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             test
 
-      - name: Decode signing material
-        shell: bash
-        env:
-          APPLE_DISTRIBUTION_P12_BASE64: ${{ secrets.APPLE_DISTRIBUTION_P12_BASE64 }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-          APPSTORE_API_PRIVATE_KEY_BASE64: ${{ secrets.APPSTORE_API_PRIVATE_KEY_BASE64 }}
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import base64
-          import os
-          from pathlib import Path
-          temp = Path(os.environ["RUNNER_TEMP"])
-          temp.joinpath("galactic-distribution.p12").write_bytes(base64.b64decode(os.environ["APPLE_DISTRIBUTION_P12_BASE64"]))
-          temp.joinpath("galactic.mobileprovision").write_bytes(base64.b64decode(os.environ["APPLE_PROVISIONING_PROFILE_BASE64"]))
-          key = os.environ.get("APPSTORE_API_PRIVATE_KEY_BASE64", "")
-          key_id = os.environ.get("APPSTORE_API_KEY_ID", "")
-          if key and key_id:
-              temp.joinpath(f"AuthKey_{key_id}.p8").write_bytes(base64.b64decode(key))
-          PY
-
-      - name: Install Apple Distribution certificate
-        shell: bash
-        env:
-          APPLE_DISTRIBUTION_P12_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_P12_PASSWORD }}
-        run: |
-          set -euo pipefail
-          KEYCHAIN_PATH="$RUNNER_TEMP/galactic-signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$RUNNER_TEMP/galactic-distribution.p12" -k "$KEYCHAIN_PATH" -P "$APPLE_DISTRIBUTION_P12_PASSWORD" -A -t cert -f pkcs12
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          echo "SIGNING_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-
-      - name: Install and verify provisioning profile
+      - name: Create signing assets and upload to App Store Connect
         shell: bash
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          PROFILE_SOURCE="$RUNNER_TEMP/galactic.mobileprovision"
-          PROFILE_PLIST="$RUNNER_TEMP/galactic-profile.plist"
-          security cms -D -i "$PROFILE_SOURCE" > "$PROFILE_PLIST"
-          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$PROFILE_PLIST")"
-          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$PROFILE_PLIST")"
-          PROFILE_TEAM="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$PROFILE_PLIST")"
-          PROFILE_APP_ID="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$PROFILE_PLIST")"
-          if [[ "$PROFILE_TEAM" != "$APPLE_TEAM_ID" ]]; then
-            echo "::error::Provisioning profile team (${PROFILE_TEAM}) does not match APPLE_TEAM_ID."
-            exit 1
-          fi
-          expected_app_id="${APPLE_TEAM_ID}.${BUNDLE_ID}"
-          if [[ "$PROFILE_APP_ID" != "$expected_app_id" ]]; then
-            echo "::error::Provisioning profile is for ${PROFILE_APP_ID}, expected ${expected_app_id}."
-            exit 1
-          fi
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          cp "$PROFILE_SOURCE" "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
-          echo "PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
-          echo "PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+          fastlane ios release
 
-      - name: Archive signed iOS app
-        working-directory: ${{ env.IOS_DIR }}
+      - name: Upload summary
+        if: success()
         shell: bash
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          set -euo pipefail
-          xcodebuild \
-            -project GalacticTrustBusiness.xcodeproj \
-            -scheme GalacticTrustBusiness \
-            -configuration Release \
-            -destination 'generic/platform=iOS' \
-            -archivePath "$RUNNER_TEMP/GalacticTrustBusiness.xcarchive" \
-            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY='Apple Distribution' \
-            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_NAME" \
-            CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER" \
-            clean archive
-
-      - name: Export signed IPA
-        shell: bash
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          set -euo pipefail
-          EXPORT_OPTIONS="$RUNNER_TEMP/ExportOptions.plist"
-          EXPORT_DIR="$RUNNER_TEMP/app-store-export"
-          cat > "$EXPORT_OPTIONS" <<EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key><string>app-store-connect</string>
-            <key>teamID</key><string>${APPLE_TEAM_ID}</string>
-            <key>signingStyle</key><string>manual</string>
-            <key>signingCertificate</key><string>Apple Distribution</string>
-            <key>provisioningProfiles</key>
-            <dict><key>${BUNDLE_ID}</key><string>${PROFILE_NAME}</string></dict>
-            <key>stripSwiftSymbols</key><true/>
-            <key>uploadSymbols</key><true/>
-          </dict>
-          </plist>
-          EOF
-          xcodebuild -exportArchive \
-            -archivePath "$RUNNER_TEMP/GalacticTrustBusiness.xcarchive" \
-            -exportPath "$EXPORT_DIR" \
-            -exportOptionsPlist "$EXPORT_OPTIONS"
-          IPA_PATH="$(find "$EXPORT_DIR" -maxdepth 1 -name '*.ipa' -print -quit)"
-          if [[ -z "$IPA_PATH" ]]; then
-            echo "::error::Xcode did not produce an IPA."
-            exit 1
-          fi
-          echo "IPA_PATH=$IPA_PATH" >> "$GITHUB_ENV"
-
-      - name: Install App Store Connect API key
-        if: ${{ inputs.upload_to_app_store }}
-        shell: bash
-        env:
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-        run: |
-          set -euo pipefail
-          mkdir -p "$HOME/.appstoreconnect/private_keys"
-          cp "$RUNNER_TEMP/AuthKey_${APPSTORE_API_KEY_ID}.p8" "$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8"
-          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8"
-
-      - name: Validate signed IPA with App Store Connect
-        if: ${{ inputs.upload_to_app_store }}
-        shell: bash
-        env:
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-          xcrun altool --validate-app -f "$IPA_PATH" -t ios --apiKey "$APPSTORE_API_KEY_ID" --apiIssuer "$APPSTORE_ISSUER_ID"
-
-      - name: Upload to App Store Connect
-        if: ${{ inputs.upload_to_app_store }}
-        shell: bash
-        env:
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-        run: |
-          set -euo pipefail
-          xcrun altool --upload-app -f "$IPA_PATH" -t ios --apiKey "$APPSTORE_API_KEY_ID" --apiIssuer "$APPSTORE_ISSUER_ID"
           {
-            echo '### Galactic Trust Business upload submitted'
+            echo '### Galactic Trust Business uploaded'
             echo ''
-            echo 'The signed IPA was submitted to App Store Connect. Apple still needs to process the build before it appears in the app record.'
+            echo 'The signed build was uploaded to App Store Connect. Apple still needs to process it before it can be selected for submission.'
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Clean up signing material
-        if: always()
-        shell: bash
-        run: |
-          set +e
-          if [[ -n "${PROFILE_UUID:-}" ]]; then
-            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision"
-          fi
-          rm -f "$HOME/.appstoreconnect/private_keys/AuthKey_"*.p8
-          if [[ -n "${SIGNING_KEYCHAIN_PATH:-}" ]]; then
-            security delete-keychain "$SIGNING_KEYCHAIN_PATH"
-          fi

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,6 +75,11 @@ platform :ios do
         bundle_identifier: app_identifier
       )
 
+      increment_build_number(
+        build_number: ENV["GITHUB_RUN_NUMBER"] || Time.now.to_i.to_s,
+        xcodeproj: project_path
+      )
+
       build_ios_app(
         project: project_path,
         scheme: "GalacticTrustBusiness",
@@ -84,7 +89,7 @@ platform :ios do
         output_directory: "build",
         output_name: "GalacticTrustBusiness.ipa",
         export_options: {
-          method: "app-store",
+          method: "app-store-connect",
           signingStyle: "manual",
           provisioningProfiles: {
             app_identifier => profile_name
@@ -98,6 +103,7 @@ platform :ios do
         ipa: "build/GalacticTrustBusiness.ipa",
         skip_metadata: true,
         skip_screenshots: true,
+        skip_waiting_for_build_processing: true,
         precheck_include_in_app_purchases: false,
         force: true,
         submit_for_review: false


### PR DESCRIPTION
Switch the iOS cloud release to use only the active App Store Connect API credentials plus Apple Team ID. The workflow now creates signing assets on the hosted macOS runner, uses a unique CI build number for retries, builds/tests the native app, and uploads to App Store Connect without requiring a manually exported P12 certificate or provisioning profile.