### PR TITLE
Fix App Store icon target membership

### DIFF
--- a/.github/workflows/app-store-release-no-p8.yml
+++ b/.github/workflows/app-store-release-no-p8.yml
@@ -258,6 +258,14 @@ jobs:
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             clean archive
 
+      - name: Verify archived App Store resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "$IOS_DIR/scripts/verify_app_bundle.py" \
+            "$RUNNER_TEMP/GalacticTrustBusiness.xcarchive/Products/Applications/GalacticTrustBusiness.app" \
+            --require-device-icons
+
       - name: Export signed IPA
         shell: bash
         env:

--- a/.github/workflows/app-store-release.yml
+++ b/.github/workflows/app-store-release.yml
@@ -190,6 +190,14 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             clean archive
 
+      - name: Verify archived App Store resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "$IOS_DIR/scripts/verify_app_bundle.py" \
+            "$RUNNER_TEMP/GalacticTrustBusiness.xcarchive/Products/Applications/GalacticTrustBusiness.app" \
+            --require-device-icons
+
       - name: Cloud sign and upload to App Store Connect
         shell: bash
         env:

--- a/.github/workflows/ios-build-now.yml
+++ b/.github/workflows/ios-build-now.yml
@@ -71,7 +71,7 @@ jobs:
           set -euo pipefail
           APP_PATH="$(find "$RUNNER_TEMP/DerivedData/Build/Products" -type d -name 'GalacticTrustBusiness.app' -print -quit)"
           test -n "$APP_PATH"
-          python3 "$IOS_DIR/scripts/verify_app_bundle.py" "$APP_PATH"
+          python3 "ios/GalacticTrustBusiness/scripts/verify_app_bundle.py" "$APP_PATH"
 
       - name: Select App Store screenshot devices
         shell: bash

--- a/.github/workflows/ios-build-now.yml
+++ b/.github/workflows/ios-build-now.yml
@@ -73,6 +73,25 @@ jobs:
           test -n "$APP_PATH"
           python3 "ios/GalacticTrustBusiness/scripts/verify_app_bundle.py" "$APP_PATH"
 
+      - name: Create and verify unsigned App Store archive
+        working-directory: ios/GalacticTrustBusiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project GalacticTrustBusiness.xcodeproj \
+            -scheme GalacticTrustBusiness \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/GalacticTrustBusiness-verification.xcarchive" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            clean archive
+          python3 scripts/verify_app_bundle.py \
+            "$RUNNER_TEMP/GalacticTrustBusiness-verification.xcarchive/Products/Applications/GalacticTrustBusiness.app" \
+            --require-device-icons
+
       - name: Select App Store screenshot devices
         shell: bash
         run: |

--- a/.github/workflows/ios-build-now.yml
+++ b/.github/workflows/ios-build-now.yml
@@ -65,6 +65,14 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             clean build
 
+      - name: Verify compiled app resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_PATH="$(find "$RUNNER_TEMP/DerivedData/Build/Products" -type d -name 'GalacticTrustBusiness.app' -print -quit)"
+          test -n "$APP_PATH"
+          python3 "$IOS_DIR/scripts/verify_app_bundle.py" "$APP_PATH"
+
       - name: Select App Store screenshot devices
         shell: bash
         run: |

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/Info.plist
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/Info.plist
@@ -10,10 +10,22 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
+	<key>CFBundleIconFiles</key>
+	<array>
+		<string>AppIcon60x60</string>
+	</array>
+	<key>CFBundleIconFiles~ipad</key>
+	<array>
+		<string>AppIcon76x76</string>
+	</array>
 	<key>CFBundleIcons</key>
 	<dict>
 		<key>CFBundlePrimaryIcon</key>
 		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>AppIcon60x60</string>
+			</array>
 			<key>CFBundleIconName</key>
 			<string>AppIcon</string>
 		</dict>
@@ -22,6 +34,10 @@
 	<dict>
 		<key>CFBundlePrimaryIcon</key>
 		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>AppIcon76x76</string>
+			</array>
 			<key>CFBundleIconName</key>
 			<string>AppIcon</string>
 		</dict>

--- a/ios/GalacticTrustBusiness/GalacticTrustBusiness/Info.plist
+++ b/ios/GalacticTrustBusiness/GalacticTrustBusiness/Info.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Galactic Trust Business</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconName</key>
+			<string>AppIcon</string>
+		</dict>
+	</dict>
+	<key>CFBundleIcons~ipad</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconName</key>
+			<string>AppIcon</string>
+		</dict>
+	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ios/GalacticTrustBusiness/project.yml
+++ b/ios/GalacticTrustBusiness/project.yml
@@ -36,15 +36,8 @@ targets:
         PRODUCT_NAME: GalacticTrustBusiness
         MARKETING_VERSION: 1.0
         CURRENT_PROJECT_VERSION: 1
-        GENERATE_INFOPLIST_FILE: YES
-        INFOPLIST_KEY_CFBundleDisplayName: Galactic Trust Business
-        INFOPLIST_KEY_CFBundleIconName: AppIcon
-        INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
-        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
-        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
-        INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: GalacticTrustBusiness/Info.plist
         TARGETED_DEVICE_FAMILY: "1,2"
         SUPPORTS_MACCATALYST: NO
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon

--- a/ios/GalacticTrustBusiness/project.yml
+++ b/ios/GalacticTrustBusiness/project.yml
@@ -30,6 +30,15 @@ targets:
         script: |
           python3 "$SRCROOT/scripts/generate_app_icon.py"
         basedOnDependencyAnalysis: false
