### PR TITLE
Remove one-time App Store release trigger

### DIFF
--- a/.github/workflows/app-store-release.yml
+++ b/.github/workflows/app-store-release.yml
@@ -2,11 +2,6 @@ name: App Store Release (No Mac Required)
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/app-store-release.yml'
 
 permissions:
   contents: read
@@ -21,7 +16,6 @@ env:
 
 jobs:
   release:
-    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[app-store-release]') }}
     name: Build, cloud sign, and upload Galactic Trust Business
     runs-on: macos-15
     timeout-minutes: 45


### PR DESCRIPTION
The corrected build has uploaded successfully to App Store Connect. This restores the App Store workflow to manual dispatch only; no application code or release checks change.