### PR TITLE
Start corrected App Store release

### DIFF
--- a/.github/workflows/app-store-release.yml
+++ b/.github/workflows/app-store-release.yml
@@ -2,6 +2,11 @@ name: App Store Release (No Mac Required)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/app-store-release.yml'
 
 permissions:
   contents: read
@@ -16,6 +21,7 @@ env:
 
 jobs:
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[app-store-release]') }}
     name: Build, cloud sign, and upload Galactic Trust Business
     runs-on: macos-15
     timeout-minutes: 45


### PR DESCRIPTION
Adds a temporary, commit-gated push trigger so the already-authorized GitHub connection can start the corrected App Store upload from `main`. The release job runs only for a merge commit containing `[app-store-release]`; manual dispatch remains unchanged. The trigger will be removed after the upload run is created.