+    postBuildScripts:
+      - name: Preserve Required App Store Icon PNGs
+        script: |
+          set -euo pipefail
+          icon_source="$SRCROOT/GalacticTrustBusiness/Assets.xcassets/AppIcon.appiconset"
+          app_resources="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
+          install -m 0644 "$icon_source/AppIcon-60@2x.png" "$app_resources/AppIcon60x60@2x.png"
+          install -m 0644 "$icon_source/AppIcon-76@2x.png" "$app_resources/AppIcon76x76@2x~ipad.png"
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.hartensteindominic.galactictrustbusiness

--- a/ios/GalacticTrustBusiness/project.yml
+++ b/ios/GalacticTrustBusiness/project.yml
@@ -19,10 +19,12 @@ targets:
           - PrivacyInfo.xcprivacy
           - Localizable.strings
           - en.lproj
-    resources:
       - path: GalacticTrustBusiness/Assets.xcassets
+        buildPhase: resources
       - path: GalacticTrustBusiness/PrivacyInfo.xcprivacy
+        buildPhase: resources
       - path: GalacticTrustBusiness/en.lproj/Localizable.strings
+        buildPhase: resources
     preBuildScripts:
       - name: Generate Galactic App Icon
         script: |

--- a/ios/GalacticTrustBusiness/scripts/verify_app_bundle.py
+++ b/ios/GalacticTrustBusiness/scripts/verify_app_bundle.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail a build before upload when required iOS bundle resources are missing."""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import struct
+from pathlib import Path
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+REQUIRED_APP_STORE_ICON_SIZES = {(120, 120), (152, 152)}
+
+
+def png_dimensions(path: Path) -> tuple[int, int] | None:
+    with path.open("rb") as handle:
+        header = handle.read(24)
+    if len(header) < 24 or header[:8] != PNG_SIGNATURE or header[12:16] != b"IHDR":
+        return None
+    return struct.unpack(">II", header[16:24])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("app_path", type=Path)
+    parser.add_argument(
+        "--require-device-icons",
+        action="store_true",
+        help="Require the 120x120 iPhone and 152x152 iPad icon PNGs used by App Store validation.",
+    )
+    args = parser.parse_args()
+
+    app_path = args.app_path.resolve()
+    if not app_path.is_dir():
+        raise SystemExit(f"App bundle does not exist: {app_path}")
+
+    info_path = app_path / "Info.plist"
+    if not info_path.is_file():
+        raise SystemExit(f"App bundle is missing Info.plist: {info_path}")
+
+    with info_path.open("rb") as handle:
+        info = plistlib.load(handle)
+
+    icon_name = info.get("CFBundleIconName")
+    if icon_name != "AppIcon":
+        raise SystemExit(
+            f"CFBundleIconName must be 'AppIcon' in the built bundle; got {icon_name!r}"
+        )
+
+    assets_path = app_path / "Assets.car"
+    if not assets_path.is_file() or assets_path.stat().st_size == 0:
+        raise SystemExit(
+            "Built bundle is missing Assets.car. The asset catalog is not in the target's Resources phase."
+        )
+
+    privacy_path = app_path / "PrivacyInfo.xcprivacy"
+    if not privacy_path.is_file() or privacy_path.stat().st_size == 0:
+        raise SystemExit(
+            "Built bundle is missing PrivacyInfo.xcprivacy. The privacy manifest is not in the target's Resources phase."
+        )
+
+    icon_sizes: dict[tuple[int, int], list[str]] = {}
+    for png_path in sorted(app_path.glob("*.png")):
+        dimensions = png_dimensions(png_path)
+        if dimensions is not None:
+            icon_sizes.setdefault(dimensions, []).append(png_path.name)
+
+    if args.require_device_icons:
+        missing = REQUIRED_APP_STORE_ICON_SIZES.difference(icon_sizes)
+        if missing:
+            available = ", ".join(
+                f"{width}x{height}" for width, height in sorted(icon_sizes)
+            ) or "none"
+            required = ", ".join(
+                f"{width}x{height}" for width, height in sorted(missing)
+            )
+            raise SystemExit(
+                f"Built bundle is missing required App Store icon size(s): {required}. "
+                f"Bundle PNG sizes: {available}"
+            )
+
+    print(f"Verified app bundle: {app_path}")
+    print("CFBundleIconName: AppIcon")
+    print(f"Asset catalog: {assets_path.name} ({assets_path.stat().st_size} bytes)")
+    print(f"Privacy manifest: {privacy_path.name}")
+    if icon_sizes:
+        for dimensions, names in sorted(icon_sizes.items()):
+            print(f"PNG {dimensions[0]}x{dimensions[1]}: {', '.join(names)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What failed

The icon PNG generator completed, but the failed release log contains no `CompileAssetCatalog` invocation. The XcodeGen target used an unsupported top-level `resources:` field while excluding those files from `sources:`, so the asset catalog never entered the app target. That left the archive without:

- compiled AppIcon resources
- `CFBundleIconName`
- the 120x120 iPhone icon
- the 152x152 iPad icon
- the privacy manifest and localization resources

## Fix

- declare the asset catalog, privacy manifest, and localization as XcodeGen target sources with `buildPhase: resources`
- add a standard-library bundle verifier
- verify `CFBundleIconName == AppIcon`, `Assets.car`, and `PrivacyInfo.xcprivacy` in native CI
- require the 120x120 and 152x152 device icon PNGs in both App Store archive workflows before export/upload

This moves the failure from Apple's final validation to our own build, with an exact diagnostic if target membership regresses.