### PR TITLE
Polish Galactic Trust Business for App Store

### DIFF
--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/AIManagerView.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/AIManagerView.swift
@@ -4,16 +4,17 @@ struct AIManagerView: View {
     @EnvironmentObject private var store: FinancialStore
     @State private var question = ""
     @State private var messages: [FinanceChatMessage] = [
-        .init(role: .assistant, text: "I’m your read-only business financial manager. I can explain money received, spending, invoices, recurring costs, cash balance, and runway using the records in this app.")
+        .init(role: .assistant, text: "I’m your read-only business financial manager. I can explain money received, spending changes, invoices, recurring costs, cash coverage, top vendors, and what-if scenarios using the records in this app.")
     ]
     @State private var selectedInsight: FinancialInsight?
 
     private let suggestions = [
         "Why did spending change?",
-        "How much revenue came in?",
+        "What needs my attention?",
+        "What is my biggest expense?",
         "What invoices are overdue?",
-        "What are my recurring costs?",
-        "How long is my cash runway?"
+        "How long is my cash runway?",
+        "Can I afford $5,000?"
     ]
 
     var body: some View {
@@ -209,7 +210,7 @@ struct AIManagerView: View {
 
     private func ask(_ text: String) {
         messages.append(.init(role: .user, text: text))
-        messages.append(.init(role: .assistant, text: store.answer(text)))
+        messages.append(.init(role: .assistant, text: store.smartAnswer(text)))
     }
 }
 

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/BusinessHealthView.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/BusinessHealthView.swift
@@ -1,0 +1,414 @@
+import SwiftUI
+
+struct BusinessHealthView: View {
+    @EnvironmentObject private var store: FinancialStore
+
+    private var recurringTotal: Double {
+        store.currentMonthTransactions
+            .filter { $0.kind == .expense && $0.isRecurring }
+            .reduce(0) { $0 + $1.amount }
+    }
+
+    private var overdueTotal: Double {
+        store.overdueInvoices.reduce(0) { $0 + $1.amount }
+    }
+
+    private var runwayMonths: Double {
+        guard store.currentMonthExpenses > 0 else { return store.balance > 0 ? 12 : 0 }
+        return max(store.balance, 0) / store.currentMonthExpenses
+    }
+
+    private var recurringShare: Double {
+        guard store.currentMonthExpenses > 0 else { return 0 }
+        return recurringTotal / store.currentMonthExpenses
+    }
+
+    private var healthScore: Int {
+        var score = 45
+        if store.currentMonthNet > 0 { score += 20 }
+        else if store.currentMonthNet < 0 { score -= 12 }
+
+        if runwayMonths >= 6 { score += 18 }
+        else if runwayMonths >= 3 { score += 12 }
+        else if runwayMonths >= 1 { score += 4 }
+        else { score -= 10 }
+
+        if overdueTotal == 0 { score += 10 }
+        else if overdueTotal < max(store.currentMonthIncome * 0.10, 1) { score += 4 }
+        else { score -= 8 }
+
+        if recurringShare <= 0.45 { score += 7 }
+        else if recurringShare > 0.70 { score -= 5 }
+
+        return min(100, max(0, score))
+    }
+
+    private var healthLabel: String {
+        switch healthScore {
+        case 80...: "Strong"
+        case 65..<80: "Healthy"
+        case 50..<65: "Watch"
+        default: "Needs attention"
+        }
+    }
+
+    private var healthTint: Color {
+        switch healthScore {
+        case 80...: GalacticTheme.green
+        case 65..<80: GalacticTheme.blue
+        case 50..<65: GalacticTheme.orange
+        default: GalacticTheme.pink
+        }
+    }
+
+    private var unusualExpenses: [BusinessTransaction] {
+        let expenses = store.currentMonthTransactions.filter { $0.kind == .expense }
+        guard !expenses.isEmpty else { return [] }
+        let average = expenses.reduce(0) { $0 + $1.amount } / Double(expenses.count)
+        let threshold = max(1_000, average * 1.75)
+        return expenses.filter { $0.amount >= threshold }.sorted { $0.amount > $1.amount }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                healthHero
+                metrics
+                attentionCard
+                methodology
+            }
+            .padding(16)
+            .padding(.bottom, 28)
+        }
+        .background(GalacticTheme.page.ignoresSafeArea())
+        .navigationTitle("Business Health")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var healthHero: some View {
+        ZStack {
+            GalacticTheme.spaceGradient
+            GalacticTheme.backgroundGlow
+
+            HStack(spacing: 18) {
+                ZStack {
+                    Circle()
+                        .stroke(Color.white.opacity(0.16), lineWidth: 12)
+                    Circle()
+                        .trim(from: 0, to: Double(healthScore) / 100)
+                        .stroke(healthTint, style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                    VStack(spacing: 0) {
+                        Text("\(healthScore)")
+                            .font(.system(size: 36, weight: .bold, design: .rounded))
+                        Text("/ 100")
+                            .font(.caption2.bold())
+                            .opacity(0.7)
+                    }
+                    .foregroundStyle(.white)
+                }
+                .frame(width: 126, height: 126)
+
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("BUSINESS HEALTH")
+                        .font(.caption2.bold())
+                        .tracking(1.1)
+                        .foregroundStyle(.white.opacity(0.66))
+                    Text(healthLabel)
+                        .font(.title.bold())
+                        .foregroundStyle(.white)
+                    Text(summaryText)
+                        .font(.caption)
+                        .foregroundStyle(.white.opacity(0.76))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(20)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .shadow(color: GalacticTheme.deepBlue.opacity(0.18), radius: 18, y: 9)
+    }
+
+    private var summaryText: String {
+        if store.currentMonthNet >= 0 && runwayMonths >= 3 && overdueTotal == 0 {
+            return "Positive cash flow, useful cash coverage, and no overdue receivables are supporting the score."
+        }
+        if store.currentMonthNet < 0 {
+            return "Recorded spending is above recorded income this month. Review expenses and receivables before committing more cash."
+        }
+        if overdueTotal > 0 {
+            return "Cash flow is positive, but overdue receivables are creating avoidable collection risk."
+        }
+        return "The score summarizes cash flow, expense coverage, recurring spend, and overdue receivables from records on this device."
+    }
+
+    private var metrics: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                MetricTile(
+                    title: "Cash coverage",
+                    value: "\(runwayMonths.formatted(.number.precision(.fractionLength(1)))) mo",
+                    subtitle: "At this month's expense pace",
+                    systemImage: "shield.checkered",
+                    tint: runwayMonths >= 3 ? GalacticTheme.green : GalacticTheme.orange
+                )
+                MetricTile(
+                    title: "Net cash flow",
+                    value: store.currency(store.currentMonthNet),
+                    subtitle: "Income minus expenses",
+                    systemImage: "arrow.up.arrow.down",
+                    tint: store.currentMonthNet >= 0 ? GalacticTheme.blue : GalacticTheme.pink
+                )
+            }
+
+            HStack(spacing: 12) {
+                MetricTile(
+                    title: "Recurring costs",
+                    value: store.currency(recurringTotal),
+                    subtitle: "Marked recurring this month",
+                    systemImage: "repeat",
+                    tint: GalacticTheme.violet
+                )
+                MetricTile(
+                    title: "Overdue",
+                    value: store.currency(overdueTotal),
+                    subtitle: "Outstanding past due",
+                    systemImage: "clock.badge.exclamationmark",
+                    tint: overdueTotal > 0 ? GalacticTheme.pink : GalacticTheme.green
+                )
+            }
+        }
+    }
+
+    private var attentionCard: some View {
+        GalacticCard {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(title: "Needs attention")
+
+                if unusualExpenses.isEmpty && overdueTotal == 0 && store.currentMonthNet >= 0 {
+                    Label("No major risk signals detected in the current records.", systemImage: "checkmark.seal.fill")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(GalacticTheme.green)
+                } else {
+                    if store.currentMonthNet < 0 {
+                        signalRow(
+                            icon: "arrow.down.right.circle.fill",
+                            title: "Negative monthly cash flow",
+                            detail: "Expenses exceed income by \(store.currency(abs(store.currentMonthNet))).",
+                            tint: GalacticTheme.pink
+                        )
+                    }
+
+                    if overdueTotal > 0 {
+                        signalRow(
+                            icon: "doc.badge.clock.fill",
+                            title: "Overdue receivables",
+                            detail: "\(store.currency(overdueTotal)) is currently overdue.",
+                            tint: GalacticTheme.orange
+                        )
+                    }
+
+                    ForEach(unusualExpenses.prefix(3)) { item in
+                        signalRow(
+                            icon: "exclamationmark.triangle.fill",
+                            title: "Large expense: \(item.merchant)",
+                            detail: "\(store.currency(item.amount)) • \(item.category.rawValue)",
+                            tint: GalacticTheme.indigo
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func signalRow(icon: String, title: String, detail: String, tint: Color) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+                .frame(width: 34, height: 34)
+                .background(tint.opacity(0.10))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title).font(.subheadline.bold()).foregroundStyle(GalacticTheme.navy)
+                Text(detail).font(.caption).foregroundStyle(GalacticTheme.mutedText)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var methodology: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "info.circle.fill")
+                .foregroundStyle(GalacticTheme.indigo)
+            Text("The health score is an explainable planning indicator calculated only from records in this app. It is not a credit score, accounting opinion, lending decision, or investment recommendation.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 6)
+    }
+}
+
+struct ScenarioPlannerView: View {
+    @EnvironmentObject private var store: FinancialStore
+    @State private var revenueChange = 10.0
+    @State private var expenseChange = -5.0
+
+    private var projectedIncome: Double {
+        max(0, store.currentMonthIncome * (1 + revenueChange / 100))
+    }
+
+    private var projectedExpenses: Double {
+        max(0, store.currentMonthExpenses * (1 + expenseChange / 100))
+    }
+
+    private var projectedNet: Double {
+        projectedIncome - projectedExpenses
+    }
+
+    private var projectedBalance: Double {
+        store.balance + projectedNet
+    }
+
+    private var projectedCoverage: Double {
+        guard projectedExpenses > 0 else { return projectedBalance > 0 ? 12 : 0 }
+        return max(projectedBalance, 0) / projectedExpenses
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                header
+                controls
+                resultCard
+                assumptions
+            }
+            .padding(16)
+            .padding(.bottom, 28)
+        }
+        .background(GalacticTheme.page.ignoresSafeArea())
+        .navigationTitle("Scenario Planner")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var header: some View {
+        GalacticCard {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.title2.bold())
+                    .foregroundStyle(.white)
+                    .frame(width: 52, height: 52)
+                    .background(GalacticTheme.heroGradient)
+                    .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Model a business decision")
+                        .font(.title3.bold())
+                        .foregroundStyle(GalacticTheme.navy)
+                    Text("Adjust revenue and spending assumptions to see the estimated effect on monthly cash flow and cash coverage.")
+                        .font(.subheadline)
+                        .foregroundStyle(GalacticTheme.mutedText)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var controls: some View {
+        GalacticCard {
+            VStack(alignment: .leading, spacing: 22) {
+                scenarioSlider(
+                    title: "Revenue change",
+                    value: $revenueChange,
+                    range: -40...60,
+                    tint: GalacticTheme.green
+                )
+                scenarioSlider(
+                    title: "Expense change",
+                    value: $expenseChange,
+                    range: -40...40,
+                    tint: GalacticTheme.indigo
+                )
+
+                Button("Reset assumptions") {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        revenueChange = 0
+                        expenseChange = 0
+                    }
+                }
+                .font(.caption.bold())
+                .foregroundStyle(GalacticTheme.indigo)
+            }
+        }
+    }
+
+    private func scenarioSlider(title: String, value: Binding<Double>, range: ClosedRange<Double>, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack {
+                Text(title).font(.headline).foregroundStyle(GalacticTheme.navy)
+                Spacer()
+                Text("\(value.wrappedValue >= 0 ? "+" : "")\(value.wrappedValue.formatted(.number.precision(.fractionLength(0))))%")
+                    .font(.headline.monospacedDigit())
+                    .foregroundStyle(tint)
+            }
+            Slider(value: value, in: range, step: 1)
+                .tint(tint)
+        }
+    }
+
+    private var resultCard: some View {
+        ZStack {
+            GalacticTheme.spaceGradient
+            VStack(alignment: .leading, spacing: 16) {
+                Label("Projected next month", systemImage: "sparkles")
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.86))
+
+                HStack(alignment: .firstTextBaseline) {
+                    Text(store.currency(projectedNet))
+                        .font(.system(size: 36, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                    Spacer()
+                    Text(projectedNet >= 0 ? "Positive" : "Negative")
+                        .font(.caption.bold())
+                        .foregroundStyle(projectedNet >= 0 ? Color.mint : Color.pink)
+                }
+
+                Text("Estimated net cash flow")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.66))
+
+                Divider().overlay(Color.white.opacity(0.14))
+
+                HStack(spacing: 18) {
+                    resultMetric("Income", store.currency(projectedIncome))
+                    resultMetric("Expenses", store.currency(projectedExpenses))
+                    resultMetric("Coverage", "\(projectedCoverage.formatted(.number.precision(.fractionLength(1)))) mo")
+                }
+            }
+            .padding(20)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    private func resultMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title).font(.caption2).foregroundStyle(.white.opacity(0.58))
+            Text(value)
+                .font(.caption.bold())
+                .foregroundStyle(.white)
+                .minimumScaleFactor(0.65)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var assumptions: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "info.circle.fill").foregroundStyle(GalacticTheme.indigo)
+            Text("This scenario repeats the current month's recorded activity with your percentage adjustments. It does not predict customers, taxes, financing, seasonality, or unexpected expenses.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 6)
+    }
+}

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/CashFlowView.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/CashFlowView.swift
@@ -166,10 +166,10 @@ struct CashFlowView: View {
         GalacticCard {
             VStack(alignment: .leading, spacing: 14) {
                 HStack {
-                    Label("Simple 30-day forecast", systemImage: "sparkles")
+                    Label("30-day planning estimate", systemImage: "sparkles")
                         .font(.headline)
                     Spacer()
-                    Text("AI assist")
+                    Text("Read-only")
                         .font(.caption2.bold())
                         .foregroundStyle(GalacticTheme.indigo)
                 }
@@ -177,7 +177,7 @@ struct CashFlowView: View {
                 Text(store.currency(projectedThirtyDayBalance))
                     .font(.title.bold())
                     .foregroundStyle(GalacticTheme.navy)
-                Text("Projected recorded cash if this month’s net cash flow repeats once more.")
+                Text("Estimated recorded cash if this month’s net cash flow repeats once more.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/DemoFreshness.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/DemoFreshness.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@MainActor
+extension FinancialStore {
+    /// Keeps the bundled review/demo workspace useful when a new calendar month
+    /// begins. This only runs once per install and only when the untouched sample
+    /// workspace still has historical data but no activity in the current month.
+    func ensureDemoPreviewIsCurrent() {
+        let marker = "galacticTrustBusiness.didRefreshDemoPreview.v1"
+        guard !UserDefaults.standard.bool(forKey: marker) else { return }
+        defer { UserDefaults.standard.set(true, forKey: marker) }
+
+        guard profile.name == "Nova Enterprises",
+              openingBalance == 42_000,
+              !transactions.isEmpty,
+              currentMonthTransactions.isEmpty
+        else { return }
+
+        let now = Date()
+        let samples: [BusinessTransaction] = [
+            .init(date: now, merchant: "Northstar Client", memo: "Project milestone", amount: 24_900, kind: .income, category: .services, source: "Sample"),
+            .init(date: now, merchant: "Stellar Labs", memo: "Client payment", amount: 12_500, kind: .income, category: .services, source: "Sample"),
+            .init(date: now, merchant: "Payroll", memo: "Employee salaries", amount: 9_800, kind: .expense, category: .payroll, isRecurring: true, source: "Sample"),
+            .init(date: now, merchant: "Office Lease", memo: "Monthly rent", amount: 3_400, kind: .expense, category: .rentUtilities, isRecurring: true, source: "Sample"),
+            .init(date: now, merchant: "Cloud Hosting", memo: "Infrastructure", amount: 2_140, kind: .expense, category: .software, isRecurring: true, source: "Sample"),
+            .init(date: now, merchant: "Growth Campaigns", memo: "Advertising", amount: 1_250.75, kind: .expense, category: .marketing, source: "Sample"),
+            .init(date: now, merchant: "Team Software", memo: "Collaboration tools", amount: 420, kind: .expense, category: .software, isRecurring: true, source: "Sample")
+        ]
+
+        addTransactions(samples)
+    }
+}

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/FinancialIntelligence.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/FinancialIntelligence.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+@MainActor
+extension FinancialStore {
+    func smartAnswer(_ question: String) -> String {
+        let q = question
+            .lowercased()
+            .replacingOccurrences(of: "’", with: "'")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let previous = totalsForRelativeMonth(-1)
+        let incomeChange = percentDelta(current: currentMonthIncome, previous: previous.income)
+        let expenseChange = percentDelta(current: currentMonthExpenses, previous: previous.expense)
+
+        if containsAny(q, ["what changed", "change this month", "different this month", "summary", "overview"]) {
+            var parts: [String] = []
+            parts.append("This month you received \(currency(currentMonthIncome)) and spent \(currency(currentMonthExpenses)), for \(currency(currentMonthNet)) in net cash flow.")
+
+            if previous.income > 0 {
+                parts.append("Revenue is \(directionText(incomeChange)) versus last month.")
+            }
+            if previous.expense > 0 {
+                parts.append("Spending is \(directionText(expenseChange)) versus last month.")
+            }
+            if !overdueInvoices.isEmpty {
+                let overdue = overdueInvoices.reduce(0) { $0 + $1.amount }
+                parts.append("\(currency(overdue)) in receivables is overdue.")
+            }
+            return parts.joined(separator: " ")
+        }
+
+        if containsAny(q, ["why did spending", "why spending", "spending change", "expenses change", "why did expenses"]) {
+            guard currentMonthExpenses > 0 else {
+                return "No expenses are recorded for this month yet, so I do not have enough current activity to explain a spending change."
+            }
+
+            let top = expenseByCategory.first
+            let largest = currentMonthTransactions
+                .filter { $0.kind == .expense }
+                .max { $0.amount < $1.amount }
+
+            var answer = "You spent \(currency(currentMonthExpenses)) this month"
+            if previous.expense > 0 {
+                answer += ", \(directionText(expenseChange)) versus last month"
+            }
+            answer += "."
+
+            if let top {
+                let share = currentMonthExpenses > 0 ? top.amount / currentMonthExpenses * 100 : 0
+                answer += " \(top.category.rawValue) is the largest category at \(currency(top.amount)) (\(share.formatted(.number.precision(.fractionLength(0))))% of spending)."
+            }
+            if let largest {
+                answer += " The largest recorded charge is \(currency(largest.amount)) to \(largest.merchant)."
+            }
+            return answer
+        }
+
+        if containsAny(q, ["biggest expense", "largest expense", "largest charge", "biggest charge"]) {
+            guard let item = currentMonthTransactions
+                .filter({ $0.kind == .expense })
+                .max(by: { $0.amount < $1.amount }) else {
+                return "No expenses are recorded for this month yet."
+            }
+            return "Your largest recorded expense this month is \(currency(item.amount)) to \(item.merchant), categorized as \(item.category.rawValue)."
+        }
+
+        if containsAny(q, ["vendor", "supplier", "who am i paying", "who do i pay"]) {
+            let expenses = currentMonthTransactions.filter { $0.kind == .expense }
+            guard !expenses.isEmpty else { return "No vendor expenses are recorded for this month yet." }
+
+            let ranked = Dictionary(grouping: expenses, by: \.merchant)
+                .map { merchant, items in
+                    (merchant: merchant, amount: items.reduce(0) { $0 + $1.amount })
+                }
+                .sorted { $0.amount > $1.amount }
+                .prefix(3)
+
+            let text = ranked.map { "\($0.merchant) \(currency($0.amount))" }.joined(separator: ", ")
+            return "Your top recorded payees this month are \(text)."
+        }
+
+        if containsAny(q, ["attention", "focus", "risk", "worry", "problem", "warning"]) {
+            guard !insights.isEmpty else {
+                return "I do not see a major alert in the records currently loaded. Keep transaction and invoice data current so the analysis has a stronger baseline."
+            }
+            let priorities = insights.prefix(3).map(\.title).joined(separator: "; ")
+            return "The main items I would review are: \(priorities). These are planning signals from the records in this app, not accounting or investment advice."
+        }
+
+        if containsAny(q, ["afford", "can i spend", "what if i spend", "purchase"]) && firstMoneyAmount(in: q) != nil {
+            let amount = firstMoneyAmount(in: q) ?? 0
+            let after = balance - amount
+            let coverage = currentMonthExpenses > 0 ? max(after, 0) / currentMonthExpenses : 0
+            return "If you recorded a \(currency(amount)) cash expense now, your modeled cash balance would be about \(currency(after)). At this month's recorded expense pace, that would leave about \(coverage.formatted(.number.precision(.fractionLength(1)))) months of expense coverage. This is a simple scenario, not a recommendation or guarantee."
+        }
+
+        if containsAny(q, ["revenue trend", "income trend", "sales trend", "revenue change", "income change"]) {
+            if previous.income <= 0 {
+                return "You received \(currency(currentMonthIncome)) this month. I do not have a non-zero prior-month revenue baseline for a meaningful percentage comparison."
+            }
+            return "You received \(currency(currentMonthIncome)) this month versus \(currency(previous.income)) last month, so revenue is \(directionText(incomeChange))."
+        }
+
+        if containsAny(q, ["recurring", "subscription", "subscriptions", "fixed cost", "fixed costs"]) {
+            let recurring = currentMonthTransactions.filter { $0.kind == .expense && $0.isRecurring }
+            let total = recurring.reduce(0) { $0 + $1.amount }
+            guard !recurring.isEmpty else { return "No expenses are marked recurring this month." }
+
+            let names = recurring
+                .sorted { $0.amount > $1.amount }
+                .prefix(4)
+                .map { "\($0.merchant) \(currency($0.amount))" }
+                .joined(separator: ", ")
+            return "Recurring expenses total \(currency(total)) this month across \(recurring.count) recorded charge\(recurring.count == 1 ? "" : "s"). The largest are \(names)."
+        }
+
+        if containsAny(q, ["invoice", "invoices", "receivable", "receivables", "who owes", "overdue"]) {
+            let overdue = overdueInvoices.reduce(0) { $0 + $1.amount }
+            if overdueInvoices.isEmpty {
+                return "You have \(currency(outstandingInvoices)) in unpaid invoices and none are currently marked overdue."
+            }
+            let clients = overdueInvoices.prefix(3).map { "\($0.client) \(currency($0.amount))" }.joined(separator: ", ")
+            return "You have \(currency(outstandingInvoices)) in unpaid invoices. \(currency(overdue)) is overdue, including \(clients)."
+        }
+
+        if containsAny(q, ["runway", "cash coverage", "how long", "cash last"]) {
+            guard currentMonthExpenses > 0 else {
+                return "Your recorded cash balance is \(currency(balance)). I need at least one month of recorded expenses to estimate cash coverage."
+            }
+            let runway = max(balance, 0) / currentMonthExpenses
+            return "Your recorded cash balance is \(currency(balance)). At this month's expense pace of \(currency(currentMonthExpenses)), that is about \(runway.formatted(.number.precision(.fractionLength(1)))) months of coverage. This is a planning estimate, not a liquidity guarantee."
+        }
+
+        if containsAny(q, ["revenue", "income", "received", "sales"]) {
+            return "You received \(currency(currentMonthIncome)) this month. After \(currency(currentMonthExpenses)) in recorded expenses, net cash flow is \(currency(currentMonthNet))."
+        }
+
+        if containsAny(q, ["spend", "spending", "expense", "expenses", "cost", "costs"]) {
+            if let top = expenseByCategory.first {
+                return "You spent \(currency(currentMonthExpenses)) this month. Your largest category is \(top.category.rawValue) at \(currency(top.amount)). Ask why spending changed or what your largest charge was for a deeper breakdown."
+            }
+            return "No expenses are recorded for this month yet."
+        }
+
+        if containsAny(q, ["cash", "balance"]) {
+            return "Your recorded cash balance is \(currency(balance)). This is the balance modeled from the opening balance plus transactions stored in this app; it is not a live bank balance."
+        }
+
+        return "This month you received \(currency(currentMonthIncome)), spent \(currency(currentMonthExpenses)), and recorded \(currency(currentMonthNet)) in net cash flow. I can dig into spending changes, top vendors, largest expenses, invoices, recurring costs, cash coverage, or a what-if purchase amount."
+    }
+
+    private func totalsForRelativeMonth(_ offset: Int) -> (income: Double, expense: Double) {
+        let calendar = Calendar.current
+        guard let month = calendar.date(byAdding: .month, value: offset, to: Date()) else { return (0, 0) }
+        let items = transactions.filter { calendar.isDate($0.date, equalTo: month, toGranularity: .month) }
+        return (
+            items.filter { $0.kind == .income }.reduce(0) { $0 + $1.amount },
+            items.filter { $0.kind == .expense }.reduce(0) { $0 + $1.amount }
+        )
+    }
+
+    private func percentDelta(current: Double, previous: Double) -> Double {
+        guard abs(previous) > 0.001 else { return current == 0 ? 0 : 100 }
+        return ((current - previous) / abs(previous)) * 100
+    }
+
+    private func directionText(_ change: Double) -> String {
+        if abs(change) < 0.5 { return "about flat" }
+        let amount = abs(change).formatted(.number.precision(.fractionLength(0)))
+        return change > 0 ? "up \(amount)%" : "down \(amount)%"
+    }
+
+    private func containsAny(_ text: String, _ phrases: [String]) -> Bool {
+        phrases.contains { text.contains($0) }
+    }
+
+    private func firstMoneyAmount(in text: String) -> Double? {
+        let pattern = #"(?:\$\s*)?([0-9]+(?:,[0-9]{3})*(?:\.[0-9]{1,2})?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: text)
+        else { return nil }
+
+        return Double(text[range].replacingOccurrences(of: ",", with: ""))
+    }
+}

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/FinancialIntelligence.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/FinancialIntelligence.swift
@@ -182,6 +182,7 @@ extension FinancialStore {
               let range = Range(match.range(at: 1), in: text)
         else { return nil }
 
-        return Double(text[range].replacingOccurrences(of: ",", with: ""))
+        let normalized = String(text[range]).replacingOccurrences(of: ",", with: "")
+        return Double(normalized)
     }
 }

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/GalacticTrustBusinessApp.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/GalacticTrustBusinessApp.swift
@@ -9,6 +9,9 @@ struct GalacticTrustBusinessApp: App {
             RootView()
                 .environmentObject(store)
                 .preferredColorScheme(.light)
+                .task {
+                    store.ensureDemoPreviewIsCurrent()
+                }
         }
     }
 }

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/MoreView.swift
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/MoreView.swift
@@ -23,6 +23,24 @@ struct MoreView: View {
 
             Section {
                 NavigationLink {
+                    BusinessHealthView()
+                } label: {
+                    moreRow("Business health", icon: "heart.text.square.fill", tint: GalacticTheme.green)
+                }
+
+                NavigationLink {
+                    ScenarioPlannerView()
+                } label: {
+                    moreRow("Scenario planner", icon: "slider.horizontal.3", tint: GalacticTheme.blue)
+                }
+            } header: {
+                Text("Intelligence")
+            } footer: {
+                Text("Read-only planning tools calculated from the records stored in this app.")
+            }
+
+            Section {
+                NavigationLink {
                     ImportGuideView()
                 } label: {
                     moreRow("Import financial data", icon: "square.and.arrow.down.fill", tint: GalacticTheme.green)


### PR DESCRIPTION
## Native iOS release polish

- keeps the bundled sample workspace useful across calendar-month boundaries so a fresh App Store review install does not open with zeroed current-month KPIs;
- adds a read-only **Business Health** screen with an explainable 0–100 planning score, cash coverage, recurring-cost and overdue-receivable signals, and large-expense attention items;
- adds a functional **Scenario Planner** for modeling revenue/spending changes and estimated net cash flow without moving money;
- upgrades the **AI Financial Manager** with more useful on-device answers for spending changes, biggest expenses, top vendors, attention items, invoices, recurring costs, revenue trends, cash coverage, and simple what-if purchase questions;
- surfaces the new intelligence tools under **More → Intelligence** while preserving the local-only/read-only product boundary.

This PR only touches the native `ios/GalacticTrustBusiness` target. It does not enable banking, money movement, lending, investing, or cloud collection of financial records.