### PR TITLE
Fix App Store release identity parsing

### DIFF
--- a/.github/workflows/app-store-release.yml
+++ b/.github/workflows/app-store-release.yml
@@ -114,8 +114,8 @@ jobs:
         run: |
           set -euo pipefail
           settings="$(xcodebuild -project GalacticTrustBusiness.xcodeproj -target GalacticTrustBusiness -configuration Release -showBuildSettings)"
-          version="$(awk -F ' = ' '/MARKETING_VERSION = / { print $2; exit }' <<< "$settings")"
-          bundle_id="$(awk -F ' = ' '/PRODUCT_BUNDLE_IDENTIFIER = / { print $2; exit }' <<< "$settings")"
+          version="$(awk -F ' = ' '$1 ~ /^[[:space:]]*MARKETING_VERSION$/ { print $2; exit }' <<< "$settings")"
+          bundle_id="$(awk -F ' = ' '$1 ~ /^[[:space:]]*PRODUCT_BUNDLE_IDENTIFIER$/ { print $2; exit }' <<< "$settings")"
           [[ "$version" == "1.0" ]] || { echo "::error::Expected marketing version 1.0, got $version"; exit 1; }
           [[ "$bundle_id" == "$BUNDLE_ID" ]] || { echo "::error::Unexpected bundle ID: $bundle_id"; exit 1; }
 


### PR DESCRIPTION
Fixes the release workflow's Xcode build-setting parsing so PRODUCT_BUNDLE_IDENTIFIER cannot accidentally match unrelated settings such as GENERATE_INFOPLIST_FILE = NO. This unblocks the no-Mac App Store release workflow.