### PR TITLE
Upgrade live ORXYZ site

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import styles from './orxyz.module.css';
 export const metadata = {
   title: 'ORXYZ | Technology, connected.',
   description:
-    'ORXYZ helps businesses evaluate practical technology solutions across robotics, automation, phone charging, smart unattended retail, and AI business tools.',
+    'Founder-led technology sourcing and coordination for businesses evaluating robotics, automation, phone charging, smart unattended retail, and selected AI business tools.',
 };
 
 const contactEmail = 'connectedtechpartners@gmail.com';
@@ -64,13 +64,48 @@ const steps = [
   },
 ];
 
+const standards = [
+  {
+    title: 'Founder-led accountability',
+    body: 'ORXYZ is operated by Dominic Hartenstein in Buffalo, New York. Provider relationships, commercial terms, and consequential commitments are reviewed personally.',
+  },
+  {
+    title: 'Permission before disclosure',
+    body: 'We avoid disclosing identifying business information to a third-party provider beyond what is appropriate for evaluation without permission.',
+  },
+  {
+    title: 'Provider responsibility stays clear',
+    body: 'The applicable provider confirms its own pricing, service area, contracts, installation, support, financing, and technical obligations in writing.',
+  },
+  {
+    title: 'Compensation is disclosed',
+    body: 'ORXYZ may receive referral or introducer compensation from a provider when a documented milestone is reached. That does not authorize ORXYZ to bind a business to a purchase or contract.',
+  },
+  {
+    title: 'No inflated deployment claims',
+    body: 'An inquiry, evaluation, introduction, signed agreement, installation, and live deployment are treated as separate stages. We do not describe an opportunity as deployed before it is confirmed.',
+  },
+  {
+    title: 'Written-first coordination',
+    body: 'Where practical, key terms, attribution, approvals, and next steps are documented so both sides can review what has — and has not — been agreed.',
+  },
+];
+
+const providerChecks = [
+  ['Service area & use-case fit', 'We confirm the provider actually serves the geography and business use case before presenting the path as viable.'],
+  ['Deployment & support responsibilities', 'Who supplies, installs, services, supports, bills, and owns the equipment should be clear before a handoff.'],
+  ['Commercial model', 'Customer obligations, provider economics, and any referral compensation should be documented rather than assumed.'],
+  ['Lead attribution', 'Where relevant, duplicate checks and attribution rules are confirmed before valuable opportunity details are disclosed.'],
+  ['Written approval before commitment', 'The business makes the final decision after reviewing current provider-specific terms.'],
+];
+
 export default function Home() {
   return (
     <main className={styles.page}>
       <div className={styles.topline}>
         <div className={`${styles.shell} ${styles.toplineInner}`}>
           <span className={styles.topDot} />
-          Buffalo, New York · Independent technology sourcing & coordination
+          Founder-led · Buffalo, New York · Independent technology sourcing & coordination
         </div>
       </div>
 
@@ -83,6 +118,7 @@ export default function Home() {
           <nav className={styles.navLinks} aria-label="Primary navigation">
             <a href="#solutions">Solutions</a>
             <a href="#process">Process</a>
+            <a href="#standards">Standards</a>
             <a href="#providers">Providers</a>
             <a href="#about">About</a>
           </nav>
@@ -107,17 +143,23 @@ export default function Home() {
               ORXYZ helps businesses identify practical technology opportunities, qualify suitable providers,
               and coordinate a clear path from evaluation to deployment.
             </p>
+            <p className={styles.heroCopy} style={{ marginTop: 14, fontSize: '14px', lineHeight: 1.7 }}>
+              ORXYZ is an independent sourcing and coordination business — not a manufacturer, lender, installer,
+              or equipment operator. Provider-specific pricing, contracts, deployment, and support remain with the
+              applicable provider unless explicitly agreed otherwise.
+            </p>
             <div className={styles.heroActions}>
               <a className={styles.primaryButton} href={businessMail}>
                 Discuss a technology need <span className={styles.arrow}>↗</span>
               </a>
-              <a className={styles.secondaryButton} href="#process">
-                See how it works <span className={styles.arrow}>↓</span>
+              <a className={styles.secondaryButton} href="#standards">
+                See our operating standards <span className={styles.arrow}>↓</span>
               </a>
             </div>
             <div className={styles.heroPoints} aria-label="ORXYZ principles">
               <span className={styles.heroPoint}>Business need first</span>
               <span className={styles.heroPoint}>Provider fit qualified</span>
+              <span className={styles.heroPoint}>Permission before disclosure</span>
               <span className={styles.heroPoint}>Written terms before commitment</span>
             </div>
           </div>
@@ -229,33 +271,62 @@ export default function Home() {
         </div>
       </section>
 
-      <section className={`${styles.section} ${styles.sectionMuted}`} id="providers">
+      <section className={`${styles.section} ${styles.sectionMuted}`} id="standards">
+        <div className={styles.shell}>
+          <div className={styles.sectionHeading}>
+            <div>
+              <div className={styles.sectionKicker}>ORXYZ operating standards</div>
+              <h2>Credibility comes from how the work is handled.</h2>
+            </div>
+            <p>
+              These standards keep introductions useful, permissioned, and commercially clear for both businesses and providers.
+            </p>
+          </div>
+          <div className={styles.audienceGrid}>
+            {standards.map((item) => (
+              <article className={styles.audienceCard} key={item.title}>
+                <b>{item.title}</b>
+                <span>{item.body}</span>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section} id="providers">
         <div className={styles.shell}>
           <div className={styles.providerPanel}>
             <div className={styles.providerCopy}>
               <div className={styles.sectionKicker}>For technology providers</div>
               <h2>Good opportunities deserve clean handoffs.</h2>
               <p>
-                ORXYZ can qualify potential business opportunities, confirm basic fit before disclosure when appropriate,
-                preserve referral attribution, and coordinate written introductions when there is genuine mutual interest.
+                ORXYZ does not sell raw lead lists. We aim to qualify real business needs, preserve attribution where appropriate,
+                and coordinate permissioned written introductions when there is genuine mutual fit.
+              </p>
+              <p>
+                ORXYZ may receive referral or introducer compensation when a documented provider milestone is reached. That
+                compensation does not authorize ORXYZ to bind a business to provider terms.
               </p>
               <a className={styles.providerButton} href={providerMail}>Discuss provider fit <span className={styles.arrow}>↗</span></a>
             </div>
             <div className={styles.providerList}>
-              <div className={styles.providerItem}><div className={styles.providerCheck}>✓</div><div><b>Qualified context</b><span>Use case, location, constraints, and what the business is actually evaluating.</span></div></div>
-              <div className={styles.providerItem}><div className={styles.providerCheck}>✓</div><div><b>Attribution clarity</b><span>Written records around the originating opportunity and commercial handoff.</span></div></div>
-              <div className={styles.providerItem}><div className={styles.providerCheck}>✓</div><div><b>No inflated claims</b><span>Interest, evaluation, installation, and earned compensation are treated as different stages.</span></div></div>
+              {providerChecks.map(([title, body]) => (
+                <div className={styles.providerItem} key={title}>
+                  <div className={styles.providerCheck}>✓</div>
+                  <div><b>{title}</b><span>{body}</span></div>
+                </div>
+              ))}
             </div>
           </div>
         </div>
       </section>
 
-      <section className={styles.section} id="about">
+      <section className={`${styles.section} ${styles.sectionMuted}`} id="about">
         <div className={`${styles.shell} ${styles.founderGrid}`}>
           <div className={styles.founderCard}>
             <div className={styles.founderMonogram}>DH</div>
             <b>Dominic Hartenstein</b>
-            <span>Founder · ORXYZ</span>
+            <span>Founder & operator · ORXYZ</span>
             <div className={styles.founderMeta}>
               <div className={styles.metaCard}><b>Based in</b><span>Buffalo, New York</span></div>
               <div className={styles.metaCard}><b>Communication</b><span>Written-first business coordination</span></div>
@@ -263,14 +334,16 @@ export default function Home() {
           </div>
           <div className={styles.founderCopy}>
             <div className={styles.sectionKicker}>About ORXYZ</div>
-            <h2>Independent by design. Precise by necessity.</h2>
+            <h2>Independent. Founder-led. Written-first.</h2>
             <p>
               ORXYZ is an independent technology sourcing and coordination business. We do not claim to manufacture the products
               we evaluate, and we do not present third-party pricing, installation, financing, revenue share, or support as guaranteed
               unless the applicable provider has confirmed those terms.
             </p>
             <p>
-              The goal is simple: understand what a business needs, find a credible path, and make the introduction clearer for everyone involved.
+              Dominic personally reviews provider relationships, commercial terms, and consequential commitments. Routine research,
+              drafting, scheduling, and administrative communication may be AI-assisted, but provider terms and business commitments
+              are not delegated to AI.
             </p>
           </div>
         </div>
@@ -299,7 +372,13 @@ export default function Home() {
             ORXYZ provides independent technology sourcing, introduction, and coordination services. Availability, pricing,
             installation, support, financing, and revenue-share terms are determined by the applicable third-party provider and remain subject to written approval.
           </div>
-          <div>© 2026 ORXYZ</div>
+          <div>
+            <div>© 2026 ORXYZ</div>
+            <div style={{ marginTop: 10, display: 'flex', gap: 14, flexWrap: 'wrap' }}>
+              <a href="/privacy">Privacy</a>
+              <a href="/terms">Terms</a>
+            </div>
+          </div>
         </div>
       </footer>
     </main>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,53 +1,41 @@
-export default function PrivacyCenter() {
+const contactEmail = 'connectedtechpartners@gmail.com';
+
+export const metadata = {
+  title: 'Privacy | ORXYZ',
+  description: 'Privacy information for the ORXYZ public website.',
+};
+
+export default function PrivacyPage() {
   return (
-    <main className="privacyPage">
-      <a className="privacyBack" href="/">← Back to Galactic Trust</a>
-      <section className="privacyHero">
-        <span className="privacyShield">✓</span>
-        <div>
-          <p>SECURITY &amp; PRIVACY</p>
-          <h1>Your financial life should stay private.</h1>
-          <span>Galactic Trust is currently a demo banking experience. This page describes the protections built into the application today and the rules for connecting future regulated providers.</span>
+    <main style={{ minHeight: '100vh', background: '#08090d', color: '#f5f7fb', padding: '64px 20px', fontFamily: 'Inter, system-ui, sans-serif' }}>
+      <div style={{ maxWidth: 820, margin: '0 auto' }}>
+        <a href="/" style={{ color: 'rgba(255,255,255,.82)', textDecoration: 'none', fontWeight: 700 }}>← ORXYZ</a>
+        <h1 style={{ margin: '34px 0 10px', fontSize: 'clamp(44px,8vw,72px)', letterSpacing: '-.055em', lineHeight: 1 }}>Privacy</h1>
+        <p style={{ color: 'rgba(255,255,255,.36)', fontSize: 13 }}>Last updated: September 9, 2026</p>
+
+        <div style={{ marginTop: 48, display: 'grid', gap: 34, color: 'rgba(255,255,255,.58)', lineHeight: 1.75, fontSize: 15 }}>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Information you provide</h2>
+            <p>If you contact ORXYZ by email, you may provide your name, email address, company information, business needs, or other information you choose to include. ORXYZ uses that information to review and respond to the inquiry and, where appropriate, coordinate potential technology opportunities.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Third-party providers</h2>
+            <p>When an opportunity may require a third-party technology provider, ORXYZ aims to keep identifying or confidential business information limited to what is appropriate for evaluation and to obtain permission before a substantive provider handoff when practical.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Website data</h2>
+            <p>This version of the ORXYZ website does not intentionally use advertising trackers or sell visitor information. Hosting, security, domain, and infrastructure providers may process standard technical information required to deliver and protect the site.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>AI-assisted administration</h2>
+            <p>Routine research, drafting, scheduling, and administrative communication may be AI-assisted. ORXYZ does not treat an AI-generated message as authority to approve provider pricing, contracts, payments, tax matters, or other consequential business commitments.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Contact</h2>
+            <p>Questions about this notice can be sent to <a href={`mailto:${contactEmail}`} style={{ color: '#fff' }}>{contactEmail}</a>.</p>
+          </section>
         </div>
-      </section>
-
-      <section className="privacyGrid">
-        <article>
-          <span>01</span>
-          <h2>Sensitive credentials</h2>
-          <p>Galactic Trust does not ask users to put passwords, PINs, CVVs, recovery codes, private keys, or one-time authentication codes into Orbit chat.</p>
-        </article>
-        <article>
-          <span>02</span>
-          <h2>Card information</h2>
-          <p>The dashboard intentionally masks card numbers and does not expose full PAN, CVV, PIN, or equivalent sensitive authentication data.</p>
-        </article>
-        <article>
-          <span>03</span>
-          <h2>Orbit support chat</h2>
-          <p>Orbit is designed for product support and general explanations. The current application does not intentionally save chat messages to an application database.</p>
-        </article>
-        <article>
-          <span>04</span>
-          <h2>Banking &amp; crypto providers</h2>
-          <p>Real banking or crypto activity stays disabled until approved provider programs, customer authentication, required disclosures, and server-side credentials are configured.</p>
-        </article>
-        <article>
-          <span>05</span>
-          <h2>Browser protections</h2>
-          <p>The production application sends restrictive security headers that limit framing, browser permissions, referrer leakage, external content, and other common web attack surfaces.</p>
-        </article>
-        <article>
-          <span>06</span>
-          <h2>Production launch</h2>
-          <p>Before real customer onboarding, the final privacy notice, data retention rules, vendor disclosures, consumer rights, support procedures, and legally required notices must match the actual live program.</p>
-        </article>
-      </section>
-
-      <section className="privacyCallout">
-        <div><strong>Demo mode is intentional.</strong><span>No real deposits or crypto trades are represented by the demo balances and prices.</span></div>
-        <a href="/">Return to dashboard</a>
-      </section>
+      </div>
     </main>
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,26 @@
 import type { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
   return [
     {
       url: 'https://orxyz.xyz/',
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
+      lastModified,
+      changeFrequency: 'weekly',
       priority: 1,
+    },
+    {
+      url: 'https://orxyz.xyz/privacy',
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: 'https://orxyz.xyz/terms',
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.3,
     },
   ];
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,49 @@
+const contactEmail = 'connectedtechpartners@gmail.com';
+
+export const metadata = {
+  title: 'Terms | ORXYZ',
+  description: 'Terms and service-role information for the ORXYZ public website.',
+};
+
+export default function TermsPage() {
+  return (
+    <main style={{ minHeight: '100vh', background: '#08090d', color: '#f5f7fb', padding: '64px 20px', fontFamily: 'Inter, system-ui, sans-serif' }}>
+      <div style={{ maxWidth: 820, margin: '0 auto' }}>
+        <a href="/" style={{ color: 'rgba(255,255,255,.82)', textDecoration: 'none', fontWeight: 700 }}>← ORXYZ</a>
+        <h1 style={{ margin: '34px 0 10px', fontSize: 'clamp(44px,8vw,72px)', letterSpacing: '-.055em', lineHeight: 1 }}>Terms</h1>
+        <p style={{ color: 'rgba(255,255,255,.36)', fontSize: 13 }}>Last updated: September 9, 2026</p>
+
+        <div style={{ marginTop: 48, display: 'grid', gap: 34, color: 'rgba(255,255,255,.58)', lineHeight: 1.75, fontSize: 15 }}>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>ORXYZ's role</h2>
+            <p>ORXYZ provides independent technology sourcing, introduction, and coordination services. ORXYZ is not, by default, the manufacturer, installer, lender, carrier, payment processor, technical support provider, or equipment owner for third-party products and services introduced through the business.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Provider terms control</h2>
+            <p>Pricing, availability, service area, equipment specifications, installation, warranties, financing, customer support, contract duration, revenue share, and other provider-specific obligations are determined by the applicable third-party provider and remain subject to that provider's current written approval and agreement with the business customer.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>No commitment without approval</h2>
+            <p>An inquiry, fit check, evaluation, referral, or introduction does not by itself create a purchase obligation, installation commitment, or deployment. Businesses should review the applicable provider's written terms before accepting any commercial commitment.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Referral compensation</h2>
+            <p>ORXYZ may receive referral, introducer, affiliate, or similar compensation from a third-party provider when a documented provider milestone is reached. The existence of potential compensation does not authorize ORXYZ to bind a business to a provider or approve provider terms on the business's behalf.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Information and accuracy</h2>
+            <p>ORXYZ aims to communicate provider and business information accurately, but third-party offerings can change. Material commercial terms should be confirmed directly in current written provider documentation before reliance.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>AI-assisted administration</h2>
+            <p>Routine research, drafting, scheduling, and administrative communication may be AI-assisted. Consequential provider terms, payment, tax, account, contractual, and business commitments are reviewed personally by Dominic Hartenstein.</p>
+          </section>
+          <section>
+            <h2 style={{ color: '#fff', fontSize: 21, marginBottom: 8 }}>Contact</h2>
+            <p>Questions about these terms can be sent to <a href={`mailto:${contactEmail}`} style={{ color: '#fff' }}>{contactEmail}</a>.</p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Moves the newest ORXYZ credibility and trust work into the Vercel-linked production repository.

Includes:
- upgraded founder-led homepage and operating standards
- clearer provider/referral disclosure language
- corrected ORXYZ privacy page replacing the legacy Galactic Trust copy
- new ORXYZ terms page
- expanded sitemap for /privacy and /terms

Production target: orxyz.xyz via Vercel-linked main branch.