### PR TITLE
Build Galactic Trust Business now

### DIFF
--- a/.github/workflows/ios-build-now.yml
+++ b/.github/workflows/ios-build-now.yml
@@ -1,0 +1,93 @@
+name: iOS Build Now (No Signing)
+
+on:
+  pull_request:
+    paths:
+      - 'ios/GalacticTrustBusiness/**'
+      - '.github/workflows/ios-build-now.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test Galactic Trust Business
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select current stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Verify Xcode
+        run: xcodebuild -version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        working-directory: ios/GalacticTrustBusiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/generate_app_icon.py
+          xcodegen generate
+
+      - name: Build for iOS Simulator
+        working-directory: ios/GalacticTrustBusiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project GalacticTrustBusiness.xcodeproj \
+            -scheme GalacticTrustBusiness \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build
+
+      - name: Run unit tests
+        working-directory: ios/GalacticTrustBusiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEVICE_ID="$(xcrun simctl list devices available -j | python3 -c 'import json,sys; d=json.load(sys.stdin)["devices"]; print(next(v["udid"] for runtime in d.values() for v in runtime if v["name"].startswith("iPhone") and v["isAvailable"]))')"
+          xcodebuild \
+            -project GalacticTrustBusiness.xcodeproj \
+            -scheme GalacticTrustBusiness \
+            -destination "platform=iOS Simulator,id=${DEVICE_ID}" \
+            -derivedDataPath "$RUNNER_TEMP/TestDerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Capture real native dashboard screenshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEVICE_ID="$(xcrun simctl list devices available -j | python3 -c 'import json,sys; d=json.load(sys.stdin)["devices"]; print(next(v["udid"] for runtime in d.values() for v in runtime if v["name"].startswith("iPhone") and v["isAvailable"]))')"
+          xcrun simctl boot "$DEVICE_ID" 2>/dev/null || true
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+          APP_PATH="$(find "$RUNNER_TEMP/DerivedData/Build/Products" -type d -name 'GalacticTrustBusiness.app' -print -quit)"
+          test -n "$APP_PATH"
+          xcrun simctl install "$DEVICE_ID" "$APP_PATH"
+          xcrun simctl launch "$DEVICE_ID" com.hartensteindominic.galactictrustbusiness
+          sleep 4
+          xcrun simctl io "$DEVICE_ID" screenshot "$RUNNER_TEMP/GalacticTrustBusiness-Dashboard.png"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$RUNNER_TEMP/GalacticTrustBusiness-Simulator.zip"
+
+      - name: Upload build and screenshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: GalacticTrustBusiness-native-preview
+          path: |
+            ${{ runner.temp }}/GalacticTrustBusiness-Simulator.zip
+            ${{ runner.temp }}/GalacticTrustBusiness-Dashboard.png
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Adds an unsigned cloud macOS build/test workflow for the native iOS app. It compiles the real SwiftUI target, runs unit tests, launches it in an iPhone simulator, captures a real native dashboard screenshot, and uploads the simulator app plus screenshot as GitHub Actions artifacts. This does not require Apple signing credentials and is intended to let us build and verify the app immediately from the phone while App Store signing remains a separate step.